### PR TITLE
**[coder-brown]** — back off repeated MCP probe failures

### DIFF
--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -527,6 +527,7 @@ class RouterHostAdapter:
         # server re-probed on the next turn instead of being frozen as a
         # capability the model is never told about.
         self._mcp_tools_cache: dict[str, ToolsAnswered] | None = None
+        self._mcp_probe_cooldown_until: dict[str, float] = {}
         # FP-0037 S1: mtime of the cache file when we last loaded from it.
         # None = never loaded from disk. Used by maybe_reload_mcp_tools_cache_from_disk
         # to detect when the CLI has written a fresher version.
@@ -2596,7 +2597,12 @@ class RouterHostAdapter:
                 self._mcp_tools_cache = {}
 
         servers = self._mcp_servers_flat()
-        unanswered = [name for name in servers if name not in self._mcp_tools_cache]
+        import time
+        unanswered = [
+            name for name in servers
+            if name not in self._mcp_tools_cache
+            and time.monotonic() >= self._mcp_probe_cooldown_until.get(name, 0.0)
+        ]
         if not unanswered:
             return
 
@@ -2627,6 +2633,7 @@ class RouterHostAdapter:
                     reason="timeout",
                     per_server_timeout=per_server_timeout,
                 )
+                self._mcp_probe_cooldown_until[server_name] = time.monotonic() + 60.0
                 return server_name, ToolsUnknown(reason="timeout")
             except Exception as exc:  # noqa: BLE001 — adapter must never raise
                 self._events.emit(
@@ -2636,6 +2643,7 @@ class RouterHostAdapter:
                     per_server_timeout=per_server_timeout,
                     detail=repr(exc),
                 )
+                self._mcp_probe_cooldown_until[server_name] = time.monotonic() + 60.0
                 return server_name, ToolsUnknown(reason="exception", detail=repr(exc))
             # mcp_list_tools may return [{"error": "..."}] instead of raising.
             # #3520: an error sentinel and NO usable tool is the same non-answer
@@ -2648,6 +2656,7 @@ class RouterHostAdapter:
             raw = [t for t in (tools or []) if isinstance(t, dict)]
             cleaned = [t for t in raw if "error" not in t and t.get("name")]
             if not cleaned and any("error" in t for t in raw):
+                self._mcp_probe_cooldown_until[server_name] = time.monotonic() + 60.0
                 self._events.emit(
                     "mcp_tool_probe_degraded",
                     server=server_name,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
@@ -54,6 +55,9 @@ logger = logging.getLogger(__name__)
 # derive their own defaults from the SAME source instead of two independently
 # hardcoded ``5.0`` literals drifting apart.
 _DEFAULT_MCP_PROBE_SECONDS = TimeoutConfig().mcp_probe_seconds
+# Persistent failures should not make every turn pay the probe timeout; the
+# cooldown is temporary so a server that recovers is re-probed automatically.
+_MCP_PROBE_FAILURE_COOLDOWN_SECONDS: float = 60.0
 
 
 @dataclass(frozen=True)
@@ -501,6 +505,7 @@ class RouterHostAdapter:
         # legacy if/elif tool-dispatch tree) → `hooks_add`'s write-target
         # helper falls back to its pre-#4215 global-write behavior.
         session_state_dir_fn: "Callable[[], Path] | None" = None,
+        clock: "Callable[[], float] | None" = None,
     ) -> None:
         self._op_ctx_source = op_context_source
         self._mcp_gateway = mcp_gateway_inputs
@@ -511,6 +516,7 @@ class RouterHostAdapter:
         self._turn_budget_engine: Any = _TURN_BUDGET_ENGINE_UNSET
         self._turn_cancel_fn = turn_cancel_fn  # #1468
         self._session_state_dir_fn = session_state_dir_fn  # #4215①
+        self._clock = clock or time.monotonic
         self._agent_name = agent_name
         self._agent_role = agent_role
         self.output_language = output_language
@@ -2597,11 +2603,10 @@ class RouterHostAdapter:
                 self._mcp_tools_cache = {}
 
         servers = self._mcp_servers_flat()
-        import time
         unanswered = [
             name for name in servers
             if name not in self._mcp_tools_cache
-            and time.monotonic() >= self._mcp_probe_cooldown_until.get(name, 0.0)
+            and self._clock() >= self._mcp_probe_cooldown_until.get(name, 0.0)
         ]
         if not unanswered:
             return
@@ -2633,7 +2638,7 @@ class RouterHostAdapter:
                     reason="timeout",
                     per_server_timeout=per_server_timeout,
                 )
-                self._mcp_probe_cooldown_until[server_name] = time.monotonic() + 60.0
+                self._mcp_probe_cooldown_until[server_name] = self._clock() + _MCP_PROBE_FAILURE_COOLDOWN_SECONDS
                 return server_name, ToolsUnknown(reason="timeout")
             except Exception as exc:  # noqa: BLE001 — adapter must never raise
                 self._events.emit(
@@ -2643,7 +2648,7 @@ class RouterHostAdapter:
                     per_server_timeout=per_server_timeout,
                     detail=repr(exc),
                 )
-                self._mcp_probe_cooldown_until[server_name] = time.monotonic() + 60.0
+                self._mcp_probe_cooldown_until[server_name] = self._clock() + _MCP_PROBE_FAILURE_COOLDOWN_SECONDS
                 return server_name, ToolsUnknown(reason="exception", detail=repr(exc))
             # mcp_list_tools may return [{"error": "..."}] instead of raising.
             # #3520: an error sentinel and NO usable tool is the same non-answer
@@ -2656,7 +2661,7 @@ class RouterHostAdapter:
             raw = [t for t in (tools or []) if isinstance(t, dict)]
             cleaned = [t for t in raw if "error" not in t and t.get("name")]
             if not cleaned and any("error" in t for t in raw):
-                self._mcp_probe_cooldown_until[server_name] = time.monotonic() + 60.0
+                self._mcp_probe_cooldown_until[server_name] = self._clock() + _MCP_PROBE_FAILURE_COOLDOWN_SECONDS
                 self._events.emit(
                     "mcp_tool_probe_degraded",
                     server=server_name,

--- a/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
@@ -208,8 +208,10 @@ async def test_payload_regains_the_mcp_tool_enum_after_a_probe_that_timed_out(
         "a probe that did not answer cannot contribute tools to the enum"
     )
 
-    # Turn 2 — the same server, now healthy. The model must be told.
+    # Turn 2 — the same server, now healthy. Simulate the retry window
+    # elapsing without sleeping; the next call must re-probe.
     probe.healthy = True
+    adapter._mcp_probe_cooldown_until[_SERVER] = 0.0
     await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
     enum = _mcp_tool_enum(adapter)
     assert enum is not None and f"{_SERVER}.{_TOOL}" in enum, (
@@ -250,6 +252,21 @@ async def test_an_answered_catalog_is_not_reprobed_on_later_turns(
 # ---------------------------------------------------------------------------
 # 2. On-disk surface — an unknown must not survive a restart
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persistent_probe_failure_is_backed_off_until_retry_window(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a persistent probe failure is not retried on the next turn."""
+    state_dir = tmp_path / "state"
+    probe = _FlakyProbe()
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=probe)
+
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    assert probe.calls == [_SERVER]
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    assert probe.calls == [_SERVER]
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
+++ b/tests/runtime/test_3520_unknown_probe_is_not_an_answer.py
@@ -116,7 +116,7 @@ class _FlakyProbe:
         return [dict(t) for t in _TOOLS]
 
 
-def _make_adapter(*, tmp_path: Path, state_dir: Path, probe) -> RouterHostAdapter:
+def _make_adapter(*, tmp_path: Path, state_dir: Path, probe, clock=None) -> RouterHostAdapter:
     events = EventLog(subscribers=[])
     workspace = tmp_path / "agents" / "test-agent"
     memory = MemoryService(
@@ -152,6 +152,7 @@ def _make_adapter(*, tmp_path: Path, state_dir: Path, probe) -> RouterHostAdapte
         ),
         state_dir=state_dir,
         universal_wrappers_enabled=False,  # #4159: preserves prior implicit default
+        clock=clock,
     )
     # #3447 / existing convention in this suite: mcp_list_tools is a real
     # RouterHostAdapter method, so the probe is wired by shadowing that one
@@ -200,7 +201,10 @@ async def test_payload_regains_the_mcp_tool_enum_after_a_probe_that_timed_out(
     """
     state_dir = tmp_path / "state"
     probe = _FlakyProbe()
-    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=probe)
+    now = [0.0]
+    adapter = _make_adapter(
+        tmp_path=tmp_path, state_dir=state_dir, probe=probe, clock=lambda: now[0],
+    )
 
     # Turn 1 — the server is too slow for the deadline.
     await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
@@ -211,7 +215,7 @@ async def test_payload_regains_the_mcp_tool_enum_after_a_probe_that_timed_out(
     # Turn 2 — the same server, now healthy. Simulate the retry window
     # elapsing without sleeping; the next call must re-probe.
     probe.healthy = True
-    adapter._mcp_probe_cooldown_until[_SERVER] = 0.0
+    now[0] = 61.0
     await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
     enum = _mcp_tool_enum(adapter)
     assert enum is not None and f"{_SERVER}.{_TOOL}" in enum, (


### PR DESCRIPTION
**[coder-brown]** — Add a per-server negative cooldown to `ensure_mcp_tools_cached()`. Timeout, exception, and unusable error-sentinel probe outcomes are remembered for 60 seconds and skipped on subsequent turns; successful answers remain cached as before, and the cooldown can re-probe after expiry.

part of #4401

Checks: targeted pytest `7 passed`; ruff pass; Tier audit `7 inspected / 0 errors`.