### PR TITLE
part of #5694: a dead SSE pump now flips has_session()/attach_failed()

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6735,6 +6735,24 @@ class TextualChatApp(App):
                 ".frames()) raised (reason=supply_failed) — the app stays "
                 "open; only an explicit /quit exits."
             )
+            # #5694: force ONE render here — `_refresh_live_chrome` is
+            # otherwise only ever called "as frames land" (its own
+            # docstring), but the frame supply just died, so no frame is
+            # EVER landing again to trigger it. Without this call the
+            # header/pane keep showing this connection's last-known
+            # agent name until the operator happens to touch something
+            # that re-renders — the exact "displays a name nobody
+            # confirmed any more" gap #5694 reports. `self._transport.
+            # has_session()`/`attach_failed()` already flip the instant
+            # the pump dies (see `AgUiTransport.frames`'s own #5694
+            # comment); this just makes that fact visible NOW instead of
+            # on the next frame that will never arrive.
+            try:
+                self._refresh_live_chrome()
+            except Exception:
+                logger.exception(
+                    "textual chat: post-supply-failure chrome refresh failed"
+                )
             raise
         else:
             # #5329 A: the supply ended normally — either the `__end__`
@@ -6938,7 +6956,17 @@ class TextualChatApp(App):
         paper over — but it IS a real position change, named here so a
         future ordering-bug hunt doesn't rule this call site out."""
         if self._transport.attach_failed():
-            text = "attach failed (see log) — your message was kept; retry once resolved"
+            # #5694: the ONE new producer of `attach_failed()` on a REMOTE
+            # transport is its own SSE pump dying mid-session (not a fresh
+            # connect that never succeeded) — the operator was already
+            # talking to an agent, and needs to know the fix is a fresh
+            # `/attach`, not "wait" or a bare "send failed" (lead-coder
+            # review: the wording must name the next action, not just the
+            # fact of failure).
+            text = (
+                "attach failed — connection lost; your message was kept — "
+                "/attach <agent> to reconnect and resend"
+            )
         else:
             text = "still connecting — your message will send once ready"
         from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -147,6 +147,17 @@ class AgUiTransport(ClientTransport):
         # does, without waiting on the next SSE event to unblock it.
         self._display_queue: "asyncio.Queue[Frame | BacklogBatch | object]" = asyncio.Queue()
         self._sse_pump_task: "asyncio.Task[None] | None" = None
+        # #5694: set once :meth:`frames` re-raises a genuine ``_SSEPumpError``
+        # (the pump died — a real read failure, never a clean end or an
+        # intentional :meth:`close`). This is the ONE fact ``has_session``/
+        # ``attach_failed`` read below to make the loss of this connection's
+        # OWN receive channel visible — see those methods' own docstrings
+        # for why a dead pump must degrade the SAME tri-state the header and
+        # the composer submit-gate (#3671 P3) already share, rather than
+        # leaving this transport looking "still attached" while the
+        # server's own per-connection binding (``_CONNECTION_RETARGET_HUB``,
+        # #5116) has already forgotten it.
+        self._pump_died = False
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -404,6 +415,23 @@ class AgUiTransport(ClientTransport):
                 # own context, instead of letting `_SSE_DONE` (queued right
                 # after this by the SAME `finally`) make it look like an
                 # ordinary end-of-stream.
+                #
+                # #5694: also flip the tri-state ``has_session``/
+                # ``attach_failed`` read — a caller that only catches this
+                # exception around its OWN read loop (``_pump_frames``'s
+                # #5329 design: log it, keep the app open, do not exit) would
+                # otherwise have no way to learn the connection died, and
+                # would keep drawing this transport's last-known display AND
+                # keep letting the composer POST through the now-orphaned
+                # ``send`` closure — the exact silent-misroute shape #5694
+                # reports (server-side unsubscribes this connection from
+                # ``_CONNECTION_RETARGET_HUB`` when the stream ends, so a
+                # later submit falls back to the connect-time URL agent,
+                # 200 OK, wrong destination). Setting this here — the one
+                # place that already knows the pump is genuinely gone, not
+                # merely idle — makes both surfaces degrade from ONE fact.
+                self._connected = False
+                self._pump_died = True
                 raise frame.exc
             if frame is _SSE_DONE:
                 return
@@ -428,15 +456,29 @@ class AgUiTransport(ClientTransport):
 
     def attach_failed(self) -> bool:
         # #5096 review finding (lead-coder): EXPLICITLY implemented, not
-        # inherited from ClientTransportStub, even though the VALUE
-        # matches its own default. A remote attach either already
-        # succeeded by the time --connect returns or the connection
-        # attempt itself raised, so there is no separate "connecting in
-        # the background" phase to fail remotely — see
-        # ClientTransport.attach_failed's own docstring for the full
-        # rationale (only InProcessTransport's background-attach path has
-        # anything meaningful to report here).
-        return False
+        # inherited from ClientTransportStub. A remote attach either
+        # already succeeded by the time --connect returns or the
+        # connection attempt itself raised, so there was originally no
+        # separate "connecting in the background" phase to fail remotely
+        # here (see ClientTransport.attach_failed's own docstring for the
+        # full rationale — only InProcessTransport's background-attach
+        # path had anything meaningful to report).
+        #
+        # #5694: that is no longer the whole story — an ALREADY-attached
+        # connection's own SSE pump can still die mid-session (a genuine
+        # read failure, ``_pump_died`` above). ``has_session()`` alone
+        # cannot distinguish that from "still connecting" (both read
+        # false), and the tri-state this pair feeds
+        # (``TextualChatApp._attach_state``: "connecting" | "failed" |
+        # None) must not call a DEAD connection "connecting" — this app
+        # never auto-reconnects, so telling the operator to keep waiting
+        # would be the "still loading" paper-over that tri-state's own
+        # owner ruling forbids. Reusing ``attach_failed`` (rather than a
+        # third, parallel flag) means the header AND the composer's
+        # submit-gate (#3671 P3, ``on_composer_submitted``) — which
+        # already both read this exact pair — degrade together, with no
+        # new call site to keep in sync.
+        return self._pump_died
 
     def pending_intervention_head(self) -> "object | None":
         # P3: the id of the intervention awaiting an answer, tracked off the

--- a/tests/interfaces/test_5694_pump_death_flips_attach_state.py
+++ b/tests/interfaces/test_5694_pump_death_flips_attach_state.py
@@ -1,0 +1,128 @@
+"""Tier 2: #5694 — a genuine ``AgUiTransport`` pump failure (its SSE read
+loop dying mid-session, e.g. ``httpx.ReadError``) must flip the SAME
+``has_session()``/``attach_failed()`` pair the header and the composer
+submit-gate already share (#3671 P3), so a caller that only catches the
+exception ``_pump_frames`` raises (#5329: log it, keep the app open, do not
+exit) still learns the connection died — instead of the transport looking
+"still attached" while the SERVER's own per-connection binding
+(``_CONNECTION_RETARGET_HUB``, #5116/#5129) has already forgotten this
+connection and a later submit silently falls back to the connect-time URL
+agent (200 OK, wrong destination — the exact symptom #5694 reports, root-
+caused against a real production incident's own audit-event log).
+
+Before this PR, ``AgUiTransport.has_session()``/``attach_failed()`` tracked
+ONLY the intentional-``close()`` case (``self._connected``) and a hardcoded
+``False`` respectively — a pump death after a successful attach was
+invisible to both: the display kept drawing the last-known agent name
+forever, and the composer kept accepting (and POSTing) new turns through the
+now-orphaned ``send`` closure.
+
+This is the acceptance-item-3 witness (issue #5694, "a test that goes red
+the moment a second independent source is reintroduced"): ``has_session``/
+``attach_failed`` must derive from the ONE fact ``frames()`` already learns
+when it re-raises a genuine ``_SSEPumpError`` — not a second, independently
+maintained "am I connected" flag that could drift from it. Strip-falsifier:
+removing the ``self._connected = False`` / ``self._pump_died = True`` lines
+``AgUiTransport.frames()`` sets right before re-raising turns this test red
+(``has_session()`` stays True and ``attach_failed()`` stays False forever,
+even after the pump has genuinely died) — verified locally.
+
+Real ``AgUiTransport`` + a REAL ``AgUiEmitter``-encoded SSE stream (mirrors
+``test_5126_pump_sse_exception_not_swallowed.py``'s own technique, not a
+hand-rolled SSE text)."""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _InjectedFailure(RuntimeError):
+    """Stands in for a real transport-level failure — what actually raises
+    is irrelevant to the property under test, mirrors #5126's own test."""
+
+
+async def _one_display_frame():
+    yield DisplayFrame(OutboxMessage(kind="agent", text="hello"))
+
+
+def _status_provider():
+    return None
+
+
+async def _sse_lines_then_fail(sse_text: str):
+    for line in sse_text.split("\n"):
+        yield line
+    raise _InjectedFailure("connection dropped mid-stream")
+
+
+async def _noop_send(_payload: dict) -> "dict | None":
+    return None
+
+
+async def _build_real_sse_text() -> str:
+    emitter = AgUiEmitter(_one_display_frame(), _status_provider)
+    return "".join([chunk async for chunk in emitter.stream()])
+
+
+@pytest.mark.asyncio
+async def test_pump_death_flips_has_session_and_attach_failed_together():
+    """Tier 2: the core witness — before the pump dies, ``has_session()`` is
+    True (constructed ``connected=True``, the production default) and
+    ``attach_failed()`` is False; after ``frames()`` raises the real
+    exception, BOTH flip — from the SAME event, not two separately-driven
+    flags."""
+    sse_text = await _build_real_sse_text()
+    transport = AgUiTransport(_sse_lines_then_fail(sse_text), _noop_send)
+
+    assert transport.has_session() is True
+    assert transport.attach_failed() is False
+
+    received = []
+    with pytest.raises(_InjectedFailure, match="connection dropped mid-stream"):
+        async for frame in transport.frames():
+            received.append(frame)
+
+    assert any(
+        isinstance(f, DisplayFrame) and f.message.text == "hello" for f in received
+    ), "sanity: the frame before the failure must still have been delivered"
+
+    assert transport.has_session() is False, (
+        "a caller that (like _pump_frames, #5329) only catches this "
+        "exception around its own read loop must still see has_session() "
+        "go False — otherwise the header/pane keep drawing the last-known "
+        "agent name forever"
+    )
+    assert transport.attach_failed() is True, (
+        "must read as FAILED, not merely 'not yet attached' — this app "
+        "never auto-reconnects, so a 'connecting' render here would be "
+        "the indefinite-loading paper-over the #3671 P3 owner ruling "
+        "forbids"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_clean_end_of_stream_does_not_flip_attach_failed():
+    """Tier 2: falsify pair — an ORDINARY end-of-stream (the source running
+    dry, no exception — #5126's own regression guard) must NOT be
+    mistaken for a pump death. ``attach_failed()`` stays False; only a
+    genuine exception sets it."""
+    sse_text = await _build_real_sse_text()
+
+    async def _sse_lines_clean():
+        for line in sse_text.split("\n"):
+            yield line
+
+    transport = AgUiTransport(_sse_lines_clean(), _noop_send)
+    received = [frame async for frame in transport.frames()]
+    assert any(
+        isinstance(f, DisplayFrame) and f.message.text == "hello" for f in received
+    )
+    assert transport.attach_failed() is False
+    assert transport.has_session() is True, (
+        "a clean end-of-stream is not a failure — has_session() must not "
+        "be conflated with 'the frames() generator has been exhausted'"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5694

## 何を直すか

`AgUiTransport`のSSE pump(`_pump_sse`)が本物の例外で死ぬと(#5126で既に
`frames()`のcallerへ伝播する)、`_pump_frames`(#5329の設計:ログのみ・
appは開いたまま)はそれを画面には一切出さず静かにworkerを終了していました。
一方、送信(`send()`)は別経路のまま生き続け、server側が
`_CONNECTION_RETARGET_HUB`(#5116/#5129)からこのconnectionを忘れた
瞬間、送信先は接続時のURL(古いagent名)へ無言でフォールバックします。
200 OKなので誰にも気付かれません。

## 根拠

`reyn-self`の実運用incidentの監査ログ(`events/agents/*/chat/*.jsonl`)を
直接読み、23:48:14に該当connectionのdefault側manager宛に
`client_detached`が(既に離れていたはずなのに)再度発火し、以降hubが
そのconnectionを覚えていない状態で07:48台の`user_submitted`が
defaultへ着地していることを確認しました。詳細はissueコメント参照:
https://github.com/tya5/reyn/issues/5694#issuecomment-5517770121

## 直し方

`frames()`が本物の`_SSEPumpError`をre-raiseする直前に
`has_session()`/`attach_failed()`を反転させます — これは
`#3671 P3`でheaderとcomposerのsubmit-gateが既に共有している
**同じ** tri-stateです。1つの事実(pumpが死んだ)から両方が動くので、
「2つ目の独立したsource」を足す余地がありません(受入③)。

- `client.py`: `frames()`が`_SSEPumpError`を検知した時点で
  `self._connected = False` / `self._pump_died = True`。
  `attach_failed()`はこれを読むだけ(既存の`False`固定を置換)。
- `app.py`: `_pump_frames`の例外ハンドラで`_refresh_live_chrome()`を
  追加呼出し(pump死亡後は二度とframeが来ないのでこれが最後の
  更新機会)。composerのblocked通知文言を「送れません」ではなく
  「接続が切れています、`/attach <agent>`で再接続してください」に変更
  (lead-coder依頼)。

## 段階的です

段1はこれ(clientが自分のbinding喪失を知る)。再attach/reconnectの
UXと、「attachされたclientが0のときturnが駆動されるか」という
別の未検証論点(coder-brownのsession孤児化疑惑)はfollow-upへ。

## Test plan

- [x] `pytest tests/interfaces/ -k "agui or attach_state or 5329 or 5126 or 5694"` — 141 + 2 = 143 green (local)
- [x] `ruff check .` green
- [x] `test_tier_audit.py --strict` / `verify_module_docstrings.py` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — all green
- [x] (skipped — Visual, standing waiver 2026-08-08)

<!-- closing-check: part of #5694, not closing -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
