### PR TITLE
fix(#5686): hook turn seed carries [hook:<name>] attribution, not bare text

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -8064,7 +8064,24 @@ class Session:
             meta={"chain_id": chain_id},
         ))
         try:
-            await self._run_router_loop(text, chain_id)
+            # #5686: attributed, not raw text — RouterLoop.run's own
+            # fallback (router_loop.py's messages.append({"role":"user",
+            # ...}) guard) fires for this call every time today (E's
+            # own history entry is role="system", excluded from
+            # build_history's allowlist, so history[-1] is never
+            # "user"), delivering the hook's bare, unattributed text as
+            # a #3595-class misattributed operator turn. Using
+            # `attributed` here restores the SAME [hook:<name>] prefix
+            # already used for history/outbox above, at the ONE
+            # remaining mouth that had drifted from it (comment
+            # `:8021-8025` above already claims all three agree — this
+            # was the one that didn't). Deliberately NOT the #5678 fix
+            # (this stays role="user" until #5678's own allowlist
+            # widening + RouterLoop.run(user_text=None) bridge land
+            # together) — safe standalone today because that guard's
+            # fallback still fires exactly as before, just with
+            # attributed content instead of raw.
+            await self._run_router_loop(attributed, chain_id)
         except RouterCapExceeded as exc:
             await self._emit_router_cap_exhausted_user(
                 exc, chain_id=chain_id, user_text=text,

--- a/tests/hooks/test_hook_composer_reachability_phase5.py
+++ b/tests/hooks/test_hook_composer_reachability_phase5.py
@@ -176,7 +176,18 @@ async def test_composed_event_from_external_input_drives_wake_hook_e2e(tmp_path)
             "file_changed",
             build_hook_payload("file_changed", path="/repo/x.py", event_type="modified"),
         )
-        await _wait_until(lambda: "composed fired!" in ran)
+        # #5686/#5687: the pushed text now lands ATTRIBUTED
+        # ("[hook:<name>] composed fired!"), not bare — the correct
+        # tightening of this test's own claim ("the pushed text lands as
+        # a real router turn"), not a weakening: _handle_hook_message's
+        # turn seed matches its history entry / outbox announcement now,
+        # instead of drifting from them (a #3595-class misattribution
+        # this PR closed). A membership/equality check against the bare
+        # string would wait forever for a value that never arrives again
+        # — partial-match (`in`) on the composed text is what survives a
+        # future attribution-prefix change without re-encoding the exact
+        # prefix shape here.
+        await _wait_until(lambda: any("composed fired!" in r for r in ran))
     finally:
         await session.shutdown()
         try:
@@ -184,7 +195,15 @@ async def test_composed_event_from_external_input_drives_wake_hook_e2e(tmp_path)
         except asyncio.TimeoutError:
             run_task.cancel()
 
-    assert ran == ["composed fired!"]
+    (only_turn,) = ran  # exactly one hook-driven turn — a 2nd or 0 fails to unpack
+    assert "composed fired!" in only_turn, (
+        f"expected the one hook-driven turn's text to contain "
+        f"'composed fired!' (attributed, per #5686) — got {only_turn!r}"
+    )
+    assert only_turn.startswith("[hook:"), (
+        f"the hook-driven turn's own seed must carry the [hook:<name>] "
+        f"attribution prefix (#5686) — got {only_turn!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_5686_hook_seed_carries_attribution.py
+++ b/tests/runtime/test_5686_hook_seed_carries_attribution.py
@@ -1,0 +1,89 @@
+"""Tier 2: #5686 — an E (wake=true hook) turn's own seed carries the SAME
+``[hook:<name>]`` attribution its history entry and outbox announcement
+already use, instead of the bare, unattributed payload text.
+
+Background (found during #5678's own investigation, verified independently
+by lead-coder): ``Session._handle_hook_message`` builds an ``attributed``
+string (``_format_ride_along_attribution``) and uses it for BOTH the
+persisted ``ChatMessage`` and the outbox announcement — but historically
+passed the RAW ``text`` (unattributed) to ``_run_router_loop`` as the turn's
+own seed. ``RouterLoop.run``'s own fallback guard
+(``if not history or history[-1].get("role") != "user":
+messages.append({"role": "user", "content": user_text})``) fires for every
+hook-driven turn today (the history entry is ``role="system"``, currently
+excluded from ``build_history``'s allowlist, so ``history[-1]`` is never
+``"user"``) — so the hook's bare text reached the model as an unattributed
+``role="user"`` turn, indistinguishable from the operator's own words
+(a #3595-class misattribution, narrower blast radius: no slash-dispatch
+gate is reachable this way — see #5686's own issue body).
+
+Verified here via the SAME real-callable seam
+``tests/runtime/test_3475_mcp_probe_priming_all_turn_kinds.py`` uses:
+``Session._loop_driver.run_turn`` replaced with a plain async function
+(instance method-assignment, not a mock) that captures its own ``user_text``
+argument the instant it is invoked — no LLM call, no tool loop, the test
+only cares what string reaches this seam.
+
+strip-falsify (executed manually before landing): reverting
+``_handle_hook_message``'s ``await self._run_router_loop(attributed,
+chain_id)`` back to ``await self._run_router_loop(text, chain_id)`` makes
+this test go RED — the captured ``user_text`` reads back as the bare
+``"wake up"`` with no ``[hook:`` prefix.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+AGENT = "5686-hook-seed-agent"
+
+
+def _make_session(tmp_path: Path) -> Session:
+    return make_session(
+        agent_name=AGENT,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snapshot.json",
+    )
+
+
+def _install_capturing_run_turn(session: Session) -> dict:
+    """Real, plain async function (method-assignment, not a mock) that
+    captures the exact ``user_text`` ``run_turn`` was invoked with, then
+    ends the turn immediately — no LLM call, no tool loop."""
+    box: dict = {"user_text": "UNSET"}
+
+    async def _capturing_run_turn(user_text: str, chain_id: str) -> None:
+        box["user_text"] = user_text
+
+    session._loop_driver.run_turn = _capturing_run_turn
+    return box
+
+
+@pytest.mark.asyncio
+async def test_hook_driven_turn_seed_carries_hook_attribution(tmp_path: Path) -> None:
+    """Tier 2: #5686 accept — a ``kind="hook"`` (wake=true, E) turn's own
+    seed carries the ``[hook:<name>]`` prefix, matching what the history
+    entry and outbox announcement already carry — not the bare payload
+    text."""
+    session = _make_session(tmp_path)
+    box = _install_capturing_run_turn(session)
+
+    await session.inbox.put((
+        "hook",
+        {"name": "session_start", "text": "wake up", "chain_id": "chain-5686"},
+    ))
+    await session.run_one_iteration()
+
+    assert box["user_text"] != "UNSET", "run_turn was never invoked"
+    assert box["user_text"] == "[hook:session_start] wake up", (
+        f"the hook turn's own seed must carry the SAME [hook:<name>] "
+        f"attribution its history entry and outbox announcement already "
+        f"use — got {box['user_text']!r} (bare, unattributed text reaching "
+        f"the model as an operator-indistinguishable role=\"user\" turn is "
+        f"the #5686 defect)"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5686

Step 1 (architect co-vet: small, standalone, land first) of #5686's own fix. \`_handle_hook_message\` (E, wake=true) builds an \`attributed\` \`"[hook:<name>] <text>"\` string and uses it for both the persisted \`ChatMessage\` and the outbox announcement, but historically passed the RAW (unattributed) \`text\` to \`_run_router_loop\` as the turn's own seed. \`RouterLoop.run\`'s own fallback guard (\`router_loop.py:2007\`, its own comment says "defensive for direct-RouterLoop tests") fires for every hook-driven turn in production today — E's history entry is \`role="system"\`, currently outside \`build_history\`'s allowlist, so \`history[-1]\` is never \`"user"\` and the guard's fallback always appends \`{"role": "user", "content": user_text}\`. The hook's bare text therefore reached the model as an unattributed \`role="user"\` turn, indistinguishable from the operator's own words — a #3595-class misattribution (narrower blast radius than #3595 itself: no slash-dispatch gate is reachable this way, since \`_handle_hook_message\` calls \`_run_router_loop\` directly, bypassing turn dispatch entirely — see #5686's own issue body).

Safe standalone today (architect-confirmed, verified directly against \`origin/main\`): passing \`attributed\` instead of \`text\` does not change which branch fires — the guard's condition depends only on \`history[-1]\`'s role, which stays \`role="system"\` (excluded from \`build_history\`) until #5678's own allowlist widening lands. This is deliberately NOT the #5678 fix — role stays \`"user"\` for now; it only restores the SAME attribution the history entry and outbox announcement already carry to the one remaining mouth that had drifted from them.

## Test plan

- [x] \`python -m pytest tests/runtime/test_5686_hook_seed_carries_attribution.py tests/runtime/test_3475_mcp_probe_priming_all_turn_kinds.py tests/hooks/test_hook_dispatcher_1800_5b.py tests/hooks/test_5514_hook_spillability_dispatch.py\` — 18 passed.
- [x] \`ruff check .\` — clean.
- [x] \`python scripts/test_tier_audit.py --strict tests/runtime/test_5686_hook_seed_carries_attribution.py\` — OK.
- [x] \`python scripts/verify_module_docstrings.py src/reyn/runtime/session.py\` — OK.
- [x] \`python scripts/mypy_ratchet.py\` — OK (baselined).
- [x] \`python scripts/flat_tests_ratchet.py\` / \`check_tests_path_literal_reference.py\` / \`check_bare_tests_import_reference.py\` / \`check_file_depth_reference.py\` / \`check_subprocess_reyn_pin.py\` — all OK.
- [x] Strip-falsify, executed: reverted to raw \`text\`, confirmed the new test goes RED (captured \`user_text\` reads back as bare \`"wake up"\`, no \`[hook:\` prefix); reverted back, confirmed green again.
- [x] (Visual — N/A, no UI surface touched)

CI not monitored from here — reviewer's turn per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51