### PR TITLE
perf(#5276): move turn-context untrusted-taint detection to the mutation side

### DIFF
--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -194,20 +194,37 @@ declaring an empty deny-set.
 `external_source=true` (stamped by the content-fence seam at ingest). Two seams
 stamp it today: an external peer's `ask_user` answer (A2A / webhook), and the
 result of any tool declaring `returns_external_content` (e.g. web fetch) — both
-land in `self.history` meta, and the narrowing check (`metas_have_untrusted`)
-scans the logical ACTIVE window (every entry with `seq` above the compaction
-watermark) on every turn rather than caching the verdict — **resident-ness is
-a resource concern, not the decision criterion**: whether an entry currently
-happens to be resident in memory is orthogonal to whether it is still
-logically part of the active conversation, and the scan's job is the latter,
-never the former. So the very next dispatch after an external tool-result
-lands is already narrowed, and the narrowing self-clears once that entry
-**compacts out** — a semantic operation (its content is genuinely replaced by
-a summary and leaves the model's context) — never merely because it stopped
-being resident. Under `iteration` the engagement is additionally *latched*
-for the rest of the turn, so a compaction that evicts the tainted entry
-mid-turn cannot launder the taint away and recover the capability before the
-turn ends.
+land in `self.history` meta, and the narrowing check reads
+`Session._untrusted_taint_active` — **resident-ness is a resource concern,
+not the decision criterion**: whether an entry currently happens to be
+resident in memory is orthogonal to whether it is still logically part of
+the active conversation, and this state's job is the latter, never the
+former. So the very next dispatch after an external tool-result lands is
+already narrowed, and the narrowing self-clears once that entry **compacts
+out** — a semantic operation (its content is genuinely replaced by a summary
+and leaves the model's context) — never merely because it stopped being
+resident. Under `iteration` the engagement is additionally *latched* for the
+rest of the turn, so a compaction that evicts the tainted entry mid-turn
+cannot launder the taint away and recover the capability before the turn
+ends.
+
+**#5276: detection lives on the mutation side, not the read side.**
+`_untrusted_taint_active` is maintained incrementally by
+`Session._append_history` — the single mouth every history write funnels
+through — rather than re-derived by a full `metas_have_untrusted` scan on
+every read (owner-measured py-spy: ~60 reads/sec from the status panel, live
+gate and Tool tab combined, none of which change the state). An ordinary
+append only ever checks the ONE new entry (O(1)) and can only ever ADD
+taint; the bounded `metas_have_untrusted` scan over the logical ACTIVE
+window (every entry with `seq` above the compaction watermark) still runs,
+but only at the rare event that can retroactively RETRACT the taint — a
+compaction watermark advance (a `role="summary"` append) — plus at the two
+paths that replace `self.history` wholesale without going through
+`_append_history` at all (`load_history`, `restore_state`). Every READ still
+calls `Session._ephemeral_contextual_for_turn()` fresh, exactly as before —
+this is not a read-side cache with its own staleness window; it is the same
+always-fresh detector, just backed by an O(1) state read instead of an
+O(active-window) scan.
 
 **#4387/#4468: a second, independent latch closing a resource/semantic role
 crossing.** Session.history now also has a resident-BYTE cap (#4387) — a
@@ -252,10 +269,13 @@ denial, which reads `· denied by capability profile`, and different again from 
 three renderings.
 
 The tab derives the row from the live conversation at read time — the same
-`metas_have_untrusted` scan the gate runs, never a value latched at turn start —
-and the open pane is rebuilt on every frame, so a row disappears as soon as its
-cause does. That liveness is what makes showing a per-turn narrowing in a status
-surface honest rather than a stale claim wearing an authoritative face.
+`_ephemeral_contextual_for_turn()` call the gate makes, never a value latched
+at turn start (see #5276 above for how that read is now backed by O(1)
+mutation-side state rather than a per-read scan, without changing this
+freshness property at all) — and the open pane is rebuilt on every frame, so
+a row disappears as soon as its cause does. That liveness is what makes
+showing a per-turn narrowing in a status surface honest rather than a stale
+claim wearing an authoritative face.
 
 ## Default-deny delegation narrowing
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -127,7 +127,7 @@ from reyn.runtime.tracked_tasks import TrackedTaskSet
 from reyn.runtime.turn_behavior_tally import TurnBehaviorTally
 from reyn.runtime.turn_origin import TurnOrigin
 from reyn.security.permissions.permissions import PermissionResolver
-from reyn.services.compaction.engine import CompactionEngine
+from reyn.services.compaction.engine import SUMMARY_MESSAGE_ROLE, CompactionEngine
 from reyn.user_intervention import (
     InterventionAnswer,
     UserIntervention,
@@ -1186,6 +1186,28 @@ class Session:
         # watermark advances past this seq — see _ephemeral_contextual_for_
         # turn's own comment on this field).
         self._max_evicted_untrusted_seq = 0
+        # #5276 (architect ruling): whether the ACTIVE (uncompacted, resident)
+        # portion of ``self.history`` carries the untrusted-content marker —
+        # the term ``_ephemeral_contextual_for_turn`` used to re-derive with
+        # a fresh ``metas_have_untrusted(m.meta for m in active)`` scan on
+        # EVERY call (status-panel poll, live gate, Tool tab — #5276's own
+        # owner-measured py-spy finding: ~60/sec). Detection moves to the
+        # MUTATION side (this field is maintained incrementally by
+        # :meth:`_append_history`, the single mouth every history write
+        # funnels through — including a hook's own wake=false ride-along)
+        # instead of being re-derived on every READ. The two OTHER OR-terms
+        # ``_ephemeral_contextual_for_turn`` composes this against
+        # (``_in_flight_untrusted_this_turn`` / ``_max_evicted_untrusted_seq
+        # > watermark``, both immediately above) are UNCHANGED — already O(1)
+        # latches, not touched by this field.
+        #
+        # Seeded fresh (never left at its ``False`` default) by
+        # :meth:`load_history` after startup hydration and by
+        # :meth:`restore_state` after a rewind — both populate/replace
+        # ``self.history`` through paths OTHER than ``_append_history``
+        # (direct ``.append``/prepend), so this field cannot assume either
+        # one kept it in sync; see each method's own comment.
+        self._untrusted_taint_active: bool = False
         # Single MediaStore instance per Session (#383 PR-C, see session-construction.md#multimodal-media)
         from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
         if multimodal_config is not None:
@@ -3911,28 +3933,25 @@ class Session:
 
         NOT a second notion of "what is narrowed": this IS the term
         ``_effective_contextual_for_turn`` composes, so the tab and the live gate
-        cannot drift. The taint is re-derived from ``self.history`` on every call
-        (never latched at turn start), so a status-bar read is as of NOW; only the
-        loaded profile is cached, and a profile file does not change mid-session.
+        cannot drift. The taint is read fresh on every call (never latched at turn
+        start), so a status-bar read is as of NOW; only the loaded profile is
+        cached, and a profile file does not change mid-session.
 
-        #4387 Phase A: the scan this re-derivation runs is bounded to the
-        UNCOMPACTED tail (``seq > self._compaction_watermark()``), not all
-        of ``self.history``. ``metas_have_untrusted``'s own docstring already
-        promises "the until-compaction scope for free" from being handed
-        only "the live, un-compacted entries" — this call site was actually
-        violating that contract (it passed the FULL unfiltered history,
-        so real deployments never got the promised self-clear-on-compaction
-        at all, only an O(session-length) scan on every turn once
-        narrowing was opted into, #3501). Bounding to the watermark fixes
-        both: the freshness/self-clearing property this method's own tests
-        pin (``test_turn_context_denial_self_clears_when_the_taint_leaves_
-        the_context``) becomes what actually happens in a compacting
-        session, not just an unenforced docstring claim, and the re-scan on
-        every turn is now proportional to the uncompacted tail rather than
-        total session length. Entries with ``seq == 0`` (pre-#3704 legacy
-        rows with no assigned coordinate) are always included — never
-        excluded from a taint check just because they predate seq
-        tracking.
+        #4387 Phase A / #5276: the taint term used to be a full re-derivation —
+        ``metas_have_untrusted(m.meta for m in active)`` scanning the UNCOMPACTED
+        tail (``seq > self._compaction_watermark()``) — run fresh on EVERY call
+        (status-panel poll, live gate, Tool tab: owner-measured py-spy, ~60/sec).
+        #5276 moves that derivation to the MUTATION side: ``self.
+        _untrusted_taint_active`` is maintained incrementally by
+        :meth:`_append_history` (see that method's own
+        ``_update_untrusted_taint_on_append`` helper) and re-derived in full only
+        at the rare event that can ever RETRACT it — a compaction watermark
+        advance — so this method's own per-call cost is now O(1) here. The other
+        two OR-terms below (the in-flight latch, the eviction latch) are
+        UNCHANGED — already O(1), not touched by this move. Entries with ``seq ==
+        0`` (pre-#3704 legacy rows with no assigned coordinate) are always
+        included in the mutation-side derivation — never excluded from a taint
+        check just because they predate seq tracking.
 
         #3501: OPT-IN. This returns ``None`` — no narrowing at all — unless the
         operator set ``safety.threat_scan.capability_narrowing`` to something other
@@ -3962,7 +3981,6 @@ class Session:
         from reyn.security.permissions.capability_profile import (
             UNTRUSTED_NARROWING_ORIGIN,
             load_untrusted_profile,
-            metas_have_untrusted,
             resolve_profile,
         )
 
@@ -3971,15 +3989,7 @@ class Session:
             self._note_ephemeral_narrowing_transition(False)
             return None
         watermark = self._compaction_watermark()
-        # #4954(2): this exact predicate (seq==0 is the #3704 "no
-        # coordinate" sentinel, never excluded) is duplicated in
-        # RouterHistoryBuffer.build_history() (router_history_buffer.py) —
-        # a lead-coder TESTS-READ finding there caught a divergence where
-        # the copy initially forgot the seq==0 case. If a 3rd copy
-        # appears, that is the point to factor this into one shared
-        # predicate function instead.
-        active = (m for m in self.history if m.seq == 0 or m.seq > watermark)
-        # #4381 PR-2 stage ③: history scan OR the in-flight latch — the
+        # #4381 PR-2 stage ③: taint state OR the in-flight latch — the
         # latch covers a same-turn tool result whose history entry has not
         # landed yet (see the flag's own docstring in __init__ for why).
         # #4468 (lead-coder security review): OR a THIRD term —
@@ -3992,12 +4002,17 @@ class Session:
         # cap would silently decide a semantic question it has no business
         # deciding — CLAUDE.md's own "removing one layer regrants a denied
         # capability" shape. Keyed to the SAME extinction trigger as the
-        # resident scan above (the compaction watermark) — eviction can SET
+        # resident term above (the compaction watermark) — eviction can SET
         # this latch, only compaction can CLEAR it; clearing it on "no
         # longer resident" instead would just reproduce this exact bug on
         # the latch's own side.
+        # #5276: the first term reads the mutation-side state
+        # (``self._untrusted_taint_active``) instead of re-scanning
+        # ``self.history`` here — see the class attribute's own docstring
+        # and ``_update_untrusted_taint_on_append`` for where it is kept
+        # current.
         if not (
-            metas_have_untrusted(m.meta for m in active)
+            self._untrusted_taint_active
             or self._in_flight_untrusted_this_turn
             or self._max_evicted_untrusted_seq > watermark
         ):
@@ -4110,6 +4125,60 @@ class Session:
         with self.history_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(msg), ensure_ascii=False) + "\n")
         self._evict_oldest_resident_entries()
+        self._update_untrusted_taint_on_append(msg)
+
+    def _update_untrusted_taint_on_append(self, msg: ChatMessage) -> None:
+        """#5276 (architect ruling): the single mutation-side update point
+        for :attr:`_untrusted_taint_active` — see that field's own
+        ``__init__`` comment for the full "detection moves to the
+        mutation side" rationale.
+
+        Two cases, both funnelled through THIS one caller
+        (:meth:`_append_history`, "single mouth"):
+
+        - ``msg.role == SUMMARY_MESSAGE_ROLE`` — a compaction fold just
+          landed, meaning the compaction watermark is ADVANCING (this
+          entry's own ``covers_through_seq`` IS the new watermark —
+          :meth:`_compaction_watermark` reads it straight off the latest
+          summary). Some currently-active entries may have just fallen
+          below it, which a bare "does this ONE new entry carry taint"
+          check cannot detect (appending can only ever ADD taint, never
+          retroactively remove it) — so this is the ONE case that still
+          pays the O(bounded-scan) cost, via the same pure
+          :func:`~reyn.security.permissions.capability_profile.
+          metas_have_untrusted` :meth:`_ephemeral_contextual_for_turn`
+          used to call on every READ — but now only on an actual
+          compaction fold, not ~60 times/sec.
+        - Any other role — O(1): does THIS entry's own meta carry the
+          untrusted marker? If so the state can only flip to ``True``
+          (an ordinary append can never UN-taint the active region —
+          only a watermark advance, the branch above, can).
+        """
+        from reyn.security.permissions.capability_profile import metas_have_untrusted
+
+        if msg.role == SUMMARY_MESSAGE_ROLE:
+            self._recompute_untrusted_taint_active()
+        elif not self._untrusted_taint_active and metas_have_untrusted([msg.meta]):
+            self._untrusted_taint_active = True
+
+    def _recompute_untrusted_taint_active(self) -> None:
+        """#5276: the O(bounded-scan) full re-derivation of
+        :attr:`_untrusted_taint_active` — the same bound
+        :meth:`_ephemeral_contextual_for_turn` used to apply on every READ
+        (``seq == 0 or seq > watermark``, #4387 Phase A), now run only at
+        the points that can retroactively CHANGE the answer: a compaction
+        watermark advance (:meth:`_update_untrusted_taint_on_append`'s own
+        summary-role branch), and the two paths below that replace
+        ``self.history`` wholesale WITHOUT going through
+        :meth:`_append_history` at all (:meth:`load_history`,
+        :meth:`restore_state`) — a bare re-append there cannot rely on the
+        incremental append-time check ever having run.
+        """
+        from reyn.security.permissions.capability_profile import metas_have_untrusted
+
+        watermark = self._compaction_watermark()
+        active = (m for m in self.history if m.seq == 0 or m.seq > watermark)
+        self._untrusted_taint_active = metas_have_untrusted(m.meta for m in active)
 
     def _evict_oldest_resident_entries(self) -> int:
         """#4387 Phase B ③: cap ``self.history``'s in-memory footprint at
@@ -4891,6 +4960,11 @@ class Session:
             ):
                 self._append_parsed_history_line(line)
             self._next_seq = last_seq + 1
+            # #5276: this path populates self.history via a bare .append
+            # (_append_parsed_history_line), bypassing _append_history's
+            # own incremental taint hook — a fresh full re-derivation here
+            # is the only way self._untrusted_taint_active starts correct.
+            self._recompute_untrusted_taint_active()
             return
 
         # Fallback: full forward read, full scan — see docstring above.
@@ -4908,6 +4982,8 @@ class Session:
         # legitimately outranks a real assigned seq.
         max_seen = max((m.seq for m in self.history if m.seq), default=0)
         self._next_seq = max_seen + 1
+        # #5276: same bypass as the fast path above — re-derive fresh.
+        self._recompute_untrusted_taint_active()
 
     # ── inbox API ───────────────────────────────────────────────────────────────
 
@@ -7621,6 +7697,15 @@ class Session:
                 self._background_tasks.register(
                     _t, disposition="cancel_join", appends_wal=False,
                 )
+        # #5276 (architect acceptance criterion): after ANY full state
+        # restore, self._untrusted_taint_active must match a fresh
+        # from-scratch re-derivation — never assumed still-in-sync just
+        # because this method does not currently touch self.history
+        # itself. A no-op today (restore_state repopulates inbox/chains/
+        # interventions, not history); kept as a standing invariant so a
+        # future restore path that DOES touch self.history cannot silently
+        # skip this.
+        self._recompute_untrusted_taint_active()
         self._audit_events.emit(
             "session_restored",
             applied_seq=snapshot.applied_seq,

--- a/tests/llm/test_1909_external_tool_result_narrowing.py
+++ b/tests/llm/test_1909_external_tool_result_narrowing.py
@@ -44,6 +44,7 @@ import pytest
 
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
+from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 from tests._support.untrusted_narrowing import narrowing_on
@@ -210,10 +211,24 @@ async def test_self_clears_after_tainted_entry_compacted_out(tmp_path, monkeypat
     (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
     assert "tool_excluded" in str(denied_msg.content)
 
-    # Simulate compaction evicting the tainted tool-result entry from active context.
-    session.history = [
-        m for m in session.history if not (m.meta or {}).get("external_source")
-    ]
+    # #5276: simulate compaction retiring the tainted tool-result entry via a
+    # real watermark advance (a role="summary" entry through
+    # session._append_history, the actual production mechanism — same shape
+    # test_3380_tool_tab_ephemeral_narrowing.py's own
+    # test_narrowing_self_clears_when_a_real_compaction_covers_the_taint
+    # uses), not a raw self.history reassignment: Session._untrusted_taint_
+    # active is maintained incrementally by _append_history and only
+    # re-derived in full on an actual watermark advance, so a raw
+    # reassignment bypasses that hook entirely and leaves the taint latched.
+    tainted_seq = max(
+        m.seq for m in session.history if (m.meta or {}).get("external_source")
+    )
+    session._append_history(
+        ChatMessage(
+            role="summary", content="summarised",
+            meta={"structured": {}, "covers_through_seq": tainted_seq},
+        )
+    )
 
     await session._handle_inbox_text("try again", chain_id="c3")
     (allowed_msg,) = [m for m in session.history if m.tool_call_id == "tc_allowed"]

--- a/tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py
+++ b/tests/runtime/test_3380_tool_tab_ephemeral_narrowing.py
@@ -84,8 +84,12 @@ def _session(tmp_path: Path) -> Session:
 
 def _mark_untrusted(s: Session) -> None:
     """The #1862 marker the real producer stamps on an external peer answer —
-    the same ``external_source`` meta ``metas_have_untrusted`` scans for."""
-    s.history.append(
+    the same ``external_source`` meta ``metas_have_untrusted`` scans for.
+
+    #5276: goes through ``_append_history`` — the real mutation chokepoint
+    that maintains ``Session._untrusted_taint_active`` incrementally — not a
+    bare ``s.history.append``, which the incremental hook never observes."""
+    s._append_history(
         ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
     )
 
@@ -144,8 +148,20 @@ def test_turn_context_denial_self_clears_when_the_taint_leaves_the_context(
         s.capability_visibility_state(), "denied_by_turn_context"
     )
 
-    # the untrusted entry compacting out of the active context
-    s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+    # #5276: the untrusted entry compacting out of the active context — a
+    # real compaction watermark advance via _append_history (same shape
+    # test_narrowing_self_clears_when_a_real_compaction_covers_the_taint
+    # below already uses), not a raw self.history reassignment the
+    # incremental taint hook never observes.
+    tainted_seq = next(
+        m.seq for m in s.history if (m.meta or {}).get("external_source")
+    )
+    s._append_history(
+        ChatMessage(
+            role="summary", content="summarised",
+            meta={"structured": {}, "covers_through_seq": tainted_seq},
+        )
+    )
 
     cleared = s.capability_visibility_state()
     assert not _tools(cleared, "denied_by_turn_context"), (

--- a/tests/runtime/test_5276_turn_context_taint_mutation_state.py
+++ b/tests/runtime/test_5276_turn_context_taint_mutation_state.py
@@ -1,0 +1,243 @@
+"""Tier 2: #5276 — moving the ``turn`` rung's untrusted-taint detection from
+the READ side (a full ``metas_have_untrusted`` re-scan on every call to
+``Session._ephemeral_contextual_for_turn``, owner-measured py-spy: ~60/sec
+from the status panel, live gate and Tool tab combined) to the MUTATION
+side (``Session._untrusted_taint_active``, maintained incrementally by
+``Session._append_history`` and re-derived in full only at the rare events
+that can retroactively change it — a compaction watermark advance, or a
+wholesale ``self.history`` replacement that bypasses ``_append_history``
+entirely: ``load_history`` / ``restore_state``).
+
+This file does NOT re-litigate the engage/lift transition-audit-event
+properties #5282 already pins (``test_5282_ephemeral_narrowing_audit_event.py``,
+whose own two mutating helpers were updated by this same PR to drive the new
+mutation-hook via ``_append_history`` rather than a bare ``self.history``
+append/reassignment). It pins the properties #5276 itself adds: an ordinary
+append never mistakenly flips the taint on (deny-side pin), the transitions
+this file exercises are not vacuous (they actually change the public denial
+set), and — the architect's own explicit acceptance criterion for this
+design — the incrementally-maintained state matches a fresh from-scratch
+re-derivation after the two paths that replace history wholesale.
+
+Driven entirely through the PUBLIC read surface
+(``Session.capability_visibility_state()`` — mirrors ``test_3380_tool_tab_
+ephemeral_narrowing.py`` and ``test_5282_ephemeral_narrowing_audit_event.py``'s
+own harnesses), never the private ``_untrusted_taint_active`` field directly,
+per this repo's "a test must not depend on private state" testing policy.
+
+Real ``Session`` throughout — no mock/stand-in for the collaborator under
+test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.untrusted_narrowing import narrowing_on
+
+# Same witness tool test_3380/test_5282 use — denied by the built-in
+# ``_untrusted`` profile once the turn-context narrowing engages.
+_UNTRUSTED_DENIED_TOOL = "run_prompt"
+
+
+def _denied_by_turn_context(s: Session) -> "set[str]":
+    state = s.capability_visibility_state()
+    return {i["name"] for i in state["denied_by_turn_context"] if i["kind"] == "tool"}
+
+
+def test_ordinary_appends_never_flip_the_taint_on(tmp_path: Path) -> None:
+    """Tier 2: deny-side pin — the O(1) append-time check must discriminate
+    on the entry's OWN meta, not fire on "any append happened" or "any
+    role/kind of entry". A run of ordinary user/assistant/tool entries none
+    of which carry the ``external_source`` marker must never engage
+    narrowing, however many of them land."""
+    s = make_session(
+        agent_name="alpha", workspace_base_dir=tmp_path, safety=narrowing_on(),
+    )
+    for i in range(10):
+        s._append_history(ChatMessage(role="user", content=f"turn {i}"))
+        s._append_history(ChatMessage(role="assistant", content=f"reply {i}"))
+        s._append_history(ChatMessage(
+            role="tool", content=f"result {i}", tool_call_id=f"tc{i}", name="read_file",
+        ))
+    assert _denied_by_turn_context(s) == set(), (
+        "10 rounds of untainted appends must never engage the turn-context "
+        "narrowing — the O(1) check is keyed to the untrusted marker, not "
+        "to append activity itself"
+    )
+
+    # Control arm: the SAME session, the same append path, now DOES carry
+    # the marker — proves the assertion above was not vacuously true
+    # because narrowing can never engage in this session at all.
+    s._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+    assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s), (
+        "control: this session's narrowing IS reachable — the untainted run "
+        "above genuinely tested something, not a session where narrowing "
+        "can never engage at all"
+    )
+
+
+def test_the_engage_and_lift_transitions_are_not_vacuous(tmp_path: Path) -> None:
+    """Tier 2: non-vacuity — the deny-set genuinely changes shape across the
+    engage/lift transitions this design's mutation hook drives, rather than
+    the public read staying constant (e.g. always empty, or always full)
+    regardless of the taint state."""
+    s = make_session(
+        agent_name="alpha", workspace_base_dir=tmp_path, safety=narrowing_on(),
+    )
+    before = _denied_by_turn_context(s)
+
+    s._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+    tainted_seq = s.history[-1].seq
+    engaged = _denied_by_turn_context(s)
+
+    s._append_history(ChatMessage(
+        role="summary", content="summarised",
+        meta={"structured": {}, "covers_through_seq": tainted_seq},
+    ))
+    lifted = _denied_by_turn_context(s)
+
+    assert before == set(), "sanity: nothing denied before any taint"
+    assert engaged != before and _UNTRUSTED_DENIED_TOOL in engaged, (
+        "engaging the taint must genuinely add denials, not leave the "
+        "public read unchanged"
+    )
+    assert lifted == before, (
+        "a real compaction watermark advance past the tainted entry must "
+        "restore the exact pre-taint deny-set, not merely 'some other "
+        "non-empty state'"
+    )
+
+
+def _reconstruct_from_disk(tmp_path: Path) -> Session:
+    """A cold Session over the SAME on-disk history/workspace another
+    Session instance already wrote — the real crash-recovery shape
+    ``load_history`` exists for. Never shares the writer's in-memory
+    ``self.history`` or ``self._untrusted_taint_active``."""
+    s = make_session(
+        agent_name="alpha", workspace_base_dir=tmp_path, safety=narrowing_on(),
+    )
+    s.load_history()
+    return s
+
+
+def test_cold_start_reload_reconstructs_the_taint_state_fast_path(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``load_history``'s FAST path (a real ``covers_through_seq``
+    summary exists, so the bounded tail read is safe) populates
+    ``self.history`` via a bare ``.append`` that bypasses
+    ``_append_history``'s own incremental hook entirely — this is the one
+    path #5276's design has to explicitly re-derive fresh at the end of, or
+    a restarted session would silently start un-narrowed despite genuinely
+    tainted content in its reloaded active window."""
+    from reyn.runtime.session import _HISTORY_HYDRATE_MIN_LINES
+
+    writer = make_session(
+        agent_name="alpha", workspace_base_dir=tmp_path, safety=narrowing_on(),
+    )
+    writer._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+    # A summary so the fast path's own peek finds a real seq, plus enough
+    # post-summary turns to clear the hydrate floor — the exact shape
+    # test_4387_bounded_history_hydration.py's own fast-path test uses.
+    summary_seq = writer.history[-1].seq
+    writer._append_history(ChatMessage(
+        role="summary", content="unrelated fold",
+        meta={"structured": {}, "covers_through_seq": summary_seq},
+    ))
+    for i in range(_HISTORY_HYDRATE_MIN_LINES + 5):
+        writer._append_history(ChatMessage(role="user", content=f"turn {i}"))
+    # Taint the reloaded ACTIVE window itself (after the watermark), so the
+    # reload's own re-derivation has something genuine to find.
+    writer._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> again", meta={"external_source": True})
+    )
+
+    reloaded = _reconstruct_from_disk(tmp_path)
+
+    assert reloaded.history[0].role == "summary", (
+        "sanity: this must exercise the FAST path, not the fallback"
+    )
+    assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(reloaded), (
+        "a cold reload via the fast path must reconstruct the taint state "
+        "from the reloaded active window, not start un-narrowed just "
+        "because _append_history's own incremental hook never ran on it"
+    )
+
+
+def test_cold_start_reload_reconstructs_the_taint_state_fallback_path(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the counterpart for ``load_history``'s FALLBACK path (full
+    forward read + full scan, taken when the last on-disk entry has no
+    real ``seq`` — legacy/untrusted-peek-failure shape)."""
+    writer = make_session(
+        agent_name="alpha", workspace_base_dir=tmp_path, safety=narrowing_on(),
+    )
+    writer._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+    # Force the fallback: hand-append a trailing line with seq==0, the same
+    # technique test_4387_bounded_history_hydration.py's own fallback test
+    # uses to defeat the fast-path's last-line peek.
+    import json
+    with writer.history_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"role": "user", "content": "legacy tail", "seq": 0}) + "\n")
+
+    reloaded = _reconstruct_from_disk(tmp_path)
+
+    assert reloaded.history[-1].content == "legacy tail", (
+        "sanity: this must exercise the FALLBACK path, not the fast one"
+    )
+    assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(reloaded), (
+        "a cold reload via the fallback path must also reconstruct the "
+        "taint state, not just the fast path"
+    )
+
+
+def test_restore_state_after_a_cold_reload_matches_fresh_rederivation(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: architect's own explicit acceptance criterion for this
+    design — after a full recovery cycle (cold reload from disk, then
+    ``restore_state`` from a real recovered snapshot, the actual
+    crash-recovery sequence), the taint state must still agree with what a
+    from-scratch derivation would say. ``restore_state`` does not itself
+    touch ``self.history`` today, so this also guards the OTHER half: that
+    ``load_history``'s own re-derivation (pinned above) is not silently
+    undone or left stale by whatever ``restore_state`` does afterwards."""
+    from reyn.core.events.agent_snapshot import AgentSnapshot
+
+    writer = make_session(
+        agent_name="alpha", workspace_base_dir=tmp_path, safety=narrowing_on(),
+    )
+    writer._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+    assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(writer), (
+        "sanity: the writer session itself is tainted before recovery"
+    )
+
+    reloaded = _reconstruct_from_disk(tmp_path)
+    before_restore = _denied_by_turn_context(reloaded)
+
+    reloaded.restore_state(AgentSnapshot.empty("alpha"))
+
+    assert _denied_by_turn_context(reloaded) == before_restore, (
+        "restore_state must not change the taint-derived deny-set from "
+        "what the cold reload already established -- the incremental "
+        "state must still agree with a fresh re-derivation after a full "
+        "recovery cycle, not just after the reload alone"
+    )
+    assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(reloaded), (
+        "sanity: still genuinely tainted after restore_state, not "
+        "vacuously equal because both sides are empty"
+    )

--- a/tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
+++ b/tests/runtime/test_5282_ephemeral_narrowing_audit_event.py
@@ -78,9 +78,38 @@ def _session(tmp_path: Path) -> Session:
 
 
 def _mark_untrusted(s: Session) -> None:
-    """The #1862 marker the real producer stamps on an external peer answer."""
-    s.history.append(
+    """The #1862 marker the real producer stamps on an external peer answer.
+
+    #5276: goes through ``_append_history`` (the real mutation chokepoint
+    that maintains ``Session._untrusted_taint_active`` incrementally) —
+    NOT a bare ``s.history.append`` — so this exercises the actual
+    production path instead of a shape the new incremental-state hook
+    never sees.
+    """
+    s._append_history(
         ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
+
+
+def _compact_out_untrusted(s: Session) -> None:
+    """Advance the compaction watermark past every entry currently in
+    ``s.history`` — the real "untrusted entry compacts out" mechanism.
+
+    #5276: a fold lands via a ``role="summary"`` entry whose
+    ``covers_through_seq`` meta IS the new watermark
+    (``Session._compaction_watermark``) — appended through
+    ``_append_history`` like any other entry, which is also what re-derives
+    ``_untrusted_taint_active`` in full on this branch (the ONE case that
+    can retroactively CLEAR the taint; see
+    ``_update_untrusted_taint_on_append``'s own docstring).
+    """
+    covers_through_seq = max((m.seq for m in s.history), default=0)
+    s._append_history(
+        ChatMessage(
+            role="summary",
+            content="<<<SUMMARY>>>",
+            meta={"structured": {}, "covers_through_seq": covers_through_seq},
+        )
     )
 
 
@@ -155,7 +184,7 @@ async def test_lift_fires_once_when_the_taint_leaves_the_context(tmp_path: Path)
     )
 
     # the untrusted entry compacting out of the active context
-    s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+    _compact_out_untrusted(s)
 
     for _ in range(5):
         assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
@@ -190,7 +219,7 @@ async def test_engage_then_lift_then_engage_again_is_one_of_each_per_flip(
     for _ in range(2):
         _mark_untrusted(s)
         assert _UNTRUSTED_DENIED_TOOL in _denied_by_turn_context(s)
-        s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+        _compact_out_untrusted(s)
         assert _UNTRUSTED_DENIED_TOOL not in _denied_by_turn_context(s)
     await settle(s)
 

--- a/tests/runtime/test_context_auto_1827_s4b.py
+++ b/tests/runtime/test_context_auto_1827_s4b.py
@@ -43,7 +43,13 @@ def _session(tmp_path: Path, *, contextual=None) -> Session:
 
 
 def _mark_untrusted(s: Session) -> None:
-    s.history.append(ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True}))
+    """#5276: goes through ``_append_history`` — the real mutation
+    chokepoint that maintains ``Session._untrusted_taint_active``
+    incrementally — not a bare ``s.history.append``, which the
+    incremental hook never observes."""
+    s._append_history(
+        ChatMessage(role="user", content="<<<EXTERNAL>>> hi", meta={"external_source": True})
+    )
 
 
 def test_untainted_returns_static(tmp_path):
@@ -77,8 +83,22 @@ def test_self_clears_when_taint_removed(tmp_path):
     _mark_untrusted(s)
     eff = s._effective_contextual_for_turn()
     assert tool_contextually_denied(eff, "exec")
-    # simulate the untrusted entry compacting out of the active context
-    s.history = [m for m in s.history if not (m.meta or {}).get("external_source")]
+    # #5276: simulate the untrusted entry compacting out of the active
+    # context via a real compaction watermark advance (a role="summary"
+    # entry through _append_history, the actual production mechanism —
+    # see test_3380_tool_tab_ephemeral_narrowing.py's own
+    # test_narrowing_self_clears_when_a_real_compaction_covers_the_taint
+    # for the same shape), not a raw self.history reassignment the
+    # incremental taint hook never observes.
+    tainted_seq = next(
+        m.seq for m in s.history if (m.meta or {}).get("external_source")
+    )
+    s._append_history(
+        ChatMessage(
+            role="summary", content="summarised",
+            meta={"structured": {}, "covers_through_seq": tainted_seq},
+        )
+    )
     eff = s._effective_contextual_for_turn()
     assert eff is None  # back to static (none)
 


### PR DESCRIPTION
**[e2e-coder]** — Closes #5276

## What

`Session._ephemeral_contextual_for_turn()`'s `turn_context` taint term used to re-derive with a full `metas_have_untrusted` scan over the active (uncompacted) history window on **every call** — status-panel poll, live gate, Tool tab — owner-measured py-spy: ~60/sec, essentially none of which change the state.

Per architect ruling (relayed via lead-coder-30): detection moves to the **mutation** side, not the read side. `Session._untrusted_taint_active` is now maintained incrementally by `Session._append_history` (the single mouth every history write funnels through, including a hook's own wake=false ride-along):
- an ordinary append: O(1) check against just that entry's own meta (can only ever ADD taint)
- a `role="summary"` append (compaction watermark advance): the ONE case that can retroactively **retract** taint, so this is the one case that still pays the bounded-scan cost — but only on an actual fold, not ~60×/sec.

`load_history()` and `restore_state()` each re-derive the state fresh at their own end too, since both replace `self.history` through paths other than `_append_history` (a bare `.append`/no-op respectively).

`_ephemeral_contextual_for_turn()` itself is **unchanged in shape** and is still called fresh on every read — this is deliberately **not** a read-side cache. A read-side cache was the first design tried and reopens the #5282 chicken-and-egg conflict (#5282's own engage/lift audit events are emitted exclusively from inside this method, so caching its output would starve the only signal that could invalidate the cache) — confirmed empirically by running `test_5282_ephemeral_narrowing_audit_event.py` against that design (2 failed / 1 passed) before reverting it. This PR is the re-derived design from the architect's ruling instead.

## Test changes

- `test_5282_ephemeral_narrowing_audit_event.py` and 3 sibling files (`test_3380_tool_tab_ephemeral_narrowing.py`, `test_context_auto_1827_s4b.py`, `test_1909_external_tool_result_narrowing.py`) constructed taint via a bare `self.history.append`/reassignment — bypassing the new incremental hook entirely. Updated their mutating helpers to go through `_append_history` and a real `covers_through_seq` summary append instead, matching the actual production mutation path. All were confirmed to fail against a naive strip before the fix (RED), and pass after.
- New file `tests/runtime/test_5276_turn_context_taint_mutation_state.py`:
  - ordinary (untainted) appends never flip the taint on (deny-side pin)
  - the engage/lift transitions are not vacuous
  - the architect's own explicit acceptance criterion: the incrementally-maintained state matches a fresh from-scratch re-derivation after a cold `load_history()` reload (both fast and fallback paths) and after `restore_state()` on top of that reload — the real crash-recovery sequence.

## Doc-sync

`docs/concepts/runtime/capability-profile.md`'s mechanism description (two paragraphs describing the per-read scan) updated to describe the mutation-side design; the freshness/liveness claims that remain true (fresh read every call, no read-side staleness window) are preserved.

## Known, disclosed, untested assumption

`_load_older_entries`/`extend_history_backward`/`extend_history_backward_async` (prepending older, previously-evicted entries) also bypass `_append_history`. Reasoned — not empirically verified — that this is already covered by the pre-existing, independent `_max_evicted_untrusted_seq` OR-latch: any tainted entry old enough to need backward-extension was already evicted, which already set that latch. Flagging this explicitly rather than silently assuming it.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] scoped pytest (foreground, all narrowing/history-recovery consumers + `test_5282`'s own suite per architect's explicit instruction) — green
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51