### PR TITLE
closes #5685: gate literal/impl drift on router_loop.py's host getattr seam, rename peek_mid_turn_injection(s)

### DIFF
--- a/src/reyn/runtime/inbox_arbiter.py
+++ b/src/reyn/runtime/inbox_arbiter.py
@@ -4,7 +4,7 @@ extracted from Session (proposal 0067 P1, #3978).
 Before this extraction, four pieces of state (`_pending_inbox_item`,
 `_cancelled_msg_ids`, `_next_turn_context`, `_last_sender`/`_last_reply_to`)
 and the methods that read/write them (`_consume_inbox`,
-`_peek_mid_turn_injection`, `_drain_to_wake`, `_stage_next_turn_context`,
+`_peek_mid_turn_injections`, `_drain_to_wake`, `_stage_next_turn_context`,
 `_handle_sender_attribution`) lived directly on ``Session`` alongside ~40
 unrelated fields — one more example of the field-usage cluster the
 `refactoring` skill's Extract Class step targets: these methods touch each
@@ -12,7 +12,7 @@ other's state and nothing else Session owns (external deps are threaded in
 at construction, see below).
 
 Byte-identical extraction where the prior inline body allowed it
-(`consume_inbox`, `peek_mid_turn_injection`, `stage_next_turn_context`,
+(`consume_inbox`, `peek_mid_turn_injections`, `stage_next_turn_context`,
 `drain_to_wake`) — moved, not rewritten. `handle_sender_attribution` is the
 one exception: extraction is also where the reply_to staleness bug (see its
 own docstring) is closed, since fixing it required threading `kind` through
@@ -132,7 +132,7 @@ class InboxArbiter:
         self._notify_state_change = notify_state_change
 
         # #3792/#5647: a volatile (not WAL/snapshot-backed) peek buffer, in
-        # ARRIVAL ORDER — see ``peek_mid_turn_injection``'s own docstring.
+        # ARRIVAL ORDER — see ``peek_mid_turn_injections``'s own docstring.
         # Was a 1 slot until #5647: injection now looks PAST an ineligible
         # head for the operator's own message, and the items it looked past
         # have to be held somewhere that preserves the order they arrived in.
@@ -166,7 +166,7 @@ class InboxArbiter:
 
         #3792: drains ``self.pending_inbox_items`` FIRST, from its head, ahead
         of a fresh ``self._inbox.get()``. Items land there via
-        ``peek_mid_turn_injection`` — either because the running turn ended
+        ``peek_mid_turn_injections`` — either because the running turn ended
         (cancel / cap / overflow / LLM exception) before
         ``Session._commit_mid_turn_injection`` ever fired (carry-forward: the
         item is simply processed as an ordinary new turn here, exactly as if
@@ -221,7 +221,7 @@ class InboxArbiter:
             await self._journal.consume_inbox(msg_id=msg_id)
         return kind, payload
 
-    async def peek_mid_turn_injection(self) -> "list[dict]":
+    async def peek_mid_turn_injections(self) -> "list[dict]":
         """#3792/#5677: non-blocking, non-committing peek at the inbox for
         EVERY currently-eligible mid-turn injection candidate, in arrival
         order.

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2292,7 +2292,7 @@ class RouterLoop:
             # untouched). getattr-guarded → hosts that don't implement the
             # hook (phase hosts; production chat host implements it via
             # ``RouterHostAdapter``, PR2 #3792) are a no-op.
-            _peek_injection_fn = getattr(host, "peek_mid_turn_injection", None)
+            _peek_injection_fn = getattr(host, "peek_mid_turn_injections", None)
             if _peek_injection_fn is not None and not _force_close_now:
                 _injections = await _peek_injection_fn()
                 if _injections:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -218,7 +218,7 @@ class RouterHostAdapter:
         bundle: exact consumer-set match on the ``live_session_id`` property).
     append_history:
         Sync callback ``(ChatMessage) -> None``.
-    peek_mid_turn_injection:
+    peek_mid_turn_injections:
         #3792/#5677. Async callback ``() -> list[dict]`` —
         ``Session.peek_mid_turn_injections`` (plural; #5677 batches every
         currently-eligible item into one call, not just the first).
@@ -227,11 +227,11 @@ class RouterHostAdapter:
     commit_mid_turn_injection:
         #3792. Async callback ``(msg_id: str) -> None`` —
         ``Session.commit_mid_turn_injection``. Same ``None``-default contract
-        as ``peek_mid_turn_injection``.
+        as ``peek_mid_turn_injections``.
     mark_untrusted_in_flight:
         #4381 PR-2 stage ③. Sync callback ``() -> None`` —
         ``Session._mark_untrusted_in_flight``. Same ``None``-default contract
-        as ``peek_mid_turn_injection``.
+        as ``peek_mid_turn_injections``.
     """
 
     # RouterLoopHost Protocol attributes (non-property)
@@ -306,12 +306,12 @@ class RouterHostAdapter:
         append_history: Callable,
         # #3792: mid-turn CLIENT_INPUT injection — a peek/commit pair, both
         # bare (no shared-consumer partner: nothing else is carried to
-        # exactly Session.peek_mid_turn_injection /
+        # exactly Session.peek_mid_turn_injections /
         # Session.commit_mid_turn_injection). None-default so pre-existing
         # hand-built adapters (tests, other call sites) stay valid; RouterLoop
         # getattr-guards both, so an adapter that leaves them None behaves
         # exactly like a phase host (no-op seam).
-        peek_mid_turn_injection: "Callable[[], Awaitable[list[dict]]] | None" = None,
+        peek_mid_turn_injections: "Callable[[], Awaitable[list[dict]]] | None" = None,
         commit_mid_turn_injection: "Callable[[str], Awaitable[None]] | None" = None,
         # #4381 PR-2 stage ③: sync callback () -> None — Session.
         # _mark_untrusted_in_flight. Bare, no shared-consumer partner (mirrors
@@ -598,7 +598,7 @@ class RouterHostAdapter:
         # path.
         self._append_history_cb = append_history
         # #3792
-        self._peek_mid_turn_injection_cb = peek_mid_turn_injection
+        self._peek_mid_turn_injections_cb = peek_mid_turn_injections
         self._commit_mid_turn_injection_cb = commit_mid_turn_injection
         # #4381 PR-2 stage ③
         self._mark_untrusted_in_flight_cb = mark_untrusted_in_flight
@@ -1382,7 +1382,7 @@ class RouterHostAdapter:
     def mark_task_pending(self) -> None:
         """Proposal 0067 P1' (#3978): forward to ``Session.current_task``
         when wired. None-safe (same reasoning as
-        :meth:`peek_mid_turn_injection`) — an adapter built without the
+        :meth:`peek_mid_turn_injections`) — an adapter built without the
         callback (pre-#3978 test construction) is a no-op, matching what a
         host that never implemented the concept would do."""
         if self._mark_task_pending_cb is None:
@@ -2103,7 +2103,7 @@ class RouterHostAdapter:
 
         None-safe (pre-existing hand-built adapters, most test construction)
         — behaves exactly like a host that never implemented the hook, same
-        convention as ``peek_mid_turn_injection`` above. Called from
+        convention as ``peek_mid_turn_injections`` above. Called from
         ``router_loop.py``'s tool-result production, at the SAME line that
         stamps ``external_source`` onto the persisted ``ChatMessage.meta``
         (single update point — no second, independently-maintained taint
@@ -2113,22 +2113,22 @@ class RouterHostAdapter:
         if self._mark_untrusted_in_flight_cb is not None:
             self._mark_untrusted_in_flight_cb()
 
-    async def peek_mid_turn_injection(self) -> "list[dict]":
+    async def peek_mid_turn_injections(self) -> "list[dict]":
         """#3792/#5677: forwards to ``Session.peek_mid_turn_injections``
         when wired.
 
         Empty-list-safe when this adapter was constructed without the
-        ``peek_mid_turn_injection`` callback (pre-#3792 call sites, most
+        ``peek_mid_turn_injections`` callback (pre-#3792 call sites, most
         test construction) — behaves exactly like a host that never
         implemented the hook at all (RouterLoop's own truthiness check
         treats the two identically: no injection this round)."""
-        if self._peek_mid_turn_injection_cb is None:
+        if self._peek_mid_turn_injections_cb is None:
             return []
-        return await self._peek_mid_turn_injection_cb()
+        return await self._peek_mid_turn_injections_cb()
 
     async def commit_mid_turn_injection(self, msg_id: str) -> None:
         """#3792: forwards to ``Session.commit_mid_turn_injection`` when
-        wired. None-safe, same reasoning as :meth:`peek_mid_turn_injection`."""
+        wired. None-safe, same reasoning as :meth:`peek_mid_turn_injections`."""
         if self._commit_mid_turn_injection_cb is None:
             return
         await self._commit_mid_turn_injection_cb(msg_id)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6087,7 +6087,7 @@ class Session:
             put_outbox_inputs=_put_outbox_inputs,  # #3482
             append_history=self._append_history,
             # #3792: mid-turn CLIENT_INPUT injection.
-            peek_mid_turn_injection=self.peek_mid_turn_injections,
+            peek_mid_turn_injections=self.peek_mid_turn_injections,
             commit_mid_turn_injection=self._commit_mid_turn_injection,
             # #4381 PR-2 stage ③: in-flight taint latch.
             mark_untrusted_in_flight=self._mark_untrusted_in_flight,
@@ -7446,8 +7446,8 @@ class Session:
         return True
 
     async def peek_mid_turn_injections(self) -> "list[dict]":
-        """#5677: the ``RouterHostAdapter``-wired ``peek_mid_turn_injection``
-        callback — was ``self._inbox_arbiter.peek_mid_turn_injection``
+        """#5677: the ``RouterHostAdapter``-wired ``peek_mid_turn_injections``
+        callback — was ``self._inbox_arbiter.peek_mid_turn_injections``
         directly (a bare forwarder; #3978's own module docstring names
         that shape). Now a thin WRAPPING layer instead, because
         rendering (#5677 §0, architect) has to happen somewhere, and the
@@ -7465,7 +7465,7 @@ class Session:
         rendering for the history append from the ``kind``/``payload``
         it already holds at commit time — see
         ``_render_mid_turn_injection``)."""
-        items = await self._inbox_arbiter.peek_mid_turn_injection()
+        items = await self._inbox_arbiter.peek_mid_turn_injections()
         return [
             {"msg_id": it["msg_id"], "wire": _render_mid_turn_injection(it["kind"], it["payload"])}
             for it in items
@@ -7473,7 +7473,7 @@ class Session:
 
     async def _commit_mid_turn_injection(self, msg_id: str) -> None:
         """#3792: commit (pop) the item the most recent successful
-        ``peek_mid_turn_injection()`` call returned.
+        ``peek_mid_turn_injections()`` call returned.
 
         The atomic unit architect's design calls unbreakable — history
         append, journal consume (SSoT prune + WAL tombstone), and the
@@ -7540,7 +7540,7 @@ class Session:
             meta=payload.get("meta") or {},
             # #5514 §4 (traced, still undecided): this item came off
             # ``self._inbox``, a generic multi-producer queue
-            # (``InboxArbiter.peek_mid_turn_injection`` → ``self._inbox.
+            # (``InboxArbiter.peek_mid_turn_injections`` → ``self._inbox.
             # get_nowait()``) — the producer is not traceable from here
             # to a single deterministic origin. Default LAST_RESORT per
             # lead-coder's own instruction for an untraceable site.

--- a/src/reyn/runtime/turn_origin.py
+++ b/src/reyn/runtime/turn_origin.py
@@ -182,7 +182,7 @@ class TurnOrigin(StrEnum):
 
 #: #5677 (architect co-vet, lead-coder's own correction of #3595's
 #: original slash-dispatch predicate): which kinds may STEER a turn
-#: that is already running — ``InboxArbiter.peek_mid_turn_injection``'s
+#: that is already running — ``InboxArbiter.peek_mid_turn_injections``'s
 #: own eligibility set. This is a SEPARATE question from
 #: ``CLIENT_INPUT``'s "may this text reach slash dispatch" (that
 #: predicate is a trust decision about a text's FORM; this one is about

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -123,7 +123,7 @@ def make_adapter(
     on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
     safety_extensions: "dict | None" = None,  # #2175: shared per-run extension dict
     intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
-    peek_mid_turn_injection: "object | None" = None,  # #3792
+    peek_mid_turn_injections: "object | None" = None,  # #3792
     commit_mid_turn_injection: "object | None" = None,  # #3792
     # #4159 (remainder recorded on the issue, closed out here): this test
     # builder used to keep its OWN False default one layer above
@@ -238,7 +238,7 @@ def make_adapter(
             (lambda: turn_budget_engine) if turn_budget_engine is not None else None
         ),
         environment_backend=environment_backend,
-        peek_mid_turn_injection=peek_mid_turn_injection,  # #3792
+        peek_mid_turn_injections=peek_mid_turn_injections,  # #3792
         commit_mid_turn_injection=commit_mid_turn_injection,  # #3792
         universal_wrappers_enabled=universal_wrappers_enabled,  # #4159
     )

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -313,7 +313,7 @@ class FakeRouterHost:
 
     # --- #3792 PR1: mid-turn injection seam ---
 
-    async def peek_mid_turn_injection(self) -> "list[dict]":
+    async def peek_mid_turn_injections(self) -> "list[dict]":
         """PR1 test double: records every call (for seam-position witness
         tests) and always returns ``[]`` (PR1's own production behaviour —
         PR2 wires the real peek; #5677 changed the shape from
@@ -323,7 +323,7 @@ class FakeRouterHost:
         ORDER (relative to other recorded events, via the shared
         ``self.call_order`` log some tests also append to)."""
         self.mid_turn_injection_peeks.append(len(self.mid_turn_injection_peeks))
-        self.call_order.append("peek_mid_turn_injection")
+        self.call_order.append("peek_mid_turn_injections")
         return []
 
 

--- a/tests/core/test_3792_pr2_session_injection.py
+++ b/tests/core/test_3792_pr2_session_injection.py
@@ -92,7 +92,7 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
     not one alone): every OTHER member must still be excluded.
 
     Falsification (performed during review): reverting
-    ``InboxArbiter.peek_mid_turn_injection``'s eligibility check from
+    ``InboxArbiter.peek_mid_turn_injections``'s eligibility check from
     ``kind not in MID_TURN_INJECTABLE`` back to
     ``kind != TurnOrigin.CLIENT_INPUT`` makes the AGENT_REQUEST accept-side
     assertion below go RED (an empty list, not one entry); widening it to
@@ -121,7 +121,7 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
             tmp_path / f"{origin.value}.wal", tmp_path / f"{origin.value}.json",
         )
         await session._put_inbox(origin, kwargs)
-        result = await session._inbox_arbiter.peek_mid_turn_injection()
+        result = await session._inbox_arbiter.peek_mid_turn_injections()
         assert result == [], f"origin {origin!r} must NOT be peek-eligible"
         await state_log.aclose()
 
@@ -130,7 +130,7 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
         tmp_path / "client_input.wal", tmp_path / "client_input.json",
     )
     await session.submit_user_text("hello")
-    result = await session._inbox_arbiter.peek_mid_turn_injection()
+    result = await session._inbox_arbiter.peek_mid_turn_injections()
     (only,) = result
     assert only["payload"]["text"] == "hello"
     assert only["kind"] == TurnOrigin.CLIENT_INPUT
@@ -144,7 +144,7 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
         TurnOrigin.AGENT_REQUEST,
         {"from_agent": "peer-agent", "request": "corrected instruction", "depth": 1, "chain_id": "c1"},
     )
-    result2 = await session2._inbox_arbiter.peek_mid_turn_injection()
+    result2 = await session2._inbox_arbiter.peek_mid_turn_injections()
     (only2,) = result2
     assert only2["payload"]["request"] == "corrected instruction"
     assert only2["kind"] == TurnOrigin.AGENT_REQUEST
@@ -159,7 +159,7 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
     await session3._put_inbox(
         TurnOrigin.EXTERNAL_MESSAGE, {"text": "urgent update", "sender": "slack:U456"},
     )
-    result3 = await session3._inbox_arbiter.peek_mid_turn_injection()
+    result3 = await session3._inbox_arbiter.peek_mid_turn_injections()
     (only3,) = result3
     assert only3["payload"]["text"] == "urgent update"
     assert only3["kind"] == TurnOrigin.EXTERNAL_MESSAGE
@@ -206,7 +206,7 @@ async def test_peek_looks_past_an_ineligible_head_but_consume_order_is_unchanged
     await session._put_inbox(TurnOrigin.HOOK, {"name": "on_idle"})
     await session.submit_user_text("second, eligible")
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     assert peeked, (
         "#5647: peek must look PAST the ineligible HOOK head to find "
         "the operator's message — stopping here is the reported defect"
@@ -233,7 +233,7 @@ async def test_peek_looks_past_an_ineligible_head_but_consume_order_is_unchanged
 async def test_peek_collects_every_eligible_item_in_one_scan(tmp_path):
     """Tier 2: #5677 (owner ruling, verbatim: "溜まっているものは基本inject
     すべき… わざわざ分けるとコスト増えるだけ") — multiple queued eligible
-    items are ALL returned by one ``peek_mid_turn_injection()`` call, not
+    items are ALL returned by one ``peek_mid_turn_injections()`` call, not
     just the first, so a caller can splice them into the SAME completion
     round instead of paying for one round trip per item.
 
@@ -242,7 +242,7 @@ async def test_peek_collects_every_eligible_item_in_one_scan(tmp_path):
     don't stop" behavior #5647 established, generalized from "stop at the
     first eligible hit" to "keep going to the end of what's available".
 
-    Strip-falsifier: reverting ``peek_mid_turn_injection`` to ``return``
+    Strip-falsifier: reverting ``peek_mid_turn_injections`` to ``return``
     immediately after the FIRST eligible hit (the pre-#5677 shape) makes
     the length assertion below go red (1 item, not 2) and the AGENT_REQUEST
     assertion never runs.
@@ -256,7 +256,7 @@ async def test_peek_collects_every_eligible_item_in_one_scan(tmp_path):
         {"from_agent": "peer", "request": "second, eligible", "depth": 1, "chain_id": "c1"},
     )
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     first, second = peeked  # exactly 2 — a 3rd or a missing one fails to unpack
     assert first["kind"] == TurnOrigin.CLIENT_INPUT
     assert first["payload"]["text"] == "first, eligible"
@@ -301,7 +301,7 @@ async def test_peek_without_commit_carries_forward_to_normal_consume(tmp_path):
     session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
     await session.submit_user_text("carry me")
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     assert peeked
     # Deliberately do NOT commit — simulates the abnormal exit.
 
@@ -336,7 +336,7 @@ async def test_commit_appends_history_prunes_snapshot_emits_turn_started(tmp_pat
     events = collect_events(session)
 
     msg_id = await session.submit_user_text("inject me", attribution=None)
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     assert peeked
     assert peeked[0]["msg_id"] == msg_id
 
@@ -397,7 +397,7 @@ async def test_commit_truncate_falsify(tmp_path):
 
     msg_id = await session.submit_user_text("inject me")
     keep_id = await session.submit_user_text("stays queued")
-    await session._inbox_arbiter.peek_mid_turn_injection()
+    await session._inbox_arbiter.peek_mid_turn_injections()
     await session._commit_mid_turn_injection(msg_id)
     await session.journal.flush()
 

--- a/tests/core/test_5647_injection_overtakes_ineligible.py
+++ b/tests/core/test_5647_injection_overtakes_ineligible.py
@@ -84,7 +84,7 @@ async def test_injection_reaches_the_operator_message_behind_two_hooks(tmp_path)
     await session._put_inbox(TurnOrigin.HOOK, dict(_HOOK))
     await session.submit_user_text("stop and look at this")
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     assert peeked, (
         "the operator's message must be reachable past the two hook items — "
         "returning [] here IS the reported defect"
@@ -123,7 +123,7 @@ async def test_the_overtaken_items_are_still_consumed_first_and_in_order(tmp_pat
     await session._put_inbox(TurnOrigin.HOOK, {"name": "second"})
     await session.submit_user_text("steer")
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     (only,) = peeked
     await session._commit_mid_turn_injection(only["msg_id"])
 
@@ -155,7 +155,7 @@ async def test_items_that_arrived_after_the_operator_keep_their_place_too(tmp_pa
     await session.submit_user_text("steer")
     await session._put_inbox(TurnOrigin.HOOK, {"name": "B"})
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     (only,) = peeked
     assert only["payload"]["text"] == "steer"
     await session._commit_mid_turn_injection(only["msg_id"])
@@ -185,7 +185,7 @@ async def test_no_injection_when_no_operator_message_is_queued(tmp_path):
     await session._put_inbox(TurnOrigin.HOOK, dict(_HOOK))
     await session._put_inbox(TurnOrigin.HOOK, dict(_HOOK))
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     assert peeked == []
     await settle(session)
     assert _mid_turn_started(events) == [], "no injection means no turn_started"
@@ -214,7 +214,7 @@ async def test_an_operator_message_at_the_head_reports_an_empty_skipped_list(tmp
 
     await session.submit_user_text("nothing ahead of me")
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     (only,) = peeked
     await session._commit_mid_turn_injection(only["msg_id"])
     await settle(session)
@@ -249,7 +249,7 @@ async def test_a_cancelled_operator_message_is_passed_over_for_the_next_one(tmp_
     await session.submit_user_text("the real one")
     await session.cancel_queued(cancelled_id)
 
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     (only,) = peeked
     assert only["payload"]["text"] == "the real one", (
         "the cancelled message must not be injected; the scan continues past "
@@ -286,7 +286,7 @@ async def test_overtaken_items_survive_a_wal_truncation_in_arrival_order(tmp_pat
     await session._put_inbox(TurnOrigin.HOOK, {"name": "B"})
 
     # Overtake, but never commit — the abnormal-exit shape.
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     assert peeked
     await settle(session)
     await state_log.aclose()
@@ -334,7 +334,7 @@ async def test_the_ride_along_drain_does_not_read_past_the_peek_buffer(tmp_path)
 
     # The peek pulls both ride-alongs into the buffer on its way to the user
     # message, which is what makes the buffer hold more than one item.
-    peeked = await session._inbox_arbiter.peek_mid_turn_injection()
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
     (only,) = peeked
     await session._commit_mid_turn_injection(only["msg_id"])
 

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -596,7 +596,7 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: Genuinely unrelated to slash: it is the ``RouterHostAdapter``-wired
 #: callback ``RouterLoop.run_loop`` invokes through the host to batch-peek
 #: eligible mid-turn injections (``session.py``'s own wiring, mirroring the
-#: already-public ``peek_mid_turn_injection``/``commit_mid_turn_injection``
+#: already-public ``peek_mid_turn_injections``/``commit_mid_turn_injection``
 #: siblings it renders on top of) — never reached via slash dispatch.
 _PUBLIC_MEMBER_CEILING = 121
 

--- a/tests/llm/test_3792_mid_turn_injection_seam_pr1.py
+++ b/tests/llm/test_3792_mid_turn_injection_seam_pr1.py
@@ -5,7 +5,7 @@ architect's design (issue #3792) splits the feature into two PRs because a
 half-landed 2-phase peek/pop breaks in BOTH directions (peek-only re-triggers
 the same utterance; pop-only loses an utterance on an abnormal exit). PR1
 lands only the seam's call site in ``RouterLoop.run_loop`` — a getattr-guarded
-host hook, ``peek_mid_turn_injection``, called once per iteration, after the
+host hook, ``peek_mid_turn_injections``, called once per iteration, after the
 cancel checkpoint and immediately before whichever send that iteration makes
 (force-close or normal). No host implements it for real yet (PR2 wires the
 real 2-phase peek/pop); this PR's own production behaviour is a no-op.
@@ -35,7 +35,7 @@ _USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
 
 class _OrderRecordingLLM:
     """Real callable (not a mock): scripts responses AND appends "send" to
-    the same ``host.call_order`` log the fake's ``peek_mid_turn_injection``
+    the same ``host.call_order`` log the fake's ``peek_mid_turn_injections``
     writes to, so a test can assert the two interleave in the right order."""
 
     def __init__(self, host: FakeRouterHost, script: list[LLMToolCallResult]) -> None:
@@ -111,7 +111,7 @@ async def test_seam_fires_before_the_send_each_round() -> None:
 
     Falsification (performed during review): moving the seam call to AFTER
     the ``_llm(...)`` call in ``run_loop`` makes this test go RED —
-    ``host.call_order`` would read ["send", "peek_mid_turn_injection", ...]
+    ``host.call_order`` would read ["send", "peek_mid_turn_injections", ...]
     instead.
     """
     host = FakeRouterHost()
@@ -124,6 +124,6 @@ async def test_seam_fires_before_the_send_each_round() -> None:
         messages=[{"role": "user", "content": "hi"}], tools=[], _univ_enabled=False,
     )
     assert host.call_order == [
-        "peek_mid_turn_injection", "send",
-        "peek_mid_turn_injection", "send",
+        "peek_mid_turn_injections", "send",
+        "peek_mid_turn_injections", "send",
     ]

--- a/tests/llm/test_3792_pr2_router_loop_injection.py
+++ b/tests/llm/test_3792_pr2_router_loop_injection.py
@@ -27,7 +27,7 @@ class _InjectingHost(FakeRouterHost):
     contract closely enough to witness the RouterLoop-side wiring, without
     duplicating the full real Session machinery this file does not own.
 
-    #5677: ``peek_mid_turn_injection`` now returns ``list[dict]`` (was
+    #5677: ``peek_mid_turn_injections`` now returns ``list[dict]`` (was
     ``dict | None``) — ``[]`` for "nothing queued", one ``{"msg_id":
     ..., "wire": {"role": ..., "content": ...}}`` entry per eligible
     item, already rendered per its own kind (``role="user"`` here since
@@ -46,8 +46,8 @@ class _InjectingHost(FakeRouterHost):
         self._peeks_before_arrival = arrives_after_round
         self._peek_count = 0
 
-    async def peek_mid_turn_injection(self) -> "list[dict]":
-        self.call_order.append("peek_mid_turn_injection")
+    async def peek_mid_turn_injections(self) -> "list[dict]":
+        self.call_order.append("peek_mid_turn_injections")
         self._peek_count += 1
         if self._peek_count <= self._peeks_before_arrival:
             return []
@@ -125,7 +125,7 @@ async def test_injected_message_lands_at_the_tail_after_a_completed_round() -> N
 @pytest.mark.asyncio
 async def test_commit_receives_the_peeked_items_own_msg_id() -> None:
     """Tier 2: #3792 — ``commit_mid_turn_injection`` is called with the
-    SAME ``msg_id`` the triggering ``peek_mid_turn_injection()`` call
+    SAME ``msg_id`` the triggering ``peek_mid_turn_injections()`` call
     returned, after (not before) the append + wire-position assert have
     both already happened in the same code path (structural — an
     ``AssertionError`` raised by the assert would propagate straight out of
@@ -170,8 +170,8 @@ async def test_no_injection_when_queue_is_empty() -> None:
     byte-identical to PR1."""
 
     class _EmptyInjectingHost(_InjectingHost):
-        async def peek_mid_turn_injection(self) -> "list[dict]":
-            self.call_order.append("peek_mid_turn_injection")
+        async def peek_mid_turn_injections(self) -> "list[dict]":
+            self.call_order.append("peek_mid_turn_injections")
             return []
 
     host = _EmptyInjectingHost()
@@ -195,8 +195,8 @@ async def test_no_injection_when_queue_is_empty() -> None:
 #
 # lead-coder's blocking review comment on PR1 (#3802) / restated for PR2:
 # ``_InjectingHost`` above is a fake this SAME file defines; renaming
-# ``RouterHostAdapter.peek_mid_turn_injection`` to anything else leaves every
-# test above green (the seam's ``getattr(host, "peek_mid_turn_injection",
+# ``RouterHostAdapter.peek_mid_turn_injections`` to anything else leaves every
+# test above green (the seam's ``getattr(host, "peek_mid_turn_injections",
 # None)`` would silently resolve to ``None`` against a real production host
 # and go permanently inert, but the fake's own identically-named method still
 # answers). A test that only exercises a fake with a name it chose to match
@@ -230,9 +230,9 @@ def _extract_mid_turn_injection_attr_names() -> "dict[str, str]":
         _ROUTER_LOOP_SRC, re.DOTALL,
     )
     by_role = {n: n for n in names}
-    assert "peek_mid_turn_injection" in by_role.values(), (
+    assert "peek_mid_turn_injections" in by_role.values(), (
         "sanity: router_loop.py's own source must still name a "
-        "peek_mid_turn_injection getattr — if this fails, the extraction "
+        "peek_mid_turn_injections getattr — if this fails, the extraction "
         "regex itself broke, not the production code"
     )
     assert "commit_mid_turn_injection" in by_role.values()
@@ -247,7 +247,7 @@ async def test_router_loop_peek_and_commit_names_resolve_on_the_real_adapter() -
     really forward to the callbacks the adapter was constructed with.
 
     Falsification (performed during review): renaming
-    ``RouterHostAdapter.peek_mid_turn_injection`` (the PRODUCTION method, in
+    ``RouterHostAdapter.peek_mid_turn_injections`` (the PRODUCTION method, in
     ``router_host_adapter.py`` — not the test's own fake) to any other name
     makes this test go RED with ``AttributeError`` — while every OTHER test
     in this file (built on ``_InjectingHost``, this file's own fake) stays
@@ -268,13 +268,13 @@ async def test_router_loop_peek_and_commit_names_resolve_on_the_real_adapter() -
         commit_calls.append(msg_id)
 
     adapter = make_adapter(universal_wrappers_enabled=False,  # #4159: not exercised by this test
-        peek_mid_turn_injection=_real_peek,
+        peek_mid_turn_injections=_real_peek,
         commit_mid_turn_injection=_real_commit,
     )
 
-    peek_fn = getattr(adapter, attr_names["peek_mid_turn_injection"], None)
+    peek_fn = getattr(adapter, attr_names["peek_mid_turn_injections"], None)
     assert peek_fn is not None, (
-        f"RouterHostAdapter has no attribute {attr_names['peek_mid_turn_injection']!r} "
+        f"RouterHostAdapter has no attribute {attr_names['peek_mid_turn_injections']!r} "
         "— the exact name router_loop.py's getattr call reads"
     )
     result = await peek_fn()

--- a/tests/runtime/test_3595_client_input_provenance_gate.py
+++ b/tests/runtime/test_3595_client_input_provenance_gate.py
@@ -311,7 +311,7 @@ _CLIENT_INPUT_SITES: "dict[tuple[str, str], _SiteDeclaration]" = {
         ),
     ),
     # #5677: the ("reyn/runtime/inbox_arbiter.py",
-    # "InboxArbiter.peek_mid_turn_injection") entry that used to live here
+    # "InboxArbiter.peek_mid_turn_injections") entry that used to live here
     # is GONE, not forgotten — verified directly (`git grep
     # 'TurnOrigin.CLIENT_INPUT' -- src/reyn/runtime/inbox_arbiter.py`
     # finds nothing). That method no longer names CLIENT_INPUT at all: its

--- a/tests/runtime/test_5364_media_store_flush_barrier.py
+++ b/tests/runtime/test_5364_media_store_flush_barrier.py
@@ -187,7 +187,7 @@ async def test_router_loop_flushes_pending_writes_before_the_llm_call(tmp_path: 
     No await happens anywhere in ``run_loop`` between the top of its
     per-iteration loop and its flush call site for a bare
     ``FakeRouterHost`` (no ``should_force_close`` /
-    ``peek_mid_turn_injection`` implemented — both getattr-guarded, both
+    ``peek_mid_turn_injections`` implemented — both getattr-guarded, both
     short-circuit BEFORE their own ``await``, never reaching it). This is
     an invariant about the CODE PATH (guard-then-await, in that order,
     both gated on a host attribute this fixture never implements), never
@@ -220,10 +220,10 @@ async def test_router_loop_flushes_pending_writes_before_the_llm_call(tmp_path: 
         "above before trusting this test (#5384 ①)"
     )
     assert (
-        '_peek_injection_fn = getattr(host, "peek_mid_turn_injection", None)'
+        '_peek_injection_fn = getattr(host, "peek_mid_turn_injections", None)'
         in _run_loop_source
     ), (
-        "run_loop's peek_mid_turn_injection guard no longer reads "
+        "run_loop's peek_mid_turn_injections guard no longer reads "
         "verbatim as this test's docstring claims — re-verify the "
         "ordering claim above before trusting this test (#5384 ①)"
     )

--- a/tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py
+++ b/tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py
@@ -1,0 +1,365 @@
+"""Tier 1: #5685 (architect ruling, lead-coder scope decision) — every
+``getattr(<host receiver>, "<literal>", ...)`` call in ``router_loop.py``
+must name an attribute that actually has a real definition somewhere in
+``src/``.
+
+## Why this exists
+
+``#5684`` renamed ``peek_mid_turn_injection``'s return shape (dict -> list)
+but kept the singular name, and ``router_loop.py:2295`` resolves the
+callback by STRING (``getattr(host, "peek_mid_turn_injection", None)``). A
+rename that touches the literal but not the implementation — or the
+implementation but not the literal — degrades to a silent, permanent no-op
+(``getattr(..., None)``): no ``AttributeError``, no red anywhere, the host
+callback simply stops firing. #5685 filed this hazard; this gate closes the
+CLASS (any future literal/implementation drift on this seam), not just the
+one instance the rename (landed in this same PR) fixes.
+
+## Why not a ``Protocol`` (architect's own ruling, rejected option ③)
+
+``getattr(host, "x", None)`` is INTENTIONALLY optional — each host
+implements a different subset (a phase host implements far fewer members
+than the production ``RouterHostAdapter``), and ``None`` IS the "this host
+doesn't do that" path. A ``Protocol`` with every member required would
+break that premise (a legitimate partial host would fail to type-check); a
+``Protocol`` with every member ``Optional`` catches nothing (a renamed-away
+member still type-checks). Neither closes the silence #5685 names — a gate
+that cross-references the literal against a real definition does.
+
+## Scope: every receiver that POINTS AT ``host`` (lead-coder's own ruling)
+
+Not just a bare ``getattr(host, ...)`` — ``router_loop.py`` also calls
+``getattr(self.host, ...)`` throughout (``self.host = host`` at
+``__init__``, and several functions do ``host = self.host`` as a local
+alias before calling ``getattr(host, ...)`` — that local rebinding is
+already covered by the bare-``host``-Name branch below, so ONLY the two
+receiver *shapes* need naming: ``host`` the ``Name`` (parameter OR a local
+re-bound from ``self.host`` — indistinguishable to a static AST walk, and
+correctly so: both ultimately name the SAME object) and ``self.host`` the
+``Attribute``. Measured (this file's own gate, not assumed): no OTHER
+host-aliasing spelling (``self._host``, a renamed local, etc.) exists in
+``router_loop.py`` today — grep confirmed zero hits for those shapes.
+Limiting the scope to the bare ``host`` receiver alone (this gate's first
+draft) undercounted the real population by MORE than half (26 measured ->
+57 actual) — narrowing by receiver *spelling* rather than by the gate's
+own stated reason ("literal and definition drift with no red") was the
+exact mistake lead-coder's own #5685 comment named and reversed.
+
+## Needle correctness (architect's own warning, hit twice this issue)
+
+``git grep -E`` (POSIX ERE) silently no-matches ``\\b``/``\\s`` — architect's
+own first census undercounted by 24 for exactly this reason. A SEPARATE
+hazard, found while building this gate: a single-line-anchored pattern
+also misses a ``getattr(...)`` call whose arguments are split across
+multiple lines (``reasoning_continuity_section``/``commit_mid_turn_
+injection``/``get_universal_wrappers_enabled`` were invisible to that
+shape). This gate uses ``ast`` throughout for both extraction passes —
+neither hazard applies to a real parse tree — and
+:func:`test_the_needle_finds_every_real_literal_a_hand_audit_confirms`
+below pins that the extractor actually reaches a SPECIFIC verified-by-hand
+set of literals, not merely "found something".
+
+## A known, accepted false-negative class (lead-coder co-vet, BLOCKING)
+
+:func:`build_src_definition_index` scans ALL of ``src/`` for a matching
+NAME — it cannot tell "the actual host object implements this" from "some
+UNRELATED class elsewhere in the tree happens to share this identifier". A
+real audit found 6 of the 55 non-allowlisted literals this way: e.g.
+``workspace`` is "defined" because ``core/op_runtime/context.py`` has an
+unrelated ``workspace: "Workspace"`` field, and ``sandbox_config`` because
+``runtime/agent.py``'s ``AgentProfile``-shaped dataclass has its own
+unrelated ``sandbox_config`` field — NEITHER has anything to do with
+``RouterHostAdapter`` or any other real host. **For those 6 literals, this
+gate's direction-2 falsify (rename the IMPLEMENTATION away, literal stays)
+does NOT fire** — the unrelated same-named definition keeps the index
+entry alive.
+
+This is accepted, not fixed, on purpose: ``host`` is duck-typed by
+design (the whole reason option ③ rejected a ``Protocol``), so there is no
+static way to ask "does THIS SPECIFIC object implement X" without
+re-introducing the tight coupling the design deliberately avoids.
+Narrowing the index to a specific class/file would trade this
+false-negative for the opposite, worse failure — a false POSITIVE (the
+gate blocking a legitimate host that implements the callback somewhere
+this narrower scan doesn't look). A conservative, whole-``src/`` index
+that occasionally under-flags a name collision is the safer of the two
+failure directions for a gate whose entire job is "don't let this seam
+break loudly for the OTHER, common case" (direction 1: rename the literal,
+forget the impl — still caught for all 57).
+:func:`test_a_same_named_unrelated_definition_masks_an_impl_rename`
+below fixes this exact boundary as a KNOWN limitation, not a silent gap.
+"""
+from __future__ import annotations
+
+import ast
+import tempfile
+from pathlib import Path
+
+from tests._support.paths import REPO_ROOT
+
+_ROUTER_LOOP = REPO_ROOT / "src" / "reyn" / "runtime" / "router_loop.py"
+_SRC_ROOT = REPO_ROOT / "src" / "reyn"
+
+#: NOT a "defect awaiting disposal" list (lead-coder's own correction,
+#: #5685: the first cut of this allowlist misread "no src/ implementation"
+#: as "dead branch" — it isn't). This is the list of host seams a doc or
+#: docstring EXPLICITLY declares optional/host-provided — each entry's
+#: value is WHERE that declaration lives (never an issue number; these
+#: entries are permanent, not pending removal). A NEW entry appearing here
+#: later is itself the thing to scrutinize: it means an undeclared,
+#: unimplemented callback was added with no doc saying so is intentional.
+_ALLOWLIST = {
+    "record_force_close": (
+        "docs/concepts/runtime/safety.ja.md:67 — \"ホストは `record_force_"
+        "close` フックを実装すればラップアップを自身のチェックポイントに永続"
+        "化できますが、chat ホストは実装していないため、このフックは現状"
+        " inert です\" (explicitly documented as an optional hook the "
+        "production chat host does not implement)."
+    ),
+    "compute_memo_key": (
+        "src/reyn/core/kernel/sub_loop_memo_key.py's own module docstring — "
+        "\"used by the phase memo path (...`PhaseRouterHost.compute_memo_"
+        "key`) and as the chat-router fallback when the host provides no "
+        "`compute_memo_key`\" (explicitly documented as an optional "
+        "phase-host-only seam; this pure-function module IS the "
+        "documented fallback for hosts that omit it)."
+    ),
+}
+
+
+def _is_host_receiver(node: "ast.expr") -> bool:
+    """True for the two receiver SHAPES router_loop.py uses to reach the
+    host object — a bare ``host`` Name (a parameter, or a local rebound
+    from ``self.host`` — see module docstring) and the ``self.host``
+    Attribute directly."""
+    if isinstance(node, ast.Name) and node.id == "host":
+        return True
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "host"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    )
+
+
+def find_host_getattr_literals(path: Path) -> "list[str]":
+    """AST-walk one file and return every literal name a
+    ``getattr(<host receiver>, "<literal>", ...)`` call resolves —
+    duplicates included (a caller wanting distinct names should
+    ``set()`` the result; kept as a list here so a test can also assert
+    on raw occurrence count if ever needed)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    literals: "list[str]" = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "getattr"):
+            continue
+        if not node.args or not _is_host_receiver(node.args[0]):
+            continue
+        if len(node.args) < 2:
+            continue
+        name_arg = node.args[1]
+        if isinstance(name_arg, ast.Constant) and isinstance(name_arg.value, str):
+            literals.append(name_arg.value)
+    return literals
+
+
+def build_src_definition_index(root: Path) -> "set[str]":
+    """One pass over every ``.py`` file under ``root``, collecting every
+    identifier DEFINED as a method/property (``def NAME(``, decorator-
+    agnostic — ``@property`` doesn't change the ``def`` node's own name),
+    a class-body annotated field (``NAME: Type``), or a ``self.NAME =``
+    assignment — the three shapes every real attribute in this codebase's
+    host classes (``RouterHostAdapter`` et al.) is defined through
+    (verified directly against that class: its dataclass-shaped fields use
+    ``AnnAssign``, its callback-forwarding methods use ``def``, its
+    private-then-property-exposed fields use ``self.NAME =`` for the
+    private half and ``def NAME(`` for the public property).
+
+    KNOWN LIMITATION (module docstring's "false-negative class" section
+    has the full account): this index is name-only, root-wide — it cannot
+    distinguish "the real host implements NAME" from "some unrelated class
+    elsewhere under ``root`` happens to define something also called
+    NAME". Accepted deliberately (the alternative, narrowing to a specific
+    class, trades this for a false-positive risk against ``host``'s
+    intentionally duck-typed design) — never silently: see
+    :func:`test_a_same_named_unrelated_definition_masks_an_impl_rename`."""
+    defined: "set[str]" = set()
+    for path in root.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                defined.add(node.name)
+            elif isinstance(node, ast.AnnAssign):
+                target = node.target
+                if isinstance(target, ast.Name):
+                    defined.add(target.id)
+                elif (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                ):
+                    defined.add(target.attr)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Attribute)
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id == "self"
+                    ):
+                        defined.add(target.attr)
+    return defined
+
+
+def test_the_needle_finds_every_real_literal_a_hand_audit_confirms():
+    """Tier 1: empty-set guard, done as a SPECIFIC-known-set check rather
+    than a bare count (#5698's own lesson, cited by lead-coder here too: a
+    count pins the CURRENT total for no behavioral reason and is a
+    format-pin `test_tier_audit.py` itself rejects). These 4 literals were
+    independently hand-verified during this gate's own construction as
+    requiring BOTH receiver shapes and BOTH the single-line and
+    multi-line call shapes to reach — a walker regressed to bare-``host``-
+    only, or to a single-line-anchored extraction, drops at least one of
+    them."""
+    literals = set(find_host_getattr_literals(_ROUTER_LOOP))
+    for needle, why in {
+        "peek_mid_turn_injections": "bare host receiver, single-line call",
+        "reasoning_continuity_section": "bare host receiver, MULTI-line call",
+        "resolver": "self.host receiver, single-line call",
+        "compute_memo_key": "self.host receiver, MULTI-line call",
+    }.items():
+        assert needle in literals, (
+            f"the extractor did not find {needle!r} ({why}) — a receiver-"
+            f"shape or line-shape regression, not a real removal (that "
+            f"literal's own call site was hand-verified present)"
+        )
+
+
+def test_every_literal_has_a_src_definition_or_a_dated_allowlist_entry():
+    """Tier 1: the acceptance-item witness (accept side) — every literal
+    ``router_loop.py`` resolves against the host, across BOTH receiver
+    shapes, has a real ``src/`` definition unless explicitly allowlisted
+    with a reason and an issue number."""
+    literals = set(find_host_getattr_literals(_ROUTER_LOOP))
+    defined = build_src_definition_index(_SRC_ROOT)
+    missing = sorted(
+        name for name in literals
+        if name not in defined and name not in _ALLOWLIST
+    )
+    assert missing == [], (
+        f"getattr(<host receiver>, {missing!r}, ...) in router_loop.py "
+        f"names an attribute with NO definition anywhere in src/, and no "
+        f"allowlist entry — a rename on one side without the other leaves "
+        f"this host callback silently, permanently inert"
+    )
+
+
+def test_allowlist_entries_are_real_gaps_not_stale_exemptions():
+    """Tier 1: deny-side companion — an allowlist entry that NO LONGER
+    corresponds to a real gap (someone since implemented it) must be
+    caught, or the allowlist silently keeps exempting a literal the gate
+    could otherwise verify."""
+    defined = build_src_definition_index(_SRC_ROOT)
+    stale = sorted(name for name in _ALLOWLIST if name in defined)
+    assert stale == [], (
+        f"{stale!r} now HAS a src/ definition — remove the allowlist "
+        f"entry/entries so the gate actually verifies it/them, instead of "
+        f"silently exempting a literal that no longer needs it"
+    )
+
+
+def test_renaming_only_the_literal_turns_the_gate_red():
+    """Tier 1: falsify pair, direction 1 — a synthetic file whose getattr
+    literal names something with NO src definition (the implementation
+    side was left on the old name) must be flagged."""
+    src = 'x = getattr(host, "renamed_literal_5685_no_impl", None)\n'
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "synthetic.py"
+        p.write_text(src, encoding="utf-8")
+        literals = set(find_host_getattr_literals(p))
+        assert literals == {"renamed_literal_5685_no_impl"}
+    defined = build_src_definition_index(_SRC_ROOT)
+    assert "renamed_literal_5685_no_impl" not in defined, (
+        "sanity: this synthetic name must not collide with anything real"
+    )
+
+
+def test_renaming_only_the_implementation_turns_the_gate_red():
+    """Tier 1: falsify pair, direction 2 — the mirror case: the
+    IMPLEMENTATION was renamed but the getattr literal (in a synthetic
+    ``router_loop.py``-shaped file) still names the OLD attribute, which
+    now has no definition either (the real implementation moved to a new
+    name the literal never followed)."""
+    old_name = "old_before_impl_rename_5685"
+    new_name = "new_after_impl_rename_5685"
+    src = f'x = getattr(host, "{old_name}", None)\n'
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "caller.py").write_text(src, encoding="utf-8")
+        # The "implementation", post-rename, lives under the NEW name only
+        # — mirrors a real def-site edit that renamed a method but never
+        # touched the getattr string reading its OLD name.
+        (tmp_path / "impl.py").write_text(
+            f"class Host:\n    def {new_name}(self): ...\n", encoding="utf-8",
+        )
+        literals = set(find_host_getattr_literals(tmp_path / "caller.py"))
+        defined = build_src_definition_index(tmp_path)
+        assert literals == {old_name}
+        assert new_name in defined
+        assert old_name not in defined, (
+            "the OLD literal must have no definition once the "
+            "implementation renamed away from it — this is the exact "
+            "silent-no-op shape #5685 reports"
+        )
+
+
+def test_a_same_named_unrelated_definition_masks_an_impl_rename():
+    """Tier 1: fixes the KNOWN false-negative boundary (module docstring's
+    own "false-negative class" section, lead-coder co-vet) — direction 2's
+    falsify above (:func:`test_renaming_only_the_implementation_turns_
+    the_gate_red`) only proves the gate catches a rename when NOTHING else
+    in the scanned tree happens to share the old name. It does not.
+
+    This is not a regression to fix — see the module docstring for why a
+    conservative, name-only, whole-``src/`` index is the accepted
+    trade-off against ``host``'s duck-typed design — but it MUST be a
+    documented, tested boundary rather than an unstated weak spot. No
+    count is asserted (#5698's own lesson, cited by lead-coder here too):
+    this pins the SHAPE of the gap (one synthetic unrelated definition is
+    enough to mask a real removal), not how many real literals happen to
+    fall in it today — that number is free to drift as the real host
+    classes and their unrelated namesakes change, without this test
+    needing to track it."""
+    shared_name = "totally_unrelated_field_name_5685"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # The "host" seam: a getattr literal with NO real host
+        # implementation anywhere (mirrors the real router_loop.py shape).
+        (tmp_path / "caller.py").write_text(
+            f'x = getattr(host, "{shared_name}", None)\n', encoding="utf-8",
+        )
+        # An UNRELATED class, in a different file, that happens to declare
+        # a field with the exact same name for a completely different
+        # purpose — never touched by, or related to, the host seam above
+        # (mirrors the real `workspace`/`op_runtime/context.py` and
+        # `sandbox_config`/`runtime/agent.py` pairs lead-coder measured).
+        (tmp_path / "unrelated.py").write_text(
+            f'class SomethingElseEntirely:\n    {shared_name}: str\n',
+            encoding="utf-8",
+        )
+        literals = set(find_host_getattr_literals(tmp_path / "caller.py"))
+        defined = build_src_definition_index(tmp_path)
+        assert literals == {shared_name}
+        assert shared_name in defined, (
+            "this IS the known false-negative: an unrelated same-named "
+            "field makes the index look satisfied even though no real "
+            "host implements this literal — if this ever starts failing, "
+            "the index became name+scope-aware and this whole boundary "
+            "(and the module docstring section describing it) should be "
+            "deleted, not patched around"
+        )


### PR DESCRIPTION
**[tui-coder]** — Closes #5685

architectの裁定どおり: ③はProtocolではなくgate（`getattr(host,"x",None)`は意図した任意性、必須Protocolはそれを壊し全Optional Protocolは何も捕まえない）。①renameを同一PRで実施、gateが安全性を担保。

## scope: `self.host`含む(lead-coder訂正)

`host`単独レシーバでのnarrowingは「gateの理由でなく形で母数を切る」誤りだったため、`self.host`も対象。結果55件が実定義あり、2件がallowlist(defectではなく**doc明示のoptional host seam**——`record_force_close`はsafety.ja.md:67、`compute_memo_key`はsub_loop_memo_key.pyのdocstring)。

母数の実測過程で「26」という当初想定が更に食い違う(実は55+2=57)ことが分かり、gate実装前に一旦停止して報告・裁定を仰ぎました(詳細はissueスレッド)。

## rename

`peek_mid_turn_injection` → `peek_mid_turn_injections`(arbiter/adapter/private field/router_loop.pyのgetattr literal/constructor kwarg/実装・test fake全部、14ファイル)。`commit_mid_turn_injection`は対象外(単数のままで正しい)。

## Test plan

- [x] `tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py`(新規、6本): 既知literalでの空振りガード/accept側/allowlist陳腐化検知/falsify両方向(合成fixture)/既知の偽陰性境界を固定するfalsify(lead-coder BLOCKING対応)
- [x] 実rename箇所でのfalsify: Editで壊す→赤確認→Editで戻す(`git checkout`/`stash`不使用)
- [x] `pytest`関連スコープ 44 green、`test_tier_audit.py --strict` 44/44 OK
- [x] `ruff check .` / `verify_module_docstrings.py` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — all green
- [x] full pytest 前景1回実行(commit後、rebase前の木) — background退避、結果は後で読了: 6 failed/13235 passed/47 skipped。6件を現在の木で再実行し確認 — 3件は既に別PRで解消済み(再実行green)、残り3件(fastmcp import chain系)はこのdev venvの環境drift(fastmcpがローカルにinstallされている)によるもので、私の変更とは無関係・CIのclean checkoutでは再現しない見込み
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7

