### PR TITLE
fix(#5702): add no-hardcoded-compaction-role-tuple to main-invariant-sweep

### DIFF
--- a/.github/workflows/main-invariant-sweep.yml
+++ b/.github/workflows/main-invariant-sweep.yml
@@ -166,3 +166,7 @@ jobs:
       - name: cancel-swallow
         if: ${{ !cancelled() }}
         run: python scripts/check_cancel_swallow.py
+
+      - name: no-hardcoded-compaction-role-tuple
+        if: ${{ !cancelled() }}
+        run: python scripts/check_no_hardcoded_compaction_role_tuple.py


### PR DESCRIPTION
**[e2e-coder]** Closes #5702

## What

`scripts/check_no_hardcoded_compaction_role_tuple.py` (#5699) shipped `pull_request`-triggered only — the exact composition gap #4257 already witnesses for 6 sibling whole-tree gate scripts: under `strict=false` (#4239), a violation created by the COMBINATION of two independently-green PRs is never caught anywhere, and the next PR to touch that path inherits a red gate an innocent change didn't cause.

Added as a 7th step to `main-invariant-sweep.yml`'s existing list, in the SAME shape every sibling step already uses:

```yaml
- name: no-hardcoded-compaction-role-tuple
  if: ${{ !cancelled() }}
  run: python scripts/check_no_hardcoded_compaction_role_tuple.py
```

No new format introduced — read the existing 8 steps first, matched their shape exactly (`name:` / `if: ${{ !cancelled() }}` / `run: python scripts/<script>.py`, no pip install needed since the script is stdlib-only).

## Accept criteria — both verified by direct execution, not assumed

1. **Green against the real current main tree**: `python scripts/check_no_hardcoded_compaction_role_tuple.py` run directly against this worktree (based on `origin/main` post-#5700) — `OK: no file under src/ (outside chat_message.py) hand-types the compaction-eligible role tuple.`
2. **Red on a real injected violation**: added a throwaway hand-typed role tuple to `compaction_controller.py` via `Edit` (not `git checkout`/`stash`), re-ran the same script — correctly failed (`exit=1`), naming exactly the file injected into. Reverted via `Edit` (not `git checkout`/`stash`), re-ran once more — confirmed green again. `git diff --stat` after revert shows only the intended `main-invariant-sweep.yml` change remains.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/check_no_hardcoded_compaction_role_tuple.py` (direct, against real main tree) — green
- [x] Strip-falsify (accept criterion 2, above) — red on injection, green on revert
- [x] `pytest tests/scripts/` (foreground, single run) — 1137 passed
- [x] (skipped — Visual, standing waiver)

No `src/`/`tests/` files changed (workflow-only), so `test_tier_audit`/`verify_module_docstrings`/`mypy_ratchet` have nothing new to scope against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51