### PR TITLE
feat(#4364): doctor gains a bounding/preference declared-vs-composed row

### DIFF
--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -141,6 +141,31 @@ PID-keyed markers each reyn CLI process writes about ITSELF at startup
 (that is the OS's job, per lead-coder's own ruling). D-2 unchanged:
 report-only — no kill, no TTL expiry; that judgment call is explicitly
 out of #5226's own scope until the count is visible at all.
+
+#4364 (this slice, 2026-09-02, lead-coder assignment — issue-comment
+candidate ②, chosen because it directly matches the owner's own
+motivating incident, "会社で llm.model の設定効果なさそうな挙動を見た"):
+declared vs. COMPOSED for every #4206 leaf with a live agent-layer
+override receptacle (:func:`_print_bounding_preference_composition`) —
+the general form C-5/C-6 already established (declared config next to
+its resolved/enforced effect), applied to axes ② (``BOUNDING_KEYS``,
+narrowest-wins, ``runtime/bounding.py``) and ③ (``PREFERENCE_KEYS``,
+last-wins, ``runtime/preferences.py``) instead of sandbox posture. Reads
+:func:`~reyn.config.config_schema.walk_config_schema`'s own ``axis``/
+``override_enabled`` metadata (#5673, landed the same day) rather than a
+second hand list — the exact "no new machinery, read and display what's
+already there" increment #4364 requires. Loads each agent's own
+``profile.yaml`` via :meth:`~reyn.runtime.profile.AgentProfile.load` —
+the SAME validated loader a real session-spawn already uses — never a
+second hand-parse. Reports mismatches only (an agent that sets no
+override, or narrows to the same value, produces no line). Session-layer
+overrides (``resolve_preference``'s third parameter) are NOT visible to
+doctor — a separate, one-shot process with no live session, the same D-2
+limitation C-2/C-3(b) already disclose for other session-scoped state;
+this function's own printed line says so explicitly. Deliberately does
+NOT cover ``B-1``..``B-4`` (the ``config validate``-side candidates from
+the same issue-comment) — lead-coder's explicit scope note: handled
+separately.
 """
 from __future__ import annotations
 
@@ -176,6 +201,22 @@ _MEASURABLE_LEAF_KEYS: Final[tuple[str, ...]] = (
     "audit_events.max_disk_usage_percent",
     "sandbox.backend",
     "sandbox.on_unsupported",
+    # #4364 (this slice, 2026-09-02): every leaf carrying a LIVE
+    # agent-layer override receptacle (config_axis.py's #4206 axes ②/③,
+    # `override_enabled=True`) — this module now reads the COMPOSED
+    # value for each (see `_print_bounding_preference_composition`),
+    # not merely the declared one, so each qualifies as measurable by
+    # this list's own criterion below.
+    "llm.model",
+    "chat.reasoning.display",
+    "cost.daily_cost_usd.warn_ratio",
+    "cost.daily_tokens.warn_ratio",
+    "cost.monthly_cost_usd.warn_ratio",
+    "cost.monthly_tokens.warn_ratio",
+    "cost.per_agent_cost_usd.warn_ratio",
+    "cost.per_agent_tokens.warn_ratio",
+    "cost.rate_limit_warn_ratio",
+    "output_language",
 )
 _MEASURABILITY_CRITERION: Final[str] = (
     "a leaf counts as measurable here iff this module reads its LIVE EFFECT "
@@ -404,6 +445,14 @@ def run(args: argparse.Namespace) -> None:
     print("Sandbox posture — declared vs. RESOLVED (absence of a declaration")
     print("does not mean unrestricted; see the resolved backend below):")
     _print_sandbox_posture(config)
+
+    # ── #4364 (this slice, 2026-09-02): bounding/preference declared vs.
+    # composed — the general "declared ↔ effective" form (C-5/C-6) applied
+    # to #4206's ②/③ agent-layer override axes.
+    print()
+    print("Agent-layer overrides — declared (project) vs. COMPOSED (after")
+    print("each agent's own bounding:/preferences:), mismatches only:")
+    _print_bounding_preference_composition(config, resolved_root)
 
     # ── C-3(b): MCP negotiated protocol version + capabilities (#4364) ─────
     print()
@@ -1088,6 +1137,133 @@ def _print_sandbox_posture(config: object) -> None:
             "is empty) — this backend's own support: "
             + ", ".join(f"{k}={v.value}" for k, v in supported.items()),
         )
+
+
+def _print_bounding_preference_composition(config: object, project_root: Path) -> None:
+    """#4364 (this slice, 2026-09-02, lead-coder assignment): declared
+    (project-level schema default) vs. COMPOSED (after applying each
+    agent's own ``bounding:``/``preferences:`` override) for every
+    #4206 leaf with a live override receptacle — the general form of
+    C-5/C-6's "declared ↔ effective" pattern, applied to axes ②/③
+    instead of sandbox posture. Owner's own motivating incident (issue
+    body, verbatim): "会社で llm.model の設定効果なさそうな挙動を見た"
+    — ``llm.model`` is exactly axis ②'s one member today.
+
+    No new machinery: reads ``config_axis.py``'s existing
+    ``walk_config_schema()`` axis/``override_enabled`` metadata (#5673),
+    composes via the SAME ``compose_model_ceiling``/``resolve_preference``
+    every real agent spawn already calls (``runtime/bounding.py``/
+    ``runtime/preferences.py``), and loads each agent's profile the SAME
+    way a real session does (``AgentProfile.load`` — the same validated
+    loader, not a second hand-parse of the YAML, D-1: measure the actual
+    loaded effect).
+
+    D-2: reads only ``.reyn/agents/<name>/profile.yaml`` — a STATIC,
+    on-disk declaration. The SESSION layer (``resolve_preference``'s own
+    ``session_preferences`` parameter) is a live, in-process value no
+    separate one-shot ``doctor`` process can see — same limitation
+    C-2/C-3(b) already disclose for other session-scoped state; this
+    function's own printed line says so (D-3) rather than silently
+    only covering 2 of the 3 real layers.
+
+    Reports ONLY a mismatch (declared != composed) — an agent that sets
+    no override, or narrows to the SAME value the project already has,
+    produces no line (lead-coder's own scope: "食い違いを報告する").
+    An agent whose profile.yaml fails to load (a bounding/preferences
+    key #4206 doesn't recognize, or an out-of-range ``bounding.model``
+    value — the same validation a real session-load already enforces,
+    ``AgentProfile.load``) is reported by name, not silently skipped —
+    the SAME defect class ``AgentProfile.load`` failing at real
+    session-start would abort with, made visible ahead of time instead
+    of at the next agent boot."""
+    from reyn.config.config_schema import resolve_config_value, walk_config_schema
+    from reyn.config_axis import Axis
+    from reyn.runtime.bounding import compose_model_ceiling
+    from reyn.runtime.preferences import resolve_preference
+    from reyn.runtime.profile import AgentProfile
+
+    bounding_nodes = [
+        n for n in walk_config_schema()
+        if n.axis == Axis.BOUNDING and n.override_enabled
+    ]
+    preference_nodes = [
+        n for n in walk_config_schema()
+        if n.axis == Axis.PREFERENCE and n.override_enabled
+    ]
+
+    agents_dir = project_root / ".reyn" / "agents"
+    agent_names = (
+        sorted(p.name for p in agents_dir.iterdir() if p.is_dir())
+        if agents_dir.is_dir() else []
+    )
+    if not agent_names:
+        print("  no .reyn/agents/<name>/ found — nothing to compose against")
+        print(
+            "  (session-layer overrides are never visible to doctor — a "
+            "separate, one-shot process with no live session, D-2)",
+        )
+        return
+
+    mismatches = 0
+    load_errors: list[str] = []
+    for agent_name in agent_names:
+        try:
+            profile = AgentProfile.load(agents_dir / agent_name)
+        except FileNotFoundError:
+            continue  # a directory with no profile.yaml — not a real agent
+        except Exception as exc:  # noqa: BLE001 — D-1: report the real failure, never swallow it silently
+            load_errors.append(f"{agent_name}: {exc}")
+            continue
+
+        for node in bounding_nodes:
+            override_key = node.override_key or node.key
+            if override_key not in profile.bounding:
+                continue
+            _found, declared_bounding = resolve_config_value(config, node.key)
+            raw_agent_bound = profile.bounding[override_key]
+            composed_bounding: "str | None" = compose_model_ceiling(
+                declared_bounding,
+                str(raw_agent_bound) if raw_agent_bound is not None else None,
+            )
+            if composed_bounding != declared_bounding:
+                mismatches += 1
+                print(
+                    f"  ⚠ [{agent_name}] {node.key} (bounding.{override_key}): "
+                    f"declared={declared_bounding!r}, composed={composed_bounding!r}",
+                )
+
+        for node in preference_nodes:
+            if node.key not in profile.preferences:
+                continue
+            _found, declared_pref = resolve_config_value(config, node.key)
+            composed_pref: object = resolve_preference(
+                node.key, declared_pref, agent_preferences=profile.preferences,
+            )
+            if composed_pref != declared_pref:
+                mismatches += 1
+                print(
+                    f"  ⚠ [{agent_name}] {node.key} (preferences.{node.key}): "
+                    f"declared={declared_pref!r}, composed={composed_pref!r}",
+                )
+
+    if load_errors:
+        print(f"  ✗ {len(load_errors)} agent profile(s) failed to load (not compared):")
+        for line in load_errors:
+            print(f"    {line}")
+    if mismatches == 0:
+        qualifier = (
+            f" (among the {len(agent_names) - len(load_errors)} that loaded)"
+            if load_errors else ""
+        )
+        print(
+            f"  ✓ no agent narrows/overrides these "
+            f"{len(bounding_nodes) + len(preference_nodes)} key(s) away from "
+            f"the project default{qualifier}",
+        )
+    print(
+        "  (session-layer overrides are never visible to doctor — a "
+        "separate, one-shot process with no live session, D-2)",
+    )
 
 
 def _print_mcp_negotiation(config: object, project_root: Path) -> None:

--- a/tests/interfaces/test_4364_bounding_preference_doctor_row.py
+++ b/tests/interfaces/test_4364_bounding_preference_doctor_row.py
@@ -1,0 +1,174 @@
+"""Tier 2: #4364 (lead-coder assignment, issue-comment candidate ②) —
+``reyn doctor`` gains a declared-vs-composed row for every #4206 leaf with a
+live agent-layer override receptacle (``BOUNDING_KEYS``/``PREFERENCE_KEYS``).
+
+No mocks — drives the real ``run`` against real ``.reyn/agents/<name>/
+profile.yaml`` files under ``tmp_path``, matching this command family's own
+established shape (``test_4364_storage_cap_doctor_row.py``).
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.doctor import run
+from reyn.runtime.profile import AgentProfile
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _header_and_disclosure(out: str) -> None:
+    """#5658-precedent falsify witness: this section's own header + the
+    session-layer-invisibility disclosure must appear in EVERY run —
+    removing the whole block (or the disclosure line inside it) flips
+    this assertion red, not just a narrower per-scenario one."""
+    assert "Agent-layer overrides" in out
+    assert "declared (project) vs. COMPOSED" in out
+    assert (
+        "session-layer overrides are never visible to doctor" in out
+    ), "the D-2 (no live session) disclosure must be printed unconditionally"
+
+
+def test_no_agents_reports_nothing_to_compose_without_fabricating(tmp_path: Path, capsys):
+    """Tier 2: deny-side — no ``.reyn/agents/`` at all. Must say so plainly,
+    never invent a mismatch."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    _header_and_disclosure(out)
+    assert "no .reyn/agents/<name>/ found" in out
+    assert "declared=" not in out, "no agent exists to compose against — no declared/composed line may appear"
+
+
+def test_agent_with_no_override_produces_no_mismatch_line(tmp_path: Path, capsys):
+    """Tier 2: accept-side (no diff) — an agent with an EMPTY bounding/
+    preferences dict (the common case) narrows nothing; the row must say
+    so positively (✓), not stay silent (silence reads identically to "not
+    checked", the same D-3 concern every other doctor row addresses)."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    _header_and_disclosure(out)
+    assert "declared=" not in out
+    assert "no agent narrows/overrides" in out
+
+
+def test_bounding_narrowing_reports_the_real_declared_and_composed_values(
+    tmp_path: Path, capsys,
+):
+    """Tier 2: accept-side — the owner's own motivating incident
+    (``llm.model``, #4206 ②). An agent's ``bounding: {model: light}``
+    against a ``standard`` project default must produce a line naming
+    BOTH real values — via the SAME ``compose_model_ceiling`` a real
+    agent spawn uses, not a hand-computed comparison."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)  # llm.model: standard
+    AgentProfile(name="alice", role="", bounding={"model": "light"}).save(
+        tmp_path / ".reyn" / "agents" / "alice",
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    _header_and_disclosure(out)
+    mismatch_line = next(line for line in out.splitlines() if "llm.model" in line and "declared=" in line)
+    assert "[alice]" in mismatch_line
+    assert "declared='standard'" in mismatch_line
+    assert "composed='light'" in mismatch_line
+
+
+def test_bounding_same_as_declared_is_not_a_mismatch(tmp_path: Path, capsys):
+    """Tier 2: falsify pair for the previous test — an agent that narrows
+    to the SAME value the project already has composes identically, so
+    NO line is printed (this is the discriminator that proves the check
+    reads the real composed value, not merely "an override key is
+    present")."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)  # llm.model: standard
+    AgentProfile(name="alice", role="", bounding={"model": "standard"}).save(
+        tmp_path / ".reyn" / "agents" / "alice",
+    )
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    _header_and_disclosure(out)
+    assert "declared=" not in out
+    assert "no agent narrows/overrides" in out
+
+
+def test_preference_override_reports_declared_and_composed(tmp_path: Path, capsys):
+    """Tier 2: accept-side — axis ③ (``PREFERENCE_KEYS``), free-override,
+    via the SAME ``resolve_preference`` a real turn uses."""
+    _write_yaml(
+        tmp_path / "reyn.yaml",
+        MINIMAL_REYN_YAML + "output_language: english\n",
+    )
+    AgentProfile(
+        name="alice", role="", preferences={"output_language": "japanese"},
+    ).save(tmp_path / ".reyn" / "agents" / "alice")
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    _header_and_disclosure(out)
+    mismatch_line = next(
+        line for line in out.splitlines() if "output_language" in line and "declared=" in line
+    )
+    assert "[alice]" in mismatch_line
+    assert "declared='english'" in mismatch_line
+    assert "composed='japanese'" in mismatch_line
+
+
+def test_invalid_profile_is_reported_by_name_not_silently_skipped(tmp_path: Path, capsys):
+    """Tier 2: an agent's profile.yaml with a bounding key #4206 doesn't
+    recognize fails the SAME ``AgentProfile.load`` validation a real
+    session-spawn would hit — doctor must name the failing agent rather
+    than silently omitting it (D-1: report the real failure, never
+    swallow it) or crashing the whole command for every other agent."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    bad_dir = tmp_path / ".reyn" / "agents" / "bob"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "profile.yaml").write_text(
+        "name: bob\nbounding:\n  not_a_real_key: standard\n", encoding="utf-8",
+    )
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    _header_and_disclosure(out)
+    assert "bob" in out
+    assert "failed to load" in out
+    # alice's own (no-op) comparison still ran — one bad profile must not
+    # abort the whole command.
+    assert "no agent narrows/overrides" in out
+
+
+def test_measurable_leaf_keys_widened_include_every_bounding_and_preference_key():
+    """Tier 2: #4364 D-3's own auditable-list discipline — widening
+    coverage is a diff to ``_MEASURABLE_LEAF_KEYS``, never a silent count
+    change (this module's own established rule, ``test_4364_pr3a_doctor_
+    cli.py``'s sibling assertion). Every key BOUNDING_KEYS/PREFERENCE_KEYS
+    resolve to must now be measurable."""
+    from reyn.config.config_schema import walk_config_schema
+    from reyn.config_axis import Axis
+    from reyn.interfaces.cli.commands.doctor import _MEASURABLE_LEAF_KEYS
+
+    override_leaf_keys = {
+        n.key for n in walk_config_schema()
+        if n.axis in (Axis.BOUNDING, Axis.PREFERENCE) and n.override_enabled
+    }
+    assert override_leaf_keys, "no BOUNDING/PREFERENCE override-enabled leaves found — test fixture stale"
+    for key in override_leaf_keys:
+        assert key in _MEASURABLE_LEAF_KEYS, (
+            f"{key!r} has a live override receptacle but is not in "
+            f"_MEASURABLE_LEAF_KEYS"
+        )


### PR DESCRIPTION
**[tui-coder]** — #4364 issue-comment candidate ②: `reyn doctor` gains a declared-vs-composed row for every #4206 leaf with a live agent-layer override receptacle (`BOUNDING_KEYS`/`PREFERENCE_KEYS`).

Directly matches the owner's own motivating incident (issue body, verbatim): "会社で `llm.model` の設定効果なさそうな挙動を見た" — `llm.model` is exactly axis ②'s one member today.

No new machinery: reads `config_axis.py`'s existing axis/`override_enabled` metadata (#5673), composes via the SAME `compose_model_ceiling`/`resolve_preference` a real agent spawn already calls, loads each agent's profile via the SAME validated `AgentProfile.load()` a real session-spawn uses. Never inspects an API key. Reports mismatches only. Unconfigured/no-agents case says so plainly, never fabricates. The one real limitation (session-layer overrides are invisible to a separate one-shot doctor process) is disclosed unconditionally so a test goes red if it's removed. `_MEASURABLE_LEAF_KEYS` widened by exactly the 10 leaves now measured.

B-1..B-4 (the `config validate`-side candidates from the same issue-comment) are explicitly out of scope here per lead-coder.

## Test plan

- [x] Local pytest, foreground, single run: 64/64 doctor-family + 7 new tests, then `tests/interfaces/` + `tests/config/` full: 2454 passed, 4 skipped.
- [x] `ruff check .` — clean.
- [x] `python scripts/mypy_ratchet.py` — 201 findings, all baselined (0 new).
- [x] `python scripts/test_tier_audit.py --strict` on the new test file — 7/7 OK.
- [x] `python scripts/verify_module_docstrings.py` on `doctor.py` — OK.
- [x] `tests/` gates (flat_tests_ratchet / check_tests_path_literal_reference / check_bare_tests_import_reference / check_file_depth_reference / check_subprocess_reyn_pin) — all OK.
- [x] (skipped — Visual, standing waiver 2026-08-08)

part of #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
