### PR TITLE
docs: part of #4733 -- control-ir.md's sandboxed_exec section didn't follow #4733's async path

### DIFF
--- a/docs/reference/runtime/control-ir.ja.md
+++ b/docs/reference/runtime/control-ir.ja.md
@@ -228,6 +228,8 @@ Control IR の op kind は `sandboxed_exec` のまま変わりません（`OP_KI
 
 発行イベント: `sandboxed_exec_started`、`sandboxed_exec_completed`（P6 監査証跡）。
 
+**`exec(collect="async")`**（#4733）は、この同じ op をバックグラウンドで実行します(インラインではなく): `session_api.run_exec_async`(`session_api.py:1349`)が自前で `SandboxedExecIROp` + `OpContext`(専用の `cancel_event`、ターンごとに共有されるものではない)を構築し、`run_sandboxed_exec` を直接呼び出します — 迂回するのはtool層のdispatchラッパーとop-dispatchのentry point `handle`(`exec.py:185`、`op_runtime/sandboxed_exec.py:15`/`:60`)のみで、op schemaもハンドラ本体(脅威スキャン、backend解決、policy/timeout解決、argv0解決、同じstarted/completedイベント)も迂回しません — 両経路の違いはstdout/stderrを蓄積しながらファイルへストリームするオプションの `sink` tee callback のみで、これは `describe_task` で読み戻せます。オペレーター向けの要約は [feature-map.md](../../feature-map.md) を参照。
+
 ## `web_search`
 
 DuckDuckGo を使って公開ウェブを検索し、構造化された結果を返します。**Tier 1** — デフォルト許可；Permission 宣言不要。`reyn.yaml` の `web.search: deny` でプロジェクト全体をブロックできます。

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -408,6 +408,8 @@ Result fields: `returncode`, `stdout`, `stderr`, `truncated`, `backend`.
 
 Events emitted: `sandboxed_exec_started`, `sandboxed_exec_completed` (P6 audit trail).
 
+**`exec(collect="async")`** (#4733) runs this SAME op in the background instead of inline: `session_api.run_exec_async` (`session_api.py:1349`) builds its own `SandboxedExecIROp` + `OpContext` (a dedicated `cancel_event`, never the shared per-turn one) and calls `run_sandboxed_exec` directly — bypassing only the tool-layer dispatch wrapper and the op-dispatch entry point `handle` (`exec.py:185`, `op_runtime/sandboxed_exec.py:15`/`:60`), never the op schema or the handler body itself (threat scan, backend resolution, policy/timeout resolution, argv0 resolution, the same started/completed events) — the two paths differ only in an optional `sink` tee callback that streams stdout/stderr to a file as it accumulates, read back via `describe_task`. See [feature-map.md](../../feature-map.md) for the operator-facing summary.
+
 ## `web_search`
 
 Searches the public web using DuckDuckGo and returns structured results. **Tier 1** — default allow; no permission declaration required. Can be blocked project-wide with `web.search: deny` in `reyn.yaml`.


### PR DESCRIPTION
**[docs-maintainer]** — part of #4733. `#5675` landed `exec(collect="async")` but the mechanism change never reached `control-ir.md`'s own `## sandboxed_exec` section — CLAUDE.md's rule ("a mechanism change makes the doc describing it stale, fix in the SAME PR") missed here, caught in lead-coder's own review after merge.

## What was wrong

`feature-map.md` got the right one-liner for `collect="async"` in the same PR, but `control-ir.md` — the canonical op-contract reference `## sandboxed_exec` points to — said nothing, so a reader following feature-map.md's cross-reference back to the op contract would have no idea the async mode exists, or reasonably assume it's "just" a variant handled inside the normal op-dispatch machinery.

## Verified before writing (an initial framing was wrong)

My first pass characterized this as "a completely separate path" — lead-coder correctly flagged that as likely overstated and asked me to open the file and check before writing. Actual shape, confirmed by reading the code directly:

- `collect="async"` bypasses the tool-layer dispatch wrapper (`exec.py`) and the op-dispatch entry point `handle` (`op_runtime/sandboxed_exec.py:15`/`:60`, the fixed `(op, ctx)` signature every op-kind handler shares).
- It does **not** bypass the op schema or the handler body: `session_api.run_exec_async` (`session_api.py:1349`) constructs its own `SandboxedExecIROp` and its own `OpContext` (with a dedicated `cancel_event`, never the shared per-turn one), then calls `run_sandboxed_exec` directly — the exact same function `handle` calls, same threat scan / backend resolution / policy+timeout resolution / argv0 resolution / P6 events.
- The only real difference is an optional `sink` tee callback that streams stdout/stderr to a file as it accumulates, read back via `describe_task`.

## Fixed

- `docs/reference/runtime/control-ir.md` — one paragraph after the `sandboxed_exec_started`/`sandboxed_exec_completed` events line, with file:line citations.
- `docs/reference/runtime/control-ir.ja.md` — same note, translated. Not obligatory under house rule 5 (the ja file wasn't itself falsified — it just carries the same coverage gap), but the same misreading risk applies to ja readers; lead-coder left the call to me, doing it in the same PR.

## Gates

```
mkdocs build --strict -f .mkdocs/mkdocs.yml           → exit 0
python scripts/check_doc_anchors.py                    → exit 0
python scripts/check_retired_config_keys_denylist.py   → exit 0
```

## Test plan

- [x] Read `exec.py:185`, `op_runtime/sandboxed_exec.py:1-70`, and `session_api.py:1340-1385` directly before writing the correction — not left at the first-pass "completely separate path" framing
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
