### PR TITLE
feat(#4364): reyn doctor -- external_transports inert-key report

### DIFF
--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -197,6 +197,32 @@ NOT build a `resolve_sandbox_policy()` call — that needs a caller-supplied
 must not invent a stand-in for. Only the declared `sandbox.policy` dict's own
 write-scope keys are shown, never a merged/resolved policy.
 
+### `external_transports:` — configured entries vs. the 2 real consumers
+
+```
+external_transports: — configured entries vs. the 2 real
+consumers (both web/AGUI-server-only; inert under `reyn chat`):
+  ⚠ 1 configured (broker) — this section is wired ONLY by interfaces/web/deps.py:411-412 (outbox interceptor) and interfaces/web/server.py:123 (cron-failure notifier), both reachable only through the web/AGUI server runner. `reyn chat` (the plain CLI) never reaches either — these entries have no effect there.
+  (doctor cannot tell whether you actually run via the web/AGUI server — if you do, these entries DO apply there; this is a static declaration check, D-2)
+```
+
+`config/loader.py`'s `_build_external_transports_config` accepts any
+transport name under `external_transports:` — but the only 2 real
+consumers of the parsed `ExternalTransportRouting` are
+`interfaces/web/deps.py`'s outbox-interceptor wiring and
+`interfaces/web/server.py`'s cron-job-failure notifier, both reachable
+only through the web/AGUI server runner. `reyn chat` (the plain CLI)
+never reaches either, so any `external_transports:` entry written for
+a `reyn chat`-only setup is inert — the SAME third-state shape
+`config.py`'s AgentProfile-unknown-key report already established
+("it is read, kept in no in-memory state, and does nothing"), applied
+here to a section that IS a recognized key.
+
+An UNCONFIGURED section prints `unconfigured` and names nothing — never
+a fabricated "0 configured" framed as a finding. Doctor cannot observe
+which runner the operator actually uses, so the line discloses that
+limit explicitly rather than asserting one mode or the other (D-2).
+
 ### MCP servers — last negotiated version/capabilities (C-3(b))
 
 ```

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -109,7 +109,7 @@ doc↔code gate](../runtime/events.md) と同じ形）。あるキーが agent/s
 | `agent_id` | 文字列 | project | restart | `reyn.yaml` | エージェントの**識別子**— P6 監査証跡と送信 HTTP ヘッダーに刻まれます。**エージェントの定義・設定はしません**（エージェント定義は `.reyn/agents/<名前>/`）。以下参照。 |
 | `auth` | マップ | project | restart | `reyn.yaml` | `reyn auth login` 用の OAuth プロバイダー設定。以下参照。 |
 | `cron` | マップ | project | restart / hot | `reyn.yaml` + `.reyn/config/cron.yaml` | スケジュール付きスキル実行。以下参照。 |
-| `external_transports` | マップ | project | restart | `reyn.yaml` | チャット向け受信トランスポート → MCP ツールルーティング（Slack / LINE / Discord など）。以下参照。 |
+| `external_transports` | マップ | project | restart | `reyn.yaml` | 受信トランスポート → MCP ツールルーティング、web/AGUI サーバランナー経由でのみ配線 — 素の `reyn chat` では inert（Slack / LINE / Discord など）。以下参照。 |
 | `multimodal` | マップ | project | restart | `reyn.yaml` | バイナリメディア（画像・音声）のサイズ上限、超過時の挙動、アーティファクト保存先、およびそれらを配信する `base_url`。以下参照。 |
 | `permissions` | マップ | project · agent · session² | restart⁷ | `reyn.yaml` | デフォルトの Permission ポリシー。以下参照。 |
 | `project_context_path` | 文字列 | project · agent³ | restart⁶ | `reyn.yaml` | すべての Phase システムプロンプトに注入する Markdown ファイル。未設定（デフォルト）: cross-tool 標準を auto-resolve — `AGENTS.md` があればそれ、なければ `REYN.md`（legacy fallback）。明示パスで 1 ファイルに固定、`""` で無効化。**#5084: エージェント自身の `.reyn/agents/<name>/profile.yaml` にも `project_context_path` を設定でき、その 1 エージェントに限り本キー（プロジェクト全体のデフォルト）を上書き（マージではなく置換）する** — 別ファイル・別メカニズム。下記の注記参照。 |
@@ -1344,29 +1344,32 @@ multimodal:
 
 ## `external_transports` ブロック
 
-チャット向け受信トランスポート → MCP ツールルーティング。外部トランスポート名（Slack / LINE / Discord / ...）を、リプライを配信する MCP ツール + ルーター出力をツール引数に shape する `args_template` にマップします。
+受信トランスポート → MCP ツールルーティング。**web/AGUI サーバランナー経由でのみ配線されます**（`interfaces/web/deps.py` の outbox interceptor と `interfaces/web/server.py` の cron ジョブ失敗通知 — grep 確認済、#4364）— **素の `reyn chat` はどちらの consumer にも到達しません**。外部トランスポート名（Slack / LINE / Discord / ...）を、リプライを配信する MCP ツール + ルーター出力をツール引数に shape する `args_template` にマップします。
+
+**フラットな形で、`transports:` のラップは不要**です — loader（`runtime/external_routing.py` の `parse_external_transports`）はこのブロックの最上位キーを全てトランスポート名として扱います。`transports:` でラップする形（以前のこの例）は、それ自体が `mcp_tool` を持たない不正な 1 エントリ（名前 `"transports"`）として静かに捨てられます — 直接確認済み: `parse_external_transports({"transports": {"slack": {...}}})` は 0 件を返します。
 
 ```yaml
 external_transports:
-  transports:
-    slack:
-      mcp_tool: slack__post_message
-      args_template:
-        channel: "${TRANSPORT_DEST}"
-        text: "${ROUTER_REPLY}"
-    line:
-      mcp_tool: line__push_message
-      args_template:
-        to: "${TRANSPORT_DEST}"
-        messages:
-          - type: text
-            text: "${ROUTER_REPLY}"
+  slack:
+    mcp_tool: slack__post_message
+    args_template:
+      channel: "${TRANSPORT_DEST}"
+      text: "${ROUTER_REPLY}"
+  line:
+    mcp_tool: line__push_message
+    args_template:
+      to: "${TRANSPORT_DEST}"
+      messages:
+        - type: text
+          text: "${ROUTER_REPLY}"
 ```
 
 | フィールド | 型 | 説明 |
 |-------|------|-------------|
-| `transports.<name>.mcp_tool` | 文字列 | リプライを配信する完全修飾 MCP ツール名 (`<server>__<tool>`)。 |
-| `transports.<name>.args_template` | マップ | MCP ツールに渡される shape。`${TRANSPORT_DEST}` はメッセージごとの宛先 ID（channel / user / room id）に解決、`${ROUTER_REPLY}` はルーターの最終テキストに解決。他の `${VAR}` 参照は標準 interpolation ルールに従って `os.environ` から解決。 |
+| `<name>.mcp_tool` | 文字列 | リプライを配信する完全修飾 MCP ツール名 (`<server>__<tool>`)。 |
+| `<name>.args_template` | マップ | MCP ツールに渡される shape。`${TRANSPORT_DEST}` はメッセージごとの宛先 ID（channel / user / room id）に解決、`${ROUTER_REPLY}` はルーターの最終テキストに解決。他の `${VAR}` 参照は標準 interpolation ルールに従って `os.environ` から解決。 |
+
+`reyn doctor` は、web/AGUI サーバ経由で実行していない限り、ここに設定されたエントリを inert として報告します — `reference/cli/doctor.md` の `external_transports:` 節を参照。
 
 トランスポートごとの contract と利用可能なテンプレート変数の全集合は `src/reyn/runtime/external_routing.py` を参照。
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -127,7 +127,7 @@ aren't.
 | `agent_id` | string | project | restart | `reyn.yaml` | Agent **identity** — stamped on the P6 audit trail and the outgoing HTTP header. Does **not** define or configure agents; agent definitions live in `.reyn/agents/<name>/`. See below. |
 | `auth` | map | project | restart | `reyn.yaml` | OAuth provider configurations for `reyn auth login`. See below. |
 | `cron` | map | project | restart / hot | `reyn.yaml` + `.reyn/config/cron.yaml` | Scheduled skill executions. See below. |
-| `external_transports` | map | project | restart | `reyn.yaml` | Inbound transport → MCP tool routing for chat (Slack / LINE / Discord etc.). See below. |
+| `external_transports` | map | project | restart | `reyn.yaml` | Inbound transport → MCP tool routing, wired only via the web/AGUI server runner — inert under plain `reyn chat` (Slack / LINE / Discord etc.). See below. |
 | `multimodal` | map | project | restart | `reyn.yaml` | Binary media (image/audio) size cap, on-oversize behaviour, artefact storage paths, and the `base_url` those artefacts are served under. See below. |
 | `permissions` | map | project · agent · session² | restart⁷ | `reyn.yaml` | Default permission policy. See below. |
 | `project_context_path` | string | project · agent³ | restart⁶ | `reyn.yaml` | Markdown file injected into every phase system prompt. Unset (default): auto-resolves the cross-tool standard — `AGENTS.md` if present, else `REYN.md` (legacy fallback). Set an explicit path to pin one file; set `""` to disable. **#5084: an agent's own `.reyn/agents/<name>/profile.yaml` may set `project_context_path` too, REPLACING (not merging with) this project-wide value for that one agent** — a separate file/mechanism from this `reyn.yaml` key. See note below. |
@@ -2643,29 +2643,48 @@ multimodal:
 
 ## `external_transports` block
 
-Inbound transport → MCP tool routing for chat. Maps an external transport name (Slack / LINE / Discord / ...) to the MCP tool that delivers replies, plus an `args_template` describing how router output is shaped into the tool's arguments.
+Inbound transport → MCP tool routing, wired ONLY through the **web/AGUI
+server runner** (`interfaces/web/deps.py`'s outbox interceptor and
+`interfaces/web/server.py`'s cron-job-failure notifier — grep-confirmed,
+#4364) — **plain `reyn chat` never reaches either consumer**, so entries
+written here have no effect there. Maps an external transport name
+(Slack / LINE / Discord / ...) to the MCP tool that delivers replies,
+plus an `args_template` describing how router output is shaped into the
+tool's arguments.
+
+**Flat, no `transports:` wrapper** — the loader
+(`runtime/external_routing.py`'s `parse_external_transports`) treats
+EVERY top-level key of this block as a transport name directly; a
+wrapping `transports:` key (an earlier version of this example) is
+itself parsed as one malformed transport named `"transports"` (no
+`mcp_tool` of its own) and silently dropped — verified directly:
+`parse_external_transports({"transports": {"slack": {...}}})` returns
+zero configured transports.
 
 ```yaml
 external_transports:
-  transports:
-    slack:
-      mcp_tool: slack__post_message
-      args_template:
-        channel: "${TRANSPORT_DEST}"
-        text: "${ROUTER_REPLY}"
-    line:
-      mcp_tool: line__push_message
-      args_template:
-        to: "${TRANSPORT_DEST}"
-        messages:
-          - type: text
-            text: "${ROUTER_REPLY}"
+  slack:
+    mcp_tool: slack__post_message
+    args_template:
+      channel: "${TRANSPORT_DEST}"
+      text: "${ROUTER_REPLY}"
+  line:
+    mcp_tool: line__push_message
+    args_template:
+      to: "${TRANSPORT_DEST}"
+      messages:
+        - type: text
+          text: "${ROUTER_REPLY}"
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `transports.<name>.mcp_tool` | string | Fully-qualified MCP tool name (`<server>__<tool>`) that delivers the reply. |
-| `transports.<name>.args_template` | map | Shape passed to the MCP tool. `${TRANSPORT_DEST}` resolves to the per-message destination identifier (channel / user / room id), `${ROUTER_REPLY}` to the router's final text. Other `${VAR}` references resolve from `os.environ` per the standard interpolation rules. |
+| `<name>.mcp_tool` | string | Fully-qualified MCP tool name (`<server>__<tool>`) that delivers the reply. |
+| `<name>.args_template` | map | Shape passed to the MCP tool. `${TRANSPORT_DEST}` resolves to the per-message destination identifier (channel / user / room id), `${ROUTER_REPLY}` to the router's final text. Other `${VAR}` references resolve from `os.environ` per the standard interpolation rules. |
+
+`reyn doctor` reports any configured entry here as inert unless you run
+via the web/AGUI server — see `reference/cli/doctor.md`'s own
+`external_transports:` section.
 
 See `src/reyn/runtime/external_routing.py` for the per-transport contract and the full set of available template variables.
 

--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -217,6 +217,11 @@ _MEASURABLE_LEAF_KEYS: Final[tuple[str, ...]] = (
     "cost.per_agent_tokens.warn_ratio",
     "cost.rate_limit_warn_ratio",
     "output_language",
+    # #4364 (this slice, 2026-09-03): reads the LIVE parsed
+    # `.transports` dict and names the actual consumer call sites
+    # (`_print_external_transports_status`) — not merely re-reading
+    # the declared value back.
+    "external_transports",
 )
 _MEASURABILITY_CRITERION: Final[str] = (
     "a leaf counts as measurable here iff this module reads its LIVE EFFECT "
@@ -453,6 +458,13 @@ def run(args: argparse.Namespace) -> None:
     print("Agent-layer overrides — declared (project) vs. COMPOSED (after")
     print("each agent's own bounding:/preferences:), mismatches only:")
     _print_bounding_preference_composition(config, resolved_root)
+
+    # ── #4364 (this slice, 2026-09-03): external_transports — configured
+    # entries are inert unless reached via the web/AGUI server runner ──────
+    print()
+    print("external_transports: — configured entries vs. the 2 real")
+    print("consumers (both web/AGUI-server-only; inert under `reyn chat`):")
+    _print_external_transports_status(config)
 
     # ── C-3(b): MCP negotiated protocol version + capabilities (#4364) ─────
     print()
@@ -1263,6 +1275,62 @@ def _print_bounding_preference_composition(config: object, project_root: Path) -
     print(
         "  (session-layer overrides are never visible to doctor — a "
         "separate, one-shot process with no live session, D-2)",
+    )
+
+
+def _print_external_transports_status(config: object) -> None:
+    """#4364 (this slice, 2026-09-03, lead-coder assignment — @tui-coder's
+    candidate ①): report ``external_transports:`` entries as INERT for
+    the surface this ``doctor`` process is most likely run from —
+    ``reyn chat`` (the plain CLI).
+
+    Same third-state shape ``config.py``'s AgentProfile-unknown-key
+    report already established (verbatim: "it is read, kept in no
+    in-memory state, and does nothing") — applied here to a section
+    that IS a recognized key (unlike that report's case), but whose
+    only 2 real consumers are both reachable exclusively through the
+    web/AGUI server runner, never through ``reyn chat``'s own
+    run-loop. No new machinery: this reads the SAME
+    ``config.external_transports.transports`` dict the loader already
+    builds (D-1 — the live parsed value, not a re-parse of the raw
+    YAML), and names the 2 real consumer call sites by file:line
+    (grep-confirmed, #4364 investigation) rather than asserting the
+    inertness in the abstract:
+
+      - ``interfaces/web/deps.py:411-412`` — the outbox interceptor
+        wiring, gated on ``config.external_transports.transports``
+        being non-empty, itself only reached from the web app's own
+        session-construction path.
+      - ``interfaces/web/server.py:123`` — the cron-job-failure
+        notifier (``_failure_notifier``), part of the web server's own
+        background runner.
+
+    D-2: this is a static declaration check — doctor has no way to
+    tell whether the operator actually runs via the web/AGUI server
+    (where these entries DO apply) or plain ``reyn chat`` (where they
+    do not); the printed line discloses that limit explicitly rather
+    than asserting one mode or the other. D-3: an UNCONFIGURED section
+    prints "unconfigured", never a fabricated "0 configured" framed as
+    a finding — matching #5658/#5679's own "declare no data, don't
+    invent a zero" posture for an absent value."""
+    external_transports = getattr(config, "external_transports", None)
+    transports = getattr(external_transports, "transports", None) or {}
+    if not transports:
+        print("  unconfigured — no external_transports: entries in reyn.yaml")
+        return
+    names = sorted(transports)
+    print(
+        f"  ⚠ {len(names)} configured ({', '.join(names)}) — this section "
+        f"is wired ONLY by interfaces/web/deps.py:411-412 (outbox "
+        f"interceptor) and interfaces/web/server.py:123 (cron-failure "
+        f"notifier), both reachable only through the web/AGUI server "
+        f"runner. `reyn chat` (the plain CLI) never reaches either — "
+        f"these entries have no effect there.",
+    )
+    print(
+        "  (doctor cannot tell whether you actually run via the web/AGUI "
+        "server — if you do, these entries DO apply there; this is a "
+        "static declaration check, D-2)",
     )
 
 

--- a/tests/interfaces/test_4364_external_transports_doctor_row.py
+++ b/tests/interfaces/test_4364_external_transports_doctor_row.py
@@ -1,0 +1,91 @@
+"""Tier 2: #4364 (lead-coder assignment, tui-coder's candidate ① — part of
+#4364) — ``reyn doctor`` gains an ``external_transports:`` inert-key row.
+
+Real defect: ``config/loader.py``'s ``_build_external_transports_config``
+accepts any transport name (``for name, raw_entry in raw.items()``), but
+the only 2 real consumers are ``interfaces/web/deps.py``'s outbox-
+interceptor wiring and ``interfaces/web/server.py``'s cron-failure
+notifier — both reachable only through the web/AGUI server runner, never
+through ``reyn chat``'s own run-loop. Same third-state shape
+``config.py``'s AgentProfile-unknown-key report already established
+("it is read, kept in no in-memory state, and does nothing"), applied
+here to a section that IS recognized but whose live effect depends on
+which runner the operator actually uses (a fact doctor cannot observe,
+D-2).
+
+No mocks — drives the real ``run`` against a real parsed config under
+``tmp_path``, matching this command family's own established shape
+(``test_4364_storage_cap_doctor_row.py``).
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.doctor import run
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+_EXTERNAL_TRANSPORTS_YAML = (
+    "external_transports:\n"
+    "  broker:\n"
+    "    mcp_tool: broker__post_message\n"
+    "    args_template:\n"
+    "      text: \"{text}\"\n"
+)
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _external_transports_section(out: str) -> str:
+    """The doctor output's ``external_transports:`` section body — from
+    its own header line up to (not including) the blank line that
+    separates it from the NEXT section (every section in this command
+    is separated by a bare ``print()``, doctor.py's own established
+    shape — see ``run()``'s own section-by-section structure)."""
+    lines = out.splitlines()
+    start = next(i for i, ln in enumerate(lines) if ln.startswith("external_transports:"))
+    end = start + 1
+    while end < len(lines) and lines[end] != "":
+        end += 1
+    return "\n".join(lines[start:end])
+
+
+def test_configured_transport_reports_inert_and_names_real_consumers(
+    tmp_path: Path, capsys,
+):
+    """Tier 2: accept-side — a declared ``external_transports.broker``
+    entry produces a row naming it BY NAME as inert under ``reyn chat``,
+    and names the 2 real consumer files."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML + _EXTERNAL_TRANSPORTS_YAML)
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    section = _external_transports_section(out)
+    assert "broker" in section
+    assert "1 configured" in section
+    assert "interfaces/web/deps.py" in section
+    assert "interfaces/web/server.py" in section
+    assert "reyn chat" in section
+
+
+def test_unconfigured_external_transports_says_so_and_names_nothing(
+    tmp_path: Path, capsys,
+):
+    """Tier 2: deny-side — with no ``external_transports:`` block at all,
+    the row must say "unconfigured" and must NOT print the "configured"
+    finding form at all (falsify pair with the test above — an
+    always-inert-warning implementation would fail THIS test; an
+    always-unconfigured implementation would fail the test above)."""
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+
+    run(Namespace(project_root=str(tmp_path)))
+    out = capsys.readouterr().out
+
+    section = _external_transports_section(out)
+    assert "unconfigured" in section
+    assert "configured (" not in section
+    assert "interfaces/web/deps.py" not in section


### PR DESCRIPTION
**[e2e-coder]** — part of #4364 (tui-coder's candidate ①).

Full rationale, exact consumer file:lines, and the disclosed pre-existing doc drift are in the commit message. Summary:

`reyn doctor` gains an `external_transports:` inert-key report — `config/loader.py` accepts any transport name under this section, but the only 2 real consumers (`interfaces/web/deps.py`'s outbox interceptor, `interfaces/web/server.py`'s cron-failure notifier) are both reachable only through the web/AGUI server runner, never `reyn chat`. Same third-state shape `config.py`'s AgentProfile-unknown-key report already established. No new machinery.

## A real doc defect found and fixed (same identifier this PR touches)

`docs/reference/config/reyn-yaml.md`/`.ja.md`'s own `external_transports` example wrapped entries in an extra `transports:` key — verified directly that this produces ZERO configured transports when parsed (the loader treats every top-level key as a transport name, so the wrapper itself becomes one malformed, silently-dropped entry). Fixed to the flat form `docs/gateway/authoring-guide.md`'s own example already uses correctly.

## Tests
`tests/interfaces/test_4364_external_transports_doctor_row.py` — falsify pair (accept names the entry + both consumer files + "reyn chat"; deny says "unconfigured" and prints neither), real parsed config, no mocks. strip-falsify executed manually: stripped the check → accept-side red, deny-side stayed green (the exact reason the pair, not either test alone, is the real witness). Reverted before commit.

## Local gates (all green)
- `ruff check .`
- `python scripts/test_tier_audit.py --strict tests/interfaces/test_4364_external_transports_doctor_row.py`
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/doctor.py`
- `python scripts/mypy_ratchet.py`
- `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`
- `pytest tests/interfaces/test_4364_*.py` — 68 passed, 1 skipped (unrelated). `pytest tests/ -k "external_transport or external_routing"` — 35 passed, 4 skipped (unrelated optional-dep extras). Both foreground, single run.

## Disclosed, not fixed (out of scope for a 1-check slice)
`docs/reference/cli/doctor.md`'s own "What this PR checks" example transcript predates #5658/#5679/#5226 (none of those sections appear there either) — my own `_MEASURABLE_LEAF_KEYS` addition makes its stale count one more wrong, but regenerating that whole transcript is a separate job than this slice.

## Test plan
- [x] 68 + 35 tests pass locally (foreground, single run each)
- [x] `ruff check .` clean
- [x] All applicable local gates green (incl. docs path-conditional gate, in order)
- [x] Strip-falsified: removed the check, confirmed accept-side red / deny-side green (the pair's own witness), reverted before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
