### PR TITLE
feat(#4206): axis metadata for all 174 ReynConfig leaves, BOUNDING_KEYS/PREFERENCE_KEYS derived

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -685,14 +685,14 @@ llm:
 
 ### `llm.router` fields
 
-| Field | Type | Default | Meaning |
-|---|---|---|---|
-| `use` | bool | `false` | Master switch. `false` → direct `litellm.acompletion`. Supersedes `REYN_LLM_USE_ROUTER`. |
-| `num_retries` | int | `3` | Infra-exception retry count (Retry-After aware). Supersedes `REYN_LLM_ROUTER_NUM_RETRIES`. |
-| `fallbacks` | map | `{}` | `primary_model → [fallback_model, …]`. Empty → single-deployment Router (no chain). |
-| `cooldown_time` | float\|null | `null` | Seconds a deployment is cooled down after `allowed_fails` failures. Only meaningful with a fallback chain. |
-| `allowed_fails` | int\|null | `null` | Failures before a deployment is cooled down. |
-| `retry_policy` | map\|null | `null` | Per-exception-type retry counts. Absent (null) → litellm defaults (`num_retries` applies uniformly). When set, constructs a `litellm.RetryPolicy` and passes it to the Router. Supported keys: `RateLimitErrorRetries`, `TimeoutErrorRetries`, `BadRequestErrorRetries`, `AuthenticationErrorRetries`, `ContentPolicyViolationErrorRetries`, `InternalServerErrorRetries`. |
+| Field | Axis | Type | Default | Meaning |
+|---|---|---|---|---|
+| `use` | project | bool | `false` | Master switch. `false` → direct `litellm.acompletion`. Supersedes `REYN_LLM_USE_ROUTER`. |
+| `num_retries` | project | int | `3` | Infra-exception retry count (Retry-After aware). Supersedes `REYN_LLM_ROUTER_NUM_RETRIES`. |
+| `fallbacks` | project | map | `{}` | `primary_model → [fallback_model, …]`. Empty → single-deployment Router (no chain). |
+| `cooldown_time` | project | float\|null | `null` | Seconds a deployment is cooled down after `allowed_fails` failures. Only meaningful with a fallback chain. |
+| `allowed_fails` | project | int\|null | `null` | Failures before a deployment is cooled down. |
+| `retry_policy` | project | map\|null | `null` | Per-exception-type retry counts. Absent (null) → litellm defaults (`num_retries` applies uniformly). When set, constructs a `litellm.RetryPolicy` and passes it to the Router. Supported keys: `RateLimitErrorRetries`, `TimeoutErrorRetries`, `BadRequestErrorRetries`, `AuthenticationErrorRetries`, `ContentPolicyViolationErrorRetries`, `InternalServerErrorRetries`. |
 
 On the Router path, retry count is **config-only**: `num_retries` is taken from
 `llm.router.num_retries` (a per-call `max_retries` is not applied), so the retry
@@ -722,10 +722,10 @@ Controls the **timing** of the Reyn self-retry layer only (semantic-retry
 behaviours — EmptyLLMResponseError, empty\_stop\_retry, compaction shrink — are
 unaffected). Both defaults are `true`.
 
-| Field | Type | Default | Meaning |
-|---|---|---|---|
-| `jitter` | bool | `true` | Apply equal jitter (AWS pattern): `sleep = base/2 + uniform(0, base/2)` where `base = min(base_s * 2**attempt, max_backoff)`. Range `[base/2, base]`. Prevents thundering herd when parallel chains retry in lockstep. `false` → pure exponential (2 s, 4 s, 8 s, 16 s). |
-| `respect_retry_after` | bool | `true` | When a retryable exception carries a `Retry-After` header (delta-seconds **or** HTTP-date), honour it (capped at `_LLM_RETRY_MAX_BACKOFF_S` = 16 s) **instead of** the jittered backoff. Falls back to jittered backoff when the header is absent or unparseable. `false` → always use jittered backoff. |
+| Field | Axis | Type | Default | Meaning |
+|---|---|---|---|---|
+| `jitter` | project | bool | `true` | Apply equal jitter (AWS pattern): `sleep = base/2 + uniform(0, base/2)` where `base = min(base_s * 2**attempt, max_backoff)`. Range `[base/2, base]`. Prevents thundering herd when parallel chains retry in lockstep. `false` → pure exponential (2 s, 4 s, 8 s, 16 s). |
+| `respect_retry_after` | project | bool | `true` | When a retryable exception carries a `Retry-After` header (delta-seconds **or** HTTP-date), honour it (capped at `_LLM_RETRY_MAX_BACKOFF_S` = 16 s) **instead of** the jittered backoff. Falls back to jittered backoff when the header is absent or unparseable. `false` → always use jittered backoff. |
 
 > **Router path**: when `llm.router.use: true`, the litellm.Router owns
 > infra-exception retry with its own `Retry-After` respect. The `llm.retry`
@@ -783,10 +783,10 @@ marker (2 columns) and a right elapsed/token readout (12 columns) — and each
 costs its width on **every** row. These two flags set what the pane opens
 with; they are independent, matching the underlying widget's own granularity.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `left` | bool | `true` | Show the left (state-marker) gutter when the pane opens. |
-| `right` | bool | `true` | Show the right (elapsed / turn-token) gutter when the pane opens. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `left` | preference | bool | `true` | Show the left (state-marker) gutter when the pane opens. |
+| `right` | preference | bool | `true` | Show the right (elapsed / turn-token) gutter when the pane opens. |
 
 Either can also be toggled at any time from the keyboard — `ctrl+g` (left) and
 `ctrl+t` (right), both listed in the TUI's Help pane. **A keyboard toggle is
@@ -841,9 +841,9 @@ not to "tool-result rendering" as a whole; the summary line, the expanded
 detail view, and a failed call's own error line are unconditionally
 covered either way.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `neutralize_body` | bool | `false` | Strip ESC/control sequences from agent-reply and tool-result body text before rendering. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `neutralize_body` | capability | bool | `false` | Strip ESC/control sequences from agent-reply and tool-result body text before rendering. |
 
 ### `chat.image_url_schemes`
 
@@ -860,9 +860,9 @@ so the fetch always routes through the SSRF-pinned client
 (`_network.py`'s `build_async_http_client(pin_ssrf=True)`) unconditionally,
 independent of this scheme setting.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `image_url_schemes` | list[str] | `[]` | Restrict `present`'s image-src fetch to these schemes; empty = unrestricted (http + https). |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `image_url_schemes` | capability | list[str] | `[]` | Restrict `present`'s image-src fetch to these schemes; empty = unrestricted (http + https). |
 
 ### `chat.empty_stop_retry`
 
@@ -890,9 +890,9 @@ is unmeasured (#3698's anyio cancel-scope is a candidate) — it only changes
 what happens *after* one is detected. The `router_empty_response_detected`
 audit event fires regardless of this setting.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `empty_stop_retry` | bool | `false` | Resend one self-describing continuation nudge (`role="system"`, #5273/#5274 — not a bare `"resume"`) when the router loop detects an empty `finish_reason="stop"` response. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `empty_stop_retry` | bounding | bool | `false` | Resend one self-describing continuation nudge (`role="system"`, #5273/#5274 — not a bare `"resume"`) when the router loop detects an empty `finish_reason="stop"` response. |
 
 ### `chat.theme`
 
@@ -906,9 +906,9 @@ is accepted — reyn's own theme, or any of Textual's built-ins (`nord`,
 Textual itself resolves the theme, not here, so this config layer never
 carries its own copy of Textual's theme registry to keep in sync.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `theme` | str \| null | `null` | Textual theme name for the interactive TUI. `null` keeps reyn's own default (`"reyn"`). |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `theme` | preference | str \| null | `null` | Textual theme name for the interactive TUI. `null` keeps reyn's own default (`"reyn"`). |
 
 ### `chat.stream_repaint_min_interval`
 
@@ -936,20 +936,20 @@ the default instead of disabling the budget — `0` means "repaint on every
 delta", the pre-#3570 behaviour the measurement above exists to keep
 operators out of.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `stream_repaint_min_interval` | float | `0.0333` (1/30) | Seconds between two repaints of the same streamed reply. Non-positive falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `stream_repaint_min_interval` | preference | float | `0.0333` (1/30) | Seconds between two repaints of the same streamed reply. Non-positive falls back to the default. |
 
 ### `chat.reasoning` fields
 
 Capture of the provider `reasoning_content` is **always-on**; these knobs gate
 what happens afterwards. Both `continuity` and `display` default **on**.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `continuity` | bool | `true` | Persist reasoning to history **and** replay the recent turns' reasoning into the next turn's system prompt (cross-user-turn reasoning continuity, a text-section mirroring `act_turn_reasoning`). Opt-out to disable persist + replay. |
-| `display` | bool | `true` | Surface reasoning in the UI (TUI + web, collapsible). Opt-out to hide it. Independent of `continuity`. |
-| `recent_turns` | int | `3` | How many recent turns' reasoning to replay under `continuity`. `<= 0` (e.g. `0` / `-1`) = unbounded (keep all). Bounding matters on Gemini — there is no provider auto-filter, so reasoning accumulates and is billed in full. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `continuity` | preference | bool | `true` | Persist reasoning to history **and** replay the recent turns' reasoning into the next turn's system prompt (cross-user-turn reasoning continuity, a text-section mirroring `act_turn_reasoning`). Opt-out to disable persist + replay. |
+| `display` | preference | bool | `true` | Surface reasoning in the UI (TUI + web, collapsible). Opt-out to hide it. Independent of `continuity`. |
+| `recent_turns` | preference | int | `3` | How many recent turns' reasoning to replay under `continuity`. `<= 0` (e.g. `0` / `-1`) = unbounded (keep all). Bounding matters on Gemini — there is no provider auto-filter, so reasoning accumulates and is billed in full. |
 
 > **Provider note**: on the Gemini-via-proxy path the reasoning is replayed as a
 > text section (the model sees it in-prompt), and `reasoning_content` is stripped
@@ -1080,11 +1080,11 @@ tool_use:
   universal_wrappers_enabled: true    # default; set false to opt out
 ```
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `scheme` | string | `enumerate-all` | Presentation for the top-level chat layer: `category` / `enumerate-all` / `retrieval`. **Default `enumerate-all`** — flat-lists actions so the LLM invokes them directly instead of hallucinating `invoke_action` names (raised direct tool-use ~30%→100%). Set to `universal-category` for a minimal-surface / many-tool catalog (discover-then-call). |
-| `transport` | string | `tool_calls` | How the model expresses a chosen action: `tool_calls` (native tool-calling) or `content_fence` (the action is expressed as fenced code in the reply text — CodeAct). |
-| `universal_wrappers_enabled` | bool | `true` | **#4552 PR-3 — moved here from `action_retrieval.universal_wrappers_enabled`** (architect's ruling: a `tool_use`/presentation-scheme property, not a retrieval setting). For a layer whose `scheme` resolves to `universal-category`, `true` (default) exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) in that layer's `tools=`.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM on that layer but remain available as wrapper backing handlers.  `search_actions` is gated separately by [`embedding.enabled`](#embedding-block) (#4564 — this flag has NO effect on `search_actions` visibility in any scheme).  Set `false` to disable the wrapper surface entirely for that layer (= legacy tools become the only addressing path again).  Does not affect a layer whose `scheme` is `enumerate-all`/`retrieval` — those never consult this flag. Setting it explicitly `true` while `scheme` isn't `universal-category` has no effect; `reyn config validate` reports that combination (#4231(C)). |
+| Key | Axis | Type | Default | Description |
+|-----|---|------|---------|-------------|
+| `scheme` | project | string | `enumerate-all` | Presentation for the top-level chat layer: `category` / `enumerate-all` / `retrieval`. **Default `enumerate-all`** — flat-lists actions so the LLM invokes them directly instead of hallucinating `invoke_action` names (raised direct tool-use ~30%→100%). Set to `universal-category` for a minimal-surface / many-tool catalog (discover-then-call). |
+| `transport` | project | string | `tool_calls` | How the model expresses a chosen action: `tool_calls` (native tool-calling) or `content_fence` (the action is expressed as fenced code in the reply text — CodeAct). |
+| `universal_wrappers_enabled` | project | bool | `true` | **#4552 PR-3 — moved here from `action_retrieval.universal_wrappers_enabled`** (architect's ruling: a `tool_use`/presentation-scheme property, not a retrieval setting). For a layer whose `scheme` resolves to `universal-category`, `true` (default) exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) in that layer's `tools=`.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM on that layer but remain available as wrapper backing handlers.  `search_actions` is gated separately by [`embedding.enabled`](#embedding-block) (#4564 — this flag has NO effect on `search_actions` visibility in any scheme).  Set `false` to disable the wrapper surface entirely for that layer (= legacy tools become the only addressing path again).  Does not affect a layer whose `scheme` is `enumerate-all`/`retrieval` — those never consult this flag. Setting it explicitly `true` while `scheme` isn't `universal-category` has no effect; `reyn config validate` reports that combination (#4231(C)). |
 
 See [Concepts: universal catalog](../../concepts/tools-integrations/universal-catalog.md) for the full `list_actions` / `describe_action` / `invoke_action` wrapper semantics (category discovery, error-recovery `suggestions`, weak-model landing design).
 
@@ -1191,10 +1191,10 @@ Priority chain (highest first):
 
 `verify_ssl` and `ca_bundle` also apply to MCP registry HTTP calls (package install).
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `web_fetch.max_download_bytes` | int | `10485760` (10MB) | Maximum response bytes `web_fetch` reads off the wire. A response whose `Content-Length` exceeds this is rejected before any body is downloaded; a chunked / unknown-length body is aborted once the stream passes the ceiling (status `too_large`). Guards against an unbounded-body memory blow-up from a hostile or runaway URL. `<= 0` or non-integer falls back to the default. |
-| `web_fetch.allow_private_ips` | bool | `false` | SSRF opt-in. When `true`, `web_fetch` / `safe.http` may fetch **private** RFC1918/ULA addresses (enterprise internal-fetch). Link-local, cloud-metadata (`169.254.169.254`), and loopback are **always** denied regardless of this flag. HTTP redirects are re-validated per hop (both the host allowlist and the IP-deny), so an allowlisted host cannot redirect to an internal target. Also exported to the `REYN_FETCH_ALLOW_PRIVATE_IPS` env var so the safe.http subprocess and registry clients honor the same opt-in. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `web_fetch.max_download_bytes` | bounding | int | `10485760` (10MB) | Maximum response bytes `web_fetch` reads off the wire. A response whose `Content-Length` exceeds this is rejected before any body is downloaded; a chunked / unknown-length body is aborted once the stream passes the ceiling (status `too_large`). Guards against an unbounded-body memory blow-up from a hostile or runaway URL. `<= 0` or non-integer falls back to the default. |
+| `web_fetch.allow_private_ips` | capability | bool | `false` | SSRF opt-in. When `true`, `web_fetch` / `safe.http` may fetch **private** RFC1918/ULA addresses (enterprise internal-fetch). Link-local, cloud-metadata (`169.254.169.254`), and loopback are **always** denied regardless of this flag. HTTP redirects are re-validated per hop (both the host allowlist and the IP-deny), so an allowlisted host cannot redirect to an internal target. Also exported to the `REYN_FETCH_ALLOW_PRIVATE_IPS` env var so the safe.http subprocess and registry clients honor the same opt-in. |
 
 > ℹ️ **#4274**: `web_fetch.*` now reaches every live chat session's
 > `web_fetch` op execution (`SessionFactoryConfig.web_fetch_config` →
@@ -1224,14 +1224,14 @@ gateway:
     tls_keyfile: /path/to/key.pem       # operator TLS key (T3); set together with tls_certfile
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `gateway.ws_max_size` | int | `16777216` (16MB) | Maximum size (bytes) of a single inbound WebSocket frame the `reyn web` gateway accepts; a larger frame is rejected by the server before delivery. Pins the WebSocket frame ceiling explicitly instead of relying on the server library's implicit default, so the bound stays in place across server-library upgrades. Operators may tighten or loosen it. `<= 0` or non-integer falls back to the default. |
-| `gateway.default_design` | str | `null` | The OpenUI host's default design slug, served by `GET /api/web/config` (#4317). Resolution priority: `REYN_WEB_DEFAULT_DESIGN` env var → this field → first available design alphabetically. Was `web.default_design` pre-#4174-T4; T4's split enumerated `ws_max_size`/`auth`/`surfaces` but dropped this field entirely, leaving it with no address in the typed schema for a full cycle — #4317 gave it one. **A genuine behavior change, not a pure bugfix**: the old key was read via a raw `yaml.safe_load` of `reyn.yaml` that bypassed the loader/schema entirely, so it kept resolving `web.default_design:` correctly the whole time despite the schema no longer knowing that key — an operator still on the old key now gets nothing here (falls through to the next priority level) instead of the silently-surviving old value. `reyn config validate`/`migrate` surface the rename via the `"web"` `RenamedKeyHint`, alongside `auth`/`ws_max_size`/`surfaces`. |
-| `gateway.auth.token` | str | `null` | The gateway's cross-machine (T3) bearer token. A **non-loopback bind refuses to start** without it (fail-closed — closes the accidental-exposure hole). A loopback bind generates an ephemeral token at startup when this is unset (printed in the launch URL, Jupyter-style), so no gateway surface is ever left unauthenticated. The token gates **every** functional surface uniformly — the AG-UI chat routes, `/api`, `/a2a`, `/mcp`, and the resource-fetch routes — not the AG-UI surface alone. |
-| `gateway.auth.require_token_on_loopback` | bool | `true` | When `true`, even loopback TCP connections must present the token (secure default — a shared multi-user host must not leave the browser loopback surface open). Same-machine UDS connections are authenticated by OS peer credentials and never need a token. |
-| `gateway.auth.tls_certfile` | str | `null` | Operator TLS certificate (PEM) for a T3 network bind. When unset, a self-signed certificate is generated at startup and its SHA-256 fingerprint is printed for trust-on-first-use pinning. Must be set together with `tls_keyfile`. |
-| `gateway.auth.tls_keyfile` | str | `null` | Operator TLS private key (PEM) paired with `tls_certfile`. Setting only one of the two is a startup error. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `gateway.ws_max_size` | project | int | `16777216` (16MB) | Maximum size (bytes) of a single inbound WebSocket frame the `reyn web` gateway accepts; a larger frame is rejected by the server before delivery. Pins the WebSocket frame ceiling explicitly instead of relying on the server library's implicit default, so the bound stays in place across server-library upgrades. Operators may tighten or loosen it. `<= 0` or non-integer falls back to the default. |
+| `gateway.default_design` | project | str | `null` | The OpenUI host's default design slug, served by `GET /api/web/config` (#4317). Resolution priority: `REYN_WEB_DEFAULT_DESIGN` env var → this field → first available design alphabetically. Was `web.default_design` pre-#4174-T4; T4's split enumerated `ws_max_size`/`auth`/`surfaces` but dropped this field entirely, leaving it with no address in the typed schema for a full cycle — #4317 gave it one. **A genuine behavior change, not a pure bugfix**: the old key was read via a raw `yaml.safe_load` of `reyn.yaml` that bypassed the loader/schema entirely, so it kept resolving `web.default_design:` correctly the whole time despite the schema no longer knowing that key — an operator still on the old key now gets nothing here (falls through to the next priority level) instead of the silently-surviving old value. `reyn config validate`/`migrate` surface the rename via the `"web"` `RenamedKeyHint`, alongside `auth`/`ws_max_size`/`surfaces`. |
+| `gateway.auth.token` | project | str | `null` | The gateway's cross-machine (T3) bearer token. A **non-loopback bind refuses to start** without it (fail-closed — closes the accidental-exposure hole). A loopback bind generates an ephemeral token at startup when this is unset (printed in the launch URL, Jupyter-style), so no gateway surface is ever left unauthenticated. The token gates **every** functional surface uniformly — the AG-UI chat routes, `/api`, `/a2a`, `/mcp`, and the resource-fetch routes — not the AG-UI surface alone. |
+| `gateway.auth.require_token_on_loopback` | project | bool | `true` | When `true`, even loopback TCP connections must present the token (secure default — a shared multi-user host must not leave the browser loopback surface open). Same-machine UDS connections are authenticated by OS peer credentials and never need a token. |
+| `gateway.auth.tls_certfile` | project | str | `null` | Operator TLS certificate (PEM) for a T3 network bind. When unset, a self-signed certificate is generated at startup and its SHA-256 fingerprint is printed for trust-on-first-use pinning. Must be set together with `tls_keyfile`. |
+| `gateway.auth.tls_keyfile` | project | str | `null` | Operator TLS private key (PEM) paired with `tls_certfile`. Setting only one of the two is a startup error. |
 
 **Transport tiers** (secure-by-default). The gateway identifies every connection: **T1** in-process (the operator's own process, no auth); **T2** same-machine cross-process over a UNIX domain socket (`reyn web --uds PATH`) identified by OS peer credentials, or loopback TCP as a fallback; **T3** cross-machine network, which requires `gateway.auth.token` and runs over TLS. An intervention answer is a permission grant, so an unauthenticated connection cannot answer.
 
@@ -1511,10 +1511,10 @@ fs_watch:
   debounce_seconds: 0.2   # optional
 ```
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `paths` | list[string] | `[]` | Directories watched recursively for create/modify/delete events. Empty (the default) → the watcher never starts, byte-identical to a build with no `fs_watch:` config. |
-| `debounce_seconds` | float | `0.2` | A burst of events for the same path within this window coalesces into a single `file_changed` fire (one logical change = one hook fire, not one fire per underlying filesystem event). |
+| Key | Axis | Type | Default | Description |
+|-----|---|------|---------|-------------|
+| `paths` | project | list[string] | `[]` | Directories watched recursively for create/modify/delete events. Empty (the default) → the watcher never starts, byte-identical to a build with no `fs_watch:` config. |
+| `debounce_seconds` | project | float | `0.2` | A burst of events for the same path within this window coalesces into a single `file_changed` fire (one logical change = one hook fire, not one fire per underlying filesystem event). |
 
 Requires the `watchdog` package: `pip install reyn[fs-watch]`. `paths`
 configured without the extra installed logs a warning once and disables the
@@ -1574,13 +1574,13 @@ sandbox:
 > longer a default; an operator who wants it back opts in. Still scope
 > `allow_write_paths` to the narrowest directories the process actually needs.
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `backend` | string | `auto` | Enforcement backend. `auto` lets the OS pick: macOS < 26 → `seatbelt` (sandbox-exec SBPL), Linux ≥ 5.13 with `sandbox-linux` extra → `landlock` (+ optional seccomp-BPF), otherwise → `noop` (audit-only, no enforcement). Explicit values force a specific backend. |
-| `on_unsupported` | string | `warn` | Policy when **no OS sandbox backend is available** — whether an explicit `backend` was forced-but-unavailable, `backend: auto` found no platform backend (the auto path honors this too), OR the selected backend **failed its enforcement self-test** (it is present but did not deny — such a backend is treated exactly like an absent one). `warn` logs a WARNING at selection and falls back to `noop` (default — not silent). `error` raises `RuntimeError` (**fail-closed** — refuse to run AI-generated code unsandboxed; set this where enforcement is required, and it works with the default `backend: auto` and against a present-but-inert backend). `ignore` silently falls back. |
-| `mode` | string | `compat` | #3823: which DEFAULT the resolved policy uses for a `policy` key the operator left **unset** below — never a key the operator wrote explicitly (an explicit `allow_X`/`deny_X` or bare bool always wins over `mode`). `compat` (default) leaves every axis at its compat default (nothing blocked; audit/events/timeout/cancel-teardown still apply). `strict` flips network/subprocess/env to their closed default (network off, subprocess denied, env passes nothing) — `allow_write_paths` is UNAFFECTED by mode (stays the caller-supplied per-op workspace floor, operator-unknowable) and read has no mode-based default at all (no `allow_read_paths` concept, #1199 — only an explicit `deny_read_paths` narrows either mode). Allowed: `{compat, strict}` — not `custom` (owner ruling: was never a third direction, was the symptom of `mode`/`policy` having no composition rule) and not `off` (expressible as `compat` with every axis at its compat default). |
-| `policy` | map | _none_ | **Agent-level (operator) sandbox policy, in the config vocabulary below (#3823).** When set, it is the deterministic policy applied to sandboxed ops **and** folded into the `SandboxLayer` of the permission intersection (`∩`) for the OS's in-process file/http gates, on the `network`/`subprocess`/`env` axes — **winning over** op-declared fields, so a skill or the LLM cannot widen it. `allow_write_paths` (and the read/write deny-lists) do NOT participate in that intersection: an operator cannot know in advance what directory an op needs, so the kernel backend consumes them directly (#3901 PR-B ③). Omitted (the default) means **no agent-level restriction**: the `SandboxLayer` stays the identity (`⊤`) and op-level fields govern, exactly as before. Sandbox authorization is an operator/run concern. See sub-keys below. |
-| `require_capabilities` | list of string | `[]` | **#4935, opt-in only.** Named-service capability classes (declared, never probed — see `reyn.security.sandbox.capability`'s own module docstring) the operator requires the RESOLVED backend to support. Today the only known name is `ipc_named_service` — e.g. Seatbelt's `com.apple.SecurityServer` grant (#4937), which `gh` needs. `dscl`/`scutil` need OTHER named services under this SAME category that are **not** granted today — requiring this capability does **not** make them work; it only rejects a backend with no mechanism at all (noop/landlock resolve to NOT_SUPPORTED; Seatbelt always resolves to SUPPORTED regardless of which specific service you actually need, since the declaration is per-category, not per-service — see `reyn.security.sandbox.capability`'s own module docstring for exactly which services are and aren't granted today). An unrecognised name raises at config-load time. Empty (the default) means this field changes nothing — no run is affected unless you name a capability. When the resolved backend does NOT support a required capability, `sandbox.on_unsupported` (the SAME 3-way knob above, not a new vocabulary) governs the response. `reyn doctor` discloses each declared backend's own support under the sandbox posture section (C-5). |
+| Key | Axis | Type | Default | Description |
+|-----|---|------|---------|-------------|
+| `backend` | capability | string | `auto` | Enforcement backend. `auto` lets the OS pick: macOS < 26 → `seatbelt` (sandbox-exec SBPL), Linux ≥ 5.13 with `sandbox-linux` extra → `landlock` (+ optional seccomp-BPF), otherwise → `noop` (audit-only, no enforcement). Explicit values force a specific backend. |
+| `on_unsupported` | capability | string | `warn` | Policy when **no OS sandbox backend is available** — whether an explicit `backend` was forced-but-unavailable, `backend: auto` found no platform backend (the auto path honors this too), OR the selected backend **failed its enforcement self-test** (it is present but did not deny — such a backend is treated exactly like an absent one). `warn` logs a WARNING at selection and falls back to `noop` (default — not silent). `error` raises `RuntimeError` (**fail-closed** — refuse to run AI-generated code unsandboxed; set this where enforcement is required, and it works with the default `backend: auto` and against a present-but-inert backend). `ignore` silently falls back. |
+| `mode` | capability | string | `compat` | #3823: which DEFAULT the resolved policy uses for a `policy` key the operator left **unset** below — never a key the operator wrote explicitly (an explicit `allow_X`/`deny_X` or bare bool always wins over `mode`). `compat` (default) leaves every axis at its compat default (nothing blocked; audit/events/timeout/cancel-teardown still apply). `strict` flips network/subprocess/env to their closed default (network off, subprocess denied, env passes nothing) — `allow_write_paths` is UNAFFECTED by mode (stays the caller-supplied per-op workspace floor, operator-unknowable) and read has no mode-based default at all (no `allow_read_paths` concept, #1199 — only an explicit `deny_read_paths` narrows either mode). Allowed: `{compat, strict}` — not `custom` (owner ruling: was never a third direction, was the symptom of `mode`/`policy` having no composition rule) and not `off` (expressible as `compat` with every axis at its compat default). |
+| `policy` | capability | map | _none_ | **Agent-level (operator) sandbox policy, in the config vocabulary below (#3823).** When set, it is the deterministic policy applied to sandboxed ops **and** folded into the `SandboxLayer` of the permission intersection (`∩`) for the OS's in-process file/http gates, on the `network`/`subprocess`/`env` axes — **winning over** op-declared fields, so a skill or the LLM cannot widen it. `allow_write_paths` (and the read/write deny-lists) do NOT participate in that intersection: an operator cannot know in advance what directory an op needs, so the kernel backend consumes them directly (#3901 PR-B ③). Omitted (the default) means **no agent-level restriction**: the `SandboxLayer` stays the identity (`⊤`) and op-level fields govern, exactly as before. Sandbox authorization is an operator/run concern. See sub-keys below. |
+| `require_capabilities` | capability | list of string | `[]` | **#4935, opt-in only.** Named-service capability classes (declared, never probed — see `reyn.security.sandbox.capability`'s own module docstring) the operator requires the RESOLVED backend to support. Today the only known name is `ipc_named_service` — e.g. Seatbelt's `com.apple.SecurityServer` grant (#4937), which `gh` needs. `dscl`/`scutil` need OTHER named services under this SAME category that are **not** granted today — requiring this capability does **not** make them work; it only rejects a backend with no mechanism at all (noop/landlock resolve to NOT_SUPPORTED; Seatbelt always resolves to SUPPORTED regardless of which specific service you actually need, since the declaration is per-category, not per-service — see `reyn.security.sandbox.capability`'s own module docstring for exactly which services are and aren't granted today). An unrecognised name raises at config-load time. Empty (the default) means this field changes nothing — no run is affected unless you name a capability. When the resolved backend does NOT support a required capability, `sandbox.on_unsupported` (the SAME 3-way knob above, not a new vocabulary) governs the response. `reyn doctor` discloses each declared backend's own support under the sandbox posture section (C-5). |
 
 ### `sandbox.policy` sub-keys
 
@@ -1629,9 +1629,9 @@ A plain top-level scalar (#4174 T5 — flattened from the old `agent: {id:
 ...}` namespace: that block held exactly one field, so the namespace added
 indirection without adding structure).
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `agent_id` | string | `reyn/<hostname>` | Stable identifier for this Reyn instance. Stamped onto every P6 event payload as `agent_id` and injected into outgoing MCP, A2A, and external HTTP requests as the `X-Reyn-Agent-Id` header (SOC2 / ISO27001 / METI v1.1 audit pattern). Recommended format: `reyn/<org>/<role>` (operator-defined). An empty string falls back to the default so leaving the field blank does not emit an empty `agent_id` into events or headers. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `agent_id` | project | string | `reyn/<hostname>` | Stable identifier for this Reyn instance. Stamped onto every P6 event payload as `agent_id` and injected into outgoing MCP, A2A, and external HTTP requests as the `X-Reyn-Agent-Id` header (SOC2 / ISO27001 / METI v1.1 audit pattern). Recommended format: `reyn/<org>/<role>` (operator-defined). An empty string falls back to the default so leaving the field blank does not emit an empty `agent_id` into events or headers. |
 
 The default `reyn/<hostname>` gives a fresh install a usable identity without operator action. Override in `reyn.yaml` when running multi-agent fleets or enterprise deployments that need a stable per-role identifier.
 
@@ -1657,12 +1657,12 @@ observability:
 
 ### `observability.otel` fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `otel.endpoint` | string | `""` | OTLP HTTP base URL (e.g. `http://localhost:4318`). Empty = not attached; the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var is honored as a fallback, so OTEL can be enabled purely from the environment. |
-| `otel.headers` | map | `{}` | Per-request HTTP headers (auth tokens, tenant ids). Values support `${VAR}` env interpolation. |
-| `otel.service_name` | string | `reyn` | The `service.name` resource attribute reported to the collector. |
-| `otel.capture_content` | bool | `false` | GenAI content-capture gate. `false` (default) emits refs and token/cost counts only — never a raw prompt/response body in a span or log. Set `true` to opt into content capture (only against a trusted collector). |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `otel.endpoint` | project | string | `""` | OTLP HTTP base URL (e.g. `http://localhost:4318`). Empty = not attached; the standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var is honored as a fallback, so OTEL can be enabled purely from the environment. |
+| `otel.headers` | project | map | `{}` | Per-request HTTP headers (auth tokens, tenant ids). Values support `${VAR}` env interpolation. |
+| `otel.service_name` | project | string | `reyn` | The `service.name` resource attribute reported to the collector. |
+| `otel.capture_content` | project | bool | `false` | GenAI content-capture gate. `false` (default) emits refs and token/cost counts only — never a raw prompt/response body in a span or log. Set `true` to opt into content capture (only against a trusted collector). |
 
 Requires the OTEL SDK: `pip install reyn[observability]`. An endpoint configured
 without the SDK installed logs once and stays not-attached (fail-open) — the
@@ -1681,9 +1681,9 @@ delegation:
 
 ### `delegation` fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `delegation.capability_default` | `inherit` \| `deny` | `inherit` | `inherit` — a delegate inherits the spawner's capability surface (no extra narrowing; byte-identical to pre-#2081). `deny` — an **unbound** delegate is narrowed by the built-in restrictive `_delegate` profile (dangerous-tool classes denied: re-delegation, side-effect execution, memory-writes, MCP install) unless a topology `capability_profile` binding re-grants it (the binding **replaces** the default — composition is most-restrictive-wins and cannot re-grant). The default-deny propagates **recursively**: a sub-delegate is itself a delegate, so a re-granted coordinator's own sub-delegates are still default-denied (no laundering). |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `delegation.capability_default` | capability | `inherit` \| `deny` | `inherit` | `inherit` — a delegate inherits the spawner's capability surface (no extra narrowing; byte-identical to pre-#2081). `deny` — an **unbound** delegate is narrowed by the built-in restrictive `_delegate` profile (dangerous-tool classes denied: re-delegation, side-effect execution, memory-writes, MCP install) unless a topology `capability_profile` binding re-grants it (the binding **replaces** the default — composition is most-restrictive-wins and cannot re-grant). The default-deny propagates **recursively**: a sub-delegate is itself a delegate, so a re-granted coordinator's own sub-delegates are still default-denied (no laundering). |
 
 Only the unbound-delegate fallback is affected. A top-level agent and any topology-bound agent are unchanged. The restrictive floor reuses the same single-sourced dangerous-tool taxonomy as the `_untrusted` content-narrowing profile; operators may tune it independently via `.reyn/capability_profiles/_delegate.yaml`.
 
@@ -2038,11 +2038,11 @@ cost_warn:
   block_on_high_cost: false              # optional confirm gate (see below)
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `enabled` | bool | `true` | Master switch. Set to `false` to silence all model-cost warnings. |
-| `model_threshold_per_1m_input_usd` | float | `5.0` | Warn when the selected model's input rate exceeds this value (USD per 1M tokens). Default catches Opus-class (~$15/1M) without triggering on Sonnet-class (~$3/1M). |
-| `block_on_high_cost` | bool | `false` | When `true`, a `/model <class>` switch to a high-cost model is held for an interactive confirmation and applies **only on approval** (routed through the shared safety-limit framework, the same one budget-exceed continuation uses). A decline leaves the current model unchanged. A non-interactive session (no TTY) **fail-closes** — it cannot show the confirm, so the high-cost switch is denied; keep this `false` to use high-cost models head-less. Session startup stays warn-only regardless of this flag. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `enabled` | preference | bool | `true` | Master switch. Set to `false` to silence all model-cost warnings. |
+| `model_threshold_per_1m_input_usd` | preference | float | `5.0` | Warn when the selected model's input rate exceeds this value (USD per 1M tokens). Default catches Opus-class (~$15/1M) without triggering on Sonnet-class (~$3/1M). |
+| `block_on_high_cost` | preference | bool | `false` | When `true`, a `/model <class>` switch to a high-cost model is held for an interactive confirmation and applies **only on approval** (routed through the shared safety-limit framework, the same one budget-exceed continuation uses). A decline leaves the current model unchanged. A non-interactive session (no TTY) **fail-closes** — it cannot show the confirm, so the high-cost switch is denied; keep this `false` to use high-cost models head-less. Session startup stays warn-only regardless of this flag. |
 
 **Pricing source:** reyn looks up model costs from the [LiteLLM pricing database](https://github.com/BerriAI/litellm) (`litellm.model_cost`). Models not in the database are treated as below-threshold (no warning). Custom or proxy models that resolve to a key in the database will be matched.
 
@@ -2066,16 +2066,16 @@ offload:
   structured_preview_chars: 600      # how much of it stays inline beside the ref
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `enabled` | bool | `false` | Master switch. `true` opts in to the text token cap, the structured inline cap, and the media follow-up budget bound. The size fields below apply only while it is `true`. |
-| `max_inline_bytes` | int | `16384` | Absolute ceiling on the inline preview a capped text result leaves behind. **Also feeds the turn budget's force-close reserve** — it is what the OS reserves for "one more increment", so lowering it lets a turn run longer before force-close fires. |
-| `preview_head_chars` | int | `6000` | How much of the body's head that inline preview keeps. The body itself is stored and referenced, never lost. |
-| `preview_tail_chars` | int | `2000` | The same for the tail. |
-| `cap_ceil_tokens` | int | `4096` | Upper clamp on the per-turn token cap, so a large-context model still gets a lean inline. |
-| `cap_alpha` | float | `0.5` | Budget-relative term: the cap is `min(cap_ceil_tokens, cap_alpha × effective_trigger)`, which keeps a capped turn compactable on a small-context model too. |
-| `structured_inline_max_chars` | int | `2000` | Serialized size at which a structured (dict/list) result is stored under its own ref instead of staying inline. |
-| `structured_preview_chars` | int | `600` | How much of that serialization stays inline beside the ref. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `enabled` | project | bool | `false` | Master switch. `true` opts in to the text token cap, the structured inline cap, and the media follow-up budget bound. The size fields below apply only while it is `true`. |
+| `max_inline_bytes` | bounding | int | `16384` | Absolute ceiling on the inline preview a capped text result leaves behind. **Also feeds the turn budget's force-close reserve** — it is what the OS reserves for "one more increment", so lowering it lets a turn run longer before force-close fires. |
+| `preview_head_chars` | bounding | int | `6000` | How much of the body's head that inline preview keeps. The body itself is stored and referenced, never lost. |
+| `preview_tail_chars` | bounding | int | `2000` | The same for the tail. |
+| `cap_ceil_tokens` | bounding | int | `4096` | Upper clamp on the per-turn token cap, so a large-context model still gets a lean inline. |
+| `cap_alpha` | bounding | float | `0.5` | Budget-relative term: the cap is `min(cap_ceil_tokens, cap_alpha × effective_trigger)`, which keeps a capped turn compactable on a small-context model too. |
+| `structured_inline_max_chars` | bounding | int | `2000` | Serialized size at which a structured (dict/list) result is stored under its own ref instead of staying inline. |
+| `structured_preview_chars` | bounding | int | `600` | How much of that serialization stays inline beside the ref. |
 
 ## `render_template` block
 
@@ -2087,10 +2087,10 @@ render_template:
   wall_clock_seconds: 5.0    # elapsed-time backstop for a runaway loop
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `max_output_chars` | int | `256000` | The streaming character budget. The render truncates the moment cumulative output exceeds it. A non-positive or non-numeric value falls back to the default. |
-| `wall_clock_seconds` | float | `5.0` | Elapsed-time backstop. Jinja2 exposes no iteration count, so wall-clock bounds a runaway loop that emits little text per step. A non-positive or non-numeric value falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `max_output_chars` | project | int | `256000` | The streaming character budget. The render truncates the moment cumulative output exceeds it. A non-positive or non-numeric value falls back to the default. |
+| `wall_clock_seconds` | project | float | `5.0` | Elapsed-time backstop. Jinja2 exposes no iteration count, so wall-clock bounds a runaway loop that emits little text per step. A non-positive or non-numeric value falls back to the default. |
 
 The defaults are generous enough for real reports / configs and tight enough that a runaway generator stops quickly. Omitting the block leaves both at their defaults (behaviour unchanged).
 
@@ -2103,9 +2103,9 @@ read_cap:
   inline_bytes: 10240   # 10 KiB — ceiling on a single inline read/load result
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `inline_bytes` | int | `10240` | Ceiling, in bytes, on what `file.read` / `load_skill` return inline before truncating. A non-positive or non-numeric value falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `inline_bytes` | bounding | int | `10240` | Ceiling, in bytes, on what `file.read` / `load_skill` return inline before truncating. A non-positive or non-numeric value falls back to the default. |
 
 **Why 10 KiB**: both consumers gained a resume mechanism the same night this default was chosen — `file.read` via `char_offset` (#4432), `load_skill` via deferring to `read_file(offset=next_offset)` (#4431). A truncated read loses at most one round-trip, not the rest of the content, which is what makes a small default safe rather than arbitrary. Omitting the block keeps this default (behaviour unchanged).
 
@@ -2118,9 +2118,9 @@ history_resident:
   max_bytes: 268435456   # 256 MiB — ceiling on Session.history's resident size
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `max_bytes` | int | `268435456` (256 MiB) | Ceiling, in bytes, on `Session.history`'s in-memory footprint. Once exceeded, the oldest resident entries are evicted (never the just-appended newest one) until the cap is met again. A non-positive or non-numeric value falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `max_bytes` | bounding | int | `268435456` (256 MiB) | Ceiling, in bytes, on `Session.history`'s in-memory footprint. Once exceeded, the oldest resident entries are evicted (never the just-appended newest one) until the cap is met again. A non-positive or non-numeric value falls back to the default. |
 
 Eviction is not information loss: `Session.history` is a cache, not the source of truth — `history.jsonl` (append-only, on disk) is, and every entry evicted from memory reloads on demand via the already-shipped backward-hydrate path (TUI scrollback paging, in-conversation search, and WAL rewind visibility all already page older entries back in as needed). This closes an unbounded-growth defect (`self.history` previously had no cap at all — see #4387) independent of any claim about what fraction of a given memory ceiling `history` itself accounts for, which this config does not measure or claim to fix.
 
@@ -2133,9 +2133,9 @@ image:
   row_height_cells: 20   # fixed height every inline image is rendered at
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `row_height_cells` | int | `20` | Fixed height, in terminal rows, for every inline image `present` renders. A non-positive or non-numeric value falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `row_height_cells` | preference | int | `20` | Fixed height, in terminal rows, for every inline image `present` renders. A non-positive or non-numeric value falls back to the default. |
 
 **Why this is operator-configurable**: the "right" row count is a function of your own terminal height and how much scrollback a photo should occupy — not something reyn can decide for every environment. 20 is a shipped default (tall enough for real photo detail, short enough not to dominate a typical terminal), not a measured "correct" number. Omitting the block keeps this default (behaviour unchanged).
 
@@ -2148,9 +2148,9 @@ tui:
   context_usage_warn_percent: 80   # ctx% at/above this gets the "ctx" label
 ```
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `context_usage_warn_percent` | int | `80` | Context-window usage percent at which the status bar labels the figure (`ctx NN%`) instead of showing it bare. A non-numeric value or one outside `0`–`100` falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `context_usage_warn_percent` | preference | int | `80` | Context-window usage percent at which the status bar labels the figure (`ctx NN%`) instead of showing it bare. A non-numeric value or one outside `0`–`100` falls back to the default. |
 
 **Why this is operator-configurable**: 80 is a shipped default (a plain, unsurprising round number), not a measured "correct" threshold for every operator's own risk tolerance or model/context window — same discipline as `image.row_height_cells` above. Omitting the block keeps this default (behaviour unchanged).
 
@@ -2357,17 +2357,17 @@ embedding:
 
 ### `embedding` fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | bool | `false` | **The provider/cost gate — one meaning only** (#4156): may reyn call an embedding provider at all. Default `false` (opt-in / predictable-safe default — embedding needs a provider + cost). Clean-break replacement for the retired `action_retrieval.embedding_class` gate (no alias) — the on/off decision lives here; the model class is the separate `default_class` field below, unaffected. **Symmetric model**: `enabled: false` hides everything below regardless of `index.*` — non-semantic discovery (`list_actions`, …) and load/invoke verbs (`invoke_action`, …) are unaffected. When `embedding.enabled` is `false`, the `embed` op pre-flights and returns a decision-enabling `status: "blocked"` result (naming this key) rather than a silent no-op or an opaque provider error. Prior to #4156, this single flag ALSO decided WHAT gets embedded (bundling the action catalog with an unconditional repo-wide index build, every router-loop turn, with no way to get one without the other) — that decision now lives in `index` below. |
-| `index.actions` | bool | `true` | #4156 — build the ~10-entry action/mcp/pipeline catalog index `search_actions` depends on, when `enabled: true`. Negligible TPM contribution (fixed, small population) — kept on by default so the pre-#4156 `search_actions` experience is unchanged for an operator who never touches this field. |
-| `index.repo_knowledge` | bool | `false` | #4156 — build the FP-0066 P3b **repo-knowledge index** (`knowledge_repo_doc` + `knowledge_repo_src` — every reachable `.md` doc and every other source file in the repo, chunked — measured at ~1,609 chunks / ~4.86M tokens on this repo at #4156's filing, and it scales with the repo, not fixed), when `enabled: true`. Scheduled on **every router-loop turn** (`sync_repo_ingest_background`, a no-op once the index is clean). **Default `false`** — this is the workload that burned through an owner's 5M TPM budget in one burst while they only wanted the ~10-entry action catalog (TPM is a tokens-per-minute ceiling; batching cannot reduce total tokens sent, only not indexing can). When this field is `false` and a turn would have ingested the repo-knowledge index, reyn logs one line per process (`repo knowledge indexing is off (embedding.index.repo_knowledge: false, the default) — ...`) rather than skipping silently. |
-| `default_class` | string | `standard` | Class used when embedding ops don't specify one (used only when `enabled: true`). Must be a key in `classes`. |
-| `batch_size` | int | `100` | Texts per embedding API call. Valid range: 1–2048. |
-| `max_concurrent_batches` | int | `1` | Parallel batch calls in flight. Valid range: 1–10. Values > 1 are accepted but log a warning until concurrent support lands. |
-| `max_retries` | int | `3` | Transient-error retries per batch call. Valid range: 0–10. |
-| `retry_backoff` | string | `exponential` | Backoff strategy: `exponential` or `linear`. |
-| `timeout` | float | `60.0` | Per-attempt deadline in seconds — how long reyn waits for one embedding attempt before giving up. `<= 0` opts out (no bound — the call is then capped only by litellm's own `request_timeout`, 6000s/attempt, which is indistinguishable from a hang; a warning is logged). The default matches `safety.timeout.llm_call_seconds`: an embedding call is the same kind of call as a chat LLM call. Applies **per attempt**, so the worst-case **wait** is `timeout × max_retries` plus backoff. **This bounds waiting, not spending — see the note below.** |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `enabled` | project | bool | `false` | **The provider/cost gate — one meaning only** (#4156): may reyn call an embedding provider at all. Default `false` (opt-in / predictable-safe default — embedding needs a provider + cost). Clean-break replacement for the retired `action_retrieval.embedding_class` gate (no alias) — the on/off decision lives here; the model class is the separate `default_class` field below, unaffected. **Symmetric model**: `enabled: false` hides everything below regardless of `index.*` — non-semantic discovery (`list_actions`, …) and load/invoke verbs (`invoke_action`, …) are unaffected. When `embedding.enabled` is `false`, the `embed` op pre-flights and returns a decision-enabling `status: "blocked"` result (naming this key) rather than a silent no-op or an opaque provider error. Prior to #4156, this single flag ALSO decided WHAT gets embedded (bundling the action catalog with an unconditional repo-wide index build, every router-loop turn, with no way to get one without the other) — that decision now lives in `index` below. |
+| `index.actions` | project | bool | `true` | #4156 — build the ~10-entry action/mcp/pipeline catalog index `search_actions` depends on, when `enabled: true`. Negligible TPM contribution (fixed, small population) — kept on by default so the pre-#4156 `search_actions` experience is unchanged for an operator who never touches this field. |
+| `index.repo_knowledge` | project | bool | `false` | #4156 — build the FP-0066 P3b **repo-knowledge index** (`knowledge_repo_doc` + `knowledge_repo_src` — every reachable `.md` doc and every other source file in the repo, chunked — measured at ~1,609 chunks / ~4.86M tokens on this repo at #4156's filing, and it scales with the repo, not fixed), when `enabled: true`. Scheduled on **every router-loop turn** (`sync_repo_ingest_background`, a no-op once the index is clean). **Default `false`** — this is the workload that burned through an owner's 5M TPM budget in one burst while they only wanted the ~10-entry action catalog (TPM is a tokens-per-minute ceiling; batching cannot reduce total tokens sent, only not indexing can). When this field is `false` and a turn would have ingested the repo-knowledge index, reyn logs one line per process (`repo knowledge indexing is off (embedding.index.repo_knowledge: false, the default) — ...`) rather than skipping silently. |
+| `default_class` | project | string | `standard` | Class used when embedding ops don't specify one (used only when `enabled: true`). Must be a key in `classes`. |
+| `batch_size` | project | int | `100` | Texts per embedding API call. Valid range: 1–2048. |
+| `max_concurrent_batches` | project | int | `1` | Parallel batch calls in flight. Valid range: 1–10. Values > 1 are accepted but log a warning until concurrent support lands. |
+| `max_retries` | project | int | `3` | Transient-error retries per batch call. Valid range: 0–10. |
+| `retry_backoff` | project | string | `exponential` | Backoff strategy: `exponential` or `linear`. |
+| `timeout` | project | float | `60.0` | Per-attempt deadline in seconds — how long reyn waits for one embedding attempt before giving up. `<= 0` opts out (no bound — the call is then capped only by litellm's own `request_timeout`, 6000s/attempt, which is indistinguishable from a hang; a warning is logged). The default matches `safety.timeout.llm_call_seconds`: an embedding call is the same kind of call as a chat LLM call. Applies **per attempt**, so the worst-case **wait** is `timeout × max_retries` plus backoff. **This bounds waiting, not spending — see the note below.** |
 
 > **`embedding.timeout` does not reduce what you are billed for.** It caps how long reyn *waits*; it does not cap how many requests the provider *receives*. One attempt can put up to **3** HTTP requests on the wire — the OpenAI SDK client retries internally (`max_retries=2` by default), underneath litellm and underneath this knob — so `max_retries: 3` can deliver up to **9** requests for a single `embed`. Measured against a fast-erroring provider, all 9 are delivered in ~7.6s with the default `timeout: 60.0`: the bound never engages at all. **Lowering `timeout` does not lower that count**, and reyn's own retry log (`attempt 1/3`) counts attempts, not requests. reyn's embedding cost report records at most one response per `embed`, so it is a lower bound on requests delivered. See [#3047](https://github.com/tya5/reyn/issues/3047) for the measurements and the open decisions.
 | `tokenizer` | string | `cl100k_base` | tiktoken encoding used for chunk-size estimation. |
@@ -2437,18 +2437,18 @@ chat:
 
 ### `chat.compaction` fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `component_weights` | map[str,int] | `{head:10, body:5, tail:15, new_msg:10, compaction_batch:60}` | Integer weights for each prompt component, normalised to `main_pool` at runtime. Sum is arbitrary; larger values give more token budget to that component. |
-| `section_weights` | map[str,int] | (per-section default) | Integer weights for sub-section allocation within the body budget. Same shape semantics as `component_weights`. |
-| `section_caps_spec_tokens` | int | `100` | Static overhead budget for `section_token_caps` serialisation in the compactor prompt. |
-| `body_token_cap` | int | `1500` | Hard cap on summary body tokens after post-truncation. |
-| `resummarize_passes` | int | `1` | Max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `0` = skip re-summary (straight to the floor). |
-| `max_schema_reprompt_attempts` | int | `1` | #4883: bounded re-prompt budget when the compaction LLM's JSON response has an empty/missing `topic_arc` (whose emptiness can't be told apart from a dead response). Exhausting the budget raises rather than silently accepting an empty summary. `0` = raise on the first invalid response, no re-prompt. `new_turn_seqs` plays no part in this: `covers_through_seq` is derived from `compact()`'s own input, never read from an LLM echo (#4951-A) — and #4951-B removed the `new_turn_seqs` key from the schema/prompt entirely, so there is nothing left to gate or not gate. |
-| `fold_persist_policy` | `never` \| `next_turn` | `next_turn` | #5296: controls whether a recovered overflow is followed by a DURABLE compaction step — on two separate branches, both gated on this SAME knob. **① Failure branch** (pre-#5578): after a measured shrink-ladder exhaustion (`UnrecoveredError`) — any overflow axis, byte-limit (HTTP 413) or token-context, since #5578 (pre-#5578 this only fired for a byte-limit cause; a token-cause exhaustion had no persisted recovery at all, so every subsequent turn re-ran the identical shrink from the same un-compacted history) — a real compaction pass runs (`force_compact_now`, a new LLM call). **② Success branch** (#5578, widened by #5612): each SUCCESSFUL fold the recovery's own shrink ladder produces is durably persisted immediately (`CompactionController.persist_recovery_summary`) — not deferred until the whole recovery episode's own success or failure (#5578's own original scope); no new LLM call, no new compaction pass, only recording a fold that already happened, as many times as the ladder folds within one episode. `next_turn` (the default — shipped, opt-out, not opt-in) keeps both branches live; `never` disables both, ending a failed recovery with the existing structured error and leaving any fold this episode already produced in-memory only (never persisted, re-paid next turn). It does not control spill directly, but the SAME durability now applies there too (#5612): reactive overflow-recovery spill (`spill_turn_content`) durably appends a `role="spill_record"` entry to `history.jsonl` once per successfully-spilled turn — spill itself is still triggered by the constraint, not by this knob, but the record it leaves behind survives a restart the same way a fold does (superseding the pre-#5612 in-memory-only `_spill_overlay`, which is gone). (Distinct from the write-time cap's own `SPILLED_META_KEY`, which is persisted as part of a NEW entry's own meta at append time — a different code path reusing the same vocabulary, not this reactive one.) |
-| `spill_granularity` | `tier` \| `turn` | `tier` | #5592: how many candidates rung① (spill) hands to ONE upstream request. **`tier` names a `Spillability` tier (`FIRST_CHOICE`/`LAST_RESORT`) — not a positional stage (`head`/`mid`/`tail`), which this field never selects.** `tier` sends every eligible candidate sharing the same `Spillability` tier in a single request — turning a request count that scaled with the number of spillable candidates into one request per tier, at most two per overflow, per positional stage. `turn` reverts to one candidate per request (the pre-#5592 behavior) — **this is NOT the safer choice**: the upstream request count then scales with candidate count, a rejected request is still billed, and its size is not observable from inside reyn (owner ruling, #5592). Population (how many candidates exist, `levers_left`'s own count) is unchanged by this field either way — only how many requests it takes to consume that population changes. |
-| `use_chars4_estimate` | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
-| `llm_call_seconds` | float (s) \| `null` | `null` | #5597: per-request timeout for the compaction LLM call (`CompactionEngine._acompletion`'s own call, via the `recorded_acompletion` funnel). `null` (default) inherits `safety.timeout.llm_call_seconds` — the SAME value the router's own main call already uses, never a separately-chosen number (owner ruling: "新しい数を作らない。routerの値をそのまま使う"). An operator override here applies to compaction calls only, leaving the router's own timeout untouched. Does not affect `num_retries`, which is resolved independently via the existing `LLMCallLimitContext`. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `component_weights` | preference | map[str,int] | `{head:10, body:5, tail:15, new_msg:10, compaction_batch:60}` | Integer weights for each prompt component, normalised to `main_pool` at runtime. Sum is arbitrary; larger values give more token budget to that component. |
+| `section_weights` | preference | map[str,int] | (per-section default) | Integer weights for sub-section allocation within the body budget. Same shape semantics as `component_weights`. |
+| `section_caps_spec_tokens` | bounding | int | `100` | Static overhead budget for `section_token_caps` serialisation in the compactor prompt. |
+| `body_token_cap` | bounding | int | `1500` | Hard cap on summary body tokens after post-truncation. |
+| `resummarize_passes` | bounding | int | `1` | Max LLM re-compression passes when a produced `topic_arc` overshoots its body budget, before the deterministic `hard_truncate` floor. `0` = skip re-summary (straight to the floor). |
+| `max_schema_reprompt_attempts` | bounding | int | `1` | #4883: bounded re-prompt budget when the compaction LLM's JSON response has an empty/missing `topic_arc` (whose emptiness can't be told apart from a dead response). Exhausting the budget raises rather than silently accepting an empty summary. `0` = raise on the first invalid response, no re-prompt. `new_turn_seqs` plays no part in this: `covers_through_seq` is derived from `compact()`'s own input, never read from an LLM echo (#4951-A) — and #4951-B removed the `new_turn_seqs` key from the schema/prompt entirely, so there is nothing left to gate or not gate. |
+| `fold_persist_policy` | preference | `never` \| `next_turn` | `next_turn` | #5296: controls whether a recovered overflow is followed by a DURABLE compaction step — on two separate branches, both gated on this SAME knob. **① Failure branch** (pre-#5578): after a measured shrink-ladder exhaustion (`UnrecoveredError`) — any overflow axis, byte-limit (HTTP 413) or token-context, since #5578 (pre-#5578 this only fired for a byte-limit cause; a token-cause exhaustion had no persisted recovery at all, so every subsequent turn re-ran the identical shrink from the same un-compacted history) — a real compaction pass runs (`force_compact_now`, a new LLM call). **② Success branch** (#5578, widened by #5612): each SUCCESSFUL fold the recovery's own shrink ladder produces is durably persisted immediately (`CompactionController.persist_recovery_summary`) — not deferred until the whole recovery episode's own success or failure (#5578's own original scope); no new LLM call, no new compaction pass, only recording a fold that already happened, as many times as the ladder folds within one episode. `next_turn` (the default — shipped, opt-out, not opt-in) keeps both branches live; `never` disables both, ending a failed recovery with the existing structured error and leaving any fold this episode already produced in-memory only (never persisted, re-paid next turn). It does not control spill directly, but the SAME durability now applies there too (#5612): reactive overflow-recovery spill (`spill_turn_content`) durably appends a `role="spill_record"` entry to `history.jsonl` once per successfully-spilled turn — spill itself is still triggered by the constraint, not by this knob, but the record it leaves behind survives a restart the same way a fold does (superseding the pre-#5612 in-memory-only `_spill_overlay`, which is gone). (Distinct from the write-time cap's own `SPILLED_META_KEY`, which is persisted as part of a NEW entry's own meta at append time — a different code path reusing the same vocabulary, not this reactive one.) |
+| `spill_granularity` | bounding | `tier` \| `turn` | `tier` | #5592: how many candidates rung① (spill) hands to ONE upstream request. **`tier` names a `Spillability` tier (`FIRST_CHOICE`/`LAST_RESORT`) — not a positional stage (`head`/`mid`/`tail`), which this field never selects.** `tier` sends every eligible candidate sharing the same `Spillability` tier in a single request — turning a request count that scaled with the number of spillable candidates into one request per tier, at most two per overflow, per positional stage. `turn` reverts to one candidate per request (the pre-#5592 behavior) — **this is NOT the safer choice**: the upstream request count then scales with candidate count, a rejected request is still billed, and its size is not observable from inside reyn (owner ruling, #5592). Population (how many candidates exist, `levers_left`'s own count) is unchanged by this field either way — only how many requests it takes to consume that population changes. |
+| `use_chars4_estimate` | bounding | bool | `false` | When `true`, use `len(text)//4` for token estimation instead of `litellm.token_counter` (latency opt-out for large deployments). |
+| `llm_call_seconds` | bounding | float (s) \| `null` | `null` | #5597: per-request timeout for the compaction LLM call (`CompactionEngine._acompletion`'s own call, via the `recorded_acompletion` funnel). `null` (default) inherits `safety.timeout.llm_call_seconds` — the SAME value the router's own main call already uses, never a separately-chosen number (owner ruling: "新しい数を作らない。routerの値をそのまま使う"). An operator override here applies to compaction calls only, leaving the router's own timeout untouched. Does not affect `num_retries`, which is resolved independently via the existing `LLMCallLimitContext`. |
 
 ### `chat.compaction.section_token_caps` fields
 
@@ -2474,13 +2474,13 @@ payload will look like). Recovery is now entirely reactive: an actual
 overflow the LLM call raises is caught by `retry_loop`'s own overflow
 ladder, not pre-empted a turn ahead of time.
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `topic_arc` | `200` | Token target for the topic-arc summary section — the only one of the five that's enforced after the LLM returns (see above). |
-| `decisions` | `400` | Token target for the decisions section, given to the LLM as prompt guidance — not enforced on the returned value. |
-| `pending` | `400` | Token target for the pending-items section, given to the LLM as prompt guidance — not enforced on the returned value. |
-| `session_user_facts` | `200` | Token target for user-facts carried across compactions, given to the LLM as prompt guidance — not enforced on the returned value. |
-| `artifacts_referenced` | `300` | Token target for artifact reference listings, given to the LLM as prompt guidance — not enforced on the returned value. |
+| Field | Axis | Default | Description |
+|-------|---|---------|-------------|
+| `topic_arc` | bounding | `200` | Token target for the topic-arc summary section — the only one of the five that's enforced after the LLM returns (see above). |
+| `decisions` | bounding | `400` | Token target for the decisions section, given to the LLM as prompt guidance — not enforced on the returned value. |
+| `pending` | bounding | `400` | Token target for the pending-items section, given to the LLM as prompt guidance — not enforced on the returned value. |
+| `session_user_facts` | bounding | `200` | Token target for user-facts carried across compactions, given to the LLM as prompt guidance — not enforced on the returned value. |
+| `artifacts_referenced` | bounding | `300` | Token target for artifact reference listings, given to the LLM as prompt guidance — not enforced on the returned value. |
 
 ### Removed keys
 
@@ -2530,20 +2530,20 @@ audit_events:
   provider_body_max_chars: 4000          # cap on the kept provider_body/provider_response (default)
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `max_bytes` | int | `10485760` (10 MB) | Rotate the active event file when it exceeds this size. `0` = no size-based rotation. |
-| `max_age_seconds` | int | `86400` (1 day) | Rotate the active event file when it exceeds this age in seconds. `0` = no age-based rotation. |
-| `cleanup_period_days` | int | `30` | Automatic-purge age axis (#4479) — files whose filename date is older than this many days are deleted. `0` disables this axis. |
-| `max_disk_usage_percent` | float | `10` | Automatic-purge size axis (#4479) — once the events directory's own total size exceeds this percent of the filesystem's current FREE space, oldest files are deleted until back under. `0` disables this axis. |
-| `backend` | string | `local` | **#4496 — where audit-events are WRITTEN.** `local` (default) preserves current behavior — events land under `.reyn/events` exactly as before this field existed. `discard` (sink-null) writes nothing to disk; subscriber delivery (the TUI/AG-UI forwarders, hooks, OTEL) and the per-emitter `audit_seq` continuity (#4496 PR-1) are UNCHANGED either way — see [Concepts: events](../../concepts/runtime/events.md#write-side-backend-4496) for the structural guarantee. **`discard` means `reyn events replay` / support-bundle / dogfood_trace have nothing to read for this run — in particular, support-bundle is the tool operators use to report bugs, so this trades that away.** `network` is not yet a valid value (an unrecognized string, `network` included, falls back to `local`) — its on-failure semantics are an open design question tracked in #4496. |
-| `agent_delta_coalesce_fragments` | int | `100` | **#4960 — architect ruling C.** `agent_delta` is durably written once per this many RAW PROVIDER CHUNKS (or `agent_delta_coalesce_interval_ms`, whichever comes first), per streaming chain, plus one final record when a stream ends. **#5261/#5268: an `agent_delta` event may itself already merge more than one raw provider chunk** (source-side merge at the LLM-call boundary, before this event is ever emitted) — the threshold's UNIT was kept as raw chunks (it sums each event's own `raw_chunk_count`, not a flat `+1` per event), so the default number of durable records per streamed reply is UNCHANGED by that merge; only the write side's own counting arithmetic became correct again. Live TUI/AG-UI delivery is UNAFFECTED (every emitted event still dispatches to subscribers unthrottled) — this only throttles what reaches `.reyn/events`. Measured (2000-delta/60KB real streamed reply, `agent_delta_include_text=true`, predating #5261's source-side merge — one event per raw chunk at measurement time): unthrottled, `agent_delta` was 99.4% of that run's audit file bytes — this figure assumes `text` is being written; with `agent_delta_include_text`'s default (`false`, below), a coalesced record's bytes are smaller and this percentage does not apply as measured. A non-positive or non-numeric value falls back to the default. |
-| `agent_delta_coalesce_interval_ms` | int | `2000` | **#4960 — the same coalescing window's time axis**, in milliseconds. Primarily protects against a process-level death (SIGKILL / OOM-kill / host crash) that the terminal-flush-on-stream-end mechanism cannot catch (a Python `finally` never runs then) — secondarily gives periodic evidence for an idle-but-long-lived stream. A non-positive or non-numeric value falls back to the default. |
-| `agent_delta_include_text` | bool | `false` | **#4666 item ① — opt-in for the streamed reply's own CONTENT** in the durable `agent_delta` record (mirrors the OpenTelemetry GenAI convention: "every attribute that can hold prompt/output content is opt-in, default metadata-only"). ITS OWN knob, deliberately not tied to `agent_delta_coalesce_*` above (owner ruling: each content opt-in gets a separate toggle) — coalescing still happens regardless of this flag; only the `text` field WITHIN an already-coalesced record is conditional. Off (default): the durable record keeps `chain_id`/`round_index`/`coalesced_fragment_count`/`audit_seq` but drops `text` — #4960's own reason for coalescing ("a partial reply of N fragments existed", for cost accountability) still holds without it. **⚠️ Default-behavior change, 2026-08-21 (#4666, owner ruling): before this field existed, `agent_delta`'s reply content was ALWAYS durably recorded — no opt-in or opt-out existed. If you relied on `.reyn/events` carrying streamed-reply text, set this to `true`.** UNCHANGED either way: live TUI/AG-UI delivery (every fragment, full text, always) and `history.jsonl` (the completed reply's own persistence, a separate mechanism entirely). |
-| `completed_response_include_text` | bool | `false` | **#4666 item ② — opt-in for the completed model→user text**: `agent_response_committed` (new kind, [events reference](../runtime/events.md) — the terminal reply, force-close/wrap-up text, tool_calls-round accompanying text) and `user_intervention_requested`'s `question`/`suggestions`/`options` (the model's `ask_user` question — governed by ② because it is content the MODEL directed at the user, the SAME reason every other kind this field covers is ②'s, not because it must share a knob with anything else). ITS OWN knob, separate from `agent_delta_include_text` above AND `user_input_include_text` below (owner ruling, same instruction: one toggle must never cover more than one content opt-in) — turning ON only one of ② or ③ for an `ask_user` exchange is a valid, deliberate operator choice (e.g. keep the question, drop the answer), not a defect. Both events fire unconditionally; off (default), `LocalEventBackend.write()` drops only the free-text field(s) — every other field (`chain_id`/`intervention_id`) is kept, so "a response was committed"/"a question was asked" remains provable without content. UNCHANGED either way: live TUI/AG-UI delivery and any opt-in OTEL subscriber. **This field also governs `ask_user`'s `question` on `tool_called.args`** (#4666 item ③b, `reyn.core.dispatch.content_declarations` — the dispatcher-level gap #4970's review found; see `user_input_include_text`'s row for the matching `answer` half and its own remaining scope note). |
-| `user_input_include_text` | bool | `false` | **#4666 item ③ — opt-in for the user's OWN typed/chosen text**, ITS OWN knob (separate from `agent_delta_include_text` and `completed_response_include_text` above, both tracked under #4666). Covers 6 kinds, one content field each (AST census — an earlier pass found 3 and undercounted): `user_submitted`/`user_message_received` (`text`), `intervention_answer_submitted` (`text`), `user_answered_intervention` (`answer_text`), `user_intervention_received` (`answer`), `router_retry_exhausted` (`user_message`, truncated to 200 chars at the emit site regardless of this flag). No coalescing here — each event is still written individually; the knob only decides whether the one content field survives. Off (default): every other field on the kind (`chain_id`/`intervention_id`/`msg_id`/`seq`/etc.) still records that a submission/answer happened. **⚠️ Default-behavior change, 2026-08-21 (#4666): before this field existed, these 6 kinds' content was ALWAYS durably recorded.** UNCHANGED either way: live subscriber delivery (TUI/AG-UI/peer broadcast) and `history.jsonl`. **This field also governs `ask_user`'s `answer` on `tool_returned.result`** (#4666 item ③b: a per-tool "this field is conversation content" declaration, `reyn.core.dispatch.content_declarations` — closes the gap #4970's review found, where `ask_user`'s question/answer reached the audit log via the generic `tool_called`/`tool_returned` kinds unconditionally, bypassing ②③ entirely). **Scope, measured, not extended by guess:** only `ask_user` declares any field today (the sole tool whose args/result structurally ARE a conversation exchange); `mcp_called.args` was measured and excluded — an MCP tool's args are model-decided call parameters, the same class as any other tool's args, not a dedicated question/answer channel. A tool that shows the user free text and forgets to declare it leaks that text silently — this bound only catches the declared set GROWING, never catches a tool that should have declared and didn't (see the registry module's own docstring for the full disclosure). |
-| `provider_body_include_text` | bool | `false` | **#4975 — architect ruling (c), a LATTICE-MEET, not its own independent opt-in.** Gates `llm_request_error`'s `provider_body`/`provider_response` (a provider's own error-response body — reyn does not control its shape, so a 4xx/5xx body could quote back request content of any of the 3 #4666 content classes above; reyn cannot tell in advance which one). Showing either field requires ALL of `agent_delta_include_text` AND `completed_response_include_text` AND `user_input_include_text` above AND this field's own opt-in — the narrowest participant wins (same `compose_resolved` lattice-meet idiom this repo's permission resolution already uses). Rejected alternatives: OR-composition (any one opt-in lets all 3 content classes through — too loose) and a brand-new independent knob (doesn't correspond to a payload an operator can name). `error_type`/`status_code` are always recorded regardless of the gate; `provider_body_length`/`provider_response_length` are also always recorded when a body existed, gate-independent, so "existed but hidden" stays distinguishable from "genuinely absent". `LocalEventBackend.declare_gaps()` names this gap while any of the 4 participants is off. Whether providers actually echo conversation content in their error bodies is a separate, unmeasured question tracked in #4975's own issue — this knob only builds the permission surface for when that's confirmed. |
-| `provider_body_max_chars` | int | `4000` | **#4975 — the cap on the SHOWN `provider_body`/`provider_response`** when `provider_body_include_text`'s meet holds (reyn cannot bound a provider's own body size otherwise). `provider_body_truncated`/`provider_response_truncated` is added only when the cap actually cut something, so a caller can tell a capped body from a genuinely short one. A non-positive or non-numeric value falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `max_bytes` | project | int | `10485760` (10 MB) | Rotate the active event file when it exceeds this size. `0` = no size-based rotation. |
+| `max_age_seconds` | project | int | `86400` (1 day) | Rotate the active event file when it exceeds this age in seconds. `0` = no age-based rotation. |
+| `cleanup_period_days` | project | int | `30` | Automatic-purge age axis (#4479) — files whose filename date is older than this many days are deleted. `0` disables this axis. |
+| `max_disk_usage_percent` | project | float | `10` | Automatic-purge size axis (#4479) — once the events directory's own total size exceeds this percent of the filesystem's current FREE space, oldest files are deleted until back under. `0` disables this axis. |
+| `backend` | project | string | `local` | **#4496 — where audit-events are WRITTEN.** `local` (default) preserves current behavior — events land under `.reyn/events` exactly as before this field existed. `discard` (sink-null) writes nothing to disk; subscriber delivery (the TUI/AG-UI forwarders, hooks, OTEL) and the per-emitter `audit_seq` continuity (#4496 PR-1) are UNCHANGED either way — see [Concepts: events](../../concepts/runtime/events.md#write-side-backend-4496) for the structural guarantee. **`discard` means `reyn events replay` / support-bundle / dogfood_trace have nothing to read for this run — in particular, support-bundle is the tool operators use to report bugs, so this trades that away.** `network` is not yet a valid value (an unrecognized string, `network` included, falls back to `local`) — its on-failure semantics are an open design question tracked in #4496. |
+| `agent_delta_coalesce_fragments` | project | int | `100` | **#4960 — architect ruling C.** `agent_delta` is durably written once per this many RAW PROVIDER CHUNKS (or `agent_delta_coalesce_interval_ms`, whichever comes first), per streaming chain, plus one final record when a stream ends. **#5261/#5268: an `agent_delta` event may itself already merge more than one raw provider chunk** (source-side merge at the LLM-call boundary, before this event is ever emitted) — the threshold's UNIT was kept as raw chunks (it sums each event's own `raw_chunk_count`, not a flat `+1` per event), so the default number of durable records per streamed reply is UNCHANGED by that merge; only the write side's own counting arithmetic became correct again. Live TUI/AG-UI delivery is UNAFFECTED (every emitted event still dispatches to subscribers unthrottled) — this only throttles what reaches `.reyn/events`. Measured (2000-delta/60KB real streamed reply, `agent_delta_include_text=true`, predating #5261's source-side merge — one event per raw chunk at measurement time): unthrottled, `agent_delta` was 99.4% of that run's audit file bytes — this figure assumes `text` is being written; with `agent_delta_include_text`'s default (`false`, below), a coalesced record's bytes are smaller and this percentage does not apply as measured. A non-positive or non-numeric value falls back to the default. |
+| `agent_delta_coalesce_interval_ms` | project | int | `2000` | **#4960 — the same coalescing window's time axis**, in milliseconds. Primarily protects against a process-level death (SIGKILL / OOM-kill / host crash) that the terminal-flush-on-stream-end mechanism cannot catch (a Python `finally` never runs then) — secondarily gives periodic evidence for an idle-but-long-lived stream. A non-positive or non-numeric value falls back to the default. |
+| `agent_delta_include_text` | project | bool | `false` | **#4666 item ① — opt-in for the streamed reply's own CONTENT** in the durable `agent_delta` record (mirrors the OpenTelemetry GenAI convention: "every attribute that can hold prompt/output content is opt-in, default metadata-only"). ITS OWN knob, deliberately not tied to `agent_delta_coalesce_*` above (owner ruling: each content opt-in gets a separate toggle) — coalescing still happens regardless of this flag; only the `text` field WITHIN an already-coalesced record is conditional. Off (default): the durable record keeps `chain_id`/`round_index`/`coalesced_fragment_count`/`audit_seq` but drops `text` — #4960's own reason for coalescing ("a partial reply of N fragments existed", for cost accountability) still holds without it. **⚠️ Default-behavior change, 2026-08-21 (#4666, owner ruling): before this field existed, `agent_delta`'s reply content was ALWAYS durably recorded — no opt-in or opt-out existed. If you relied on `.reyn/events` carrying streamed-reply text, set this to `true`.** UNCHANGED either way: live TUI/AG-UI delivery (every fragment, full text, always) and `history.jsonl` (the completed reply's own persistence, a separate mechanism entirely). |
+| `completed_response_include_text` | project | bool | `false` | **#4666 item ② — opt-in for the completed model→user text**: `agent_response_committed` (new kind, [events reference](../runtime/events.md) — the terminal reply, force-close/wrap-up text, tool_calls-round accompanying text) and `user_intervention_requested`'s `question`/`suggestions`/`options` (the model's `ask_user` question — governed by ② because it is content the MODEL directed at the user, the SAME reason every other kind this field covers is ②'s, not because it must share a knob with anything else). ITS OWN knob, separate from `agent_delta_include_text` above AND `user_input_include_text` below (owner ruling, same instruction: one toggle must never cover more than one content opt-in) — turning ON only one of ② or ③ for an `ask_user` exchange is a valid, deliberate operator choice (e.g. keep the question, drop the answer), not a defect. Both events fire unconditionally; off (default), `LocalEventBackend.write()` drops only the free-text field(s) — every other field (`chain_id`/`intervention_id`) is kept, so "a response was committed"/"a question was asked" remains provable without content. UNCHANGED either way: live TUI/AG-UI delivery and any opt-in OTEL subscriber. **This field also governs `ask_user`'s `question` on `tool_called.args`** (#4666 item ③b, `reyn.core.dispatch.content_declarations` — the dispatcher-level gap #4970's review found; see `user_input_include_text`'s row for the matching `answer` half and its own remaining scope note). |
+| `user_input_include_text` | project | bool | `false` | **#4666 item ③ — opt-in for the user's OWN typed/chosen text**, ITS OWN knob (separate from `agent_delta_include_text` and `completed_response_include_text` above, both tracked under #4666). Covers 6 kinds, one content field each (AST census — an earlier pass found 3 and undercounted): `user_submitted`/`user_message_received` (`text`), `intervention_answer_submitted` (`text`), `user_answered_intervention` (`answer_text`), `user_intervention_received` (`answer`), `router_retry_exhausted` (`user_message`, truncated to 200 chars at the emit site regardless of this flag). No coalescing here — each event is still written individually; the knob only decides whether the one content field survives. Off (default): every other field on the kind (`chain_id`/`intervention_id`/`msg_id`/`seq`/etc.) still records that a submission/answer happened. **⚠️ Default-behavior change, 2026-08-21 (#4666): before this field existed, these 6 kinds' content was ALWAYS durably recorded.** UNCHANGED either way: live subscriber delivery (TUI/AG-UI/peer broadcast) and `history.jsonl`. **This field also governs `ask_user`'s `answer` on `tool_returned.result`** (#4666 item ③b: a per-tool "this field is conversation content" declaration, `reyn.core.dispatch.content_declarations` — closes the gap #4970's review found, where `ask_user`'s question/answer reached the audit log via the generic `tool_called`/`tool_returned` kinds unconditionally, bypassing ②③ entirely). **Scope, measured, not extended by guess:** only `ask_user` declares any field today (the sole tool whose args/result structurally ARE a conversation exchange); `mcp_called.args` was measured and excluded — an MCP tool's args are model-decided call parameters, the same class as any other tool's args, not a dedicated question/answer channel. A tool that shows the user free text and forgets to declare it leaks that text silently — this bound only catches the declared set GROWING, never catches a tool that should have declared and didn't (see the registry module's own docstring for the full disclosure). |
+| `provider_body_include_text` | project | bool | `false` | **#4975 — architect ruling (c), a LATTICE-MEET, not its own independent opt-in.** Gates `llm_request_error`'s `provider_body`/`provider_response` (a provider's own error-response body — reyn does not control its shape, so a 4xx/5xx body could quote back request content of any of the 3 #4666 content classes above; reyn cannot tell in advance which one). Showing either field requires ALL of `agent_delta_include_text` AND `completed_response_include_text` AND `user_input_include_text` above AND this field's own opt-in — the narrowest participant wins (same `compose_resolved` lattice-meet idiom this repo's permission resolution already uses). Rejected alternatives: OR-composition (any one opt-in lets all 3 content classes through — too loose) and a brand-new independent knob (doesn't correspond to a payload an operator can name). `error_type`/`status_code` are always recorded regardless of the gate; `provider_body_length`/`provider_response_length` are also always recorded when a body existed, gate-independent, so "existed but hidden" stays distinguishable from "genuinely absent". `LocalEventBackend.declare_gaps()` names this gap while any of the 4 participants is off. Whether providers actually echo conversation content in their error bodies is a separate, unmeasured question tracked in #4975's own issue — this knob only builds the permission surface for when that's confirmed. |
+| `provider_body_max_chars` | project | int | `4000` | **#4975 — the cap on the SHOWN `provider_body`/`provider_response`** when `provider_body_include_text`'s meet holds (reyn cannot bound a provider's own body size otherwise). `provider_body_truncated`/`provider_response_truncated` is added only when the cap actually cut something, so a caller can tell a capped body from a genuinely short one. A non-positive or non-numeric value falls back to the default. |
 
 Setting both `max_bytes` and `max_age_seconds` to `0` disables rotation entirely. `backend: discard` makes both rotation fields moot (nothing is ever written to rotate).
 
@@ -2564,9 +2564,9 @@ artifacts:
   remote_fallback_limit: 50   # default
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `remote_fallback_limit` | int | `50` | Caps the ref-table fallback to the N NEWEST entries (newest-first). A non-positive or non-numeric value falls back to the default. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `remote_fallback_limit` | bounding | int | `50` | Caps the ref-table fallback to the N NEWEST entries (newest-first). A non-positive or non-numeric value falls back to the default. |
 
 `remote_fallback_limit` is a **UX-scale default, not a performance one** — a single `stat()` costs order-microseconds, so even 10,000 rows costs tens of milliseconds; the binding constraint is how many newest-first rows an operator would ever actually scroll through in a list pane, which is a couple of dozen at most. The Artifacts pane's own disclosure text always states "newest N of M" so a truncation is never silent — raise this value if your own usage wants more history visible at once.
 
@@ -2580,10 +2580,10 @@ storage:
   pin: []                  # agent names whose content is never evicted
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `max_bytes` | int \| null | `null` (unlimited) | Project-wide cap across every session's history-content. A non-positive or non-numeric value falls back to unlimited — the same state as omitting the key entirely, never a silently-active cap of some other size. |
-| `pin` | list[str] | `[]` | Agent names (not session ids) whose own history-content is NEVER an eviction candidate under this cap, regardless of whether that agent's process is currently running. A non-list value, or a non-string list entry, is dropped rather than propagated. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `max_bytes` | project | int \| null | `null` (unlimited) | Project-wide cap across every session's history-content. A non-positive or non-numeric value falls back to unlimited — the same state as omitting the key entirely, never a silently-active cap of some other size. |
+| `pin` | project | list[str] | `[]` | Agent names (not session ids) whose own history-content is NEVER an eviction candidate under this cap, regardless of whether that agent's process is currently running. A non-list value, or a non-string list entry, is dropped rather than propagated. |
 
 This is a **DIFFERENT number from `MediaStoreConfig`'s own per-store `history_content_max_bytes`** (2 GiB, not operator-configurable here) — that field is a per-SESSION fail-safe backstop; this one bounds the WHOLE `.reyn/memory/history-content/` tree across every session in the project, which is the number an operator can actually name (nobody chooses how many sessions a project spawns, so "N bytes per session" would silently mean "N × session-count total"). The two never share a name on purpose — reusing one name for both would make it unreadable which cap is actually in effect for a given eviction.
 
@@ -2604,17 +2604,17 @@ voice:
   max_duration_s: 300.0   # auto-cancel recordings longer than this (seconds)
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | bool | `true` | Set `false` to hard-disable F2 dictation even when deps are installed. |
-| `model` | string | `small` | Whisper model size: `tiny` / `base` / `small` / `medium` / `large-v3`. |
-| `language` | string \| null | `ja` | ISO 639-1 language code. `""` or `null` enables auto-detection (less reliable for short clips). |
-| `device` | string | `cpu` | Inference device: `cpu` or `cuda`. `auto` is not supported — it picks the wrong device on some Mac setups. |
-| `compute_type` | string | `int8` | Quantisation: `int8` / `float16` / `float32`. |
-| `sample_rate` | int | `16000` | Sample rate (Hz). Whisper expects 16 kHz mono — do not change. |
-| `cpu_threads` | int | `4` | CPU threads for faster-whisper. `0` = OpenMP default. Pinning to 4 avoids OpenMP/Python-threading deadlocks on Apple Silicon. |
-| `num_workers` | int | `1` | Parallel transcription streams. `1` keeps memory + thread usage low. |
-| `max_duration_s` | float | `300.0` | Auto-cancel recordings longer than this (seconds). Prevents runaway memory growth from unattended recordings. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `enabled` | project | bool | `true` | Set `false` to hard-disable F2 dictation even when deps are installed. |
+| `model` | project | string | `small` | Whisper model size: `tiny` / `base` / `small` / `medium` / `large-v3`. |
+| `language` | project | string \| null | `ja` | ISO 639-1 language code. `""` or `null` enables auto-detection (less reliable for short clips). |
+| `device` | project | string | `cpu` | Inference device: `cpu` or `cuda`. `auto` is not supported — it picks the wrong device on some Mac setups. |
+| `compute_type` | project | string | `int8` | Quantisation: `int8` / `float16` / `float32`. |
+| `sample_rate` | project | int | `16000` | Sample rate (Hz). Whisper expects 16 kHz mono — do not change. |
+| `cpu_threads` | project | int | `4` | CPU threads for faster-whisper. `0` = OpenMP default. Pinning to 4 avoids OpenMP/Python-threading deadlocks on Apple Silicon. |
+| `num_workers` | project | int | `1` | Parallel transcription streams. `1` keeps memory + thread usage low. |
+| `max_duration_s` | project | float | `300.0` | Auto-cancel recordings longer than this (seconds). Prevents runaway memory growth from unattended recordings. |
 
 ## `multimodal` block
 
@@ -2630,14 +2630,14 @@ multimodal:
   model_capability_overrides: {}  # declared media capabilities for a proxied/uncataloged model
 ```
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `max_bytes` | int | `5000000` (5 MB) | Decoded-payload byte cap before the on-oversize gate fires. Counts the binary size (`len(response.content)` / `len(file_bytes)`), not the base64-encoded shape. |
-| `on_oversize` | string | `ask` | What to do when a piece of media exceeds `max_bytes`: `ask` (prompt the user via the intervention bus with size + source info; yes loads the media, no drops it), `allow` (silently accept; use in trusted non-interactive pipelines), `deny` (silently reject; the op returns `status="denied"` — use in cost-sensitive contexts). |
-| `media_dir` | string | `.reyn/media` | Project-relative directory for image binary storage. Files are flat-named with timestamp + chain-id + tool prefix so `ls -la` sorts chronologically. Operator-browseable and operator-deleteable. |
-| `tool_results_dir` | string | `.reyn/tool-results` | Project-relative directory for text-y tool result dumps. |
-| `base_url` | string \| null | `null` | Optional canonical URL prefix for cross-host `path_ref` consumption. When set (e.g. `"https://reyn.example.com"` from a deployed `reyn web`), saved artefacts carry a `url` field pointing at `<base_url>/agents/<agent>/tool-results/<artifact>` so A2A peers / MCP clients / browsers can fetch the body via the resources router. Unset → no `url` field minted (same-host fast-path only). |
-| `model_capability_overrides` | `{model: {capability_field: bool}}` | `{}` | **(#5509)** Declares a model's media capability when litellm's own catalog doesn't know the model string at all. This is the ORDINARY case, not an edge case, for a proxy-routed deployment (a name like `openai/my-proxy-model` misses litellm's static catalog — `get_model_info` raises for it) — without a declaration, **every non-text attachment for that model silently degrades to a lossless path-ref instead of being embedded inline**, which reads to a user as "attachments stopped working". `capability_field` is NOT any litellm `get_model_info` field — only the ones reyn's own code actually queries (`reyn.llm.model_media_capability.QUERIED_CAPABILITY_FIELDS_BY_MODALITY`'s own values; today just `supports_vision`) — a wider litellm field would be accepted but silently do nothing. A one-time warning (`media_capability_unknown` in the log, naming the exact key to set) fires the first time this happens for a given `(model, capability_field)` pair. See `reyn.llm.model_media_capability`'s own module docstring for the full 3-state (supported / unsupported / unknown) resolution rule. Example: `{"openai/my-proxy-model": {"supports_vision": true}}`. |
+| Field | Axis | Type | Default | Description |
+|-------|---|------|---------|-------------|
+| `max_bytes` | bounding | int | `5000000` (5 MB) | Decoded-payload byte cap before the on-oversize gate fires. Counts the binary size (`len(response.content)` / `len(file_bytes)`), not the base64-encoded shape. |
+| `on_oversize` | bounding | string | `ask` | What to do when a piece of media exceeds `max_bytes`: `ask` (prompt the user via the intervention bus with size + source info; yes loads the media, no drops it), `allow` (silently accept; use in trusted non-interactive pipelines), `deny` (silently reject; the op returns `status="denied"` — use in cost-sensitive contexts). |
+| `media_dir` | project | string | `.reyn/media` | Project-relative directory for image binary storage. Files are flat-named with timestamp + chain-id + tool prefix so `ls -la` sorts chronologically. Operator-browseable and operator-deleteable. |
+| `tool_results_dir` | project | string | `.reyn/tool-results` | Project-relative directory for text-y tool result dumps. |
+| `base_url` | project | string \| null | `null` | Optional canonical URL prefix for cross-host `path_ref` consumption. When set (e.g. `"https://reyn.example.com"` from a deployed `reyn web`), saved artefacts carry a `url` field pointing at `<base_url>/agents/<agent>/tool-results/<artifact>` so A2A peers / MCP clients / browsers can fetch the body via the resources router. Unset → no `url` field minted (same-host fast-path only). |
+| `model_capability_overrides` | project | `{model: {capability_field: bool}}` | `{}` | **(#5509)** Declares a model's media capability when litellm's own catalog doesn't know the model string at all. This is the ORDINARY case, not an edge case, for a proxy-routed deployment (a name like `openai/my-proxy-model` misses litellm's static catalog — `get_model_info` raises for it) — without a declaration, **every non-text attachment for that model silently degrades to a lossless path-ref instead of being embedded inline**, which reads to a user as "attachments stopped working". `capability_field` is NOT any litellm `get_model_info` field — only the ones reyn's own code actually queries (`reyn.llm.model_media_capability.QUERIED_CAPABILITY_FIELDS_BY_MODALITY`'s own values; today just `supports_vision`) — a wider litellm field would be accepted but silently do nothing. A one-time warning (`media_capability_unknown` in the log, naming the exact key to set) fires the first time this happens for a given `(model, capability_field)` pair. See `reyn.llm.model_media_capability`'s own module docstring for the full 3-state (supported / unsupported / unknown) resolution rule. Example: `{"openai/my-proxy-model": {"supports_vision": true}}`. |
 
 ## `external_transports` block
 

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from reyn.config_axis import Axis
+
 # ── FP-0004: safety: section (user-facing unified schema) ──────────────────
 # PR22: CostConfig + CostLimitConfig live in `reyn.runtime.budget` (re-exported here
 # for ReynConfig typing). They include domain logic (warn_threshold etc.)
@@ -59,10 +61,10 @@ class LoopConfig:
     condition is a single observed cycle, observer lead-coder).
     """
 
-    max_router_calls_per_turn: int = 3
-    max_agent_hops: int = 3
-    max_router_iterations: int = 5
-    max_tool_calls_per_turn: int = 50
+    max_router_calls_per_turn: int = field(default=3, metadata={"axis": Axis.BOUNDING})
+    max_agent_hops: int = field(default=3, metadata={"axis": Axis.BOUNDING})
+    max_router_iterations: int = field(default=5, metadata={"axis": Axis.BOUNDING})
+    max_tool_calls_per_turn: int = field(default=50, metadata={"axis": Axis.BOUNDING})
 
 
 @dataclass
@@ -101,10 +103,10 @@ class TimeoutConfig:
             CPU load; it does not itself change the default.
     """
 
-    llm_call_seconds: float = 60.0
-    llm_max_retries: int = 3
-    chain_seconds: float = 60.0
-    mcp_probe_seconds: float = 5.0
+    llm_call_seconds: float = field(default=60.0, metadata={"axis": Axis.BOUNDING})
+    llm_max_retries: int = field(default=3, metadata={"axis": Axis.BOUNDING})
+    chain_seconds: float = field(default=60.0, metadata={"axis": Axis.BOUNDING})
+    mcp_probe_seconds: float = field(default=5.0, metadata={"axis": Axis.BOUNDING})
 
 
 ON_LIMIT_MODES = ("interactive", "unattended", "auto_extend")
@@ -152,9 +154,9 @@ class OnLimitConfig:
     as a refusal.
     """
 
-    mode: Literal["interactive", "unattended", "auto_extend"] = "interactive"
-    auto_extend_times: int = 1
-    ask_timeout_seconds: float = 0.0
+    mode: Literal["interactive", "unattended", "auto_extend"] = field(default="interactive", metadata={"axis": Axis.BOUNDING})
+    auto_extend_times: int = field(default=1, metadata={"axis": Axis.BOUNDING})
+    ask_timeout_seconds: float = field(default=0.0, metadata={"axis": Axis.BOUNDING})
 
 
 # ``safety.threat_scan.capability_narrowing`` — the untrusted-content CAPABILITY
@@ -203,12 +205,12 @@ class ThreatScanConfig:
       ``_untrusted`` profile), one ladder of three settings. See
       ``CAPABILITY_NARROWING_MODES`` below.
     """
-    enabled: bool = True
-    fail_open: bool = True
-    fence_enabled: bool = True
-    block_severity: str = "block"
-    custom_patterns: list = field(default_factory=list)
-    capability_narrowing: str = "off"
+    enabled: bool = field(default=True, metadata={"axis": Axis.BOUNDING})
+    fail_open: bool = field(default=True, metadata={"axis": Axis.BOUNDING})
+    fence_enabled: bool = field(default=True, metadata={"axis": Axis.BOUNDING})
+    block_severity: str = field(default="block", metadata={"axis": Axis.BOUNDING})
+    custom_patterns: list = field(default_factory=list, metadata={"axis": Axis.BOUNDING})
+    capability_narrowing: str = field(default="off", metadata={"axis": Axis.BOUNDING})
 
     def __post_init__(self) -> None:
         if self.capability_narrowing not in CAPABILITY_NARROWING_MODES:
@@ -254,9 +256,9 @@ class CostWarnConfig:
       session (no TTY) fail-closes (the switch is denied) since it cannot
       confirm. Session-startup stays warn-only regardless of this flag.
     """
-    enabled: bool = True
-    model_threshold_per_1m_input_usd: float = 5.0
-    block_on_high_cost: bool = False
+    enabled: bool = field(default=True, metadata={"axis": Axis.PREFERENCE})
+    model_threshold_per_1m_input_usd: float = field(default=5.0, metadata={"axis": Axis.PREFERENCE})
+    block_on_high_cost: bool = field(default=False, metadata={"axis": Axis.PREFERENCE})
 
 
 @dataclass
@@ -316,14 +318,14 @@ class OffloadConfig:
     value MUST go through ``context_builder.INLINE_CAP_BYTES_PER_TOKEN``,
     never a second independently-derived ratio.
     """
-    enabled: bool = False
-    max_inline_bytes: int = 16_384
-    preview_head_chars: int = 6_000
-    preview_tail_chars: int = 2_000
-    cap_ceil_tokens: int = 4_096
-    cap_alpha: float = 0.5
-    structured_inline_max_chars: int = 2_000
-    structured_preview_chars: int = 600
+    enabled: bool = field(default=False, metadata={"axis": Axis.PROJECT})
+    max_inline_bytes: int = field(default=16_384, metadata={"axis": Axis.BOUNDING})
+    preview_head_chars: int = field(default=6_000, metadata={"axis": Axis.BOUNDING})
+    preview_tail_chars: int = field(default=2_000, metadata={"axis": Axis.BOUNDING})
+    cap_ceil_tokens: int = field(default=4_096, metadata={"axis": Axis.BOUNDING})
+    cap_alpha: float = field(default=0.5, metadata={"axis": Axis.BOUNDING})
+    structured_inline_max_chars: int = field(default=2_000, metadata={"axis": Axis.BOUNDING})
+    structured_preview_chars: int = field(default=600, metadata={"axis": Axis.BOUNDING})
 
 
 def _build_offload_config(raw: object) -> "OffloadConfig":
@@ -386,8 +388,8 @@ class RenderTemplateConfig:
     that a runaway generator stops quickly; an operator raises them for a large
     report or lowers them to harden a shared host.
     """
-    max_output_chars: int = 256_000
-    wall_clock_seconds: float = 5.0
+    max_output_chars: int = field(default=256_000, metadata={"axis": Axis.PROJECT})
+    wall_clock_seconds: float = field(default=5.0, metadata={"axis": Axis.PROJECT})
 
 
 def _build_render_template_config(raw: object) -> "RenderTemplateConfig":
@@ -464,7 +466,7 @@ class ReadCapConfig:
     claim like "another tool uses N" that a reader could dispute without
     being able to verify it against reyn's own behaviour.
     """
-    inline_bytes: int = 10_240   # 10 KiB
+    inline_bytes: int = field(default=10_240, metadata={"axis": Axis.BOUNDING})   # 10 KiB
 
 
 def _build_read_cap_config(raw: object) -> "ReadCapConfig":
@@ -523,7 +525,7 @@ class HistoryResidentConfig:
     one would make ordinary scrollback/rewind pay for reloads more often than
     necessary.
     """
-    max_bytes: int = 256 * 1024 * 1024  # 256 MiB
+    max_bytes: int = field(default=256 * 1024 * 1024, metadata={"axis": Axis.BOUNDING})  # 256 MiB
 
 
 def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
@@ -571,7 +573,7 @@ class ImageConfig:
     short terminal (or one who wants larger previews) can change it
     without a code edit.
     """
-    row_height_cells: int = 20
+    row_height_cells: int = field(default=20, metadata={"axis": Axis.PREFERENCE})
 
 
 def _build_image_config(raw: object) -> "ImageConfig":
@@ -613,7 +615,7 @@ class TuiConfig:
     window — the config key exists specifically so an operator who wants
     an earlier or later warning can change it without a code edit.
     """
-    context_usage_warn_percent: int = 80
+    context_usage_warn_percent: int = field(default=80, metadata={"axis": Axis.PREFERENCE})
 
 
 def _build_tui_config(raw: object) -> "TuiConfig":
@@ -684,12 +686,12 @@ class SpawnConfig:
             fails the step. ``0`` = unlimited.
     """
 
-    max_depth: int = 10
-    max_children: int = 20
+    max_depth: int = field(default=10, metadata={"axis": Axis.BOUNDING})
+    max_children: int = field(default=20, metadata={"axis": Axis.BOUNDING})
     # Pipeline S5 fan-out spawn bounds (#2187 for_each). Conservative finite
     # defaults; 0 = unlimited (operator opt-out).
-    max_pipeline_fan_out_depth: int = 5
-    max_pipeline_spawns: int = 100
+    max_pipeline_fan_out_depth: int = field(default=5, metadata={"axis": Axis.BOUNDING})
+    max_pipeline_spawns: int = field(default=100, metadata={"axis": Axis.BOUNDING})
 
 
 @dataclass
@@ -721,11 +723,11 @@ class SafetyConfig:
 @dataclass
 class CompactionSectionCaps:
     """Per-section token budgets for chat_summary BODY."""
-    topic_arc: int = 200
-    decisions: int = 400
-    pending: int = 400
-    session_user_facts: int = 200
-    artifacts_referenced: int = 300
+    topic_arc: int = field(default=200, metadata={"axis": Axis.BOUNDING})
+    decisions: int = field(default=400, metadata={"axis": Axis.BOUNDING})
+    pending: int = field(default=400, metadata={"axis": Axis.BOUNDING})
+    session_user_facts: int = field(default=200, metadata={"axis": Axis.BOUNDING})
+    artifacts_referenced: int = field(default=300, metadata={"axis": Axis.BOUNDING})
 
 
 @dataclass
@@ -768,25 +770,25 @@ class CompactionConfig:
         "tail":             15,
         "new_msg":          10,
         "compaction_batch": 60,
-    })
+    }, metadata={"axis": Axis.PREFERENCE})
     section_weights: dict = field(default_factory=lambda: {
         "topic_arc":            5,    # abstract suppression
         "decisions":            40,   # specific data emphasis
         "pending":              25,
         "session_user_facts":   10,
         "artifacts_referenced": 35,   # path/line preservation
-    })
+    }, metadata={"axis": Axis.PREFERENCE})
     # section_caps_spec_tokens: static overhead budget for section_token_caps
     # serialisation in the compactor prompt.
-    section_caps_spec_tokens: int = 100
+    section_caps_spec_tokens: int = field(default=100, metadata={"axis": Axis.BOUNDING})
     # Tokeniser opt-out (Axis 10): set True for latency-sensitive deployments.
-    use_chars4_estimate: bool = False
-    body_token_cap: int = 1500          # hard cap on summary body tokens (post-truncation)
+    use_chars4_estimate: bool = field(default=False, metadata={"axis": Axis.BOUNDING})
+    body_token_cap: int = field(default=1500, metadata={"axis": Axis.BOUNDING})          # hard cap on summary body tokens (post-truncation)
     # #271 re-summarize (T2): max LLM re-compression passes when a produced
     # topic_arc overshoots body_budget, before the deterministic T3
     # hard_truncate floor. 1 = one judgment-based re-summary then floor; 0 =
     # skip T2 (straight to the floor, = pre-#271 behaviour).
-    resummarize_passes: int = 1
+    resummarize_passes: int = field(default=1, metadata={"axis": Axis.BOUNDING})
     # #4883: bounded re-prompt budget when the compaction JSON response is
     # missing topic_arc (a syntactically-valid but content-free response,
     # e.g. "{}", previously accepted silently as an empty summary). #4951-B:
@@ -805,14 +807,14 @@ class CompactionConfig:
     # existing try/except turns that into a compaction_failed event, never
     # a silently-accepted empty summary) — operator-tunable via this field
     # if a specific deployment's models warrant a different budget.
-    max_schema_reprompt_attempts: int = 1
+    max_schema_reprompt_attempts: int = field(default=1, metadata={"axis": Axis.BOUNDING})
     # #5296: stop-line for same-turn recovery after a measured payload
     # constraint. This stop-line applies only to the irreversible
     # compaction step; it never controls spill. Spill is triggered by the
     # constraint itself, not by this policy. `never` permits only reversible
     # reductions; `next_turn` (the default) preserves compaction for the
     # following turn.
-    fold_persist_policy: Literal["never", "next_turn"] = "next_turn"
+    fold_persist_policy: Literal["never", "next_turn"] = field(default="next_turn", metadata={"axis": Axis.PREFERENCE})
     # #5592 (owner ruling, real-machine incident: 2469 spillable
     # raw_middle candidates -> 2469 compact() calls at ~6s each, ~4.1
     # hours, same shape independently possible on the main_call/head-tail
@@ -825,7 +827,7 @@ class CompactionConfig:
     # escape hatch: it is NOT the safer choice (a rejected request is
     # still billed and its own size is not observable from inside reyn —
     # see docs/reference/config/reyn-yaml.md's own entry for this field).
-    spill_granularity: Literal["tier", "turn"] = "tier"
+    spill_granularity: Literal["tier", "turn"] = field(default="tier", metadata={"axis": Axis.BOUNDING})
     # #5597 (owner real machine: a compaction LLM call with no per-request
     # timeout hung 11+ minutes when the upstream stopped responding — the
     # main-loop call already has `safety.timeout.llm_call_seconds`; this
@@ -849,7 +851,7 @@ class CompactionConfig:
     # Unmeasured today (lead-coder's own real-machine incident had only 2
     # data points, 18.7s and >4min-before-500) — the default stays
     # inherited, not a new number, until a real p95 says otherwise.
-    llm_call_seconds: "float | None" = None
+    llm_call_seconds: "float | None" = field(default=None, metadata={"axis": Axis.BOUNDING})
     # #4957 (owner: "max iterations は config ノブにしておいた方が良いね") —
     # retry_loop's own `max_iterations` safety cap, previously a signature
     # default only (8) with no operator-facing knob: router_loop_driver.py
@@ -873,7 +875,7 @@ class CompactionConfig:
     # warns once at load if the key is set. A follow-up PR removes the
     # field/parsing entirely and registers the key in
     # `check_retired_config_keys_denylist.py`'s denylist.
-    max_shrink_iterations: int = 8
+    max_shrink_iterations: int = field(default=8, metadata={"axis": Axis.BOUNDING})
     section_token_caps: CompactionSectionCaps = field(default_factory=CompactionSectionCaps)
 
     def __post_init__(self) -> None:
@@ -908,9 +910,9 @@ class ReasoningConfig:
       ``continuity``. ``<= 0`` (e.g. 0 / -1) = unbounded (keep all). Bounding
       matters on gemini (no provider auto-filter → reasoning is billed in full).
     """
-    continuity: bool = True
-    display: bool = True
-    recent_turns: int = 3
+    continuity: bool = field(default=True, metadata={"axis": Axis.PREFERENCE})
+    display: bool = field(default=True, metadata={"axis": Axis.PREFERENCE, "override_enabled": True})
+    recent_turns: int = field(default=3, metadata={"axis": Axis.PREFERENCE})
 
 
 # #3273 (#4223 removed ``inline``/``auto`` — owner instruction, 2026-08-11):
@@ -956,8 +958,8 @@ class GutterConfig:
     ``FlowView`` flags — ``left_gutter_visible`` / ``right_gutter_visible``);
     reyn does not invent a coarser or finer one.
     """
-    left: bool = True
-    right: bool = True
+    left: bool = field(default=True, metadata={"axis": Axis.PREFERENCE})
+    right: bool = field(default=True, metadata={"axis": Axis.PREFERENCE})
 
 
 @dataclass
@@ -1051,13 +1053,13 @@ class ChatConfig:
     """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
-    render_mode: Literal["alt-screen", "plain"] = "alt-screen"
+    render_mode: Literal["alt-screen", "plain"] = field(default="alt-screen", metadata={"axis": Axis.PREFERENCE})
     gutters: GutterConfig = field(default_factory=GutterConfig)
-    neutralize_body: bool = False
-    image_url_schemes: "list[str]" = field(default_factory=list)
-    empty_stop_retry: bool = False
-    theme: "str | None" = None
-    stream_repaint_min_interval: float = 1 / 30
+    neutralize_body: bool = field(default=False, metadata={"axis": Axis.CAPABILITY})
+    image_url_schemes: "list[str]" = field(default_factory=list, metadata={"axis": Axis.CAPABILITY})
+    empty_stop_retry: bool = field(default=False, metadata={"axis": Axis.BOUNDING})
+    theme: "str | None" = field(default=None, metadata={"axis": Axis.PREFERENCE})
+    stream_repaint_min_interval: float = field(default=1 / 30, metadata={"axis": Axis.PREFERENCE})
 
 
 def _build_reasoning_config(raw: object) -> ReasoningConfig:

--- a/src/reyn/config/config_schema.py
+++ b/src/reyn/config/config_schema.py
@@ -67,6 +67,42 @@ class SchemaNode:
     ``str``, or a ``Literal[...]`` — ``None`` for dict leaves. Lets callers
     introspect valid values (e.g. pick a non-default ``Literal`` member)."""
 
+    axis: "object | None" = None
+    """#4206: the :class:`~reyn.config_axis.Axis` this leaf is
+    classified under (from ``field(metadata={"axis": Axis.X})``), or
+    ``None`` for a leaf with no axis metadata yet. Typed ``object`` (not
+    ``Axis`` directly) to keep this module free of a hard import on
+    ``config_axis`` — the SAME reason ``desc``/``fallback`` extraction
+    above reads raw ``field.metadata`` rather than importing their own
+    owning modules. ``tests/config/test_4206_axis_coverage.py`` is the
+    ONE place ``None`` here is asserted to never occur for a real leaf."""
+
+    override_enabled: bool = False
+    """#4206: True when this leaf's field ALSO declares
+    ``"override_enabled": True`` alongside its axis — a SEPARATE,
+    narrower claim than the axis itself ("this leaf has a LIVE
+    agent/session override receptacle today", not just "this leaf is
+    classified under axis X"; see ``reyn.config_axis.Axis``'s own
+    module docstring). ``runtime.bounding.BOUNDING_KEYS`` /
+    ``runtime.preferences.PREFERENCE_KEYS`` derive from exactly this
+    flag (filtered by axis), never from axis membership alone."""
+
+    override_key: "str | None" = None
+    """#4206: the key an operator actually writes inside a ``bounding:``/
+    ``preferences:`` override block for this leaf, when it differs from
+    ``key`` (this leaf's own full dotted ``ReynConfig`` path) — from
+    ``field(metadata={"override_key": "..."})``. ``None`` (the default)
+    means "same as ``key``", true for every #4206 PREFERENCE_KEYS member
+    today. The ONE real exception found deriving ``BOUNDING_KEYS``:
+    ``llm.model``'s own override block writes the bare ``model`` (an
+    established, tested operator-facing vocabulary — ``bounding: {model:
+    ...}`` — that predates this leaf's own nesting under ``llm:``, and
+    which ``BOUNDING_KEYS``/``compose_model_ceiling`` callers already
+    read by that bare name). Never used for a leaf's OWN identity
+    (``key`` stays canonical everywhere else, incl. ``reyn config get/
+    set``) — only for what the SEPARATE override-block vocabulary
+    accepts."""
+
 
 #: Sentinel for fields whose default can only be computed by calling
 #: ``default_factory()``.  We eagerly call the factory so this sentinel
@@ -911,6 +947,9 @@ def _walk(
                 default=default,
                 is_dict_leaf=True,
                 desc=desc,
+                axis=_field_axis(dc_field),
+                override_enabled=_field_override_enabled(dc_field),
+                override_key=_field_override_key(dc_field),
             ))
         elif dataclasses.is_dataclass(inner):
             # Nested dataclass — recurse.
@@ -926,6 +965,9 @@ def _walk(
                 is_dict_leaf=False,
                 desc=desc,
                 field_type=inner,
+                axis=_field_axis(dc_field),
+                override_enabled=_field_override_enabled(dc_field),
+                override_key=_field_override_key(dc_field),
             ))
 
 
@@ -935,6 +977,38 @@ def _field_desc(f: dataclasses.Field) -> str:  # type: ignore[type-arg]
     if meta and isinstance(meta, typing.Mapping):
         return str(meta.get("desc", ""))
     return ""
+
+
+def _field_axis(f: dataclasses.Field) -> "object | None":  # type: ignore[type-arg]
+    """Extract ``axis`` from ``field(metadata={'axis': Axis.X, ...})``, or
+    return ``None`` — the SAME extraction shape :func:`_field_desc` uses
+    for ``desc``, mirrored here for #4206's own axis metadata."""
+    meta = getattr(f, "metadata", None)
+    if meta and isinstance(meta, typing.Mapping):
+        return meta.get("axis")
+    return None
+
+
+def _field_override_enabled(f: dataclasses.Field) -> bool:  # type: ignore[type-arg]
+    """Extract ``override_enabled`` from ``field(metadata={'override_enabled':
+    True, ...})``, or return ``False`` — see :class:`SchemaNode`'s own
+    ``override_enabled`` field docstring for why this is a SEPARATE flag
+    from ``axis``."""
+    meta = getattr(f, "metadata", None)
+    if meta and isinstance(meta, typing.Mapping):
+        return bool(meta.get("override_enabled", False))
+    return False
+
+
+def _field_override_key(f: dataclasses.Field) -> "str | None":  # type: ignore[type-arg]
+    """Extract ``override_key`` from ``field(metadata={'override_key':
+    '...', ...})``, or return ``None`` — see :class:`SchemaNode`'s own
+    ``override_key`` field docstring."""
+    meta = getattr(f, "metadata", None)
+    if meta and isinstance(meta, typing.Mapping):
+        value = meta.get("override_key")
+        return str(value) if value is not None else None
+    return None
 
 
 def _is_schema_internal(f: dataclasses.Field) -> bool:  # type: ignore[type-arg]

--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from reyn.config_axis import Axis
+
 
 @dataclass
 class EmbeddingIndexConfig:
@@ -52,8 +54,8 @@ class EmbeddingIndexConfig:
                          deferring to an owner:decide gate.
     """
 
-    actions: bool = True
-    repo_knowledge: bool = False
+    actions: bool = field(default=True, metadata={"axis": Axis.PROJECT})
+    repo_knowledge: bool = field(default=False, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass
@@ -163,19 +165,20 @@ class EmbeddingConfig:
                        exceeds this value (UX gap fix B, ADR-0033 §2.1).
     """
 
-    enabled: bool = False
+    enabled: bool = field(default=False, metadata={"axis": Axis.PROJECT})
     index: EmbeddingIndexConfig = field(default_factory=EmbeddingIndexConfig)
-    default_class: str = "standard"
+    default_class: str = field(default="standard", metadata={"axis": Axis.PROJECT})
     classes: dict[str, EmbeddingClassSpec] = field(
-        default_factory=lambda: dict(_DEFAULT_EMBEDDING_CLASSES)
+        default_factory=lambda: dict(_DEFAULT_EMBEDDING_CLASSES),
+        metadata={"axis": Axis.PROJECT},
     )
-    batch_size: int = 100
-    max_concurrent_batches: int = 1
-    max_retries: int = 3
-    retry_backoff: Literal["exponential", "linear"] = "exponential"
-    timeout: float = 60.0
-    tokenizer: str = "cl100k_base"
-    cost_warn_threshold: int = 10000
+    batch_size: int = field(default=100, metadata={"axis": Axis.PROJECT})
+    max_concurrent_batches: int = field(default=1, metadata={"axis": Axis.PROJECT})
+    max_retries: int = field(default=3, metadata={"axis": Axis.PROJECT})
+    retry_backoff: Literal["exponential", "linear"] = field(default="exponential", metadata={"axis": Axis.PROJECT})
+    timeout: float = field(default=60.0, metadata={"axis": Axis.PROJECT})
+    tokenizer: str = field(default="cl100k_base", metadata={"axis": Axis.PROJECT})
+    cost_warn_threshold: int = field(default=10000, metadata={"axis": Axis.PROJECT})
 
     def resolve_class(self, name: str) -> EmbeddingClassSpec:
         """Look up a class by name; raise ``KeyError`` if unknown."""

--- a/src/reyn/config/execution.py
+++ b/src/reyn/config/execution.py
@@ -1,7 +1,9 @@
 """reyn.config.execution — execution config: Plan/TimeTravel/ToolUse. (#1682 #3 split)."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from reyn.config_axis import Axis
 
 
 @dataclass
@@ -61,9 +63,9 @@ class ToolUseConfig:
     not as an oversight.
     """
 
-    scheme: str = "enumerate-all"
-    transport: str = "tool_calls"
-    universal_wrappers_enabled: bool = True
+    scheme: str = field(default="enumerate-all", metadata={"axis": Axis.PROJECT})
+    transport: str = field(default="tool_calls", metadata={"axis": Axis.PROJECT})
+    universal_wrappers_enabled: bool = field(default=True, metadata={"axis": Axis.PROJECT})
 
 
 def _build_tool_use_config(raw: object) -> ToolUseConfig:

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -14,6 +14,7 @@ from typing import Literal
 # inside function bodies — see e.g. its own register_freeform_leaf_*
 # call sites).
 from reyn.config.config_schema import FAILS_OPEN, FAILS_SAFE
+from reyn.config_axis import Axis
 from reyn.security.secrets.oauth import OAuthProviderConfig
 
 
@@ -77,7 +78,7 @@ class DelegationConfig:
     topology-bound agent are unchanged.
     """
 
-    capability_default: str = "inherit"
+    capability_default: str = field(default="inherit", metadata={"axis": Axis.CAPABILITY})
 
     def __post_init__(self) -> None:
         if self.capability_default not in ("inherit", "deny"):
@@ -125,24 +126,24 @@ class RouterConfig:
     (the ``ssl_verify`` → env → default idiom).
     """
 
-    use: bool = False
-    num_retries: int = 3
+    use: bool = field(default=False, metadata={"axis": Axis.PROJECT})
+    num_retries: int = field(default=3, metadata={"axis": Axis.PROJECT})
     # model_name → [fallback model_names]. Converted to litellm's
     # ``[{primary: [fallbacks]}]`` form when the Router is built. Empty → no
     # chain (single-deployment Router).
-    fallbacks: dict = field(default_factory=dict)
+    fallbacks: dict = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
     # seconds a deployment is cooled down after ``allowed_fails`` failures
     # (None → litellm default). Only meaningful with a fallback chain.
-    cooldown_time: float | None = None
+    cooldown_time: float | None = field(default=None, metadata={"axis": Axis.PROJECT})
     # failures before a deployment is cooled down (None → litellm default).
-    allowed_fails: int | None = None
+    allowed_fails: int | None = field(default=None, metadata={"axis": Axis.PROJECT})
     # per-exception-type retry counts (None → litellm defaults, i.e. no typed
     # policy). A mapping of RetryPolicy field names → counts; constructed into a
     # ``litellm.RetryPolicy`` at Router build time. Supported keys:
     #   RateLimitErrorRetries, TimeoutErrorRetries, BadRequestErrorRetries,
     #   AuthenticationErrorRetries, ContentPolicyViolationErrorRetries,
     #   InternalServerErrorRetries.
-    retry_policy: dict | None = None
+    retry_policy: dict | None = field(default=None, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass
@@ -163,8 +164,8 @@ class RetryConfig:
       Lets the provider's guidance drive wait time on 429/503 responses.
     """
 
-    jitter: bool = True
-    respect_retry_after: bool = True
+    jitter: bool = field(default=True, metadata={"axis": Axis.PROJECT})
+    respect_retry_after: bool = field(default=True, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass
@@ -186,16 +187,16 @@ class LLMConfig:
     # #1672 default model class used when a phase has no model_class.
     model: str = field(
         default="standard",
-        metadata={"desc": "Default model class used when a phase has no model_class."},
+        metadata={"axis": Axis.BOUNDING, "override_enabled": True, "override_key": "model", "desc": "Default model class used when a phase has no model_class."},
     )
     # Map of model class names to LiteLLM model strings.
     models: dict[str, "str | dict"] = field(
         default_factory=dict,
-        metadata={"desc": "Map of model class names to LiteLLM model strings."},
+        metadata={"axis": Axis.PROJECT, "desc": "Map of model class names to LiteLLM model strings."},
     )
     # #1672 per-purpose model-class override (router / control_ir / tool / judge).
     # Unset purpose -> `model` (see MODEL_CLASS_PURPOSES / ReynConfig.model_class_for).
-    model_class_by_purpose: dict[str, str] = field(default_factory=dict)
+    model_class_by_purpose: dict[str, str] = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
     # #4206 T1 (②bounding, ``model`` key): operator-declared CEILING on the
     # model class a call may use — restrict-only, reject-not-clamp (same
     # shape as #3903①'s ``SandboxPolicy.max_timeout_seconds``). ``None``
@@ -204,19 +205,19 @@ class LLMConfig:
     # call site, so a future call site cannot forget it.
     model_max_class: "str | None" = field(
         default=None,
-        metadata={"desc": "Ceiling on the model class calls may use (light/standard/strong). Unset = unbounded."},
+        metadata={"axis": Axis.PROJECT, "desc": "Ceiling on the model class calls may use (light/standard/strong). Unset = unbounded."},
     )
     # LiteLLM proxy: non-secret base URL only. API keys must be env vars
     # (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) — never stored in config files.
     api_base: str = field(
         default="",
-        metadata={"desc": "LiteLLM proxy base URL. Set this if you route requests through a local proxy."},
+        metadata={"axis": Axis.PROJECT, "desc": "LiteLLM proxy base URL. Set this if you route requests through a local proxy."},
     )
     # Attach Anthropic-style cache_control markers to the system prompt so
     # providers that support prompt caching (Anthropic, AWS Bedrock Claude) can
     # reuse the prefix across calls. Ignored by providers that don't recognize
     # cache_control (Gemini / OpenAI proxies pass-through).
-    prompt_cache_enabled: bool = True
+    prompt_cache_enabled: bool = field(default=True, metadata={"axis": Axis.PROJECT})
 
 
 # #1672: the logical purposes whose model class is configurable via
@@ -379,7 +380,7 @@ class AuthConfig:
     operator declares providers they want to authenticate against.
     """
 
-    providers: dict[str, "OAuthProviderConfig"] = field(default_factory=dict)
+    providers: dict[str, "OAuthProviderConfig"] = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
 
 
 def _build_auth_config(raw: object) -> AuthConfig:
@@ -517,10 +518,10 @@ class AuditEventsConfig:
     OPPOSITE of what this field does — kept only as a historical note in
     case an old comment elsewhere still cites the rejected-0 behavior.
     """
-    max_bytes: int = 10 * 1024 * 1024     # 10 MB
-    max_age_seconds: int = 24 * 60 * 60   # 1 day
-    cleanup_period_days: int = 30
-    max_disk_usage_percent: float = 10.0
+    max_bytes: int = field(default=10 * 1024 * 1024, metadata={"axis": Axis.PROJECT})     # 10 MB
+    max_age_seconds: int = field(default=24 * 60 * 60, metadata={"axis": Axis.PROJECT})   # 1 day
+    cleanup_period_days: int = field(default=30, metadata={"axis": Axis.PROJECT})
+    max_disk_usage_percent: float = field(default=10.0, metadata={"axis": Axis.PROJECT})
     # #4496 PR-2: the WRITE-side backend. `local` (default) preserves
     # current behavior unchanged — audit-events land under `.reyn/events`
     # exactly as before this field existed. `discard` writes nothing
@@ -538,7 +539,7 @@ class AuditEventsConfig:
     # `.transport` stay plain `str` because THEIR domain is an open,
     # pluggable registry a literal type can't enumerate; this field's
     # domain is closed, so it belongs on the Literal side of that split.
-    backend: Literal["local", "discard"] = "local"
+    backend: Literal["local", "discard"] = field(default="local", metadata={"axis": Axis.PROJECT})
     # #4960 (architect ruling C): ``agent_delta`` (one audit-event per
     # streamed content chunk) is coalesced to one durable write-side
     # record per this many fragments, or `agent_delta_coalesce_interval_
@@ -548,8 +549,8 @@ class AuditEventsConfig:
     # real-run benchmark) these defaults are derived from. Live TUI/AG-UI
     # delivery is completely unaffected — this only throttles what
     # reaches disk.
-    agent_delta_coalesce_fragments: int = 100
-    agent_delta_coalesce_interval_ms: int = 2_000
+    agent_delta_coalesce_fragments: int = field(default=100, metadata={"axis": Axis.PROJECT})
+    agent_delta_coalesce_interval_ms: int = field(default=2_000, metadata={"axis": Axis.PROJECT})
     # #4666 (owner ruling): the streamed reply's own CONTENT
     # (`agent_delta`'s `text` field) is opt-in, default off, its OWN
     # knob — deliberately NOT unified with any other content opt-in
@@ -564,7 +565,7 @@ class AuditEventsConfig:
     # are always kept, so #4960's own reason for existing (cost
     # accountability for a call whose usage record never lands) survives
     # `text` being dropped.
-    agent_delta_include_text: bool = False
+    agent_delta_include_text: bool = field(default=False, metadata={"axis": Axis.PROJECT})
     # #4666②: the completed model→user text — the terminal reply, any
     # force-close/wrap-up text, tool_calls-round accompanying text (all via
     # `agent_response_committed`), and the `ask_user` question (via the
@@ -581,7 +582,7 @@ class AuditEventsConfig:
     # TUI/AG-UI subscriber delivery, and any opt-in OTEL subscriber, are
     # UNAFFECTED by this flag — same disclosure as `agent_delta_include_
     # text`'s own comment: this only throttles what reaches disk.
-    completed_response_include_text: bool = False
+    completed_response_include_text: bool = field(default=False, metadata={"axis": Axis.PROJECT})
     # #4666 item ③ (owner ruling): "user input" gets its OWN opt-in too —
     # deliberately separate from `agent_delta_include_text` AND
     # `completed_response_include_text` above (owner: each content opt-in
@@ -594,7 +595,7 @@ class AuditEventsConfig:
     # NOT close: ask_user's question/answer also reach the audit log via
     # `tool_called.args`/`tool_returned.result` (a separate emit path) —
     # see the same docstring.
-    user_input_include_text: bool = False
+    user_input_include_text: bool = field(default=False, metadata={"axis": Axis.PROJECT})
     # #4975 (architect ruling, issuecomment-5384508845, correcting an
     # earlier "messages" left-operand that named a knob which does not
     # exist): a provider's 4xx/5xx error response can echo BACK content
@@ -624,7 +625,7 @@ class AuditEventsConfig:
     # not shown" stays distinguishable from "there was none" — see
     # ``_emit_llm_request_error``'s own comment for exactly which fields
     # this flag gates.
-    provider_body_include_text: bool = False
+    provider_body_include_text: bool = field(default=False, metadata={"axis": Axis.PROJECT})
     # #4975: reyn cannot bound a provider's own error-body size — an
     # explicit, operator-adjustable cap (never a baseless embedded
     # constant, CLAUDE.md's own "no unjustified constants" rule) applied
@@ -632,7 +633,7 @@ class AuditEventsConfig:
     # ``provider_body_length`` above is unaffected (always the TRUE
     # length, truncation-independent, so a truncated body is still
     # honestly labeled).
-    provider_body_max_chars: int = 4000
+    provider_body_max_chars: int = field(default=4000, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass
@@ -669,7 +670,7 @@ class ArtifactsConfig:
     Truncation is disclosed, never silent — see ``chrome.py``'s
     consolidated fallback-source disclosure text ("newest N of M")."""
 
-    remote_fallback_limit: int = 50
+    remote_fallback_limit: int = field(default=50, metadata={"axis": Axis.BOUNDING})
 
 
 @dataclass
@@ -733,10 +734,10 @@ class StorageConfig:
     # comment disclosed as NOT exhaustive). See `config_schema.FAILS_SAFE`
     # / `FAILS_OPEN`'s own docstring for what the two mean.
     max_bytes: "int | None" = field(
-        default=None, metadata={"fallback": FAILS_SAFE},
+        default=None, metadata={"axis": Axis.PROJECT, "fallback": FAILS_SAFE},
     )
     pin: "list[str]" = field(
-        default_factory=list, metadata={"fallback": FAILS_OPEN},
+        default_factory=list, metadata={"axis": Axis.PROJECT, "fallback": FAILS_OPEN},
     )
 
 
@@ -1343,10 +1344,10 @@ class SandboxConfig:
             an operator/run concern, not a per-phase one.
     """
 
-    backend: str = "auto"
-    on_unsupported: str = "warn"
-    mode: str = DEFAULT_SANDBOX_MODE
-    policy: dict | None = None
+    backend: str = field(default="auto", metadata={"axis": Axis.CAPABILITY})
+    on_unsupported: str = field(default="warn", metadata={"axis": Axis.CAPABILITY})
+    mode: str = field(default=DEFAULT_SANDBOX_MODE, metadata={"axis": Axis.CAPABILITY})
+    policy: dict | None = field(default=None, metadata={"axis": Axis.CAPABILITY})
     # #4935: opt-in capability requirement (D1 companion to `enforced_axes`
     # — see `reyn.security.sandbox.capability`'s own module docstring for
     # the design). Default EMPTY: declaring nothing here changes nothing —
@@ -1363,7 +1364,7 @@ class SandboxConfig:
     # governs the response — see
     # `reyn.security.sandbox.policy.unsupported_required_capabilities`
     # for the resolution-time consumer.
-    require_capabilities: "list[str]" = field(default_factory=list)
+    require_capabilities: "list[str]" = field(default_factory=list, metadata={"axis": Axis.CAPABILITY})
 
     def __post_init__(self) -> None:
         if self.backend not in _SANDBOX_BACKENDS:
@@ -1492,7 +1493,7 @@ class CronConfig:
     ``reyn cron run``).
     """
 
-    jobs: list[CronJobConfig] = field(default_factory=list)
+    jobs: list[CronJobConfig] = field(default_factory=list, metadata={"axis": Axis.PROJECT})
 
 
 def _build_cron_config(raw: object) -> CronConfig:
@@ -1616,8 +1617,8 @@ class FsWatchConfig:
     same class of concern as sandbox policy, hence the same OUT-set gate.
     """
 
-    paths: list[str] = field(default_factory=list)
-    debounce_seconds: float = 0.2
+    paths: list[str] = field(default_factory=list, metadata={"axis": Axis.PROJECT})
+    debounce_seconds: float = field(default=0.2, metadata={"axis": Axis.PROJECT})
 
 
 def _build_fs_watch_config(raw: object) -> FsWatchConfig:

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from reyn._http_limits import MAX_DOWNLOAD_BYTES
+from reyn.config_axis import Axis
 
 
 @dataclass
@@ -23,21 +24,21 @@ class VoiceConfig:
     language and produce empty transcripts. Set `language: ""` (empty
     string) or `null` in YAML to opt back into auto-detect.
     """
-    enabled: bool = True              # set False to hard-disable F2 even if deps installed
-    model: str = "small"              # tiny | base | small | medium | large-v3
-    language: str | None = "ja"       # ISO code; "" or null in YAML = auto-detect
-    device: str = "cpu"               # cpu | cuda  (faster-whisper has no metal backend
+    enabled: bool = field(default=True, metadata={"axis": Axis.PROJECT})              # set False to hard-disable F2 even if deps installed
+    model: str = field(default="small", metadata={"axis": Axis.PROJECT})              # tiny | base | small | medium | large-v3
+    language: str | None = field(default="ja", metadata={"axis": Axis.PROJECT})       # ISO code; "" or null in YAML = auto-detect
+    device: str = field(default="cpu", metadata={"axis": Axis.PROJECT})               # cpu | cuda  (faster-whisper has no metal backend
                                       # — "auto" silently picks the wrong thing on
                                       # some Mac setups, so default to explicit cpu)
-    compute_type: str = "int8"        # int8 | float16 | float32
-    sample_rate: int = 16000          # Whisper expects 16 kHz mono
-    cpu_threads: int = 4              # 0 = OpenMP default (= os.cpu_count()); pinning
+    compute_type: str = field(default="int8", metadata={"axis": Axis.PROJECT})        # int8 | float16 | float32
+    sample_rate: int = field(default=16000, metadata={"axis": Axis.PROJECT})          # Whisper expects 16 kHz mono
+    cpu_threads: int = field(default=4, metadata={"axis": Axis.PROJECT})              # 0 = OpenMP default (= os.cpu_count()); pinning
                                       # to 4 on Mac avoids the OpenMP/Python-threading
                                       # deadlock seen with high core counts on Apple
                                       # Silicon. Override per-machine if needed.
-    num_workers: int = 1              # parallel transcribe streams; we only ever run
+    num_workers: int = field(default=1, metadata={"axis": Axis.PROJECT})              # parallel transcribe streams; we only ever run
                                       # one at a time, so 1 keeps memory + threads low
-    max_duration_s: float = 300.0     # auto-stop AND TRANSCRIBE (not cancel) a
+    max_duration_s: float = field(default=300.0, metadata={"axis": Axis.PROJECT})     # auto-stop AND TRANSCRIBE (not cancel) a
                                       # recording left open longer than this
 
 
@@ -86,10 +87,10 @@ class WebFetchConfig:
             SSRF-guard surfaces (the safe.http subprocess + registry clients)
             see the same opt-in.
     """
-    verify_ssl: bool | None = None
-    ca_bundle: str | None = None
-    max_download_bytes: int = MAX_DOWNLOAD_BYTES  # single-source (#1913 class)
-    allow_private_ips: bool = False  # #1956 SSRF: opt-in to private RFC1918/ULA
+    verify_ssl: bool | None = field(default=None, metadata={"axis": Axis.CAPABILITY})
+    ca_bundle: str | None = field(default=None, metadata={"axis": Axis.CAPABILITY})
+    max_download_bytes: int = field(default=MAX_DOWNLOAD_BYTES, metadata={"axis": Axis.BOUNDING})  # single-source (#1913 class)
+    allow_private_ips: bool = field(default=False, metadata={"axis": Axis.CAPABILITY})  # #1956 SSRF: opt-in to private RFC1918/ULA
 
 
 # Default WebSocket max frame size (bytes) for the `reyn web` gateway. Pins
@@ -112,10 +113,10 @@ class AuthConfig:
     the browser loopback surface unauthenticated). ``tls_certfile`` /
     ``tls_keyfile`` override the self-signed TOFU material for a T3 bind.
     """
-    token: str | None = None
-    require_token_on_loopback: bool = True
-    tls_certfile: str | None = None
-    tls_keyfile: str | None = None
+    token: str | None = field(default=None, metadata={"axis": Axis.PROJECT})
+    require_token_on_loopback: bool = field(default=True, metadata={"axis": Axis.PROJECT})
+    tls_certfile: str | None = field(default=None, metadata={"axis": Axis.PROJECT})
+    tls_keyfile: str | None = field(default=None, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass
@@ -143,7 +144,7 @@ class SurfacesConfig:
             a2a: {enabled: true}    # opt in to A2A
             mcp: {enabled: true}    # opt in to MCP
     """
-    enabled: dict[str, bool] = field(default_factory=dict)
+    enabled: dict[str, bool] = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass
@@ -167,10 +168,10 @@ class GatewayConfig:
     `reyn web` gateway's own setting, same category as the other three).
     Extend here when ``gateway.search`` gets its own knobs.
     """
-    ws_max_size: int = DEFAULT_WS_MAX_SIZE
+    ws_max_size: int = field(default=DEFAULT_WS_MAX_SIZE, metadata={"axis": Axis.PROJECT})
     auth: AuthConfig = field(default_factory=AuthConfig)
     surfaces: SurfacesConfig = field(default_factory=SurfacesConfig)
-    default_design: str | None = None
+    default_design: str | None = field(default=None, metadata={"axis": Axis.PROJECT})
 
 
 def _build_web_fetch_config(raw: object) -> WebFetchConfig:
@@ -350,12 +351,12 @@ class MultimodalConfig:
     paths #365 (read_file binary) and #366 (user chat input image) reuse
     them. Issue #383 PR-C extends with the storage paths.
     """
-    max_bytes: int = 5_000_000
-    on_oversize: Literal["ask", "allow", "deny"] = "ask"
-    media_dir: str = ".reyn/media"
-    tool_results_dir: str = ".reyn/tool-results"
-    base_url: str | None = None
-    model_capability_overrides: "dict[str, dict[str, bool]]" = field(default_factory=dict)
+    max_bytes: int = field(default=5_000_000, metadata={"axis": Axis.BOUNDING})
+    on_oversize: Literal["ask", "allow", "deny"] = field(default="ask", metadata={"axis": Axis.BOUNDING})
+    media_dir: str = field(default=".reyn/media", metadata={"axis": Axis.PROJECT})
+    tool_results_dir: str = field(default=".reyn/tool-results", metadata={"axis": Axis.PROJECT})
+    base_url: str | None = field(default=None, metadata={"axis": Axis.PROJECT})
+    model_capability_overrides: "dict[str, dict[str, bool]]" = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
 
 
 def _build_multimodal_config(raw: object) -> MultimodalConfig:

--- a/src/reyn/config/observability.py
+++ b/src/reyn/config/observability.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from reyn.config_axis import Axis
+
 
 @dataclass
 class OtelConfig:
@@ -33,10 +35,10 @@ class OtelConfig:
             convention; only enable against a trusted collector).
     """
 
-    endpoint: str = ""
-    headers: dict[str, str] = field(default_factory=dict)
-    service_name: str = "reyn"
-    capture_content: bool = False
+    endpoint: str = field(default="", metadata={"axis": Axis.PROJECT})
+    headers: dict[str, str] = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
+    service_name: str = field(default="reyn", metadata={"axis": Axis.PROJECT})
+    capture_content: bool = field(default=False, metadata={"axis": Axis.PROJECT})
 
 
 @dataclass

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -61,6 +61,7 @@ from reyn.config.media import (
 from reyn.config.observability import (
     ObservabilityConfig,
 )
+from reyn.config_axis import Axis
 from reyn.runtime.budget.budget import CostConfig
 from reyn.runtime.external_routing import ExternalTransportRouting
 
@@ -76,7 +77,7 @@ class ReynConfig:
     # `build_system_prompt(output_language=...)`.
     output_language: str | None = field(
         default=None,
-        metadata={"desc": "Language code injected into the context frame for all LLM outputs."},
+        metadata={"axis": Axis.PREFERENCE, "override_enabled": True, "desc": "Language code injected into the context frame for all LLM outputs."},
     )
     # #1829: LLM-layer config — the litellm.Router resilience surface
     # (llm.router.*: use / num_retries / fallbacks / cooldown_time /
@@ -99,7 +100,7 @@ class ReynConfig:
     # — clean break, no alias; existing reyn.yaml `shell:` keys must be renamed.)
     permissions: dict = field(
         default_factory=dict,
-        metadata={"desc": "Pre-declare `allow`/`deny` for specific Control IR ops, skipping the interactive prompt."},
+        metadata={"axis": Axis.CAPABILITY, "desc": "Pre-declare `allow`/`deny` for specific Control IR ops, skipping the interactive prompt."},
     )
     # MCP server definitions.  Merged across config sources (servers dict is shallow-merged;
     # local overrides project which overrides global).
@@ -126,7 +127,7 @@ class ReynConfig:
     #         headers:
     #           Authorization: "Bearer ${GITHUB_TOKEN}"
     #           X-API-Version: "2024-01-01"
-    mcp: dict = field(default_factory=dict)
+    mcp: dict = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
     # FP-0016 Component E — agent identity for audit trail + HTTP header
     # propagation. Default `reyn/<hostname>` when reyn.yaml has no
     # `agent_id:` key. Read by Session to construct its EventLog and
@@ -134,7 +135,7 @@ class ReynConfig:
     # #4174 T5: flattened from the `agent: {id: ...}` namespace (a
     # single-field wrapper — same disposition as T1's `python:` deletion)
     # to a plain top-level scalar.
-    agent_id: str = field(default_factory=_default_agent_id)
+    agent_id: str = field(default_factory=_default_agent_id, metadata={"axis": Axis.PROJECT})
     # #2081 — cross-agent delegation policy. ``delegation.capability_default``
     # (inherit|deny, default=inherit) selects the capability floor an UNBOUND
     # delegated agent receives. Default ``inherit`` = byte-identical to pre-#2081.
@@ -195,7 +196,7 @@ class ReynConfig:
     #
     # An explicit value pins one path (e.g. ``"CLAUDE.md"`` to reuse that
     # source); ``""`` disables injection entirely.
-    project_context_path: str | None = None
+    project_context_path: str | None = field(default=None, metadata={"axis": Axis.PROJECT})
     # RAG embedding settings (ADR-0033 Phase 1). Default-completed: usable
     # without any reyn.yaml edits after `pip install reyn` + OPENAI_API_KEY.
     embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
@@ -254,14 +255,14 @@ class ReynConfig:
     # #1800 slice 5b: the raw ``hooks:`` block (a list of hook entries). Kept raw
     # here and parsed via ``load_hooks`` at Session construction. Empty (default)
     # → empty registry → the HookDispatcher is a no-op.
-    hooks: list = field(default_factory=list)
+    hooks: list = field(default_factory=list, metadata={"axis": Axis.PROJECT})
     # Hook-Event Redesign Phase 4b/5 (proposal 0059 §5/§9, #2880/#2881): the raw
     # ``composers:`` block (a list of Composer definitions). Kept raw here and
     # parsed via ``reyn.hooks.composer.load_composers`` at Session construction
     # (the startup/OUT-set layer of the same 4-layer additive combine ``hooks:``
     # uses). Empty (default) → no composers → ``start_composers`` is never
     # called → byte-identical to pre-Composer behavior.
-    composers: list = field(default_factory=list)
+    composers: list = field(default_factory=list, metadata={"axis": Axis.PROJECT})
     # #4552 PR-3+4: `action_retrieval` field DELETED entirely (was FP-0034's
     # universal catalog gating + action retrieval, D13/D14). Its 4 fields
     # were removed/moved across the #4552 arc: hot_list_n/hot_list_seed
@@ -295,7 +296,7 @@ class ReynConfig:
     # full incident this fixes).
     external_transports: "ExternalTransportRouting" = field(
         default_factory=ExternalTransportRouting,
-        metadata={"dict_leaf": True},
+        metadata={"axis": Axis.PROJECT, "dict_leaf": True},
     )
     # #2548 PR-A: skill registry config. Raw dict passed to
     # reyn.data.skills.registry.build_skill_registry at session /
@@ -314,7 +315,7 @@ class ReynConfig:
     # the pair describes 4 states, not 6. The removed `auto_invoke` key is
     # rejected at load by loader._validate_skill_visibility.
     # Merged across config tiers by name (explicit entries win on collision).
-    skills: dict = field(default_factory=dict)
+    skills: dict = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
     # Pipeline registry config. Raw dict passed to
     # reyn.data.pipelines.registry.build_pipeline_registry at session-factory
     # time (SessionFactoryConfig.from_config). Pipelines are registered PURELY
@@ -338,7 +339,7 @@ class ReynConfig:
     # Absent/empty → no pipelines loaded. Merged across config tiers by name
     # (explicit entries win on collision) — same union-merge shape as
     # ``skills`` (see ``_merge`` in loader.py).
-    pipelines: dict = field(default_factory=dict)
+    pipelines: dict = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
     # FP-0054 PR-C: named-presentation-template registry config. Raw dict passed to
     # reyn.data.presentations.registry.build_presentation_registry at session-factory
     # time (SessionFactoryConfig.from_config). A named template's value is a
@@ -358,7 +359,7 @@ class ReynConfig:
     #         enabled: true                            # optional, default true
     # Merged across config tiers by name (explicit entries win on collision) — same
     # union-merge shape as ``skills`` / ``pipelines`` (see ``_merge`` in loader.py).
-    presentations: dict = field(default_factory=dict)
+    presentations: dict = field(default_factory=dict, metadata={"axis": Axis.PROJECT})
 
     # #4194: the policy-tier unknown/renamed config-key COUNT
     # (``loader._warn_unknown_config_keys``'s return value, attached here

--- a/src/reyn/config_axis.py
+++ b/src/reyn/config_axis.py
@@ -1,0 +1,101 @@
+"""#4206 — the 4 config axes every ``ReynConfig`` leaf is classified
+under, and why the axis lives on the FIELD rather than being inferred.
+
+Architect ruling (2026-08-11, corrected 2026-09-02T04:01 to a full
+159/174-leaf classification, 要判定 0): a config key's "can a narrower
+layer — agent profile / session config — override the project default"
+question does NOT collapse to "permission or not" (``model`` is the
+counter-example: not a capability, but a shared, bounded resource whose
+free override would let a child exhaust the parent's budget). Four axes,
+by DISTINCT composition rule:
+
+- :attr:`Axis.CAPABILITY` — restrict-only (a narrower layer may only
+  narrow, never widen; existing agent/session capability-profile
+  machinery).
+- :attr:`Axis.BOUNDING` — a narrower layer may only narrow a shared,
+  bounded resource's ceiling; the operator holds the actual ceiling.
+  Composition: narrowest-wins (see ``runtime/bounding.py``).
+- :attr:`Axis.PREFERENCE` — free override; the last layer present wins,
+  no ceiling check (see ``runtime/preferences.py``).
+- :attr:`Axis.PROJECT` — no override receptacle at all; structurally
+  process-shared or a placement/deployment concern (transport, storage
+  directories, external registries) — NOT "unclassified", a real 4th
+  answer to "who may override this" (architect: "属さない key は0").
+
+## Why the axis lives on the dataclass FIELD
+
+``metadata={"axis": Axis.X}`` on the field declaration, walked via
+``config_schema.walk_config_schema()`` — the SAME canonical enumeration
+``reyn config fields``/``get``/``set`` already use — rather than a
+hand-maintained lookup table living in a 4th place. A hand list drifts
+the moment a new leaf is added without updating it (the exact defect
+class #4655 closed for the schema's own unknown-key detection); the
+Tier 2 gate in ``tests/config/test_4206_axis_coverage.py`` asserts EVERY
+real leaf carries an axis, so a new leaf added without one goes red at
+review time instead of silently defaulting to "unclassified".
+
+## ``override_enabled`` — a SEPARATE, narrower flag
+
+Classifying a leaf's axis is NOT the same claim as "this leaf has a
+live override receptacle" (``BOUNDING_KEYS``/``PREFERENCE_KEYS``,
+``runtime/bounding.py``/``runtime/preferences.py``). Architect's own
+explicit instruction (2026-09-02T04:01): do NOT bulk-add every
+newly-bounding-classified leaf (~40) into ``BOUNDING_KEYS`` at once —
+only the leaves with a MEASURED real demand for an agent/session
+override get ``metadata={"axis": Axis.BOUNDING, "override_enabled":
+True}``; the rest carry the axis (for the completeness gate and doc
+surface) without a live receptacle yet, matching ``bounding.py``'s own
+pre-existing discipline ("adding an unused key here would repeat the
+exact 'declared but nobody reads it' shape #4655 closed"). Today that
+is exactly the 1 pre-existing ``BOUNDING_KEYS`` member (``llm.model``)
+and the 9 pre-existing ``PREFERENCE_KEYS`` members — this PR changes
+WHERE that fact is declared (on the field, derived via
+``walk_config_schema()``), not WHICH leaves currently have a receptacle.
+
+## ``override_key`` — the ONE real exception found deriving ``BOUNDING_KEYS``
+
+A leaf's own dotted ``ReynConfig`` path is not always what an operator
+writes inside the override block. ``llm.model``'s ``bounding:`` entry
+is the bare ``model`` — an established, tested vocabulary
+(``bounding: {model: "standard"}``) that predates this leaf's own
+nesting under ``llm:``, discovered live while deriving
+``BOUNDING_KEYS`` (a naive derivation from ``node.key`` alone would
+have silently produced ``{"llm.model"}``, breaking every real
+``bounding: {model: ...}`` caller). ``field(metadata={"override_key":
+"model"})`` records the override block's OWN vocabulary for this one
+leaf; every other #4206 leaf's override key equals its dotted path
+(the common case, no ``override_key`` needed).
+
+## Why this module lives at ``reyn.config_axis``, not ``reyn.config.config_axis``
+
+A genuine circular import, found live (not assumed) while migrating
+``runtime/budget/budget.py``'s own ``CostLimitConfig``/``CostConfig``
+dataclasses to carry axis metadata: those classes need ``Axis`` bound
+at CLASS-BODY time (``field(metadata={"axis": Axis.BOUNDING})``), but
+``reyn.config`` (the PACKAGE) eagerly imports ``config/chat.py``,
+which imports ``CostConfig``/``CostLimitConfig`` FROM
+``runtime.budget.budget`` — so ``budget.py`` importing anything from
+INSIDE the ``reyn.config`` package (even a leaf submodule) at its own
+module top level re-enters ``reyn/config/__init__.py`` while
+``budget.py`` itself is still mid-initialization (verified directly:
+``ImportError: cannot import name 'CostConfig' from partially
+initialized module``). Living as its own top-level module — ``reyn/
+__init__.py`` performs NO eager submodule imports (its own docstring)
+— breaks the cycle structurally: importing ``reyn.config_axis`` never
+touches ``reyn.config``'s own package init at all.
+"""
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Axis(StrEnum):
+    """The 4 config axes — see this module's own docstring."""
+
+    CAPABILITY = "capability"
+    BOUNDING = "bounding"
+    PREFERENCE = "preference"
+    PROJECT = "project"
+
+
+__all__ = ["Axis"]

--- a/src/reyn/runtime/bounding.py
+++ b/src/reyn/runtime/bounding.py
@@ -56,9 +56,18 @@ def _derive_bounding_keys() -> "frozenset[str]":
     only the leaves with MEASURED real demand get
     ``"override_enabled": True`` — today that is exactly the 1
     pre-existing member this set already had by hand (``llm.model``).
-    Imports lazily for the same reason ``preferences.py``'s own
-    derivation does — this module has no other reason to need the full
-    config tree at its own import time."""
+    Note on import timing (corrected, measured directly against the PR
+    head — the prior wording here was wrong): the full config tree
+    genuinely IS pulled in at THIS module's own import time —
+    ``BOUNDING_KEYS`` below is evaluated at module scope, so
+    ``config_schema`` (and the whole ``ReynConfig`` tree behind it)
+    loads then regardless of whether this ``import`` sits inside the
+    function body or at the top of the file. See
+    ``reyn.runtime.preferences._derive_preference_keys``'s own docstring
+    for where the real circular import lives (``runtime/budget/budget.py``,
+    fixed there via a PEP 562 ``__getattr__`` deferral) and why the lazy
+    import kept here is not load-bearing for it — it stays only for
+    symmetry with that sibling helper."""
     from reyn.config.config_schema import walk_config_schema
     from reyn.config_axis import Axis
     return frozenset(

--- a/src/reyn/runtime/bounding.py
+++ b/src/reyn/runtime/bounding.py
@@ -42,9 +42,40 @@ from __future__ import annotations
 
 from reyn.llm.model_resolver import STANDARD_CLASSES
 
-#: The ONE key #4206 ②'s current scope covers — see the module docstring
-#: for why ``timeout``/``router_max_iterations`` are not (yet) here.
-BOUNDING_KEYS: "frozenset[str]" = frozenset({"model"})
+
+def _derive_bounding_keys() -> "frozenset[str]":
+    """#4206 (architect ruling, 2026-09-02T04:01): every ``ReynConfig``
+    leaf whose field declares BOTH ``axis=Axis.BOUNDING`` and
+    ``override_enabled=True`` — the SAME derivation shape
+    ``reyn.runtime.preferences._derive_preference_keys`` uses for ③.
+    Classifying a leaf ``Axis.BOUNDING`` is NOT the same claim as "this
+    leaf has a live ``bounding:`` override receptacle" — see
+    ``reyn.config_axis.Axis``'s own module docstring: architect's
+    explicit instruction was NOT to bulk-add every newly-bounding-
+    classified leaf (~40, mostly ``safety.*``) into this set at once,
+    only the leaves with MEASURED real demand get
+    ``"override_enabled": True`` — today that is exactly the 1
+    pre-existing member this set already had by hand (``llm.model``).
+    Imports lazily for the same reason ``preferences.py``'s own
+    derivation does — this module has no other reason to need the full
+    config tree at its own import time."""
+    from reyn.config.config_schema import walk_config_schema
+    from reyn.config_axis import Axis
+    return frozenset(
+        node.override_key or node.key for node in walk_config_schema()
+        if node.axis == Axis.BOUNDING and node.override_enabled
+    )
+
+
+#: See :func:`_derive_bounding_keys` — the ONE key #4206 ②'s current
+#: scope covers (``llm.model``, this file's own ``"model"`` bounding-
+#: mapping key — see the module docstring for why ``timeout``/
+#: ``router_max_iterations`` are not (yet) here). DERIVED from field
+#: metadata (#4206, architect ruling), replacing the pre-#4206
+#: hand-typed ``frozenset({"model"})`` — same content, same composition
+#: mechanism (:func:`compose_model_ceiling` below is unchanged), only
+#: the SOURCE of this one set moved.
+BOUNDING_KEYS: "frozenset[str]" = _derive_bounding_keys()
 
 
 class UnknownBoundingKeyError(ValueError):

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -20,6 +20,7 @@ are not tied to any specific domain.
 """
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 import logging
@@ -30,6 +31,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from reyn.config_axis import Axis
 from reyn.llm.pricing import (
     CostBreakdown,
     EmbeddingCost,
@@ -48,13 +50,33 @@ logger = logging.getLogger(__name__)
 #: hand-maintained literal set (PREFERENCE_KEYS stays the ONE declaration
 #: of the ③ axis's vocabulary; this module only needs to know which of
 #: those keys IT is the consumer for).
+#:
+#: #4206 (this migration): PREFERENCE_KEYS itself now derives from
+#: ``walk_config_schema()`` — which walks ``ReynConfig``, which imports
+#: THIS module's own ``CostConfig``/``CostLimitConfig`` (via
+#: ``config/chat.py``). Computing this set at MODULE IMPORT time (the
+#: pre-#4206 shape, a plain module-level assignment) would therefore
+#: import ``reyn.runtime.preferences`` while THIS module is still
+#: mid-initialization — a genuine circular import (verified directly:
+#: ``ImportError: cannot import name 'PREFERENCE_KEYS' from partially
+#: initialized module``), not merely an ordering nuisance. Deferred via
+#: module ``__getattr__`` (PEP 562) instead: every real reference stays
+#: the same bare ``_WARN_RATIO_PREFERENCE_KEYS`` name (no caller,
+#: including ``test_4724_warn_ratio_overrides.py``'s own module-level
+#: import, needs to change), but the VALUE is computed lazily on first
+#: access — by which point ``ReynConfig``'s full class tree (including
+#: this module's own classes) has already finished importing.
+@functools.cache
 def _load_warn_ratio_preference_keys() -> "frozenset[str]":
     from reyn.runtime.preferences import PREFERENCE_KEYS
 
     return frozenset(k for k in PREFERENCE_KEYS if k.startswith("cost."))
 
 
-_WARN_RATIO_PREFERENCE_KEYS: "frozenset[str]" = _load_warn_ratio_preference_keys()
+def __getattr__(name: str) -> object:
+    if name == "_WARN_RATIO_PREFERENCE_KEYS":
+        return _load_warn_ratio_preference_keys()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 #: Models already reported as unpriced (#3695). Once per model per process:
 #: the condition holds for every call to that model, so a per-call warning
@@ -127,8 +149,8 @@ class CostLimitConfig:
     sets this key gets.
     """
 
-    hard_limit: float | None = None
-    warn_ratio: float = 0.8
+    hard_limit: float | None = field(default=None, metadata={"axis": Axis.BOUNDING})
+    warn_ratio: float = field(default=0.8, metadata={"axis": Axis.PREFERENCE, "override_enabled": True})
 
     @property
     def warn_threshold(self) -> float | None:
@@ -180,18 +202,19 @@ def _validate_warn_ratio_overrides(overrides: "dict[str, float] | None") -> None
         return
     from reyn.runtime.preferences import PREFERENCE_KEYS, UnknownPreferenceKeyError
 
-    unknown = set(overrides) - _WARN_RATIO_PREFERENCE_KEYS
+    warn_ratio_keys = _load_warn_ratio_preference_keys()
+    unknown = set(overrides) - warn_ratio_keys
     if unknown:
         raise UnknownPreferenceKeyError(
             f"warn_ratio_overrides: unrecognized key(s) {sorted(unknown)!r} — "
             f"not in the cost.* warn-ratio subset of PREFERENCE_KEYS "
-            f"({sorted(_WARN_RATIO_PREFERENCE_KEYS)!r})."
+            f"({sorted(warn_ratio_keys)!r})."
         )
     # Defensive: PREFERENCE_KEYS itself is the ONE declaration (#4206); this
     # subset is DERIVED from it (never a second, independently-drifting
     # literal set), so the assert below is a not-both-drifted guard, not a
     # live check against operator input.
-    assert _WARN_RATIO_PREFERENCE_KEYS <= PREFERENCE_KEYS  # noqa: S101
+    assert warn_ratio_keys <= PREFERENCE_KEYS  # noqa: S101
 
 
 @dataclass
@@ -205,8 +228,8 @@ class CostConfig:
 
     per_agent_tokens: CostLimitConfig = field(default_factory=CostLimitConfig)
     per_agent_cost_usd: CostLimitConfig = field(default_factory=CostLimitConfig)
-    rate_limit_per_minute: dict[str, int] = field(default_factory=dict)
-    rate_limit_warn_ratio: float = 0.8
+    rate_limit_per_minute: dict[str, int] = field(default_factory=dict, metadata={"axis": Axis.BOUNDING})
+    rate_limit_warn_ratio: float = field(default=0.8, metadata={"axis": Axis.PREFERENCE, "override_enabled": True})
     # PR25: persistent daily / monthly quota (reset automatically at period boundary)
     daily_tokens: CostLimitConfig = field(default_factory=CostLimitConfig)
     daily_cost_usd: CostLimitConfig = field(default_factory=CostLimitConfig)

--- a/src/reyn/runtime/preferences.py
+++ b/src/reyn/runtime/preferences.py
@@ -9,45 +9,66 @@ override (if present) -> session-layer override (if present); the LAST one
 present wins outright. There is no "child cannot widen past parent" check
 here — that's what makes this axis ③, not ②.
 
-## PREFERENCE_KEYS — a hand-maintained declaration, not derived
+## PREFERENCE_KEYS — DERIVED from field metadata (#4206, architect ruling
+## 2026-09-02T04:01)
 
-The set below is the ONE place this axis's key vocabulary is declared.
-Lead-coder ruling: a typed dataclass per key was rejected (breaks "the
-mechanism stays the same as ③ grows" — #4206's own explicit requirement),
-so this is a flat ``dict[str, object]`` keyed by dotted config-path string
-instead. That shape alone would reproduce the #4655 "silent no-op" defect
-class (a typo'd/renamed key silently doing nothing forever) — closed the
-same way #4655 closed it for config-schema dict-leaves: :func:`validate_preferences`
-raises LOUDLY on any key not in this set, rather than accepting and
-ignoring it.
+Was a hand-maintained declaration (9 keys, typed out by hand here); now
+derived from ``metadata={"axis": Axis.PREFERENCE, "override_enabled":
+True}`` on the owning ``ReynConfig`` leaf's own field declaration —
+:func:`~reyn.config.config_schema.walk_config_schema` is the SAME
+canonical enumeration ``reyn config fields``/``get``/``set`` already
+use, so this set can no longer drift from what the schema itself says
+(closing the #4655 "silent no-op" defect class one level up: a
+hand-typed SECOND copy of a fact the schema already declares).
 
-**Known, accepted tradeoff (lead-coder, explicit)**: this IS "one more
-declaration" to keep in sync as the ③ set grows — #4206's own classification
-of which config keys belong to which axis is not yet derivable from code
-(it lives in the issue's own prose), and making it derivable is a SEPARATE
-future task, deliberately not mixed into this slice.
+**The CONTENT is derived; the COMPOSITION MECHANISM is not** (architect,
+same ruling): a typed dataclass per key was rejected (breaks "the
+mechanism stays the same as ③ grows"), so :func:`validate_preferences`/
+:func:`compose_preferences` below are unchanged — only the SOURCE of
+this one set moved.
+
+**``override_enabled`` is a SEPARATE, narrower flag from the axis
+itself** — classifying a leaf ``Axis.PREFERENCE`` is not the same claim
+as "this leaf has a live ``preferences:`` override receptacle". Adding
+a new leaf's axis metadata does NOT put it in this set; only a field
+ALSO carrying ``"override_enabled": True`` is (see
+``reyn.config_axis.Axis``'s own module docstring for the full
+reasoning — the same distinction ``runtime/bounding.py`` makes for
+``BOUNDING_KEYS``). Today that is exactly the 9 pre-existing members
+this set already had by hand: ``output_language``,
+``chat.reasoning.display``, one ``warn_ratio`` per of the 6
+``CostLimitConfig`` dimensions (``runtime/budget/budget.py``), and
+``cost.rate_limit_warn_ratio`` — this migration changes WHERE that fact
+is declared, not WHICH leaves currently have a receptacle.
 """
 from __future__ import annotations
 
-#: The 9 keys #4206's confirmed classification places in axis ③ for this
-#: first slice: ``output_language``, ``chat.reasoning.display``, one
-#: ``warn_ratio`` per of the 6 ``CostLimitConfig`` dimensions
-#: (``runtime/budget/budget.py``'s ``CostConfig``), and
+
+def _derive_preference_keys() -> "frozenset[str]":
+    """Every ``ReynConfig`` leaf whose field declares BOTH
+    ``axis=Axis.PREFERENCE`` and ``override_enabled=True`` — see this
+    module's own docstring for why the axis classification alone is not
+    enough. Imports lazily (module-level import would pull
+    ``config_schema`` → ``ReynConfig`` at ``reyn.runtime.preferences``
+    import time — this module has no other reason to need the full
+    config tree that early)."""
+    from reyn.config.config_schema import walk_config_schema
+    from reyn.config_axis import Axis
+    return frozenset(
+        node.key for node in walk_config_schema()
+        if node.axis == Axis.PREFERENCE and node.override_enabled
+    )
+
+
+#: See :func:`_derive_preference_keys` — the 9 keys #4206's confirmed
+#: classification places in axis ③ with a live override receptacle:
+#: ``output_language``, ``chat.reasoning.display``, one ``warn_ratio``
+#: per of the 6 ``CostLimitConfig`` dimensions, and
 #: ``cost.rate_limit_warn_ratio``. Every entry is a dotted path matching
 #: the SAME key names ``reyn.yaml`` uses for the project-level default
 #: (``config/chat.py``'s own parsing), so an agent/session override reads
 #: as "the same setting, one layer down" — not a renamed shadow key.
-PREFERENCE_KEYS: "frozenset[str]" = frozenset({
-    "output_language",
-    "chat.reasoning.display",
-    "cost.per_agent_tokens.warn_ratio",
-    "cost.per_agent_cost_usd.warn_ratio",
-    "cost.daily_tokens.warn_ratio",
-    "cost.daily_cost_usd.warn_ratio",
-    "cost.monthly_tokens.warn_ratio",
-    "cost.monthly_cost_usd.warn_ratio",
-    "cost.rate_limit_warn_ratio",
-})
+PREFERENCE_KEYS: "frozenset[str]" = _derive_preference_keys()
 
 
 class UnknownPreferenceKeyError(ValueError):

--- a/src/reyn/runtime/preferences.py
+++ b/src/reyn/runtime/preferences.py
@@ -48,10 +48,24 @@ def _derive_preference_keys() -> "frozenset[str]":
     """Every ``ReynConfig`` leaf whose field declares BOTH
     ``axis=Axis.PREFERENCE`` and ``override_enabled=True`` — see this
     module's own docstring for why the axis classification alone is not
-    enough. Imports lazily (module-level import would pull
-    ``config_schema`` → ``ReynConfig`` at ``reyn.runtime.preferences``
-    import time — this module has no other reason to need the full
-    config tree that early)."""
+    enough.
+
+    Note on import timing (corrected, measured directly against the PR
+    head — the prior wording here was wrong): the full config tree
+    genuinely IS pulled in at THIS module's own import time — ``PREFERENCE_
+    KEYS`` below is evaluated at module scope, so ``config_schema`` (and the
+    whole ``ReynConfig`` tree behind it) loads then, whether the ``import``
+    statement sits inside this function body or at the top of the file;
+    moving it to module scope was verified not to reintroduce the
+    circular import this module was originally written to avoid. The
+    real cycle lived one hop over, in ``runtime/budget/budget.py`` (its
+    own module-scope ``_WARN_RATIO_PREFERENCE_KEYS`` needing
+    ``PREFERENCE_KEYS`` while ``budget.py`` was itself still
+    mid-initialization inside ``config/chat.py``'s import chain) and is
+    fixed there via a PEP 562 ``__getattr__`` deferral — see that
+    module's own comment. The lazy import kept here is not load-bearing
+    for that cycle; it stays only for symmetry with ``runtime/bounding.py``'s
+    identical helper."""
     from reyn.config.config_schema import walk_config_schema
     from reyn.config_axis import Axis
     return frozenset(

--- a/tests/config/test_4206_axis_coverage.py
+++ b/tests/config/test_4206_axis_coverage.py
@@ -1,0 +1,154 @@
+"""Tier 2: #4206 — every real ``ReynConfig`` leaf carries axis metadata
+(``metadata={"axis": Axis.X}``), architect's full classification
+(2026-09-02T04:01, 159-leaf table + 15 leaves resolved by direct
+sibling-analogy while migrating — see this PR's own body for the
+discrepancy and how each was resolved).
+
+Gate shape (architect's own prescription): walk ``ReynConfig`` via
+``walk_config_schema()`` — the SAME canonical enumeration ``reyn config
+fields``/``get``/``set`` already use, never a hand-maintained list — and
+assert every leaf's ``.axis`` is set. **Vacuity guard required**: an
+empty leaf population would pass this check for the wrong reason (a
+schema-walk regression silently emptying the population reads
+identically to "every leaf classified"), so leaf non-emptiness is
+asserted FIRST, separately.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from reyn.config.config_schema import SchemaNode, walk_config_schema
+from reyn.config_axis import Axis
+
+
+def test_the_leaf_population_itself_is_not_empty() -> None:
+    """Tier 1: vacuity guard — must run (and pass) BEFORE the coverage
+    assertion below has any meaning. An empty leaf list would make
+    "every leaf has an axis" vacuously true for the wrong reason (a
+    schema-walk regression, not real classification coverage)."""
+    leaves = walk_config_schema()
+    assert leaves, "walk_config_schema() returned no leaves — the vacuity guard itself failed"
+
+
+def test_every_real_leaf_has_an_axis_classification() -> None:
+    """Tier 2: the gate itself — 0 leaves without ``axis`` metadata. A new
+    leaf added to any ``ReynConfig`` dataclass without ``field(metadata=
+    {"axis": Axis.X})`` fails this test, not silently defaulting to
+    "unclassified" (architect's own explicit requirement)."""
+    leaves = walk_config_schema()
+    unclassified = [n.key for n in leaves if n.axis is None]
+    assert not unclassified, (
+        f"{len(unclassified)} leaf(ves) carry no axis metadata — every real "
+        f"ReynConfig leaf must declare field(metadata={{'axis': Axis.X}}): "
+        f"{sorted(unclassified)}"
+    )
+
+
+def test_every_axis_value_is_a_real_axis_member() -> None:
+    """Tier 2: accept-side sibling — every non-``None`` axis is actually
+    one of the 4 declared :class:`Axis` members, not e.g. a typo'd bare
+    string that would satisfy "is not None" while being meaningless."""
+    leaves = walk_config_schema()
+    for node in leaves:
+        assert node.axis in set(Axis), f"{node.key}: axis={node.axis!r} is not a real Axis member"
+
+
+def test_strip_falsify_a_leaf_with_no_axis_metadata_fails_the_gate() -> None:
+    """Tier 2: strip-falsify the gate itself — a synthetic dataclass with
+    ONE field carrying no axis metadata must be caught by the SAME
+    coverage check above, proving it actually bites rather than passing
+    for an unrelated reason (e.g. a broken ``.axis`` attribute always
+    reading ``None`` would make BOTH the real gate and this negative
+    control pass, hiding the real gate never doing anything)."""
+    @dataclasses.dataclass
+    class _NoAxisLeaf:
+        unclassified_field: int = 0
+
+    leaves = walk_config_schema(cls=_NoAxisLeaf)
+    assert leaves, "the synthetic fixture itself produced no leaves — broken test setup"
+    unclassified = [n.key for n in leaves if n.axis is None]
+    assert unclassified == ["unclassified_field"]
+
+
+def test_strip_falsify_a_leaf_with_axis_metadata_passes() -> None:
+    """Tier 2: accept-side sibling to the strip-falsify above — the SAME
+    synthetic shape, but WITH axis metadata, produces zero unclassified
+    leaves. Together the two prove the gate discriminates on the actual
+    presence of axis metadata, not on some other property of the field."""
+    @dataclasses.dataclass
+    class _WithAxisLeaf:
+        classified_field: int = dataclasses.field(
+            default=0, metadata={"axis": Axis.PROJECT},
+        )
+
+    leaves = walk_config_schema(cls=_WithAxisLeaf)
+    assert leaves
+    unclassified = [n.key for n in leaves if n.axis is None]
+    assert unclassified == []
+
+
+# ---------------------------------------------------------------------------
+# BOUNDING_KEYS / PREFERENCE_KEYS — derived-from-metadata regression pins
+# ---------------------------------------------------------------------------
+
+
+def test_preference_keys_content_is_unchanged_by_the_migration_to_derivation() -> None:
+    """Tier 2: #4206's own migration condition — PREFERENCE_KEYS's CONTENT
+    must be byte-identical to the pre-migration hand-typed 9-key set
+    (only its SOURCE moved, from a literal to a schema-metadata
+    derivation); a content drift here — silently gaining or losing a
+    member — would be a real regression this pin catches."""
+    from reyn.runtime.preferences import PREFERENCE_KEYS
+
+    assert PREFERENCE_KEYS == frozenset({
+        "output_language",
+        "chat.reasoning.display",
+        "cost.per_agent_tokens.warn_ratio",
+        "cost.per_agent_cost_usd.warn_ratio",
+        "cost.daily_tokens.warn_ratio",
+        "cost.daily_cost_usd.warn_ratio",
+        "cost.monthly_tokens.warn_ratio",
+        "cost.monthly_cost_usd.warn_ratio",
+        "cost.rate_limit_warn_ratio",
+    })
+
+
+def test_bounding_keys_content_is_unchanged_by_the_migration_to_derivation() -> None:
+    """Tier 2: same regression pin as above, for BOUNDING_KEYS — this one
+    ALSO exercises the ``override_key`` metadata dimension (``llm.model``
+    derives to bare ``"model"``, not ``"llm.model"``) found live while
+    migrating this exact set; a bug in that mapping would surface here as
+    ``{"llm.model"}`` instead of ``{"model"}``."""
+    from reyn.runtime.bounding import BOUNDING_KEYS
+
+    assert BOUNDING_KEYS == frozenset({"model"})
+
+
+def test_preference_keys_and_bounding_keys_derive_from_the_same_walk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: both sets ultimately read from the SAME
+    ``walk_config_schema()`` enumeration — strip-falsified: replacing
+    ``walk_config_schema`` with one that returns an axis-free node for
+    every leaf must empty BOTH derived sets (proving neither silently
+    fell back to a hand-typed default when the schema walk changes)."""
+    import reyn.config.config_schema as config_schema_module
+
+    real_walk = config_schema_module.walk_config_schema
+
+    def _stripped_walk(cls: object = None) -> "list[SchemaNode]":
+        return [
+            dataclasses.replace(n, axis=None, override_enabled=False, override_key=None)
+            for n in real_walk(cls)  # type: ignore[arg-type]
+        ]
+
+    monkeypatch.setattr(config_schema_module, "walk_config_schema", _stripped_walk)
+
+    # Re-import the derivation functions fresh (they read walk_config_schema
+    # lazily inside their own function bodies, so calling them again after
+    # the monkeypatch is enough — no module reload needed).
+    from reyn.runtime.bounding import _derive_bounding_keys
+    from reyn.runtime.preferences import _derive_preference_keys
+
+    assert _derive_preference_keys() == frozenset()
+    assert _derive_bounding_keys() == frozenset()

--- a/tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py
+++ b/tests/core/test_3475_probe_degradation_visibility_and_timeout_config.py
@@ -283,6 +283,15 @@ def _is_float_literal_5(node: ast.expr | None, value: float = 5.0) -> bool:
 
 
 def _dataclass_field_default(tree: ast.Module, class_name: str, field_name: str) -> ast.expr | None:
+    """Return the AST expression this field's default actually evaluates to.
+
+    #4206 wrapped every `ReynConfig` leaf's declaration in
+    `field(default=..., metadata={...})` (axis metadata lives on the field, not
+    inferred) — so `stmt.value` is now an `ast.Call` to `field(...)`, not the
+    bare literal. Unwrap it to the `default=` keyword's own value, which is
+    what this test actually cares about (is the CANONICAL default a literal
+    5.0), not the declaration's outer shape.
+    """
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
             for stmt in node.body:
@@ -292,7 +301,17 @@ def _dataclass_field_default(tree: ast.Module, class_name: str, field_name: str)
                     and stmt.target.id == field_name
                     and stmt.value is not None
                 ):
-                    return stmt.value
+                    value = stmt.value
+                    if (
+                        isinstance(value, ast.Call)
+                        and isinstance(value.func, ast.Name)
+                        and value.func.id == "field"
+                    ):
+                        for kw in value.keywords:
+                            if kw.arg == "default":
+                                return kw.value
+                        return None  # default_factory or no default at all
+                    return value
     return None
 
 

--- a/tests/core/test_offload_unify_3580.py
+++ b/tests/core/test_offload_unify_3580.py
@@ -297,7 +297,12 @@ def test_the_reference_documents_the_shipped_defaults() -> None:
 
     table = Path("docs/reference/config/reyn-yaml.md").read_text(encoding="utf-8")
     for name, expected in _SHIPPED_DEFAULTS.items():
-        row = re.search(rf"\| `{re.escape(name)}` \| \w+ \| `([0-9.]+)` \|", table)
+        # 1+ plain-word columns (Axis, Type, ...) may sit between the Field
+        # cell and the backtick-quoted Default cell -- #4206 added an "Axis"
+        # column to this table, so the column count is no longer fixed at
+        # exactly one (Type). Match the Default cell positionally by its own
+        # shape (a backtick-quoted number) rather than pinning a column count.
+        row = re.search(rf"\| `{re.escape(name)}` \|(?:\s*\w+\s*\|)+\s*`([0-9.]+)`\s*\|", table)
         assert row is not None, f"{name} has no row in reyn-yaml.md's offload table"
         assert float(row.group(1)) == float(expected), (
             f"reyn-yaml.md documents {name}={row.group(1)}, code ships {expected}"


### PR DESCRIPTION
**[e2e-coder]** — part of #4206.

Architect's full 159-leaf classification (2026-09-02T04:01, 要判定 0) implemented per lead-coder's own 4-step prescription (re-issued verbatim, not re-designed):

1. Every `ReynConfig` leaf's dataclass field carries `field(metadata={"axis": Axis.X})` — new `Axis` StrEnum (`capability`/`bounding`/`preference`/`project`).
2. `BOUNDING_KEYS` (`runtime/bounding.py`) / `PREFERENCE_KEYS` (`runtime/preferences.py`) are now **derived** from that metadata via `config_schema.walk_config_schema()`, replacing the pre-#4206 hand-typed frozensets. Content unchanged — only the source moved (regression-pinned).
3. `tests/config/test_4206_axis_coverage.py` — Tier 2 gate: every real leaf has axis metadata (0 unclassified), vacuity-guarded (leaf population non-empty, asserted first) and strip-falsified (a synthetic no-axis leaf fails; a synthetic with-axis leaf passes).
4. `docs/reference/config/reyn-yaml.md` — an `Axis` column added to every genuine per-leaf table (32 tables, one column, no separate table).

## 3 real findings surfaced while implementing (verified, not guessed around)

**① Leaf count discrepancy — 174 real leaves, not architect's own 159.** Their table used `cost` as shorthand for its own 14 real sub-leaves, and a stale `gateway.auth.providers` name for what are actually 4 leaves (`token`/`require_token_on_loopback`/`tls_certfile`/`tls_keyfile`); `unknown_config_key_count`/`unknown_config_keys` in their table are report-*function* names, not real schema leaves (excluded). Every one of the 15 resulting un-tabulated leaves was classified by **direct analogy to an explicitly-classified sibling in the same table**:
- `chat.compaction.llm_call_seconds` → bounding (matches `safety.timeout.llm_call_seconds`)
- 6× `cost.*.hard_limit` → bounding, 7× `cost.*.warn_ratio` → preference (matches architect's own "`cost` は bounding；`warn_ratio` は preference" summary — and these 7 `warn_ratio` leaves are exactly `PREFERENCE_KEYS`'s own 7 pre-existing `cost.*` members)
- 4× `gateway.auth.*` → project (matches every sibling `gateway.*` leaf)

**② A genuine circular import**, found live (not assumed) migrating `runtime/budget/budget.py`'s `CostConfig`/`CostLimitConfig`: those classes are imported *by* `config/chat.py` (which `reyn.config`'s package `__init__` eagerly loads), but now need `Axis` bound at class-body time. Importing `Axis` from inside the `reyn.config` package re-entered `reyn/config/__init__.py` mid-initialization (`ImportError: cannot import name 'CostConfig' from partially initialized module`, verified directly). Fixed by moving `Axis` to its own top-level module — `reyn.config_axis`, not `reyn.config.config_axis` — since `reyn/__init__.py` performs no eager submodule imports (its own docstring), so importing it never touches `reyn.config`'s package init. A second, narrower instance of the same root cause (`budget.py`'s own `_WARN_RATIO_PREFERENCE_KEYS`, needing `PREFERENCE_KEYS`, which now needs `budget.py`'s own classes already defined) is fixed via a module `__getattr__` (PEP 562) deferring the computation to first real access — zero caller-side changes, including the pre-existing test that imports the name directly.

**③ `BOUNDING_KEYS` vocabulary mismatch.** `llm.model`'s real `bounding:` override key is the bare `model` (`bounding: {model: "standard"}`, an established, tested vocabulary — `session.py`'s `_agent_profile_bounding().get("model")`) — **NOT** the dotted `llm.model` `walk_config_schema()` itself reports. A naive derivation would have silently produced `{"llm.model"}`, breaking every real `bounding: {model: ...}` caller. **Caught before it shipped**, by `BOUNDING_KEYS`'s own regression-pin test in `test_4206_axis_coverage.py`. Fixed with a narrower, separate metadata field — `override_key` — recording the override block's own vocabulary for the ONE leaf where it diverges from the dotted path; every other #4206 leaf needs no `override_key` at all.

## BLOCKING round fixed (head a33c57097 -> 9d37e4126)

Lead-coder's CI run surfaced 2 real instances of the SAME defect family as finding ③ above (wrapping every field in `field(metadata=...)` changes its declaration FORM, breaking a consumer reading the declaration directly):

**1. `max_inline_bytes has no row in reyn-yaml.md's offload table`** (`test_offload_unify_3580.py:301`). The row was never actually lost from the doc -- the test's regex assumed exactly ONE plain-word column (Type) between the Field cell and the backtick-quoted Default cell; the new Axis column made it two (Axis, Type), so the fixed-shape regex silently stopped matching. Fixed by matching 1+ plain-word columns instead of exactly one.

**2. `the canonical default must live on TimeoutConfig.mcp_probe_seconds as the literal 5.0 -- found something else`** (`test_3475_probe_degradation_visibility_and_timeout_config.py:315`). **Judgment call, per the gate's own stated intent** ("exactly ONE literal 5.0 default exists ... the config definition is the canonical source"): the canonical default legitimately still lives as a literal `5.0` inside `field(default=5.0, ...)` -- the test's own AST helper was reading the outer declaration shape (now an `ast.Call`), not the default value it actually cares about. Fixed the test helper to unwrap a `field(...)` call to its own `default=` keyword before checking for the literal, which preserves the assertion's real intent (single source of truth for `5.0`) without changing what "canonical" means or touching the source declaration.

**3. Census** (`tests/` and `scripts/`, per the accept criterion -- 2 real instances via CI means "0 more" cannot be claimed without measuring): every `ast.parse`/`ast.walk` user and every `reyn-yaml.md` reader in both trees was checked for a `ReynConfig` field-declaration read. Only the 2 above touch a field's declaration shape directly; the rest either read real instances via `getattr` (`test_3501_untrusted_narrowing_opt_in.py`), read a table already gated by fixed column index and untouched by the Axis-column patch (`test_4206_slice1_profile_reload_class.py`'s reload-class table), or inspect unrelated AST shapes (env-var writes, event-kind vocab, etc). No further instances found.

**4. Docstring correction** (`runtime/preferences.py` / `runtime/bounding.py`, `_derive_preference_keys`/`_derive_bounding_keys`): the claim "this module has no other reason to need the full config tree at its own import time" was false, per lead-coder's own direct measurement -- `PREFERENCE_KEYS`/ `BOUNDING_KEYS` are evaluated at module scope, so the full tree loads at THIS module's own import time regardless of where the `import` statement sits (verified directly: moved the import to module scope and re-imported clean, no cycle). The real circular import lives in `runtime/budget/budget.py`'s own `_WARN_RATIO_PREFERENCE_KEYS` (fixed there via a PEP 562 `__getattr__` deferral, already landed); the lazy import kept in `preferences.py`/`bounding.py` is not load-bearing for that cycle and stays only for symmetry between the two. Both docstrings now say this.

Local gates re-run: `ruff check .` / `test_tier_audit.py --strict` (3 changed test files) / `verify_module_docstrings.py` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` -- all green. No `docs/` files touched this round (the doc content was never wrong, only the test's regex needed to see through the new column). 699 passed, 1 skipped (#4206-adjacent sweep + the 2 previously-red files), foreground, single run.


## Docs scope (documented, not silently narrowed)

3 tables deliberately left without an `Axis` column: the top-level "Declared in" summary table and the per-agent "reload class" table are **both CI-gate-checked** (`test_config_reference_declared_in_4206.py`, by fixed column index) — adding a column would need a matching gate update, and their own rows are section-level (spanning multiple axes) or already redundant with `PREFERENCE_KEYS`/`BOUNDING_KEYS` membership; the `cost` block's own Scope/Persists/Reset table's rows each cover 2 leaves with *different* axes (`hard_limit`=bounding, `warn_ratio`=preference), so a single per-row axis value would misrepresent it.

No ADR added — lead-coder's own 4-step prescription (the authoritative scope for this assignment) didn't call for one; happy to add one if wanted on review.

## Local gates (all green)
- `ruff check .`
- `python scripts/test_tier_audit.py --strict tests/config/test_4206_axis_coverage.py` — 8/8 clean
- `python scripts/verify_module_docstrings.py <all touched src files>`
- `python scripts/mypy_ratchet.py`
- `python scripts/flat_tests_ratchet.py`
- `python scripts/check_tests_path_literal_reference.py`
- `python scripts/check_bare_tests_import_reference.py`
- `python scripts/check_file_depth_reference.py`
- `python scripts/check_subprocess_reyn_pin.py`
- `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py` (docs/ touched, in that order)
- `pytest tests/config/ tests/llm/ tests/repo/test_config_reference_declared_in_4206.py tests/runtime/ -k "4206 or 4724 or bounding or preference or budget or profile or config"` — 674 passed, foreground, single run

## Test plan
- [x] 674 tests pass locally (foreground, single run)
- [x] `ruff check .` clean
- [x] All applicable local gates green (incl. the docs path-conditional gate, in order)
- [x] Strip-falsified: the axis-coverage gate itself verified to fail on a synthetic no-axis leaf and pass on a synthetic with-axis leaf; `BOUNDING_KEYS`/`PREFERENCE_KEYS` content pinned to their pre-migration values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51

