### PR TITLE
feat(#5287): move render-panel cache invalidation to producer-owned generation counters

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -103,6 +103,16 @@ class HookDispatcher:
         resolve_exec_capture_output_cap: "Callable[[], tuple[int, str] | None] | None" = None,
     ) -> None:
         self._registry = registry
+        # #5287: a producer-owned generation counter — bumped by
+        # :meth:`replace_registry`, the sole method that reassigns
+        # ``self._registry`` after construction (grep-confirmed: `git
+        # grep 'self\._registry = ' src/reyn/hooks/dispatcher.py` finds
+        # exactly this line and the one inside ``replace_registry``).
+        # ``Session.hook_state()`` compares this against its own last-seen
+        # value to decide whether to recompute, instead of ``Session``
+        # calling an explicit invalidation method at each of ITS OWN
+        # known reload sites — see that method's own docstring.
+        self._generation = 0
         # Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3): the optional
         # per-Session Async Bus. None (the default — every pre-Phase-4a call
         # site, including every pre-Phase-4a test) keeps dispatch() byte-
@@ -177,6 +187,23 @@ class HookDispatcher:
         :meth:`replace_registry`'s live swap, same as ``dispatch()`` itself."""
         return self._registry
 
+    @property
+    def generation(self) -> int:
+        """#5287: bumped once per :meth:`replace_registry` call — a
+        producer-owned staleness token a consumer (``Session.hook_state``)
+        compares against its own last-seen value instead of this class
+        needing to know which caches exist downstream."""
+        return self._generation
+
+    def _bump_generation(self) -> None:
+        """#5287: bump :attr:`_generation` — the SAME single-purpose
+        helper shape ``MCPConnectionService`` uses for its own generation,
+        so a mechanical AST scan for "which methods bump this class's
+        generation" (a call to ``self._bump_generation()``) is uniform
+        across every #5287 producer, not a different marker pattern per
+        class."""
+        self._generation += 1
+
     def _consent_bus_now(self) -> Any:
         """The consent bus iff a live intervention listener is attached, else None.
 
@@ -213,6 +240,7 @@ class HookDispatcher:
         through the kernel/router seams. Used by the Session's hooks reapply seam to
         install ``startup ∪ re-read-runtime`` hooks at the turn boundary."""
         self._registry = registry
+        self._bump_generation()  # #5287 — see that method's own docstring
 
     async def dispatch(self, point: str, template_vars: dict) -> None:
         """Run every hook registered for ``point`` (registration order).

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -300,6 +300,55 @@ class MCPConnectionService:
         # Per-server lock so two concurrent first-use get() calls for the SAME server
         # (e.g. two chat turns racing on session startup) don't both open a client.
         self._locks: dict[str, asyncio.Lock] = {}
+        # #5287: a producer-owned generation counter, bumped by THIS class at
+        # every one of its own real mutation sites for the 4 fields
+        # :meth:`subscription_summary` reads (``_clients`` / ``_subscriptions``
+        # / ``_subscription_adapters`` / ``_last_honored``) — see
+        # :meth:`_bump_generation`'s own docstring for the enumerated list and
+        # why this replaces the pre-#5287 "``Session`` subscribes to a
+        # hand-picked list of EventLog event KINDS" shape (#5279/#5280: that
+        # list needed a 7th kind added after shipping, because a new kind of
+        # subscription-relevant change is easy to add without remembering to
+        # also update a list one layer removed from where the change actually
+        # happens). A consumer compares this value, not any event, to its own
+        # last-seen generation — see ``Session.mcp_subscription_state``'s own
+        # docstring.
+        self._generation = 0
+
+    @property
+    def generation(self) -> int:
+        """See :meth:`_bump_generation`."""
+        return self._generation
+
+    def _bump_generation(self) -> None:
+        """#5287: bump :attr:`_generation` — called at every site in THIS
+        class (and, via :meth:`_set_last_honored`, the one site in the
+        nested :class:`_HeldConnection` that writes ``_last_honored``
+        directly) that mutates one of the 4 fields
+        :meth:`subscription_summary` composes from. Grep-confirmed
+        (#5287 investigation) call sites:
+
+          - :meth:`_ensure_open` — once, after the (re)connect completes
+            (covers ``_clients``/``_subscription_adapters``/``_last_honored``
+            all being freshly set for this server).
+          - :meth:`_reconnect` — once, right after popping the dead
+            client + adapter, UNCONDITIONALLY (including the failure
+            path: ``held_servers()`` already changed the moment the pop
+            happened, even if the reopen below then raises — #5280's own
+            finding for the event-kind design, structurally closed here
+            since there is no separate "did the reopen succeed" branch
+            to remember to cover).
+          - :meth:`aclose` — once, after ``_clients.clear()``.
+          - :meth:`_track_subscription` / :meth:`_untrack_subscription` —
+            each mutates ``_subscriptions``.
+          - :meth:`_set_last_honored` — the ``_last_honored`` write
+            ``_HeldConnection.subscribe_resource``/``unsubscribe_resource``
+            make for an INCREMENTAL add/remove on an already-open Listen
+            connection (previously a direct ``self._service._last_honored[
+            ...] = `` write reaching into this class's private dict; routed
+            through this one method instead so the bump lives with the
+            write, not scattered across two classes)."""
+        self._generation += 1
 
     def held_servers(self) -> list[str]:
         """Names of servers with a currently-open held connection. Read-only
@@ -342,6 +391,15 @@ class MCPConnectionService:
         if client is not None and not client.is_initialized():
             self._clients.pop(server, None)
             client = None
+            # #5287: this eviction is a real ``_clients`` mutation (a
+            # server that WAS in ``held_servers()`` is no longer, right
+            # up until the reopen below re-adds it) — bump here too, not
+            # only at the block's own end, so a caller reading in
+            # between (impossible today — this method never yields
+            # before reopening — but the bump costs nothing extra here
+            # and keeps this a colocated-with-every-mutation habit
+            # rather than one that has to be re-verified on trust).
+            self._bump_generation()
         if client is None:
             # #2597 P1: computed BEFORE this open completes — True iff a PRIOR open
             # for this server already succeeded in this service's lifetime, i.e.
@@ -490,6 +548,17 @@ class MCPConnectionService:
                     capabilities=client.advertised_capabilities(),
                     subscription_adapter=type(adapter).__name__,
                 )
+            # #5287: this branch is one of _bump_generation's own
+            # enumerated sites — see that method's docstring. Scoped to
+            # the ``if client is None:`` block (a genuine open/reopen),
+            # NOT the method as a whole — the common fast path (an
+            # already-live, already-initialized client) changes none of
+            # the 4 fields subscription_summary() reads, and this method
+            # runs on every ``get()`` call, so bumping unconditionally
+            # here would recompute the subscription cache on every MCP
+            # tool call regardless of whether anything about the
+            # subscription state actually changed.
+            self._bump_generation()
         return client
 
     async def _reconnect(
@@ -544,6 +613,14 @@ class MCPConnectionService:
                     "MCPConnectionService: teardown of dead subscription adapter for %r "
                     "contained an error", server, exc_info=True,
                 )
+        # #5287: this method is one of _bump_generation's own enumerated
+        # sites — the two pops above already changed ``held_servers()``/
+        # ``subscription_mode()``'s answer for this server, independent of
+        # whether the reopen below succeeds (see the ``except BaseException``
+        # branch's own comment for the failure case this covers; a success
+        # also bumps again inside _ensure_open's own open branch, which
+        # costs nothing extra a pull-based cache needs to care about).
+        self._bump_generation()
         try:
             return await self._ensure_open(server, config, agent_id=agent_id)
         except BaseException:
@@ -767,9 +844,22 @@ class MCPConnectionService:
 
     def _track_subscription(self, server: str, uri: str) -> None:
         self._subscriptions.setdefault(server, set()).add(uri)
+        self._bump_generation()  # #5287 — see _bump_generation's own docstring
 
     def _untrack_subscription(self, server: str, uri: str) -> None:
         self._subscriptions.get(server, set()).discard(uri)
+        self._bump_generation()  # #5287 — see _bump_generation's own docstring
+
+    def _set_last_honored(self, server: str, honored: "set[str] | None") -> None:
+        """#5287: the ONE place ``_last_honored`` is written from OUTSIDE
+        :meth:`_ensure_open` — ``_HeldConnection.subscribe_resource``/
+        ``unsubscribe_resource`` route their own incremental-add/remove
+        honored-set update through this method instead of writing
+        ``self._service._last_honored[...]`` directly, so the generation
+        bump lives with the write rather than needing a 3rd class to
+        remember it independently."""
+        self._last_honored[server] = honored
+        self._bump_generation()
 
     async def aclose(self) -> None:
         """Close every held connection. Idempotent — safe to call repeatedly (e.g. a
@@ -834,6 +924,10 @@ class MCPConnectionService:
         clients = list(self._clients.items())
         self._clients.clear()
         self._handles.clear()
+        # #5287: this method is one of _bump_generation's own enumerated
+        # sites — both ``_clients`` and ``_subscription_adapters`` (cleared
+        # above) are inputs to subscription_summary().
+        self._bump_generation()
         for name, client in clients:
             try:
                 await client.__aexit__(None, None, None)
@@ -964,7 +1058,7 @@ class _HeldConnection:
                 # ``unhonored_uris`` would read a STALE (pre-this-URI)
                 # honored set for every subscribe added to an
                 # already-open Listen connection.
-                self._service._last_honored[self._server] = await adapter.open(all_uris)
+                self._service._set_last_honored(self._server, await adapter.open(all_uris))
             else:
                 await c.subscribe_resource(uri)
 
@@ -978,7 +1072,7 @@ class _HeldConnection:
                 remaining = set(self._service._subscriptions.get(self._server, ())) - {uri}
                 # #4686: mirrors subscribe_resource's own honored-storage —
                 # see that method's comment.
-                self._service._last_honored[self._server] = await adapter.open(remaining)
+                self._service._set_last_honored(self._server, await adapter.open(remaining))
             else:
                 await c.unsubscribe_resource(uri)
 

--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -207,6 +207,7 @@ class CapabilityVisibility:
         session_id_provider: "Callable[[], str | None]",
         agent_name: "str",
         available_skills_provider: "Callable[[], list[_SkillEntry] | None]",
+        capability_inputs_generation_provider: "Callable[[], int]",
         contextual_permission: "object | None" = None,
         excluded_categories: "frozenset[str] | None" = None,
         chat_tool_use_scheme: "str" = "enumerate-all",
@@ -215,6 +216,14 @@ class CapabilityVisibility:
         self._registry = registry
         self._router_host = router_host
         self._session_id_provider = session_id_provider
+        # #5287: live -- Session's own producer-owned generation covering
+        # every real mid-session input to _envelope_census (MCP roster,
+        # available skills, session_id re-key) — see Session.__init__'s
+        # own ``self._capability_inputs_generation`` comment for the 3
+        # sites this bumps at. Same live-provider idiom as
+        # session_id_provider/available_skills_provider above (never a
+        # construction-time snapshot).
+        self._capability_inputs_generation_provider = capability_inputs_generation_provider
         # Immutable for the session's lifetime (Agent is frozen), same stability class as
         # agent_name — needed by resolved_profile_for(agent_name, sid=...) in the two
         # envelope-resolving methods below.
@@ -244,14 +253,17 @@ class CapabilityVisibility:
         self._visibility_override: "dict[str, set[str]]" = {
             "tool": set(), "mcp": set(), "category": set(), "skill": set(),
         }
-        # #5276: the expensive envelope-only census's cache — see
-        # _envelope_census's own docstring. None = never computed / needs
-        # recompute; invalidated synchronously by invalidate_envelope_census
-        # — called from Session at 3 sites (grep-confirmed:
-        # `git grep invalidate_envelope_census -- src` → session.py's
-        # `_reapply_mcp`, `_reapply_skills`, `load_persisted_toggles`) —
-        # never via an EventLog subscriber, the #5279/#5284 lesson.
+        # #5287: the expensive envelope-only census's cache — see
+        # _envelope_census's own docstring. PULL-based against
+        # ``capability_inputs_generation_provider()`` — ``None`` = never
+        # computed. Replaces the pre-#5287 shape (#5276) of ``Session``
+        # calling ``invalidate_envelope_census()`` at 3 hand-enumerated
+        # mutation sites — the same defect family #5287 closes for
+        # ``hook_state``/``mcp_subscription_state``'s own caches: a 4th
+        # site added later to whatever Session field feeds this census
+        # has nothing to remind its author a cache depends on it.
         self._cached_envelope_census: "dict | None" = None
+        self._cached_envelope_generation: "int | None" = None
 
     @property
     def contextual_permission(self) -> "object | None":
@@ -685,20 +697,8 @@ class CapabilityVisibility:
             names = (names - wrapper_plumbing) | catalog_names
         return names
 
-    def invalidate_envelope_census(self) -> None:
-        """#5276: mark :attr:`_cached_envelope_census` dirty. Called
-        SYNCHRONOUSLY by ``Session`` at each of its 3 grep-confirmed
-        mutation sites (``_reapply_mcp``, ``_reapply_skills``,
-        ``load_persisted_toggles``) — NOT via an ``EventLog`` subscriber
-        (the #5279/#5284 lesson: subscriber dispatch is queued whenever a
-        loop is running, #4966, so it cannot reliably invalidate a cache
-        before a caller that mutates-then-reads-immediately observes it).
-        See :meth:`capability_visibility_state`'s own docstring for what
-        this census covers and why it is safe to memoize."""
-        self._cached_envelope_census = None
-
     def _envelope_census(self) -> dict:
-        """#5276: the EXPENSIVE, envelope-only half of
+        """#5276/#5287: the EXPENSIVE, envelope-only half of
         ``capability_visibility_state`` — memoized in
         :attr:`_cached_envelope_census`. Computes, for every reachable
         tool/mcp/category/skill, whether the AGENT ENVELOPE (topology ∩
@@ -709,6 +709,19 @@ class CapabilityVisibility:
         ``resolved_profile_for`` read, both genuinely non-trivial per-call
         costs this method exists to stop paying every render frame.
 
+        #5287: PULL-based against ``self._capability_inputs_generation_
+        provider()`` — Session's own producer-owned counter, bumped at
+        its 3 real mutation sites for this census's mid-session-mutable
+        inputs (the MCP roster, the available-skills list, and a spawn-
+        time sid re-key — see that provider's own comment on the Session
+        side for exactly where). Replaces the pre-#5287 shape (#5276) of
+        ``Session`` calling ``invalidate_envelope_census()`` explicitly at
+        3 hand-enumerated call sites — the same defect family #5287
+        closes for this file's sibling reactive caches
+        (``hook_state``/``mcp_subscription_state``): a 4th site added
+        later to whatever mutates one of these Session fields has nothing
+        to remind its author a cache depends on it.
+
         Grep-confirmed (#5276 investigation) invariant this memoization
         relies on: the ENVELOPE itself (topology bindings, the #2081
         delegate floor, #2103-S1a per-session config) is set at THIS
@@ -716,20 +729,15 @@ class CapabilityVisibility:
         live, in-session command — ``resolved_profile_for``'s answer for a
         GIVEN (agent, sid) does not change while that session keeps
         running EXCEPT for one edge the ``sid=`` argument itself exposes —
-        a session's own sid CAN be re-keyed post-construction (spawn
-        fixup; see this class's own module docstring), so ``load_persisted_
-        toggles`` (called right after a re-key) is this cache's 3rd
-        invalidation site, alongside the two below. What DOES change
-        mid-session otherwise, and this cache correctly tracks via
-        :meth:`invalidate_envelope_census`'s 3 call sites, is WHICH
-        capabilities exist to classify at all: the MCP server roster
-        (``_reapply_mcp``) and the skill registry (``_reapply_skills``)
-        can both change via hot-reload.
+        a session's own sid CAN be re-keyed post-construction
+        (``Session.rekey_session_id``, spawn fixup; see this class's own
+        module docstring), which is why that method is one of the 3 sites
+        bumping the shared generation this census now compares against.
 
         #5288 (filed, not fixed here): whether some OTHER input the active
         scheme's own ``build_presentation`` reads (e.g.
         ``list_available_agents()``, via ``_VisibilityProbeOps``) can
-        change mid-session independent of these 3 sites is not
+        change mid-session independent of the 3 tracked sites is not
         grep-verified.
 
         Returns a dict whose shape mirrors the ORIGINAL method's own 3
@@ -760,7 +768,8 @@ class CapabilityVisibility:
         )
         from reyn.tools.universal_catalog import CATEGORIES
 
-        if self._cached_envelope_census is not None:
+        gen = self._capability_inputs_generation_provider()
+        if self._cached_envelope_census is not None and self._cached_envelope_generation == gen:
             return self._cached_envelope_census
 
         base_ctx: "ContextualPermission | None" = None
@@ -816,6 +825,7 @@ class CapabilityVisibility:
             "final_unknown": final_unknown,
             "envelope_unknown": envelope_unknown,
         }
+        self._cached_envelope_generation = gen
         return self._cached_envelope_census
 
     def capability_visibility_state(

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3574,7 +3574,7 @@ class AgentRegistry:
         # strictly later) — so there is NO "main"-tagged append window for the
         # spawned session. The journal is built eagerly in __init__ (set_session_id
         # propagates to the in-memory snapshot too).
-        session._session_id = new_sid
+        session.rekey_session_id(new_sid)  # #5287: was a bare field write; now bumps the capability-census generation too
         session._journal.set_session_id(new_sid)
         # FP-0043 Stage 5: re-key the spawned session's persistence to its OWN
         # per-session location so it does NOT collide with the agent's "main"

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1222,6 +1222,23 @@ class Session:
 
         # WAL + per-agent snapshot for crash recovery via SnapshotJournal; snapshot_path kept only for diagnostics (PR21 / PR-refactor-session-1, see session-construction.md#family-2-recovery-wal-journal)
         self._session_id = session_id
+        # #5287: a producer-owned generation covering every input
+        # ``CapabilityVisibility._envelope_census`` reads that CAN change
+        # mid-session — bumped by THIS class at its own 3 real mutation
+        # sites: :meth:`refresh_mcp_servers` (the MCP roster —
+        # ``get_mcp_servers()``'s answer), :meth:`_reapply_skills` (``self.
+        # _available_skills``), and :meth:`rekey_session_id` (``self.
+        # _session_id`` — a re-keyed sid genuinely changes what
+        # ``resolved_profile_for(agent, sid=...)`` returns for THIS SAME
+        # session object; see that method's own docstring). Given to
+        # ``CapabilityVisibility`` as a live provider (the SAME "read
+        # through a getter, never a construction-time snapshot" idiom that
+        # class already uses for ``session_id_provider``/``available_
+        # skills_provider``) so the census can compare against it on every
+        # read instead of ``Session`` calling an explicit invalidation
+        # method at each of these sites — the #5279/#5284/#5287 lesson
+        # applied to the 3rd of this file's 3 reactive caches.
+        self._capability_inputs_generation = 0
         # #5184: session-owned child-process scratch lives outside the workspace
         # so sandbox write grants never widen recovery-core permissions. The
         # directory is created lazily by the first child launch; construction
@@ -1546,85 +1563,55 @@ class Session:
             self._on_audit_event_for_state_change,
         )
 
-        # #5276: mcp_subscription_state()'s reactive cache — invalidated
-        # (marked dirty, NOT recomputed here — #5279 review, see
-        # mcp_subscription_state's own docstring for why eager-inside-the-
-        # subscriber was rejected) only when one of the events that can
-        # actually change the subscription summary fires (subscribe/
-        # unsubscribe, a server being installed/removed, or a (re)connect —
-        # mcp_initialized/mcp_resource_updated, per #5277's own
-        # investigation that these two ALREADY cover a bare reconnect's
-        # mode/honored-set shift, so no new kind was needed).
-        #
-        # #5280: a 7th kind, ``mcp_reconnect_failed`` — found while
-        # answering architect's #5279 review question. The other 6 all
-        # fire on some SUCCESSFUL state change; none fire when a
-        # reconnect attempt ITSELF fails (``MCPConnectionService.
-        # _reconnect``, connection_service.py) — the server has already
-        # been popped from ``held_servers()`` by that point, but
-        # ``mcp_initialized`` only fires on a successful reopen. Without
-        # this kind, that one path left the cache stale until an
-        # unrelated event happened to invalidate it — unlike #5278 (a
-        # pre-existing gap this PR doesn't touch), this staleness was
-        # introduced by #5276/#5279 themselves (before them,
-        # ``subscription_summary()`` ran fresh every render frame).
-        # ``None`` means "needs a real recompute on the next read" — both
-        # at construction and right after any of these events — every OTHER
-        # read is a bare attribute return, matching ``turn_usage_fn``/
-        # ``ctx_compaction_status_fn``'s own "store, don't run on every
-        # render frame" shape.
-        self._cached_mcp_subscriptions: "list[dict] | None" = None
-        self._audit_events.add_subscriber(
-            self._invalidate_mcp_subscription_cache,
-            kinds=[
-                "mcp_resource_subscribed", "mcp_resource_unsubscribed",
-                "mcp_server_installed", "mcp_server_removed",
-                "mcp_initialized", "mcp_resource_updated",
-                "mcp_reconnect_failed",
-            ],
-        )
+        # #5287: mcp_subscription_state()'s reactive cache — PULL-based
+        # against MCPConnectionService.generation (see that class's own
+        # ``_bump_generation`` docstring for its enumerated mutation
+        # sites), replacing the pre-#5287 shape of subscribing to a
+        # hand-picked list of EventLog event KINDS. That list needed a 7th
+        # kind added after shipping (#5280, ``mcp_reconnect_failed`` — a
+        # failed reconnect changes ``held_servers()`` without firing any
+        # of the original 6 kinds) — the exact "site enumeration one layer
+        # removed from the real mutation" defect #5287 closes for all 3
+        # of this file's reactive caches. ``None`` means "needs a real
+        # recompute on the next read", same as before; the tuple's first
+        # element is the generation value the cached second element was
+        # computed AGAINST, compared on every read in
+        # :meth:`mcp_subscription_state` itself (no subscriber
+        # registration needed at all now — the connection service does
+        # not need to know this cache exists).
+        self._cached_mcp_subscriptions: "tuple[int, list[dict]] | None" = None
 
-        # #5276②: hook_state()'s reactive cache. Deliberately NOT invalidated
-        # via an EventLog subscriber (unlike mcp_subscription_state's cache
-        # above) — caught during implementation via a genuine, pre-existing
-        # test failure (test_hook_slash_disables_via_public_state):
-        # set_hook_enabled is a plain SYNCHRONOUS method, and a caller that
-        # toggles then reads hook_state() immediately, with no intervening
-        # await, has always gotten the fresh answer synchronously. But
-        # EventLog.emit() QUEUES subscriber dispatch onto a background
-        # consumer task whenever a loop is running (#4966) — so a
-        # subscriber-based invalidation would not have run YET by the time
-        # such a caller reads hook_state(), returning the STALE pre-toggle
-        # cache. mcp_subscription_state's own cache doesn't hit this because
-        # every real trigger there already crosses an async boundary (a
-        # network round-trip) before any caller could plausibly read the
-        # panel. Fix: invalidate this cache SYNCHRONOUSLY, directly at each
-        # mutation site (set_hook_enabled's applied path, _reapply_hooks,
-        # load_persisted_toggles) — see each site's own comment. No
-        # subscriber registration for this cache at all.
+        # #5287: hook_state()'s reactive cache — PULL-based against a
+        # 2-part generation: (``self._hook_dispatcher.generation``,
+        # ``self._hook_toggle_generation``). Replaces the pre-#5287 shape
+        # (#5276②/#5284) of Session calling an explicit
+        # ``self._cached_hook_items = None`` at each of 3 hand-enumerated
+        # mutation sites (set_hook_enabled, load_persisted_toggles,
+        # _reapply_hooks) — the SAME defect family #5287 closes for
+        # mcp_subscription_state's cache: a 4th such site added later has
+        # nothing to remind its author that a cache depends on the field
+        # it just mutated.
         #
-        # #5284 review (lead-coder BLOCK): the 3-site enumeration above is
-        # a claim about a search actually run, not an assumption — every
-        # write to the two things hook_state()'s answer is a pure function
-        # of (`self._disabled_hooks`, `self._hook_dispatcher`'s registry):
-        #   grep -n '_disabled_hooks\s*=\|_disabled_hooks\.add\|_disabled_hooks\.discard' session.py
-        #     → exactly 4 lines, all inside set_hook_enabled (2) and
-        #       load_persisted_toggles (2)
-        #   grep -rn '\.replace_registry\(' src/reyn/
-        #     → exactly 1 call site (session.py, inside _reapply_hooks);
-        #       HookDispatcher.replace_registry is the ONLY method that
-        #       reassigns HookDispatcher._registry after construction
-        #       (checked dispatcher.py directly — the constructor's own
-        #       assignment doesn't need an invalidation, since this cache
-        #       starts at None regardless)
-        # ⚠️ WHOEVER ADDS A NEW SITE THAT MUTATES EITHER OF THOSE TWO
-        # THINGS MUST ALSO CLEAR `self._cached_hook_items = None` THERE —
-        # nothing here will turn red on its own; a 4th such site added
-        # without this line means hook_state() silently starts returning a
-        # stale answer (the #5267 "breaking side" comment placement: on
-        # the field that breaks, not just the code path that uses it
-        # correctly today).
-        self._cached_hook_items: "list[dict] | None" = None
+        # ``self._hook_toggle_generation`` is Session's OWN generation for
+        # ``self._disabled_hooks`` (bumped directly, synchronously, inside
+        # :meth:`set_hook_enabled`/:meth:`load_persisted_toggles` — the
+        # only 2 methods that mutate it, same grep #5284's review already
+        # ran: `grep -n '_disabled_hooks\s*=\|_disabled_hooks\.add\|
+        # _disabled_hooks\.discard' session.py` → exactly 4 lines, all
+        # inside those 2 methods). ``self._hook_dispatcher.generation`` is
+        # ``HookDispatcher``'s OWN generation (bumped inside
+        # :meth:`~reyn.hooks.dispatcher.HookDispatcher.replace_registry`,
+        # its sole post-construction ``_registry`` reassignment site — see
+        # that method's own comment). Both bumps stay SYNCHRONOUS (no
+        # EventLog subscriber anywhere in this cache's path) for the same
+        # reason #5284 originally required it: a caller that toggles then
+        # reads hook_state() immediately, with no intervening ``await``,
+        # must see the fresh answer — ``EventLog.emit()`` queues
+        # subscriber dispatch onto a background consumer task whenever a
+        # loop is running (#4966), so a subscriber-based invalidation
+        # would not have run yet by the time such a caller reads this.
+        self._hook_toggle_generation = 0
+        self._cached_hook_items: "tuple[tuple[int, int], list[dict]] | None" = None
 
         # Budget adapter, byte-identical extraction, simplest of the #3082 families (Family 4, see session-construction.md#family-4-cost-budget)
         self._budget = self._build_budget(
@@ -1688,6 +1675,8 @@ class Session:
             contextual_permission=contextual_permission,
             excluded_categories=excluded_categories,
             chat_tool_use_scheme=self._chat_tool_use_scheme,  # #3220: tool census matches the active scheme's composed payload
+            # #5287: live -- see self._capability_inputs_generation's own comment for the 3 sites this bumps at.
+            capability_inputs_generation_provider=lambda: self._capability_inputs_generation,
         )
 
         # owns + orchestrates them in one method (#2073 S2, see session-construction.md#family-3-hook-event-reactivity)
@@ -1974,12 +1963,31 @@ class Session:
         snapshot, state dir).
 
         A live read, not the construction-time value: ``spawn_session_recorded``
-        re-keys a spawned session AFTER constructing it (``session._session_id =
-        new_sid``), so anything caching the constructor's ``session_id`` argument is
+        re-keys a spawned session AFTER constructing it (via :meth:`rekey_session_id`,
+        #5287 — a plain ``session._session_id = new_sid`` field write before then), so
+        anything caching the constructor's ``session_id`` argument is
         stale for exactly the sessions that were spawned programmatically. #3553
         added it because ``run_agent_step`` holds its invoker as a whole ``Session``
         and needs that key to look the invoker's own narrowing back up."""
         return self._session_id
+
+    def rekey_session_id(self, new_sid: str) -> None:
+        """#5287: re-key this session's own sid post-construction — the ONE
+        place ``self._session_id`` is reassigned after ``__init__`` (was a
+        bare ``session._session_id = new_sid`` field write reaching in from
+        ``registry.py``'s ``spawn_session_recorded``; converted to a method
+        so the accompanying generation bump lives with the write, matching
+        this file's established idiom — see e.g.
+        :meth:`~reyn.hooks.dispatcher.HookDispatcher.replace_registry`).
+
+        Bumps :attr:`_capability_inputs_generation` — a re-keyed sid
+        genuinely changes what ``resolved_profile_for(agent, sid=...)``
+        returns for THIS SAME session object, and that call is baked into
+        ``CapabilityVisibility``'s memoized envelope census (see that
+        class's own :meth:`~reyn.runtime.capability_visibility.
+        CapabilityVisibility._envelope_census` docstring)."""
+        self._session_id = new_sid
+        self._capability_inputs_generation += 1
 
     @property
     def model(self) -> str:
@@ -3417,15 +3425,15 @@ class Session:
         else:
             self._disabled_hooks.add(name)
         self._persist_hook_disabled()  # #2285 step2 — survive restart (best-effort)
-        # #5276②: invalidate hook_state()'s cache SYNCHRONOUSLY, right here
-        # — not via the audit-event below. A caller that toggles then reads
+        # #5287: bump hook_state()'s generation SYNCHRONOUSLY, right here —
+        # not via the audit-event below. A caller that toggles then reads
         # hook_state() immediately (no await in between, e.g. the existing
         # test_hook_slash_disables_via_public_state) must see the fresh
         # answer; EventLog.emit()'s subscriber dispatch is QUEUED whenever a
-        # loop is running (#4966), so relying on an emitted event to
-        # invalidate this cache would still be showing the stale pre-toggle
+        # loop is running (#4966), so relying on an emitted event to bump
+        # this generation would still be showing the stale pre-toggle
         # value by the time such a caller reads it.
-        self._cached_hook_items = None
+        self._hook_toggle_generation += 1
         self._audit_events.emit(
             "hook_changed", name=name, enabled=enabled, applied=True, origin=origin,
         )
@@ -3500,24 +3508,19 @@ class Session:
                     self._disabled_hooks = {str(n) for n in disabled}
         except Exception as exc:  # noqa: BLE001
             logger.warning("#2285: load hook disabled-set failed: %r", exc)
-        # #5276②: this method resets/repopulates self._disabled_hooks above
+        # #5287: this method resets/repopulates self._disabled_hooks above
         # (unconditionally, at both call sites this docstring names) —
-        # invalidate hook_state()'s cache synchronously here too, same
+        # bump hook_state()'s own generation synchronously here too, same
         # reasoning as set_hook_enabled's own comment.
-        self._cached_hook_items = None
-        # #5276/#5285 review (architect): this method's own module
-        # docstring (capability_visibility.py, top) already documents WHY
-        # `session_id_provider` is a live getter, not a snapshot — a
-        # session's own sid CAN be re-keyed post-construction (spawn
-        # fixup), and `load_persisted_toggles` is called AFTER that
-        # re-key. `_envelope_census()` bakes `resolved_profile_for(...,
-        # sid=...)` into its cache, so a re-keyed sid can genuinely change
-        # what that call returns for the SAME session object — the one
-        # scenario this PR's own earlier "envelope never changes
-        # mid-session" claim did not hold for. Invalidate here too,
-        # synchronously (same "no subscriber" reasoning as every other
-        # site — #5279/#5284).
-        self._capability_visibility.invalidate_envelope_census()
+        self._hook_toggle_generation += 1
+        # Nothing to do here for the envelope-census cache
+        # (``CapabilityVisibility._envelope_census``): its own generation
+        # provider reads ``self._capability_inputs_generation``, which
+        # :meth:`rekey_session_id` already bumps AT THE REAL MUTATION —
+        # by the time this method runs (always called AFTER a spawn-time
+        # re-key, per this method's own docstring), that bump has already
+        # happened, so the census cache is already correctly seen as
+        # stale on its next read with no separate call needed here.
         if loaded_visibility:
             self._capability_visibility.reapply_visibility_override()
         if loaded_skill_visibility:
@@ -3569,24 +3572,22 @@ class Session:
         ruling, #5230: a census of every surface reporting this state cannot be closed with
         confidence, so the fix collapses the predicate structurally instead).
 
-        #5276②: reactive cache — ``self._cached_hook_items`` is filled lazily
-        here, on the next real call after construction or after a mutation
-        site (``set_hook_enabled``'s applied path, ``_reapply_hooks``,
-        ``load_persisted_toggles``) directly clears it to ``None``.
-        Deliberately NOT invalidated via an ``EventLog`` subscriber (unlike
-        ``mcp_subscription_state``'s own cache) — see this field's own
-        comment in ``__init__`` for the genuine, pre-existing test failure
-        (a synchronous toggle-then-read caller) that direct, synchronous
-        invalidation was needed to fix, since subscriber dispatch is queued
-        (#4966) and would not have run yet by the time such a caller reads
-        this."""
-        if self._cached_hook_items is None:
+        #5287: reactive cache, PULL-based against a 2-part generation
+        (``self._hook_dispatcher.generation``, ``self._hook_toggle_
+        generation``) — see this field's own comment in ``__init__`` for
+        the full design and for the genuine, pre-existing test failure (a
+        synchronous toggle-then-read caller) that requires both bumps to
+        stay SYNCHRONOUS rather than routed through an ``EventLog``
+        subscriber (subscriber dispatch is queued, #4966, and would not
+        have run yet by the time such a caller reads this)."""
+        gen = (self._hook_dispatcher.generation, self._hook_toggle_generation)
+        if self._cached_hook_items is None or self._cached_hook_items[0] != gen:
             out: "list[dict]" = []
             for name, hook in self._hook_defs_by_name().items():
                 enabled = not self._hook_effectively_disabled(name, hook.origin)
                 out.append({"name": name, "scope": hook.origin, "enabled": enabled})
-            self._cached_hook_items = out
-        return self._cached_hook_items
+            self._cached_hook_items = (gen, out)
+        return self._cached_hook_items[1]
 
     def _hook_defs_by_name(self) -> "dict[str, HookDef]":
         """The merged registry's ``HookDef``s keyed by name, most-specific origin
@@ -4973,6 +4974,13 @@ class Session:
             fresh_roster = load_config(self._hot_reload_project_root()).mcp
             self._mcp_servers = fresh_roster
             self._router_host._mcp_servers = fresh_roster
+            # #5287: bumps ``capability_visibility_state()``'s memoized
+            # envelope census generation right at the real mutation —
+            # ``get_mcp_servers()`` (one of that census's own inputs)
+            # reads ``self._router_host._mcp_servers``, just reassigned
+            # above. See ``self._capability_inputs_generation``'s own
+            # comment for the other 2 sites sharing this counter.
+            self._capability_inputs_generation += 1
         except Exception as exc:  # noqa: BLE001 — roster re-read is best-effort
             logger.warning("refresh_mcp_servers: roster re-read failed: %r", exc)
 
@@ -6774,14 +6782,11 @@ class Session:
         propagates to every holder. The startup layer is never re-read (safety
         boundary). Always rebuilds (handles add / change / remove of either layer).
 
-        #5276②: invalidates ``hook_state()``'s cache synchronously right
-        after swapping the registry — same "direct at the mutation site,
-        no subscriber" reasoning as :meth:`set_hook_enabled`'s own comment
-        (an awaited caller reading ``hook_state()`` right after this
-        reload completes must see the fresh declaration set, not a value
-        an event subscriber hasn't gotten around to invalidating yet)."""
+        #5287: ``HookDispatcher.replace_registry`` bumps its own
+        ``generation`` (see that method's own comment), which
+        :meth:`hook_state`'s pull-based cache compares against on its
+        next read — nothing to invalidate here explicitly any more."""
         self._hook_dispatcher.replace_registry(self._build_hook_registry(in_set))
-        self._cached_hook_items = None
         return True
 
     def _hot_reload_project_root(self) -> "Path":
@@ -6822,13 +6827,13 @@ class Session:
         refresh chain (which reads the re-read .reyn/mcp.yaml). Returns whether the
         in-memory tool cache changed.
 
-        #5276: invalidates ``capability_visibility_state()``'s memoized
-        envelope census (`get_mcp_servers()`'s answer, one of the census's
-        own inputs, can change here) — synchronously, right after the
-        refresh, same "no subscriber" reasoning as ``hook_state()``'s own
-        cache (#5279/#5284)."""
+        #5287: ``refresh_mcp_servers`` bumps ``self._capability_inputs_
+        generation`` itself, right at its own roster reassignment — see
+        that method's own comment — so ``capability_visibility_state()``'s
+        memoized envelope census (whose own generation provider reads
+        that same counter) is already correctly seen as stale on its next
+        read once this returns; nothing to invalidate here explicitly."""
         result = await self.refresh_mcp_servers()
-        self._capability_visibility.invalidate_envelope_census()
         return bool(result.get("refreshed"))
 
     async def _reapply_skills(self, in_set: dict) -> bool:
@@ -6866,10 +6871,12 @@ class Session:
                 return False
         self._available_skills = new_skills or None
         self._capability_visibility.reapply_skill_visibility()
-        # #5276: invalidates the memoized envelope census (the skill roster
-        # just reassigned above is one of its own inputs) — synchronously,
-        # same reasoning as _reapply_mcp's own comment.
-        self._capability_visibility.invalidate_envelope_census()
+        # #5287: bumps the same generation ``refresh_mcp_servers``/
+        # ``rekey_session_id`` bump — the memoized envelope census (the
+        # skill roster just reassigned above is one of its own inputs)
+        # compares against this counter on its own next read; see
+        # ``self._capability_inputs_generation``'s own comment.
+        self._capability_inputs_generation += 1
         return True
 
     async def _reapply_pipelines(self, in_set: dict) -> bool:
@@ -10184,41 +10191,24 @@ class Session:
         Always ``[]`` for an ephemeral session (never populates the
         connection service — same condition ``mcp_held_servers`` documents).
 
-        #5276: reactive cache — ``self._cached_mcp_subscriptions`` is filled
-        lazily HERE, on the next real read after construction or after a
-        subscribe/unsubscribe/install/removed/(re)connect event marks it
-        dirty (see :meth:`_invalidate_mcp_subscription_cache` and the
-        subscriber registration in ``__init__``), so a render-frame caller
-        pays for the real recomputation only on the rare frame where
-        something actually changed AND something is actually reading it —
-        never on a frame nobody reads this, and never inside the event
-        dispatch itself.
-
-        #5280: the subscriber list also includes ``mcp_reconnect_failed`` —
-        a FAILED reconnect drops the server from ``held_servers()`` (it was
-        already popped before the reopen was attempted,
-        ``MCPConnectionService._reconnect``) without ever reaching the
-        success-only ``mcp_initialized`` emit, so this dedicated kind is
-        what invalidates the cache on that specific path.
-
-        #5279 review (architect BLOCK on an earlier draft that recomputed
-        EAGERLY inside the subscriber callback instead of merely marking
-        dirty): that shape had two real problems, both closed by moving
-        the recompute here instead. (1) ``EventLog``'s dispatch loop
-        isolates each subscriber with its own try/except (#4963/#4961 A) —
-        a raise from ``subscription_summary()`` inside the subscriber
-        would be silently swallowed, leaving the STALE cached value in
-        place with nobody aware a refresh failed (before #5276, every
-        read hit the real call directly, so a raise was never silently
-        absorbed this way). (2) recomputing on every qualifying EVENT ties
-        the actual compute cost to whatever paces those events — e.g.
-        ``mcp_resource_updated``'s cadence is controlled by the remote MCP
-        server, not by this session — so a headless run that never reads
-        this value went from 0 real computations (pre-#5276) to one per
-        event (the eager draft), with no bounding subject. Marking dirty
-        here instead bounds the cost to actual READS, exactly like every
-        other cache in this file, and a raise here propagates to THIS
-        call's own caller exactly as it always did.
+        #5287: reactive cache, PULL-based against
+        ``MCPConnectionService.generation`` — replaces the pre-#5287
+        shape (#5276/#5279/#5280) of subscribing to a hand-picked list of
+        EventLog event KINDS believed to cover every mutation that could
+        change this answer, which needed a 7th kind added after shipping
+        (``mcp_reconnect_failed`` — a failed reconnect changes
+        ``held_servers()`` without firing any of the original 6). Every
+        read compares the connection service's LIVE generation to the
+        one the cached value was computed against; a mismatch (or no
+        cache yet) triggers a real recompute, stored alongside the
+        generation it was computed at. No subscriber registration
+        exists for this cache at all now — see
+        ``MCPConnectionService._bump_generation``'s own docstring for
+        the exhaustive, colocated-with-the-real-mutation site list this
+        replaces the event-kind guesswork with. A raise from
+        ``subscription_summary()`` still propagates to THIS call's own
+        caller directly (nothing catches it on the way here, same as
+        before).
 
         Recomputation itself is still this SAME thin forwarder to
         ``MCPConnectionService.subscription_summary`` — see that method's
@@ -10226,21 +10216,10 @@ class Session:
         single-producer reasoning behind both this method and
         ``RouterHostAdapter.mcp_list_subscriptions`` reading the same
         source)."""
-        if self._cached_mcp_subscriptions is None:
-            self._cached_mcp_subscriptions = self._mcp_connection_service.subscription_summary()
-        return self._cached_mcp_subscriptions
-
-    def _invalidate_mcp_subscription_cache(self, _event: object) -> None:
-        """#5276: the subscriber callback wired to the events that can
-        actually change :meth:`mcp_subscription_state`'s answer — marks the
-        cache dirty (``None``) rather than recomputing here; the next real
-        call to :meth:`mcp_subscription_state` does the actual work,
-        lazily, on its own caller's stack (see that method's own #5279
-        review paragraph for why eager-inside-the-subscriber was rejected).
-        Takes the event only to match the ``Subscriber`` shape
-        (``Callable[[Event], None]``) — the event itself carries no
-        information this invalidation needs beyond "something happened"."""
-        self._cached_mcp_subscriptions = None
+        gen = self._mcp_connection_service.generation
+        if self._cached_mcp_subscriptions is None or self._cached_mcp_subscriptions[0] != gen:
+            self._cached_mcp_subscriptions = (gen, self._mcp_connection_service.subscription_summary())
+        return self._cached_mcp_subscriptions[1]
 
     async def aclose_background_tasks(self) -> None:
         """#4759 teardown: drain every background task this session (or a

--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -39,7 +39,8 @@ Ownership split:
   ``Session._session_id`` / ``Session._ephemeral`` LIVE — both are
   Session-owned state REASSIGNED post-construction by the owning
   ``AgentRegistry`` (``session_id``: spawn-time re-key, ``registry.py``
-  ``spawn_session_recorded``; ``ephemeral``: ``registry.py``
+  ``spawn_session_recorded`` via :meth:`Session.rekey_session_id` — #5287,
+  was a bare ``session._session_id = new_sid`` field write; ``ephemeral``: ``registry.py``
   ``spawn_session`` / ``pipeline_executor_driver.py`` set it True AFTER
   ``Session.__init__`` returns, via :meth:`Session.mark_ephemeral` — #5336,
   was a bare private-attribute write), so a snapshot copied once at
@@ -49,8 +50,8 @@ Ownership split:
   reads through a live getter rather than owning a second, staleable copy.
   ★ Ground correction vs the #3133 P3 firm comment (which specified plain
   ``session_id: str`` / ``ephemeral: bool``): both fields are mutated by
-  external assignment (``session._session_id = ...`` /
-  ``session.mark_ephemeral()``) after construction, so a plain constructor
+  external calls (``session.rekey_session_id(...)`` / ``session.
+  mark_ephemeral()``) after construction, so a plain constructor
   value would freeze the pre-mutation value forever — the same pattern
   #3129 already solved with a provider.
 """

--- a/tests/runtime/test_5276_hook_items_reactive_cache.py
+++ b/tests/runtime/test_5276_hook_items_reactive_cache.py
@@ -13,10 +13,14 @@ and an existing caller toggles then reads ``hook_state()`` immediately,
 with no intervening ``await`` — but ``EventLog.emit()`` QUEUES subscriber
 dispatch onto a background consumer task whenever a loop is running
 (#4966), so the invalidating subscriber would not have run yet by the time
-such a caller reads the (still-stale) cache. Fix: invalidate SYNCHRONOUSLY,
-directly at each mutation site (``set_hook_enabled``'s applied path,
-``_reapply_hooks``, ``load_persisted_toggles``) — no subscriber for this
-cache at all.
+such a caller reads the (still-stale) cache. Fix: bump a generation
+SYNCHRONOUSLY, directly at each mutation site (``set_hook_enabled``'s
+applied path, ``load_persisted_toggles`` — both bump ``Session``'s own
+``_hook_toggle_generation``; ``_reapply_hooks`` bumps ``HookDispatcher``'s
+own ``generation`` inside ``replace_registry`` — #5287) — no subscriber
+for this cache at all, and (#5287) no explicit invalidation CALL either:
+``hook_state()`` compares the live 2-part generation to its own
+last-seen value on every read instead.
 
 Real ``Session``/``HookDispatcher`` — no mocks, mirrors
 ``test_5222_hook_state_origin_aware.py``'s own real-seam pattern. Uses the
@@ -192,8 +196,9 @@ def test_load_persisted_toggles_invalidates_the_cache(tmp_path, monkeypatch) -> 
     restart-recovery shape ``load_persisted_toggles`` exists for), THEN
     calling ``load_persisted_toggles()`` must make the NEXT ``hook_state()``
     read reflect the persisted disable — proving this site's own
-    ``self._cached_hook_items = None`` line is load-bearing (removing it
-    reproduces this test going red with no other change)."""
+    ``self._hook_toggle_generation += 1`` line (#5287; was ``self.
+    _cached_hook_items = None``) is load-bearing (removing it reproduces
+    this test going red with no other change)."""
     import yaml
 
     _write_agent_hook(tmp_path, "myhook")

--- a/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
+++ b/tests/runtime/test_5276_mcp_subscription_reactive_cache.py
@@ -1,45 +1,40 @@
-"""Tier 2: #5276 — ``Session.mcp_subscription_state()``'s reactive cache.
+"""Tier 2: #5276/#5287 — ``Session.mcp_subscription_state()``'s reactive cache.
 
 Root cause: this method used to forward straight to
 ``MCPConnectionService.subscription_summary()`` on EVERY call, including
 every render frame the status panel drew. That composition is real work
 (iterates every held server, per-URI honored-set lookups) for a value that
-only ever changes on a handful of specific events (subscribe/unsubscribe,
-a server install/remove, or a (re)connect). Fix: a subscriber registered
-once in ``Session.__init__`` marks the cache DIRTY (``None``) — never
-recomputes itself — when one of those events fires; the actual
-recomputation happens lazily, on the next real ``mcp_subscription_state()``
-call, on that caller's own stack.
+only ever changes on a genuine subscription-relevant mutation.
 
-Corrected mid-review (architect BLOCK on an earlier draft that recomputed
-EAGERLY inside the subscriber callback, #5279): (1) ``EventLog``'s
-per-subscriber try/except (#4963/#4961 A) would silently swallow a raise
-from an eager recompute, leaving a stale value in place with nobody aware
-a refresh failed; (2) recomputing per EVENT ties the real cost to
-whatever paces those events (e.g. a remote MCP server's own reconnect
-cadence), not to whether anyone is actually reading the value — a
-headless run that never reads this went from 0 real computations to one
-per event. Marking dirty instead bounds the cost to actual reads, exactly
-like every other cache in this file.
+#5276's original fix (a subscriber registered in ``Session.__init__``
+marking the cache dirty when one of a hand-picked list of EventLog event
+KINDS fired) needed a 7th kind added after shipping (#5280,
+``mcp_reconnect_failed`` — a failed reconnect drops a server from
+``held_servers()`` without firing any of the original 6) — a defect class
+found to recur across this file's 2 sibling reactive caches too
+(``hook_state``/``capability_visibility_state``'s envelope census).
+
+#5287: the cache is now PULL-based against
+``MCPConnectionService.generation`` — a producer-owned counter that class
+bumps at every one of ITS OWN mutation sites (see
+``MCPConnectionService._bump_generation``'s own docstring for the
+enumerated list). ``Session.mcp_subscription_state()`` compares the LIVE
+generation to the one its cached value was computed against on every
+read; no subscriber registration exists for this cache at all any more —
+the connection service does not need to know the cache exists, and a
+NEW mutation site added inside ``MCPConnectionService`` automatically
+covers this cache correctly as long as it calls ``_bump_generation()``
+(colocated with the real mutation, not a hand-picked event-kind guess
+one layer removed from it).
 
 Real ``Session`` + real ``MCPConnectionService`` (no held servers — this
 file tests the CACHING mechanism, not connection/subscription composition
 correctness, which #4686's own suite already covers against a real MCP
 subprocess). Uses the #4403 counting technique (wrap the real
-``subscription_summary``, count real calls) and
-``tests/_support/events.py``'s ``settle`` (#3868/#4966) to wait for the
-subscriber's queued dispatch before reading the post-event state.
-
-#5280 (found while answering architect's #5279 review question, fixed in
-that issue's own PR): a 7th kind, ``mcp_reconnect_failed``, was added to
-the subscriber list — a FAILED reconnect (``MCPConnectionService.
-_reconnect``) drops a server from ``held_servers()`` without ever
-reaching the success-only ``mcp_initialized`` emit, so none of the
-original 6 kinds fired on that path. See
-``test_mcp_reconnect_failed_also_marks_dirty`` below for the cache-side
-witness, and ``tests/mcp/test_5280_mcp_reconnect_failed_event.py`` for
-the real ``MCPConnectionService._reconnect`` witness that the event
-actually fires on a genuine reopen failure.
+``subscription_summary``, count real calls). Generation bumps are driven
+directly via the connection service's own real internal mutation methods
+(``_track_subscription``/``_untrack_subscription``/``aclose``) — the SAME
+methods #5287's implementation instrumented, not a synthetic stand-in.
 """
 from __future__ import annotations
 
@@ -79,8 +74,8 @@ def _counting_wrapper(monkeypatch, service) -> dict:
 @pytest.mark.asyncio
 async def test_repeated_reads_cost_one_real_compute(tmp_path, monkeypatch) -> None:
     """Tier 2: acceptance — 3 repeated ``mcp_subscription_state()`` reads
-    with NO intervening event cost exactly 1 real ``subscription_summary``
-    call (the first, lazy fill), not 3."""
+    with NO intervening generation bump cost exactly 1 real
+    ``subscription_summary`` call (the first, lazy fill), not 3."""
     s = _make_session(tmp_path)
     call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
 
@@ -90,107 +85,93 @@ async def test_repeated_reads_cost_one_real_compute(tmp_path, monkeypatch) -> No
 
     assert call_count["n"] == 1, (
         f"expected exactly 1 real subscription_summary call across 3 reads "
-        f"with no intervening event, got {call_count['n']}"
+        f"with no intervening generation bump, got {call_count['n']}"
     )
     assert r1 == r2 == r3 == []
 
 
 @pytest.mark.asyncio
-async def test_a_relevant_event_marks_dirty_but_does_not_itself_recompute(
-    tmp_path, monkeypatch,
-) -> None:
-    """Tier 2: acceptance — after the first (lazy) read, emitting ONE of
-    the events that can change the subscription summary marks the cache
-    dirty WITHOUT itself costing a real call (the subscriber only sets
-    ``None`` — #5279 review: recomputing inside the subscriber would
-    silently swallow a raise via EventLog's per-subscriber try/except, and
-    would tie the real cost to event cadence rather than actual reads).
-    The NEXT real read is what pays for exactly one more real call."""
+async def test_a_real_mutation_is_seen_on_the_next_read_only(tmp_path, monkeypatch) -> None:
+    """Tier 2: acceptance — after the first (lazy) read, a real
+    ``MCPConnectionService`` mutation (``_track_subscription``, the same
+    private method ``_HeldConnection.subscribe_resource`` calls on a
+    successful subscribe) bumps ``generation``; the cache does not
+    recompute until the NEXT read, and a read with no further mutation in
+    between costs nothing more."""
     s = _make_session(tmp_path)
     call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
 
     s.mcp_subscription_state()  # lazy fill: 1 real call
     assert call_count["n"] == 1
 
-    # #5557: this emit only drives the dirty-marking scenario — every
-    # assert in this test reads `call_count` (an unrelated collaborator's
-    # own call tally via `_counting_wrapper`), never this emit's own
-    # type/data. The event kind matters only insofar as it's IN the
-    # subscribed set; the payload is arbitrary.
-    s._audit_events.emit("mcp_resource_subscribed", server="srv", uri="resource://x")
-    await settle(s._audit_events)
-
+    # Drives the real mutation directly (the same private method
+    # ``_HeldConnection.subscribe_resource`` calls on a successful
+    # subscribe) — a generation VALUE is an implementation detail this
+    # test does not assert on directly (Tier 4: no private-state assert);
+    # what's observable, and asserted below, is the CACHE's own behavior.
+    s._mcp_connection_service._track_subscription("srv", "resource://x")
     assert call_count["n"] == 1, (
-        f"the event itself must NOT trigger a real call (only marks dirty), "
-        f"got {call_count['n']} real calls total"
+        f"bumping generation must NOT itself trigger a real call, got "
+        f"{call_count['n']} real calls total"
     )
 
     # The next real read pays for exactly one more real call (the lazy fill).
     s.mcp_subscription_state()
     assert call_count["n"] == 2, (
         f"expected exactly 1 more real call on the first read after the "
-        f"dirty-marking event, got {call_count['n']} real calls total"
+        f"generation bump, got {call_count['n']} real calls total"
     )
 
-    # A further read with no intervening event is once again a bare cache
-    # return — 0 additional calls.
+    # A further read with no intervening mutation is once again a bare
+    # cache return — 0 additional calls.
     s.mcp_subscription_state()
     assert call_count["n"] == 2, (
-        f"a read with no intervening event must cost nothing more, got "
+        f"a read with no intervening mutation must cost nothing more, got "
         f"{call_count['n']} real calls total"
     )
 
 
 @pytest.mark.asyncio
-async def test_mcp_reconnect_failed_also_marks_dirty(tmp_path, monkeypatch) -> None:
-    """Tier 2: #5280 — a 7th subscribed kind, added after this file's own
-    original 6 (found while answering architect's #5279 review question):
-    a FAILED reconnect (``MCPConnectionService._reconnect``) drops a server
-    from ``held_servers()`` without ever reaching the success-only
-    ``mcp_initialized`` emit — this kind is what invalidates the cache on
-    that path instead. Same shape as
-    ``test_a_relevant_event_marks_dirty_but_does_not_itself_recompute``
-    above, for the new kind."""
+async def test_aclose_also_bumps_generation(tmp_path, monkeypatch) -> None:
+    """Tier 2: #5287 — ``aclose()`` (teardown) is one of ``_bump_generation``'s
+    own enumerated sites: it clears ``_clients``/``_subscription_adapters``,
+    both real inputs to ``subscription_summary()``. Same shape as the
+    previous test, for this mutation site."""
     s = _make_session(tmp_path)
     call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
 
     s.mcp_subscription_state()  # lazy fill: 1 real call
     assert call_count["n"] == 1
 
-    # #5557: same reasoning as the previous test — drives dirty-marking,
-    # every assert reads `call_count`, not this emit's own event.
-    s._audit_events.emit("mcp_reconnect_failed", server="srv")
-    await settle(s._audit_events)
+    await s._mcp_connection_service.aclose()
 
-    assert call_count["n"] == 1, (
-        f"the event itself must NOT trigger a real call (only marks dirty), "
+    s.mcp_subscription_state()
+    assert call_count["n"] == 2, (
+        f"expected exactly 1 more real call on the first read after aclose(), "
         f"got {call_count['n']} real calls total"
     )
 
-    s.mcp_subscription_state()
-    assert call_count["n"] == 2, (
-        f"#5280 REGRESSION: expected exactly 1 more real call on the first "
-        f"read after mcp_reconnect_failed, got {call_count['n']} real calls total"
-    )
-
 
 @pytest.mark.asyncio
-async def test_an_unrelated_event_does_not_trigger_a_recompute(tmp_path, monkeypatch) -> None:
-    """Tier 2: falsification contrast — an event OUTSIDE the subscribed
-    kind set must not recompute (proves the subscriber is kind-filtered,
-    not firing on every event)."""
+async def test_an_event_emit_alone_no_longer_triggers_a_recompute(tmp_path, monkeypatch) -> None:
+    """Tier 2: #5287 — deliberate simplification, stated as a positive
+    assertion (not merely "still passes"): this cache no longer subscribes
+    to ANY EventLog event kind at all (the pre-#5287 hand-picked 7-kind
+    list — #5276/#5279/#5280 — needed a kind added after shipping once
+    already). Emitting a real subscription-shaped event with NO
+    accompanying ``MCPConnectionService`` mutation must not recompute —
+    only a real generation bump does."""
     s = _make_session(tmp_path)
     call_count = _counting_wrapper(monkeypatch, s._mcp_connection_service)
 
     s.mcp_subscription_state()  # lazy fill: 1 real call
     assert call_count["n"] == 1
 
-    # #5557: same reasoning — this is the falsification contrast (an
-    # unrelated kind), asserts still only read `call_count`.
-    s._audit_events.emit("user_submitted", text="hello", chain_id="c1", msg_id="m1", seq=1)
+    s._audit_events.emit("mcp_resource_subscribed", server="srv", uri="resource://x")
     await settle(s._audit_events)
 
+    s.mcp_subscription_state()
     assert call_count["n"] == 1, (
-        f"an unrelated event kind must not trigger a recompute, got "
-        f"{call_count['n']} real calls total"
+        f"an event emit with no real MCPConnectionService mutation behind it "
+        f"must not trigger a recompute, got {call_count['n']} real calls total"
     )

--- a/tests/runtime/test_5276_visibility_census_reactive_cache.py
+++ b/tests/runtime/test_5276_visibility_census_reactive_cache.py
@@ -1,6 +1,6 @@
-"""Tier 2: #5276 (visibility_items) — the EXPENSIVE, envelope-only half of
-``capability_visibility_state()`` (the tool/mcp/category/skill census
-against the agent envelope) is memoized; only the CHEAP overlay
+"""Tier 2: #5276/#5287 (visibility_items) — the EXPENSIVE, envelope-only
+half of ``capability_visibility_state()`` (the tool/mcp/category/skill
+census against the agent envelope) is memoized; only the CHEAP overlay
 (``/visibility`` override + per-turn ephemeral taint) recomputes every call.
 
 Root cause: ``capability_visibility_state()`` used to redo the ENTIRE
@@ -16,12 +16,23 @@ census causes no staleness there — EXCEPT one real edge the census's own
 ``sid=self._session_id_provider()`` argument exposes: a session's own sid
 CAN be re-keyed post-construction (spawn fixup — see
 ``capability_visibility.py``'s own module docstring), so a stale cache
-survives-then-lies for the SAME session object across a re-key. Caught
-during review (architect, #5285): invalidated at 3 sites, not 2 —
-``_reapply_mcp``/``_reapply_skills`` (the MCP roster / skill registry, WHICH
-capabilities exist to classify) AND ``load_persisted_toggles`` (called
-after a re-key completes, per that method's own docstring), all
-synchronously (the #5279/#5284 lesson: no ``EventLog`` subscriber).
+survives-then-lies for the SAME session object across a re-key.
+
+#5276/#5285: invalidated at 3 hand-enumerated sites (``_reapply_mcp``/
+``_reapply_skills``/``load_persisted_toggles``), each calling
+``invalidate_envelope_census()`` explicitly, no ``EventLog`` subscriber
+(the #5279/#5284 lesson).
+
+#5287: PULL-based instead, against ``Session``'s own producer-owned
+``self._capability_inputs_generation`` counter — bumped at the 3 REAL
+mutation sites (``refresh_mcp_servers``'s roster reassignment,
+``_reapply_skills``'s ``_available_skills`` reassignment, and the new
+``Session.rekey_session_id`` — the sid re-key itself, not the
+``load_persisted_toggles`` call that happens to follow it). The same
+defect family closed for this file's sibling reactive caches
+(``hook_state``/``mcp_subscription_state``): a hand-enumerated call-site
+list needs updating every time a NEW site is added; a generation bumped
+at the real mutation does not.
 
 Real ``AgentRegistry``/``Session`` (real envelope via
 ``spawn_session_recorded(narrowing=...)``) — no mocks, mirrors
@@ -244,13 +255,47 @@ async def test_skill_reload_invalidates_the_census(tmp_path, monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_load_persisted_toggles_invalidates_the_census(tmp_path, monkeypatch) -> None:
-    """Tier 2: acceptance — the 3rd invalidation site (architect B on
-    #5285, finding ①): ``load_persisted_toggles`` is called right after a
-    session re-key, and the census's own ``sid=self._session_id_provider()``
-    argument means a re-key CAN change what it should return for the SAME
-    session object. Calling ``load_persisted_toggles()`` must invalidate
-    the cache, so a subsequent read costs exactly 1 more real computation."""
+async def test_rekey_session_id_invalidates_the_census(tmp_path, monkeypatch) -> None:
+    """Tier 2: #5287 — the 3rd invalidation site (originally architect B on
+    #5285, finding ①, re-targeted at the REAL mutation by #5287): the
+    census's own ``sid=self._session_id_provider()`` argument means a
+    session re-key CAN change what it should return for the SAME session
+    object. ``Session.rekey_session_id`` — the one place ``self.
+    _session_id`` is reassigned post-construction (``registry.py``'s
+    ``spawn_session_recorded``, real production call site exercised via
+    the same registry-driven spawn every other test in this file uses) —
+    bumps ``self._capability_inputs_generation`` directly, so a
+    subsequent read costs exactly 1 more real computation."""
+    reg = _make_registry(tmp_path)
+    s = reg.get_session("alice", await reg.spawn_session_recorded(
+        "alice", presentation_consumer=None, intervention_bridge=None,
+    ))
+    call_count = _counting_wrapper(monkeypatch, s._capability_visibility)
+
+    s.capability_visibility_state()
+    assert call_count["n"] == 1
+
+    s.rekey_session_id("a-different-sid")
+    s.capability_visibility_state()
+
+    assert call_count["n"] == 2, (
+        f"expected exactly 1 more real census computation after "
+        f"rekey_session_id, got {call_count['n']} real calls total"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_persisted_toggles_alone_does_not_trigger_a_recompute(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #5287 — deliberate simplification, stated as a positive
+    assertion: ``load_persisted_toggles`` no longer invalidates the
+    census by itself (pre-#5287, it did so unconditionally, on the
+    reasoning that it always runs right after a re-key — but the
+    generation bump now lives at the re-key itself, so a
+    ``load_persisted_toggles`` call with NO re-key in between — e.g. the
+    construction/restore path this method's own docstring also names,
+    where the sid never changes — correctly costs nothing more)."""
     reg = _make_registry(tmp_path)
     s = reg.get_session("alice", await reg.spawn_session_recorded(
         "alice", presentation_consumer=None, intervention_bridge=None,
@@ -263,7 +308,8 @@ async def test_load_persisted_toggles_invalidates_the_census(tmp_path, monkeypat
     s.load_persisted_toggles()
     s.capability_visibility_state()
 
-    assert call_count["n"] == 2, (
-        f"expected exactly 1 more real census computation after "
-        f"load_persisted_toggles, got {call_count['n']} real calls total"
+    assert call_count["n"] == 1, (
+        f"load_persisted_toggles with no accompanying re-key must not "
+        f"trigger a real census recompute, got {call_count['n']} real "
+        f"calls total"
     )

--- a/tests/runtime/test_5287_generation_producer_coverage.py
+++ b/tests/runtime/test_5287_generation_producer_coverage.py
@@ -1,49 +1,80 @@
-"""Tier 2: #5287 — every producer's own "which methods bump my generation"
-set is DERIVED FROM THE CLASS's real source (AST), not a hand-typed list in
-this test (#5228's own lesson: a hand-typed enumeration in the TEST can
-silently drift from what the class actually does, the exact "declared but
-not measured" shape this repo keeps closing). A vacuity guard (the derived
-set must be non-empty) runs first, so an AST pattern that stopped matching
-anything would fail LOUDLY here instead of this file quietly asserting
-over an empty collection.
+"""Tier 2: #5287 — every producer's own generation-bump coverage is
+verified as ``mutators ⊆ bumpers``, both sets DERIVED FROM THE CLASS's
+real source (AST), not hand-typed in this test (#5228's own lesson: a
+hand-typed enumeration in the TEST can silently drift from what the class
+actually does).
 
-Each of the 3 producers #5287 gives a ``generation`` counter to —
-``HookDispatcher`` (``src/reyn/hooks/dispatcher.py``), ``MCPConnectionService``
-(``src/reyn/mcp/connection_service.py``), and ``Session`` itself (2 narrower
-counters — ``_hook_toggle_generation``/``_capability_inputs_generation``,
-not a class-wide ``generation`` since ``Session`` is not itself the sole
-owner of a single cache's inputs) — bumps via one of 2 uniform markers:
+**Corrected mid-review (lead-coder BLOCK on #5676, head 6d6b27f95): the
+FIRST version of this file asserted only ``bumpers == {known set}`` — the
+set of methods CALLING ``self._bump_generation()``. That direction cannot
+catch #5287's own actual defect class: a NEW method that mutates the
+tracked state WITHOUT calling the bump helper never appears in ``bumpers``
+at all, so ``bumpers == {known set}`` stays exactly as true (and green) as
+before that method existed — it silently fails to grow. #5287's own
+verbatim requirement was the OTHER direction: "WHOEVER ADDS A NEW SITE
+THAT MUTATES ... nothing here will turn red on its own" — a forgotten
+bump must turn something red.**
 
-  - a call to ``self._bump_generation()`` (``HookDispatcher``/
-    ``MCPConnectionService``, each with their own private helper of that
-    exact name — #5287 deliberately used the SAME marker shape across both
-    so this scan needs one pattern, not one per class).
-  - an augmented assignment ``self.<attr> += 1`` (``Session``'s 2 narrower
-    counters — a full private-helper-per-counter felt like ceremony on an
-    already very large class; the marker is the attribute name itself).
+Fixed by deriving a SECOND, independent set — ``mutators`` — every method
+whose body actually reassigns/mutates the tracked attribute(s), via a
+DIFFERENT AST pattern (direct/annotated assignment, subscript-assignment,
+or a call to a known in-place-mutating method — ``pop``/``clear``/
+``discard``/``add``/``update``/``setdefault``/``remove``/etc. — whose
+RECEIVER chain, however many ``.get(...)``/``.setdefault(...)`` deep,
+roots at ``self.<attr>``; e.g. both ``self._subscriptions.setdefault(k,
+set()).add(v)`` and ``self._subscriptions.get(k, set()).discard(v)``
+count, because the object each actually mutates is the SAME instance
+stored inside ``self._subscriptions``, never a copy) — then asserting
+``mutators <= bumpers``. A future site that mutates the tracked state
+without its own bump now genuinely widens ``mutators`` past ``bumpers``
+and turns THIS assertion red, independent of what ``bumpers`` itself
+contains.
 
-strip-falsify (recorded here, executed manually before landing): removing
-any ONE of the enumerated bump lines from its production method (a) drops
-that method's name from this file's own AST-derived set (the completeness
-assertions below go red — the enumeration itself changed), and (b) makes
-the matching functional test in this file (which calls the REAL method and
-asserts the counter moved) go red independently. Both were verified by
-hand: deleting ``MCPConnectionService._track_subscription``'s own
-``self._bump_generation()`` line reproduced exactly this — the
-completeness assert failed (the derived set no longer contained
-``_track_subscription``) AND ``test_mcpconnectionservice_track_and_
-untrack_subscription_bump`` failed independently (generation stayed put).
+**Naming fragility, disclosed (per lead-coder's own request — "どう名指
+したか、なぜ壊れにくいかを1行"):** the tracked attribute is named by its
+OWN field identifier (``_registry``, ``_clients``/``_subscriptions``/
+``_subscription_adapters``/``_last_honored``, ``_disabled_hooks``,
+``_available_skills``/``_session_id``/``_mcp_servers``) — a private field
+that is itself the SAME name the production module's own #5287 comments
+already reference (e.g. ``MCPConnectionService._bump_generation``'s own
+docstring enumerates these 4 by name). A rename of the field would need
+to touch every production read/write site too (the field would stop
+existing under its old name), so this scanner breaking on a rename is the
+CORRECT failure — it would break loudly (0 mutators found, tripping the
+vacuity guard) rather than silently miscounting, not a fragile coincidence.
+
+``__init__`` is excluded from the mutator scan for every producer: the
+constructor's own INITIAL assignment never needs a bump (no cache exists
+yet to go stale relative to it — the same reasoning
+``HookDispatcher.generation``'s own docstring already gives, generalized
+to every producer here).
+
+strip-falsify, re-executed with the corrected direction (recorded here,
+executed manually before landing): temporarily removed
+``_track_subscription``'s own ``self._bump_generation()`` call — this
+time ``mutators`` still (correctly) contains ``_track_subscription``
+(the ``.setdefault(...).add(...)`` mutation is still there), but
+``bumpers`` no longer does, so ``mutators <= bumpers`` fails loudly
+(``{'_track_subscription'}`` is the reported extra element) — the exact
+"forgot to bump" scenario #5287 exists to catch. Reverted before commit.
+Also verified the FIRST version's own gap directly: with the SAME
+mutation removed, the old ``bumpers == {known set WITHOUT
+_track_subscription}`` assertion (re-derived, not the stale literal)
+still passed — confirming the old direction really was blind to this.
 
 Functional coverage note (disclosed, not silently narrowed):
 ``MCPConnectionService._ensure_open``/``_reconnect`` are structurally
 enumerated below (their own ``self._bump_generation()`` calls are real,
-grep-confirmed AST hits) but NOT independently functionally witnessed in
-THIS file — both require a genuine (re)connect, already exercised by
+grep-confirmed AST hits, and both are genuine ``mutators`` too — verified
+by the subset assertion itself) but NOT independently functionally
+witnessed in THIS file with a live call — both require a genuine
+(re)connect, already exercised by
 ``tests/mcp/test_5280_mcp_reconnect_failed_event.py`` and #4686's own
-suite against a real MCP subprocess; duplicating that harness here just to
-re-prove "generation moved" was judged not worth the added real-subprocess
-dependency for a file whose own job is the ENUMERATION witness, not
-connection-lifecycle correctness (already covered elsewhere).
+suite against a real MCP subprocess; duplicating that harness here just
+to re-prove "generation moved" was judged not worth the added
+real-subprocess dependency for a file whose own job is the coverage
+witness, not connection-lifecycle correctness (already covered
+elsewhere).
 """
 from __future__ import annotations
 
@@ -60,6 +91,19 @@ _DISPATCHER_PY = REPO_ROOT / "src" / "reyn" / "hooks" / "dispatcher.py"
 _CONNECTION_SERVICE_PY = REPO_ROOT / "src" / "reyn" / "mcp" / "connection_service.py"
 _SESSION_PY = REPO_ROOT / "src" / "reyn" / "runtime" / "session.py"
 
+#: In-place mutating method names this scan treats as "this call mutates
+#: its receiver" — the vocabulary every #5287 mutation site in this repo
+#: actually uses (dict/set primitives only; no custom mutator methods are
+#: involved in any of the 3 producers' tracked fields).
+_MUTATING_METHOD_NAMES = frozenset({
+    "pop", "popitem", "clear", "discard", "add", "update",
+    "setdefault", "remove", "extend", "append", "insert",
+})
+
+#: Never counted as a mutator needing its own bump — see the module
+#: docstring's own paragraph on why.
+_EXCLUDE_METHODS = frozenset({"__init__"})
+
 
 def _class_node(tree: ast.Module, class_name: str) -> ast.ClassDef:
     for node in ast.walk(tree):
@@ -70,7 +114,8 @@ def _class_node(tree: ast.Module, class_name: str) -> ast.ClassDef:
 
 def _methods_calling(tree: ast.Module, class_name: str, call_name: str) -> "set[str]":
     """Every method of *class_name* whose body contains a call to
-    ``self.<call_name>()`` — the ``self._bump_generation()`` marker."""
+    ``self.<call_name>()`` — the ``self._bump_generation()`` marker
+    (``HookDispatcher``/``MCPConnectionService``)."""
     cls = _class_node(tree, class_name)
     out: "set[str]" = set()
     for method in cls.body:
@@ -90,7 +135,8 @@ def _methods_calling(tree: ast.Module, class_name: str, call_name: str) -> "set[
 
 
 def _methods_augassigning(tree: ast.Module, class_name: str, attr_name: str) -> "set[str]":
-    """Every method of *class_name* whose body contains ``self.<attr_name> += ...``."""
+    """Every method of *class_name* whose body contains ``self.<attr_name>
+    += ...`` — the bump marker for ``Session``'s 2 narrower counters."""
     cls = _class_node(tree, class_name)
     out: "set[str]" = set()
     for method in cls.body:
@@ -109,20 +155,90 @@ def _methods_augassigning(tree: ast.Module, class_name: str, attr_name: str) -> 
     return out
 
 
+def _chain_rooted_at_self_attr(node: ast.expr, attr_name: str) -> bool:
+    """True if ``self.<attr_name>`` appears ANYWHERE inside *node* — used
+    on a mutating call's own RECEIVER expression (``call.func.value``) so
+    an arbitrarily-deep ``.get(...)``/``.setdefault(...)`` chain rooted at
+    ``self.<attr_name>`` still counts (the object actually mutated by the
+    outer call is the same instance stored inside that field, never a
+    copy)."""
+    for n in ast.walk(node):
+        if (
+            isinstance(n, ast.Attribute)
+            and n.attr == attr_name
+            and isinstance(n.value, ast.Name)
+            and n.value.id == "self"
+        ):
+            return True
+    return False
+
+
+def _methods_mutating(
+    tree: ast.Module, class_name: str, attr_name: str,
+) -> "set[str]":
+    """Every method of *class_name* (excluding :data:`_EXCLUDE_METHODS`)
+    that mutates ``self.<attr_name>`` — direct or annotated reassignment,
+    a subscript-assignment rooted at it, or a call to a known in-place
+    mutator (:data:`_MUTATING_METHOD_NAMES`) whose receiver chain roots
+    at it. See the module docstring for the full pattern list and why."""
+    cls = _class_node(tree, class_name)
+    out: "set[str]" = set()
+    for method in cls.body:
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if method.name in _EXCLUDE_METHODS:
+            continue
+        hit = False
+        for node in ast.walk(method):
+            if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+                targets = (
+                    node.targets if isinstance(node, ast.Assign)
+                    else [node.target]
+                )
+                for t in targets:
+                    if (
+                        isinstance(t, ast.Attribute) and t.attr == attr_name
+                        and isinstance(t.value, ast.Name) and t.value.id == "self"
+                    ):
+                        hit = True
+                    elif (
+                        isinstance(t, ast.Subscript)
+                        and _chain_rooted_at_self_attr(t.value, attr_name)
+                    ):
+                        hit = True
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in _MUTATING_METHOD_NAMES
+                and _chain_rooted_at_self_attr(node.func.value, attr_name)
+            ):
+                hit = True
+            if hit:
+                break
+        if hit:
+            out.add(method.name)
+    return out
+
+
 # ── HookDispatcher ───────────────────────────────────────────────────────
 
 
-def test_hookdispatcher_bump_sites_are_derived_and_non_empty() -> None:
-    """Tier 2: vacuity guard + completeness pin — the AST-derived set of
-    ``HookDispatcher`` methods calling ``self._bump_generation()`` is
-    non-empty AND matches the known real site exactly (a regression pin:
-    a new mutation site added later without its own bump would silently
-    NOT appear here, which is exactly what this pin exists to catch — see
-    the module docstring's strip-falsify)."""
+def test_hookdispatcher_every_registry_mutator_bumps_generation() -> None:
+    """Tier 2: the #5287 acceptance criterion itself — every method that
+    reassigns ``self._registry`` (this class's own tracked field) must be
+    among the methods calling ``self._bump_generation()``. A NEW mutator
+    added later without its own bump widens ``mutators`` past ``bumpers``
+    and fails HERE, independent of what ``bumpers`` itself contains."""
     tree = ast.parse(_DISPATCHER_PY.read_text(encoding="utf-8"))
-    sites = _methods_calling(tree, "HookDispatcher", "_bump_generation")
-    assert sites, "no HookDispatcher method calls self._bump_generation() at all"
-    assert sites == {"replace_registry"}, sites
+    mutators = _methods_mutating(tree, "HookDispatcher", "_registry")
+    bumpers = _methods_calling(tree, "HookDispatcher", "_bump_generation")
+    assert mutators, "no HookDispatcher method mutates self._registry at all"
+    assert mutators <= bumpers, (
+        f"mutates _registry without bumping generation: {mutators - bumpers}"
+    )
+    # Regression pin (content, not the acceptance criterion itself -- see
+    # module docstring for why this direction alone is insufficient).
+    assert bumpers == {"replace_registry"}, bumpers
 
 
 def test_hookdispatcher_replace_registry_bumps_generation() -> None:
@@ -141,18 +257,27 @@ def test_hookdispatcher_replace_registry_bumps_generation() -> None:
 
 # ── MCPConnectionService ─────────────────────────────────────────────────
 
+_MCP_TRACKED_FIELDS = ("_clients", "_subscriptions", "_subscription_adapters", "_last_honored")
 
-def test_mcpconnectionservice_bump_sites_are_derived_and_non_empty() -> None:
-    """Tier 2: vacuity guard + completeness pin — see the module docstring
-    for why ``_ensure_open``/``_reconnect`` are enumerated here (real AST
-    hits) but not independently functionally witnessed in this file."""
+
+def test_mcpconnectionservice_every_mutator_bumps_generation() -> None:
+    """Tier 2: the #5287 acceptance criterion — every method mutating any
+    of the 4 fields ``subscription_summary()`` composes from must be
+    among the methods calling ``self._bump_generation()``."""
     tree = ast.parse(_CONNECTION_SERVICE_PY.read_text(encoding="utf-8"))
-    sites = _methods_calling(tree, "MCPConnectionService", "_bump_generation")
-    assert sites, "no MCPConnectionService method calls self._bump_generation() at all"
-    assert sites == {
+    mutators: "set[str]" = set()
+    for field in _MCP_TRACKED_FIELDS:
+        mutators |= _methods_mutating(tree, "MCPConnectionService", field)
+    bumpers = _methods_calling(tree, "MCPConnectionService", "_bump_generation")
+    assert mutators, "no MCPConnectionService method mutates any tracked field at all"
+    assert mutators <= bumpers, (
+        f"mutates tracked state without bumping generation: {mutators - bumpers}"
+    )
+    # Regression pin (content, not the acceptance criterion itself).
+    assert bumpers == {
         "_ensure_open", "_reconnect", "aclose",
         "_track_subscription", "_untrack_subscription", "_set_last_honored",
-    }, sites
+    }, bumpers
 
 
 def test_mcpconnectionservice_track_and_untrack_subscription_bump() -> None:
@@ -188,21 +313,35 @@ async def test_mcpconnectionservice_aclose_bumps() -> None:
 # ── Session's own 2 narrower generation counters ─────────────────────────
 
 
-def test_session_hook_toggle_generation_bump_sites_are_derived_and_non_empty() -> None:
-    """Tier 2: vacuity guard + completeness pin for ``Session``'s
+def test_session_hook_toggle_generation_covers_every_disabled_hooks_mutator() -> None:
+    """Tier 2: the #5287 acceptance criterion for ``Session``'s
     ``_hook_toggle_generation`` (the ``_disabled_hooks``-owning counter —
     see that field's own comment in ``Session.__init__``)."""
     tree = ast.parse(_SESSION_PY.read_text(encoding="utf-8"))
-    sites = _methods_augassigning(tree, "Session", "_hook_toggle_generation")
-    assert sites, "no Session method increments self._hook_toggle_generation at all"
-    assert sites == {"set_hook_enabled", "load_persisted_toggles"}, sites
+    mutators = _methods_mutating(tree, "Session", "_disabled_hooks")
+    bumpers = _methods_augassigning(tree, "Session", "_hook_toggle_generation")
+    assert mutators, "no Session method mutates self._disabled_hooks at all"
+    assert mutators <= bumpers, (
+        f"mutates _disabled_hooks without bumping _hook_toggle_generation: {mutators - bumpers}"
+    )
+    assert bumpers == {"set_hook_enabled", "load_persisted_toggles"}, bumpers
 
 
-def test_session_capability_inputs_generation_bump_sites_are_derived_and_non_empty() -> None:
-    """Tier 2: vacuity guard + completeness pin for ``Session``'s
+def test_session_capability_inputs_generation_covers_every_tracked_mutator() -> None:
+    """Tier 2: the #5287 acceptance criterion for ``Session``'s
     ``_capability_inputs_generation`` (the envelope-census counter — see
-    that field's own comment in ``Session.__init__``)."""
+    that field's own comment in ``Session.__init__``). Tracked fields:
+    ``_available_skills`` (the skill roster), ``_session_id`` (a spawn-
+    time re-key), ``_mcp_servers`` (Session's own copy of the MCP roster,
+    reassigned in the SAME method as the ``RouterHostAdapter`` one it
+    mirrors — see ``refresh_mcp_servers``'s own comment)."""
     tree = ast.parse(_SESSION_PY.read_text(encoding="utf-8"))
-    sites = _methods_augassigning(tree, "Session", "_capability_inputs_generation")
-    assert sites, "no Session method increments self._capability_inputs_generation at all"
-    assert sites == {"rekey_session_id", "refresh_mcp_servers", "_reapply_skills"}, sites
+    mutators: "set[str]" = set()
+    for field in ("_available_skills", "_session_id", "_mcp_servers"):
+        mutators |= _methods_mutating(tree, "Session", field)
+    bumpers = _methods_augassigning(tree, "Session", "_capability_inputs_generation")
+    assert mutators, "no Session method mutates any tracked field at all"
+    assert mutators <= bumpers, (
+        f"mutates tracked state without bumping _capability_inputs_generation: {mutators - bumpers}"
+    )
+    assert bumpers == {"rekey_session_id", "refresh_mcp_servers", "_reapply_skills"}, bumpers

--- a/tests/runtime/test_5287_generation_producer_coverage.py
+++ b/tests/runtime/test_5287_generation_producer_coverage.py
@@ -1,0 +1,208 @@
+"""Tier 2: #5287 — every producer's own "which methods bump my generation"
+set is DERIVED FROM THE CLASS's real source (AST), not a hand-typed list in
+this test (#5228's own lesson: a hand-typed enumeration in the TEST can
+silently drift from what the class actually does, the exact "declared but
+not measured" shape this repo keeps closing). A vacuity guard (the derived
+set must be non-empty) runs first, so an AST pattern that stopped matching
+anything would fail LOUDLY here instead of this file quietly asserting
+over an empty collection.
+
+Each of the 3 producers #5287 gives a ``generation`` counter to —
+``HookDispatcher`` (``src/reyn/hooks/dispatcher.py``), ``MCPConnectionService``
+(``src/reyn/mcp/connection_service.py``), and ``Session`` itself (2 narrower
+counters — ``_hook_toggle_generation``/``_capability_inputs_generation``,
+not a class-wide ``generation`` since ``Session`` is not itself the sole
+owner of a single cache's inputs) — bumps via one of 2 uniform markers:
+
+  - a call to ``self._bump_generation()`` (``HookDispatcher``/
+    ``MCPConnectionService``, each with their own private helper of that
+    exact name — #5287 deliberately used the SAME marker shape across both
+    so this scan needs one pattern, not one per class).
+  - an augmented assignment ``self.<attr> += 1`` (``Session``'s 2 narrower
+    counters — a full private-helper-per-counter felt like ceremony on an
+    already very large class; the marker is the attribute name itself).
+
+strip-falsify (recorded here, executed manually before landing): removing
+any ONE of the enumerated bump lines from its production method (a) drops
+that method's name from this file's own AST-derived set (the completeness
+assertions below go red — the enumeration itself changed), and (b) makes
+the matching functional test in this file (which calls the REAL method and
+asserts the counter moved) go red independently. Both were verified by
+hand: deleting ``MCPConnectionService._track_subscription``'s own
+``self._bump_generation()`` line reproduced exactly this — the
+completeness assert failed (the derived set no longer contained
+``_track_subscription``) AND ``test_mcpconnectionservice_track_and_
+untrack_subscription_bump`` failed independently (generation stayed put).
+
+Functional coverage note (disclosed, not silently narrowed):
+``MCPConnectionService._ensure_open``/``_reconnect`` are structurally
+enumerated below (their own ``self._bump_generation()`` calls are real,
+grep-confirmed AST hits) but NOT independently functionally witnessed in
+THIS file — both require a genuine (re)connect, already exercised by
+``tests/mcp/test_5280_mcp_reconnect_failed_event.py`` and #4686's own
+suite against a real MCP subprocess; duplicating that harness here just to
+re-prove "generation moved" was judged not worth the added real-subprocess
+dependency for a file whose own job is the ENUMERATION witness, not
+connection-lifecycle correctness (already covered elsewhere).
+"""
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.mcp.connection_service import MCPConnectionService
+from tests._support.paths import REPO_ROOT
+
+_DISPATCHER_PY = REPO_ROOT / "src" / "reyn" / "hooks" / "dispatcher.py"
+_CONNECTION_SERVICE_PY = REPO_ROOT / "src" / "reyn" / "mcp" / "connection_service.py"
+_SESSION_PY = REPO_ROOT / "src" / "reyn" / "runtime" / "session.py"
+
+
+def _class_node(tree: ast.Module, class_name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    raise AssertionError(f"class {class_name!r} not found")
+
+
+def _methods_calling(tree: ast.Module, class_name: str, call_name: str) -> "set[str]":
+    """Every method of *class_name* whose body contains a call to
+    ``self.<call_name>()`` — the ``self._bump_generation()`` marker."""
+    cls = _class_node(tree, class_name)
+    out: "set[str]" = set()
+    for method in cls.body:
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(method):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == call_name
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                out.add(method.name)
+                break
+    return out
+
+
+def _methods_augassigning(tree: ast.Module, class_name: str, attr_name: str) -> "set[str]":
+    """Every method of *class_name* whose body contains ``self.<attr_name> += ...``."""
+    cls = _class_node(tree, class_name)
+    out: "set[str]" = set()
+    for method in cls.body:
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(method):
+            if (
+                isinstance(node, ast.AugAssign)
+                and isinstance(node.target, ast.Attribute)
+                and node.target.attr == attr_name
+                and isinstance(node.target.value, ast.Name)
+                and node.target.value.id == "self"
+            ):
+                out.add(method.name)
+                break
+    return out
+
+
+# ── HookDispatcher ───────────────────────────────────────────────────────
+
+
+def test_hookdispatcher_bump_sites_are_derived_and_non_empty() -> None:
+    """Tier 2: vacuity guard + completeness pin — the AST-derived set of
+    ``HookDispatcher`` methods calling ``self._bump_generation()`` is
+    non-empty AND matches the known real site exactly (a regression pin:
+    a new mutation site added later without its own bump would silently
+    NOT appear here, which is exactly what this pin exists to catch — see
+    the module docstring's strip-falsify)."""
+    tree = ast.parse(_DISPATCHER_PY.read_text(encoding="utf-8"))
+    sites = _methods_calling(tree, "HookDispatcher", "_bump_generation")
+    assert sites, "no HookDispatcher method calls self._bump_generation() at all"
+    assert sites == {"replace_registry"}, sites
+
+
+def test_hookdispatcher_replace_registry_bumps_generation() -> None:
+    """Tier 2: functional witness for the one enumerated site above."""
+    dispatcher = HookDispatcher(
+        HookRegistry(defs=[]),
+        put_inbox=lambda **kw: None,
+        stage_next_turn_context=lambda **kw: None,
+    )
+    assert dispatcher.generation == 0
+    dispatcher.replace_registry(HookRegistry(defs=[]))
+    assert dispatcher.generation == 1
+    dispatcher.replace_registry(HookRegistry(defs=[]))
+    assert dispatcher.generation == 2
+
+
+# ── MCPConnectionService ─────────────────────────────────────────────────
+
+
+def test_mcpconnectionservice_bump_sites_are_derived_and_non_empty() -> None:
+    """Tier 2: vacuity guard + completeness pin — see the module docstring
+    for why ``_ensure_open``/``_reconnect`` are enumerated here (real AST
+    hits) but not independently functionally witnessed in this file."""
+    tree = ast.parse(_CONNECTION_SERVICE_PY.read_text(encoding="utf-8"))
+    sites = _methods_calling(tree, "MCPConnectionService", "_bump_generation")
+    assert sites, "no MCPConnectionService method calls self._bump_generation() at all"
+    assert sites == {
+        "_ensure_open", "_reconnect", "aclose",
+        "_track_subscription", "_untrack_subscription", "_set_last_honored",
+    }, sites
+
+
+def test_mcpconnectionservice_track_and_untrack_subscription_bump() -> None:
+    """Tier 2: functional witness for 2 of the enumerated sites above."""
+    service = MCPConnectionService()
+    assert service.generation == 0
+    service._track_subscription("srv", "resource://x")
+    assert service.generation == 1
+    service._untrack_subscription("srv", "resource://x")
+    assert service.generation == 2
+
+
+def test_mcpconnectionservice_set_last_honored_bumps() -> None:
+    """Tier 2: functional witness for the 3rd of the enumerated sites —
+    the delegation point that replaced ``_HeldConnection``'s own former
+    direct ``self._service._last_honored[...] = `` write (#5287)."""
+    service = MCPConnectionService()
+    assert service.generation == 0
+    service._set_last_honored("srv", {"resource://x"})
+    assert service.generation == 1
+    assert service.unhonored_uris("srv") == []
+
+
+@pytest.mark.asyncio
+async def test_mcpconnectionservice_aclose_bumps() -> None:
+    """Tier 2: functional witness for the 4th of the enumerated sites."""
+    service = MCPConnectionService()
+    gen_before = service.generation
+    await service.aclose()
+    assert service.generation == gen_before + 1
+
+
+# ── Session's own 2 narrower generation counters ─────────────────────────
+
+
+def test_session_hook_toggle_generation_bump_sites_are_derived_and_non_empty() -> None:
+    """Tier 2: vacuity guard + completeness pin for ``Session``'s
+    ``_hook_toggle_generation`` (the ``_disabled_hooks``-owning counter —
+    see that field's own comment in ``Session.__init__``)."""
+    tree = ast.parse(_SESSION_PY.read_text(encoding="utf-8"))
+    sites = _methods_augassigning(tree, "Session", "_hook_toggle_generation")
+    assert sites, "no Session method increments self._hook_toggle_generation at all"
+    assert sites == {"set_hook_enabled", "load_persisted_toggles"}, sites
+
+
+def test_session_capability_inputs_generation_bump_sites_are_derived_and_non_empty() -> None:
+    """Tier 2: vacuity guard + completeness pin for ``Session``'s
+    ``_capability_inputs_generation`` (the envelope-census counter — see
+    that field's own comment in ``Session.__init__``)."""
+    tree = ast.parse(_SESSION_PY.read_text(encoding="utf-8"))
+    sites = _methods_augassigning(tree, "Session", "_capability_inputs_generation")
+    assert sites, "no Session method increments self._capability_inputs_generation at all"
+    assert sites == {"rekey_session_id", "refresh_mcp_servers", "_reapply_skills"}, sites


### PR DESCRIPTION
**[e2e-coder]** — part of #5276, addresses #5287.

Full rationale, per-producer bump-site enumeration, and the disclosed behavior change (`load_persisted_toggles` alone no longer invalidates the census — only a real re-key does) are in the commit message. Summary:

`hook_state`/`mcp_subscription_state`/`capability_visibility_state`'s envelope census each made the CONSUMER (`Session`) enumerate every invalidating mutation site — a hand-picked EventLog event-kind list (7 kinds, one added post-ship, #5280) or an explicit `invalidate()` call at N hand-enumerated sites. Both shapes needed mid-air fixes twice already (#5279/#5280/#5284/#5285). Fixed uniformly across all 3: the PRODUCER owns a `generation: int`, bumped at its own real mutation sites; the consumer compares `(generation, cached_value)` on every read. No subscriber, no explicit invalidate() call, no event-kind list — a new mutation site just needs `self._bump_generation()`, colocated with the mutation.

Producers: `HookDispatcher` (bumped in `replace_registry`), `MCPConnectionService` (bumped at 6 real sites — `_ensure_open`/`_reconnect`/`aclose`/`_track_subscription`/`_untrack_subscription`/a new `_set_last_honored` helper replacing `_HeldConnection`'s former direct private-dict write), and `Session` itself (2 narrower counters — `_hook_toggle_generation`, `_capability_inputs_generation`, the latter bumped by a new `rekey_session_id` method replacing a bare `session._session_id = new_sid` field write from `registry.py`).

## Tests
- 3 existing reactive-cache files updated: only the sub-tests driving the OLD mechanism directly were replaced with the new mechanism's real equivalents; every behavior-only sub-test (call-count assertions via the pre-existing #4403 technique) needed no change.
- New `tests/runtime/test_5287_generation_producer_coverage.py`: AST-DERIVED (not hand-typed) enumeration of each producer's bump sites, vacuity-guarded + content-pinned, with functional witnesses calling the real methods. strip-falsify executed manually before landing (recorded in the file's own docstring): removing one bump line reproduces both the completeness pin and the functional witness going red independently — verified, reverted before commit.

## Local gates (all green)
- `ruff check .`
- `python scripts/test_tier_audit.py --strict` (4 changed/new test files)
- `python scripts/verify_module_docstrings.py` (all touched src files)
- `python scripts/mypy_ratchet.py`
- `python scripts/flat_tests_ratchet.py`
- `python scripts/check_tests_path_literal_reference.py`
- `python scripts/check_bare_tests_import_reference.py`
- `python scripts/check_file_depth_reference.py`
- `python scripts/check_subprocess_reyn_pin.py`
- No `docs/` touched — docs gate chain not required.
- `pytest tests/runtime/ tests/hooks/ tests/mcp/ tests/interfaces/test_5276_config_derived_fields_memoized.py` (deselecting one unrelated pre-existing local-env failure, confirmed identical on unmodified origin/main via `git stash`) — 661 passed, 1 skipped. Plus `-k "spawn or session_id or capability or visibility or hook or mcp_subscription"` — 327 passed. Both foreground, single run.

## Test plan
- [x] 661 + 327 tests pass locally (foreground, single run each)
- [x] `ruff check .` clean
- [x] All applicable local gates green
- [x] Strip-falsified: manually removed one producer's bump call, confirmed both the AST-completeness pin and the functional witness go red independently, reverted before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51


## BLOCKING fixed (head 6d6b27f95 -> 667d4fe57)

Lead-coder found the gate's assertion direction was inverted: it checked `bumpers == {known set}` (methods calling `self._bump_generation()`), which cannot catch #5287's own defect class — a new mutator added without its own bump silently never widens `bumpers`, so the check stays green. Fixed by deriving a SECOND, independent AST set (`mutators`, every method that actually mutates the tracked field) and asserting `mutators <= bumpers` instead — a forgotten bump now widens `mutators` past `bumpers` and turns this red, naming the exact missing site.

Naming fragility disclosed per lead-coder's request (see the test module's own docstring): the tracked attribute is named by its real field identifier, the same name the production module's own #5287 comments reference; a rename would break every production call site too, so this scanner failing loudly (vacuity guard) on a rename is the correct failure, not a fragile coincidence. `__init__` is excluded from the mutator scan (a constructor's own initial assignment never needs a bump), verified this doesn't hide anything real.

strip-falsify re-executed with the corrected direction: removing `_track_subscription`'s own bump call now makes `mutators <= bumpers` fail with `{'_track_subscription'}` named explicitly. Also directly verified the FIRST version's own blindness (a re-derived, not hand-typed, old-style equality check still passes with the same line removed). Reverted before commit.

657 passed, 1 skipped, foreground single run. All local gates green.
