### PR TITLE
refactor(#5519): axis-label description marker replaces the gate's hand list

### DIFF
--- a/.github/workflows/axis-label-gate.yml
+++ b/.github/workflows/axis-label-gate.yml
@@ -1,12 +1,12 @@
 name: Axis label gate
 
-# #5499 — an issue with no priority-axis label gets `needs-axis`; an
+# #5499/#5519 — an issue with no priority-axis label gets `needs-axis`; an
 # issue that gains one has it removed. See scripts/axis_label_gate.py's
-# own module docstring for the vocabulary design, why it is one small
-# hand-written pattern reconciled against the live repo label list every
-# run (not a hand-enumerated list of every current axis label, and not
-# derivable from label description/color — both measured and rejected),
-# and why both directions (add / remove) are required.
+# own module docstring for the vocabulary design: every axis label's own
+# GitHub description carries a marker (#5519), reconciled against the
+# live repo label list every run — no hand-enumerated list of axis label
+# names lives in this script at all — and why both directions (add /
+# remove) are required.
 #
 # Trigger: opened AND labeled/unlabeled (not opened-only) — architect's
 # own accept criterion is explicitly BOTH directions ("ラベル無しで

--- a/scripts/axis_label_gate.py
+++ b/scripts/axis_label_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""#5499 — flag an issue with `needs-axis` the moment it carries no
+"""#5499/#5519 — flag an issue with `needs-axis` the moment it carries no
 priority-axis label, and un-flag it the moment it gains one.
 
 ## Why this exists (owner + lead-coder measurement, #5497/#5499)
@@ -15,69 +15,55 @@ failure mode is forgetting the rule exists at all. This closes the gap the
 way CLAUDE.md's own hard rule prescribes: "If CI can catch the violation,
 write the gate, not a rule here."
 
-## What counts as an "axis" label — measured, not assumed
+## What counts as an "axis" label — a description marker, not a hand list
 
-The obvious design ("derive the vocabulary from each label's own
-`description`, no hand list at all") was tried first and REJECTED by
-direct measurement: of the 8 axis labels
-`docs/deep-dives/contributing/issue-management.md` §4/§5 names (`band`,
-`owner-hit`, `silent`, `blocks-others`, `ours-only`, `thin:retrieval`,
-`thin:evaluation`, `priority:next`) plus the `no-axis` opt-out, only 3
-(`no-axis`, `ours-only`, `priority:next`) even contain the word "軸"
-anywhere in their description — `band`/`owner-hit`/`silent`/
-`blocks-others`/`thin:retrieval`/`thin:evaluation` do not, so no
-description-text scan can recover the set. Filed as #5519: a common
-description marker (e.g. a leading `axis:`) would close this gap for
-real, but editing repo labels is owner/lead territory, out of scope here.
+#5499's own first landing tried deriving the vocabulary straight from each
+label's `description` and rejected it by direct measurement: of the 9 axis
+labels (`band`, `owner-hit`, `silent`, `blocks-others`, `ours-only`,
+`thin:retrieval`, `thin:evaluation`, `priority:next`, `no-axis`), only 3
+even contained the word "軸" anywhere in their description — no scan of the
+EXISTING text could recover the set, so #5499 fell back to a small
+hand-written pattern in this script instead (prefix families plus a
+hand-enumerated exact-name set), which #5519 itself named as the disclosed
+limitation: "a new, unprefixed axis is created" still requires editing this
+file, and a renamed/deleted exact-name label silently narrows the gate's
+coverage until someone notices the RED.
 
-The fallback (architect ruling, #5499, 2026-08-29): a small PATTERN lives
-in this script, in ONE named constant (:data:`AXIS_LABEL_VOCABULARY` —
-lead-coder's own follow-up correction: "語彙は script 内に散らさず1つの
-名前付き定数に", the same landing shape #5517's own
-``QUERIED_CAPABILITY_FIELDS_BY_MODALITY`` took) — not a hand-enumerated
-list of every current axis label value, but the handful of PREFIX
-FAMILIES (`priority:`, `roi:`, `thin:`) plus standalone names that
-#5497's own investigation already measured (`git grep "priority:next|
-roi:|owner-hit|ours-only|no-axis|thin:retrieval"`). A new `roi:*` /
-`thin:*` / `priority:*` value is picked up automatically; the exact-name
-set only grows when a genuinely new, unprefixed axis is created (rare,
-and each such PR already touches this file's own docstring by
-construction). Label COLOR was also tried and rejected (lead-coder's own
-measurement): `thin:retrieval` and `thin:evaluation` share the identical
-color `5319E7`, so color carries no more structure than description does.
+#5519 (architect ruling via lead-coder, 2026-08-30) closes that gap for
+real: every axis label's `description` on GitHub now ENDS with the literal
+marker :data:`AXIS_DESCRIPTION_MARKER` (`"[axis]"`) — a small, one-time
+repo-label edit (owner/lead territory, done alongside this PR). The label
+DECLARES its own axis-hood; this script only has to recognise the marker
+(:func:`label_declares_axis`, a pure string check with no vocabulary of
+label names at all), then intersect that against the live repo label list
+(:func:`resolve_axis_vocabulary`) exactly the way #5499 always did. A new
+axis label picked up automatically the moment its own description carries
+the marker — no script edit, ever, for any future axis (prefixed or not).
+`no-axis` (the explicit "judged, none applies" opt-out) carries the same
+marker: an issue carrying it has been triaged and must NOT be flagged,
+the same as any other axis label.
 
-**The vocabulary actually used every run is the INTERSECTION of this
-pattern against the LIVE repo label list** (:func:`resolve_axis_vocabulary`)
-— never trusted blind. BOTH directions of that intersection are checked
-(lead-coder's #5499 correction to an earlier one-directional draft — "誰
-かがラベルを1つ消した日に gate が黙って狭まり…緑のままになります", the
-same "silently narrows, stays green" shape #5517 was just fixed for):
-
-  1. live label matched a prefix → included in ``matched`` by
-     construction (every live label is scanned against the pattern, so
-     there is no live-side gap to separately detect).
-  2. pattern-declared exact name → must still exist live. If ANY exact
-     name has vanished (a rename/delete), :attr:`AxisVocabulary.ok` is
-     False and the workflow fails RED — not a silent note, since a
-     silent note is exactly the hole this correction closes.
-
-If the LIVE-matched intersection is additionally EMPTY (every named axis
-label vanished from the repo — #5482's own "a scanned population must
-never legitimately reach 0" shape), that is also RED. A separate test
-(`test_5499_axis_label_gate.py`) asserts :data:`AXIS_LABEL_VOCABULARY`
-itself is non-empty independent of any live reconciliation — lead-coder's
-#5499 condition ②, PR-body vacuity disclosure "merge 後 誰にも届きません".
+If the LIVE-matched set is EMPTY (every marked axis label vanished from the
+repo, or the marker itself was stripped from every description — #5482's
+own "a scanned population must never legitimately reach 0" shape), that is
+RED, not silently "nothing to check". A separate test
+(`test_5499_axis_label_gate.py`) pins :func:`label_declares_axis` itself
+against marked/unmarked description strings, purely (no network) — the
+live reconciliation (:func:`resolve_axis_vocabulary` against a REAL `gh
+api` label list) is exercised only by this script at gate-run time, per
+lead-coder's own caution that a label-description-dependent test would be
+network-flaky in CI if it tried to hit GitHub directly.
 
 ## Both directions, by design (accept criterion, architect + lead-coder)
 
 A gate that only ever ADDS `needs-axis` and never removes it is the same
-shape as tonight's #5517 incident (a predicate nobody could falsify in
-the direction that matters) — "always flag, never unflag" passes every
-smoke test while doing nothing useful once an issue IS triaged. This
-module's :func:`compute_label_action` is symmetric: MISSING → add,
-PRESENT → remove, and a `needs-axis`-carrying issue that already has no
-other axis label is a no-op (idempotent — the workflow may fire on
-`opened`, `labeled`, AND `unlabeled`, and must not toggle-loop).
+shape as #5517's own incident (a predicate nobody could falsify in the
+direction that matters) — "always flag, never unflag" passes every smoke
+test while doing nothing useful once an issue IS triaged. This module's
+:func:`compute_label_action` is symmetric: MISSING → add, PRESENT →
+remove, and a `needs-axis`-carrying issue that already has no other axis
+label is a no-op (idempotent — the workflow may fire on `opened`,
+`labeled`, AND `unlabeled`, and must not toggle-loop).
 
 ## Scope: never closes, never blocks
 
@@ -95,78 +81,56 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
-
-@dataclass(frozen=True)
-class _AxisLabelPattern:
-    """Single named constant carrying the whole vocabulary definition
-    (lead-coder ruling, #5499, 2026-08-29: "語彙は script 内に散らさず1つ
-    の名前付き定数に" — the same landing shape #5517's
-    ``QUERIED_CAPABILITY_FIELDS_BY_MODALITY`` took). Neither field is a
-    structural derivation — both description text (only 3/9 axis labels
-    even contain "軸") and label color (``thin:retrieval`` and
-    ``thin:evaluation`` share the identical color ``5319E7``, measured by
-    lead-coder) were tried and rejected. The hand-written ``exact`` set is
-    a disclosed limitation, not a design choice — filed as #5519."""
-
-    # Prefix families: any live label starting with one of these counts
-    # as an axis label, whatever value follows the colon (`roi:high`,
-    # `thin:retrieval`, a future `priority:blocked`, ...) — no hand-
-    # enumeration of every value in a family.
-    prefixes: "tuple[str, ...]"
-    # Exact, unprefixed axis-label names — #5497's own measured set
-    # (`git grep "priority:next|roi:|owner-hit|ours-only|no-axis|thin:
-    # retrieval"`), minus the ones already covered by a prefix above.
-    # `no-axis` is included: it is the explicit "judged, none applies"
-    # marker — an issue carrying it has been triaged and must NOT be
-    # flagged.
-    exact: "frozenset[str]"
-
-    def matches(self, label_name: str) -> bool:
-        if label_name in self.exact:
-            return True
-        return any(label_name.startswith(prefix) for prefix in self.prefixes)
-
-
-AXIS_LABEL_VOCABULARY = _AxisLabelPattern(
-    prefixes=("priority:", "roi:", "thin:"),
-    exact=frozenset(
-        {"band", "owner-hit", "silent", "blocks-others", "ours-only", "no-axis"}
-    ),
-)
+# #5519: the ONE marker every axis label's description ends with — see
+# module docstring. Kept as a single named constant, same landing shape
+# #5499's own AXIS_LABEL_VOCABULARY took (lead-coder: "語彙は script 内に
+# 散らさず1つの名前付き定数に"), even though this constant is now a
+# single string, not a name list — the label descriptions on GitHub are
+# the vocabulary now, not this file.
+AXIS_DESCRIPTION_MARKER = "[axis]"
 
 NEEDS_AXIS_LABEL = "needs-axis"
 
 
+def label_declares_axis(description: "str | None") -> bool:
+    """Pure — no I/O. True iff *description* ends with
+    :data:`AXIS_DESCRIPTION_MARKER` (trailing whitespace ignored, so a
+    stray trailing space on GitHub's own side does not silently un-mark a
+    label). A label whose description is missing/blank, or that mentions
+    "軸"/"axis" in prose without the structured marker, does NOT count —
+    this is the one thing that makes the vocabulary machine-checkable
+    instead of prose-checkable (#5519's own reason for existing)."""
+    return (description or "").rstrip().endswith(AXIS_DESCRIPTION_MARKER)
+
+
 @dataclass(frozen=True)
 class AxisVocabulary:
-    """The live-reconciled result of matching :data:`AXIS_LABEL_VOCABULARY`
-    against the repo's actual label list — see module docstring. ``ok`` is
-    false whenever EITHER direction of the reconciliation found a gap —
-    lead-coder's #5499 correction: reporting a vanished exact name without
-    failing the job is the exact "gate silently narrows, stays green"
-    shape #5517 was just fixed for. Both directions are checked:
-    live-label-matched-a-prefix → always included in ``matched`` (by
-    construction — every live label is scanned against the pattern, so
-    there is no live-side gap to separately detect); pattern-exact-name
-    → must still exist live (``vanished_exact_names``, checked here)."""
+    """The live-reconciled result of scanning the repo's actual labels for
+    :func:`label_declares_axis` — see module docstring. ``ok`` is false
+    when the matched set is empty: #5482's own "a scanned population must
+    never legitimately reach 0" shape, now covering both "every marked
+    label was deleted" and "the marker was stripped from every
+    description" in one check, since both look identical from here (a
+    label declares axis-hood or it does not; there is no separate
+    hand-list side to go stale)."""
 
-    matched: "frozenset[str]"  # live labels that satisfy the pattern
-    vanished_exact_names: "tuple[str, ...]"  # exact names with no live match
+    matched: "frozenset[str]"  # live label names whose description is marked
 
     @property
     def ok(self) -> bool:
-        return bool(self.matched) and not self.vanished_exact_names
+        return bool(self.matched)
 
 
-def resolve_axis_vocabulary(live_label_names: "list[str]") -> AxisVocabulary:
-    """Pure — no I/O. Intersects :data:`AXIS_LABEL_VOCABULARY` against a
-    live label name list."""
-    live = set(live_label_names)
-    matched = frozenset(name for name in live if AXIS_LABEL_VOCABULARY.matches(name))
-    vanished = tuple(
-        sorted(name for name in AXIS_LABEL_VOCABULARY.exact if name not in live)
+def resolve_axis_vocabulary(live_labels: "list[dict]") -> AxisVocabulary:
+    """Pure — no I/O. *live_labels* is the repo's label list, each entry
+    carrying at least ``name`` and ``description`` (the shape ``gh api
+    repos/<repo>/labels`` returns). No hand-written name list is
+    consulted at all — every live label is scanned on its own
+    description."""
+    matched = frozenset(
+        entry["name"] for entry in live_labels if label_declares_axis(entry.get("description"))
     )
-    return AxisVocabulary(matched=matched, vanished_exact_names=vanished)
+    return AxisVocabulary(matched=matched)
 
 
 def compute_label_action(
@@ -184,8 +148,8 @@ def compute_label_action(
 
 def format_needs_axis_comment(vocabulary: "frozenset[str]") -> str:
     """The vocabulary actually consulted THIS run, named in the comment
-    (architect condition ②) — so a false positive from a not-yet-
-    pattern-matched new axis label reads as self-explaining, not silent
+    (architect condition ②) — so a false positive from a label whose
+    description is not (yet) marked reads as self-explaining, not silent
     ("貼られた人がその場で一覧の古さに気づける")."""
     listed = ", ".join(f"`{name}`" for name in sorted(vocabulary))
     return (
@@ -194,8 +158,9 @@ def format_needs_axis_comment(vocabulary: "frozenset[str]") -> str:
         f"`docs/deep-dives/contributing/issue-management.md` §5), and "
         f"this `{NEEDS_AXIS_LABEL}` label will be removed automatically.\n\n"
         f"Vocabulary checked this run: {listed}\n\n"
-        f"(If your label isn't in that list, the vocabulary may be "
-        f"stale — see #5519.)"
+        f"(A label counts as an axis label when its own GitHub description "
+        f"ends with `{AXIS_DESCRIPTION_MARKER}` — if yours should be here "
+        f"and isn't, its description is missing that marker; see #5519.)"
     )
 
 
@@ -204,12 +169,12 @@ def format_needs_axis_comment(vocabulary: "frozenset[str]") -> str:
 # ---------------------------------------------------------------------------
 
 
-def _fetch_repo_label_names(repo: str) -> "list[str]":
+def _fetch_repo_labels(repo: str) -> "list[dict]":
     result = subprocess.run(
         ["gh", "api", f"repos/{repo}/labels", "--paginate"],
         capture_output=True, text=True, check=True,
     )
-    return [entry["name"] for entry in json.loads(result.stdout)]
+    return json.loads(result.stdout)
 
 
 def _fetch_issue_label_names(repo: str, issue_number: str) -> "list[str]":
@@ -232,25 +197,16 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: "list[str] | None" = None) -> int:
     args = build_parser().parse_args(argv)
 
-    live_labels = _fetch_repo_label_names(args.repo)
+    live_labels = _fetch_repo_labels(args.repo)
     vocabulary = resolve_axis_vocabulary(live_labels)
-    if vocabulary.vanished_exact_names:
-        print(
-            "RED: axis-label names in this script's own vocabulary no "
-            f"longer exist in the repo's live label list: "
-            f"{', '.join(vocabulary.vanished_exact_names)} — the gate's "
-            "coverage silently narrowed. Update AXIS_LABEL_VOCABULARY in "
-            "scripts/axis_label_gate.py (see #5519).",
-            file=sys.stderr,
-        )
-    if not vocabulary.matched:
-        print(
-            "RED: the axis-label vocabulary matched ZERO live repo "
-            "labels — every named axis label has vanished. Refusing to "
-            "silently treat every issue as axis-labeled.",
-            file=sys.stderr,
-        )
     if not vocabulary.ok:
+        print(
+            "RED: no live repo label's description carries the "
+            f"{AXIS_DESCRIPTION_MARKER!r} marker — every axis label has "
+            "either been deleted or had its marker stripped. Refusing to "
+            "silently treat every issue as axis-labeled. See #5519.",
+            file=sys.stderr,
+        )
         return 1
 
     issue_labels = _fetch_issue_label_names(args.repo, args.issue)

--- a/tests/scripts/test_5499_axis_label_gate.py
+++ b/tests/scripts/test_5499_axis_label_gate.py
@@ -1,88 +1,106 @@
-"""Tier 1: #5499 — the pure decision logic behind the axis-label gate.
+"""Tier 1: #5499/#5519 — the pure decision logic behind the axis-label gate.
 
-See `scripts/axis_label_gate.py`'s own module docstring for why the
-vocabulary is a small hand-written pattern (not derived from label
-description or color — both were measured and rejected) and why both
-directions of live-reconciliation must be checked, not just one.
+See `scripts/axis_label_gate.py`'s own module docstring for the full design
+history: #5499's first landing carried a hand-written name/prefix
+vocabulary (description-text and label-color derivation were both measured
+and rejected at the time); #5519 replaced it with a description MARKER
+every axis label now carries on GitHub, so the vocabulary lives entirely in
+live label descriptions and this script no longer hand-enumerates any
+label name.
+
+Only the pure marker-check (:func:`label_declares_axis`) and the pure
+decision functions built on top of it are tested here — lead-coder's own
+caution (#5519): a test that hits the live `gh api` label list would be
+network-dependent and CI-flaky. The live reconciliation
+(:func:`resolve_axis_vocabulary` against a real label list) is exercised
+by the gate script itself at run time, not by this file.
 """
 from __future__ import annotations
 
 from scripts.axis_label_gate import (
-    AXIS_LABEL_VOCABULARY,
+    AXIS_DESCRIPTION_MARKER,
     NEEDS_AXIS_LABEL,
     compute_label_action,
     format_needs_axis_comment,
+    label_declares_axis,
     resolve_axis_vocabulary,
 )
 
 
-def test_the_vocabulary_constant_itself_is_not_empty() -> None:
-    """Tier 1: accept-side / noise guard, lead-coder's #5499 condition ②
-    — independent of any live reconciliation, the constant this whole
-    gate is built on must be non-empty, or every downstream test below
-    would pass vacuously."""
-    assert AXIS_LABEL_VOCABULARY.prefixes
-    assert AXIS_LABEL_VOCABULARY.exact
+def test_the_marker_constant_itself_is_not_empty() -> None:
+    """Tier 1: accept-side / noise guard — independent of any live
+    reconciliation, the marker this whole gate is built on must be a real,
+    non-empty string, or every downstream test below would pass vacuously
+    (a blank marker would make ``str.endswith("")`` always True)."""
+    assert AXIS_DESCRIPTION_MARKER
 
 
-def test_resolve_matches_a_prefixed_live_label_not_individually_named() -> None:
-    """Tier 1: a live label matching a PREFIX family (not itself in the
-    hand-written exact set) must be picked up — this is the whole point
-    of using prefixes instead of enumerating every roi:/thin:/priority:
-    value."""
-    live = ["roi:high", "bug", "documentation", *AXIS_LABEL_VOCABULARY.exact]
+def test_label_declares_axis_when_description_ends_with_the_marker() -> None:
+    """Tier 1: the accept side — a description ending with the marker,
+    whatever text precedes it (mirrors the real repo labels: some already
+    mention "軸" in prose, some don't — the marker is what counts, not the
+    prose around it)."""
+    assert label_declares_axis(f"憲章の cross-cutting band に掛かる {AXIS_DESCRIPTION_MARKER}")
+    assert label_declares_axis(f"plain english description {AXIS_DESCRIPTION_MARKER}")
+    # Trailing whitespace after the marker must not silently un-mark it.
+    assert label_declares_axis(f"trailing space after marker {AXIS_DESCRIPTION_MARKER}  ")
+
+
+def test_label_declares_axis_is_false_without_the_marker() -> None:
+    """Tier 1: deny-side pin — the property #5519's own acceptance
+    criterion names explicitly: adding a brand-new label whose
+    description does NOT carry the marker must never be picked up as an
+    axis label, however plausible its own prose sounds (including prose
+    that mentions "軸"/"axis" without the structured marker) — a "treats
+    everything as axis" implementation would pass every OTHER test in
+    this file but fail this one."""
+    assert not label_declares_axis("Something isn't working")
+    assert not label_declares_axis("")
+    assert not label_declares_axis(None)
+    # Mentions the concept in prose but never carries the marker itself —
+    # this is the exact #5499-era gap #5519 exists to close: prose-text
+    # scanning cannot be trusted, only the structured marker can.
+    assert not label_declares_axis("この issue は優先順位の軸に関わる")
+    # The marker appears, but not at the END — must not match either
+    # (avoids treating "[axis] this label's real subject" as declared,
+    # which would let an unrelated axis-shaped label slip through unmarked).
+    assert not label_declares_axis(f"{AXIS_DESCRIPTION_MARKER} not trailing")
+
+
+def test_resolve_matches_only_labels_whose_description_carries_the_marker() -> None:
+    """Tier 1: :func:`resolve_axis_vocabulary` end to end — a marked label
+    is matched, an unmarked one (however label-like its NAME looks) is
+    not, and there is no hand-written name list involved anywhere in this
+    path."""
+    live = [
+        {"name": "band", "description": f"cross-cutting band {AXIS_DESCRIPTION_MARKER}"},
+        {"name": "priority:next", "description": f"次に取るべき {AXIS_DESCRIPTION_MARKER}"},
+        {"name": "bug", "description": "Something isn't working"},
+        {"name": "roi:high", "description": None},  # marker-less: not matched
+    ]
     vocab = resolve_axis_vocabulary(live)
-    assert "roi:high" in vocab.matched
+    assert vocab.matched == frozenset({"band", "priority:next"})
+    assert "bug" not in vocab.matched
+    assert "roi:high" not in vocab.matched, (
+        "a plausibly-named label with no marker in its description must "
+        "never be treated as an axis label — this is the deny-side pin "
+        "#5519's acceptance criteria name explicitly"
+    )
     assert vocab.ok
 
 
-def test_resolve_matches_an_exact_named_live_label() -> None:
-    """Tier 1: a live label in the hand-written exact set is matched."""
-    live = ["bug", *AXIS_LABEL_VOCABULARY.exact]
-    vocab = resolve_axis_vocabulary(live)
-    assert "band" in vocab.matched
-    assert vocab.ok
-
-
-def test_resolve_does_not_match_an_unrelated_live_label() -> None:
-    """Tier 1: deny-side sibling — a live label matching neither a prefix
-    nor the exact set (the ordinary case: bug/documentation/enhancement/
-    ...) must never be treated as an axis label."""
-    vocab = resolve_axis_vocabulary(["bug", "documentation", "enhancement"])
-    assert vocab.matched == frozenset()
-
-
-def test_resolve_flags_red_when_every_named_axis_label_vanished() -> None:
+def test_resolve_flags_red_when_no_live_label_carries_the_marker() -> None:
     """Tier 1: #5482's "a scanned population must never legitimately
-    reach 0" shape — if the live label list contains NONE of the
-    vocabulary's names at all, ``ok`` must be False, never silently
-    treated as "nothing to check"."""
-    vocab = resolve_axis_vocabulary(["bug", "documentation"])
+    reach 0" shape — covers BOTH "every marked label was deleted" and
+    "the marker was stripped from every description" identically, since
+    there is no separate hand-list side to distinguish them anymore."""
+    live = [
+        {"name": "bug", "description": "Something isn't working"},
+        {"name": "documentation", "description": "Docs"},
+    ]
+    vocab = resolve_axis_vocabulary(live)
     assert not vocab.matched
     assert not vocab.ok
-
-
-def test_resolve_flags_red_when_an_exact_name_vanished_even_if_others_match() -> None:
-    """Tier 1: lead-coder's #5499 correction — a vanished EXACT name must
-    fail (``ok`` False) even when OTHER vocabulary members still match
-    live labels. A pre-fix version of this gate only checked the
-    intersection-empty case and silently narrowed coverage otherwise
-    (the same shape #5517 was blocked for) — this pins the fix."""
-    live = ["roi:high", "thin:retrieval"]  # "band" et al. never appear
-    vocab = resolve_axis_vocabulary(live)
-    assert vocab.matched  # some real match exists...
-    assert vocab.vanished_exact_names  # ...but an exact name is missing
-    assert not vocab.ok  # ...so this must still be red
-
-
-def test_resolve_reports_no_vanished_names_when_all_exact_names_are_live() -> None:
-    """Tier 1: accept-side sibling to the previous test — when every
-    exact name in the vocabulary is present live, nothing is reported as
-    vanished."""
-    live = set(AXIS_LABEL_VOCABULARY.exact) | {"bug"}
-    vocab = resolve_axis_vocabulary(sorted(live))
-    assert vocab.vanished_exact_names == ()
-    assert vocab.ok
 
 
 def test_action_is_add_when_issue_has_no_axis_label() -> None:
@@ -115,8 +133,8 @@ def test_action_is_noop_when_needs_axis_already_correctly_present() -> None:
 def test_comment_names_the_vocabulary_actually_checked() -> None:
     """Tier 1: architect's #5499 condition ② — the needs-axis comment
     must enumerate the vocabulary used THIS run, so a false positive from
-    a not-yet-pattern-matched new axis label is self-explaining rather
-    than silent."""
+    an unmarked label is self-explaining rather than silent."""
     comment = format_needs_axis_comment(frozenset({"band", "roi:high"}))
     assert "band" in comment
     assert "roi:high" in comment
+    assert AXIS_DESCRIPTION_MARKER in comment


### PR DESCRIPTION
**[e2e-coder]** — Closes #5519

## What

#5499's axis-label gate (`scripts/axis_label_gate.py`) used to carry a small hand-written vocabulary (`AXIS_LABEL_VOCABULARY`: prefix families + a hand-enumerated exact-name set) reconciled against the live repo label list every run. #5519's own measurement (filed while implementing #5499) found this could never be fully closed by scanning existing label *description text* — only 3/9 axis labels even contained the word "軸".

Per architect ruling (relayed via lead-coder): every axis label's own GitHub `description` now ends with a literal marker, `[axis]` — the label declares its own axis-hood, so the gate no longer hand-enumerates any label name at all.

**12 repo labels edited** (via `gh label edit`, real GitHub state, not a mock): `band`, `owner-hit`, `silent`, `blocks-others`, `ours-only`, `no-axis`, `priority:next`, `roi:high`, `roi:medium`, `roi:low`, `thin:evaluation`, `thin:retrieval`. Existing description text is preserved verbatim; the marker is purely appended (harmonizes with the 3 labels — `no-axis`/`ours-only`/`priority:next` — that already mention "軸" in prose, without rewriting that prose).

`scripts/axis_label_gate.py`:
- `label_declares_axis(description) -> bool` — pure, no vocabulary of label names.
- `resolve_axis_vocabulary(live_labels)` — intersects the marker check against the live `gh api` label list (unchanged shape from #5499: never trusted blind).
- Dropped `vanished_exact_names` — there is no separate hand-list side left to go stale independently of the live description scan, so the single empty-match-set check (#5482's "a scanned population must never legitimately reach 0" shape) now covers both failure modes identically.

## Verified against the real, now-edited repo labels

Not just the unit tests — ran `resolve_axis_vocabulary` against a real `gh api repos/tya5/reyn/labels` fetch after editing the labels: it matches exactly the 12 intended axis labels and correctly excludes all 23 other repo labels (`bug`, `severity:*`, `status:*`, `cost:*`, `owner:decide`, `needs-axis` itself, etc.) — pasted output verified label-by-label.

## Accept criteria (all 3, per lead-coder's ruling comment)

- [x] gate has no hand list — `AXIS_LABEL_VOCABULARY` removed entirely; `label_declares_axis` carries no label names.
- [x] a label without the marker is never picked up as an axis label — `test_label_declares_axis_is_false_without_the_marker` + `test_resolve_matches_only_labels_whose_description_carries_the_marker`'s deny-side arm. Confirmed by strip-falsify: forcing `label_declares_axis` to always return `True` turned 3 tests red.
- [x] vacuity guard — `test_resolve_flags_red_when_no_live_label_carries_the_marker` (and the live `main()` path returns exit 1 + stderr RED in that case, unchanged shape from #5499).

## Test design note (per lead-coder's own caution)

Tests are pure — no network. `label_declares_axis`/`resolve_axis_vocabulary`/`compute_label_action`/`format_needs_axis_comment` are all exercised against constructed data, never a real `gh api` call — the live reconciliation is exercised by the gate script itself at workflow-run time, matching the existing `test_5499_axis_label_gate.py`'s own established pattern.

## Doc-sync

`.github/workflows/axis-label-gate.yml`'s own comment (the only other place describing the old hand-list design) updated to match — swept via `git grep` for every other reference to the changed identifiers (`AXIS_LABEL_VOCABULARY`, `resolve_axis_vocabulary`, `vanished_exact_names`, `_fetch_repo_label_names`); no `docs/` file references the gate's internal vocabulary design, so none needed updating.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_5499_axis_label_gate.py`
- [x] `python scripts/verify_module_docstrings.py scripts/axis_label_gate.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] scoped pytest (foreground, `tests/scripts/`) — green, 1129 passed
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51