### PR TITLE
fix(#5705): unbounded settle for the two-stage focus deferral in #4751's hotkey test

### DIFF
--- a/tests/interfaces/test_4751_intervention_panel_hotkeys.py
+++ b/tests/interfaces/test_4751_intervention_panel_hotkeys.py
@@ -34,12 +34,57 @@ policy.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import RadioButton, RadioSet, TabbedContent
 
 from reyn.interfaces.inline.textual_chat.intervention_panel import InterventionPanel
 from reyn.intervention_choices import file_access_choices, generic_yn_choices
+
+
+async def _settle_until(pilot, until) -> None:
+    """Pump until ``until()`` is true (#3748: unbounded, owner policy) —
+    duplicated from ``test_textual_chat_intervention_panel_3299.py``'s own
+    helper of the same name (not shared via ``tests/_support`` today; this
+    is the second call site).
+
+    #5705 (owner real-machine incident, root cause): ``radio.has_focus``
+    lands via a TWO-STAGE deferral — ``add_pending`` posts a
+    ``TabbedContent.TabActivated`` message, whose handler
+    (``InterventionPanel.on_tabbed_content_tab_activated``) then calls
+    ``self.call_after_refresh(radios[0].focus)``, a SECOND deferred step.
+    A single ``pilot.pause()`` (this test's own pre-fix shape) relies on
+    ``Pilot.pause()``'s ``wait_for_idle`` — a wall-clock/CPU-time heuristic
+    ("has this process stopped actively working") — to happen to flush
+    both stages before returning. Under real CPU contention (measured:
+    the full suite's own ``-n auto`` xdist run, and directly reproduced
+    locally by running ONLY this one test alongside unrelated CPU-bound
+    background load — 1 failure in 8 runs) the heuristic can be fooled by
+    scheduler PREEMPTION into reporting "idle" before the second deferred
+    stage has actually run — not a version-specific bug (reproduced under
+    contention on 3.11; #5705's own CI evidence showed 3.12 fail too), not
+    an ordering dependency on another test's state (this repro used no
+    other test at all), and not the ``RuntimeError: Event loop is closed``
+    #5705 also observed nearby in one CI log (a separate test's own
+    concurrent symptom under the same contention — this repro reproduced
+    the ``has_focus`` failure with NO other test running, so that error
+    is not this failure's cause).
+
+    Fixed with an UNBOUNDED condition-wait, never a fixed pump COUNT
+    (e.g. two ``pilot.pause()`` calls) — a count is a duration floor
+    wearing a different unit (#5705 review, lead-coder: "回数の見積もり
+    ... CLAUDE.md が禁じる duration の floor と同じ"): a fixed count
+    happens to cover today's two-stage chain but reintroduces the exact
+    same class of failure the day a third deferral stage is added. The
+    ceiling is CI's own ``--timeout=120`` (pytest-timeout), never a
+    marker or sleep written into this test."""
+    while True:
+        await pilot.pause()
+        if until():
+            return
+        await asyncio.sleep(0.01)
 
 
 class _PanelOnlyApp(App):
@@ -94,8 +139,17 @@ async def test_pressing_a_displayed_hotkey_selects_but_does_not_confirm():
                 for c in generic_yn_choices()
             ],
         )
-        await pilot.pause()
+        # #5705: unbounded settles, not a fixed pump count — see
+        # _settle_until's own docstring for the two-stage deferral this
+        # waits out. Stage 1: the tab itself must have activated
+        # (`tabs.active` non-empty) before `_active_pane` can resolve it
+        # at all.
+        tabs = panel.query_one(TabbedContent)
+        await _settle_until(pilot, lambda: tabs.active != "")
         radio = _active_pane(panel).query_one(RadioSet)
+        # Stage 2: the deferred focus call (`call_after_refresh`, fired
+        # from stage 1's own message handler).
+        await _settle_until(pilot, lambda: radio.has_focus)
         assert radio.has_focus
         assert _selected_label(panel) == "[y]es", "pre-highlight must start on the first option"
 


### PR DESCRIPTION
**[e2e-coder]** Closes #5705

## Root cause — not a version bug, not an xdist ordering dependency

`main` (`a31e391bd`) went red on `pytest (Python 3.11)`: `assert radio.has_focus` False in `test_pressing_a_displayed_hotkey_selects_but_does_not_confirm` (`tests/interfaces/test_4751_intervention_panel_hotkeys.py:99`). lead-coder-30 later found the same test also failed under 3.12 in a follow-up PR's own CI — the version axis is a dead end, both were ruled out by direct measurement, not assumed.

**Mechanism** (confirmed by reading `InterventionPanel.on_tabbed_content_tab_activated`): `radio.has_focus` lands via a **two-stage deferral** — `add_pending()` posts a `TabbedContent.TabActivated` message; that message's handler then calls `self.call_after_refresh(radios[0].focus)`, a **second** deferred step. The test's own single `await pilot.pause()` relies on `Pilot.pause()`'s `wait_for_idle` — a wall-clock/CPU-time heuristic ("has this process stopped actively working") — to happen to flush both stages before the assertion runs.

## Reproduced directly, in isolation

Ran **only this one test**, locally, under Python 3.11, alongside unrelated CPU-bound background load (10 busy-loop processes) — **no other pytest test running at all**:

- 1 failure in 8 runs, exact same `assert radio.has_focus` → `assert False`.

This isolates the cause to CPU-contention timing alone:
- **Rules out the version axis** — reproduced on 3.11 under contention; consistent with lead-coder-30's later CI evidence that 3.12 failed too.
- **Rules out six-questions ⑤ (cross-test accumulated state)** — nothing else was running when it failed.
- **`RuntimeError: Event loop is closed`** (found by lead-coder-30 nearby in one CI log) is very likely a **separate, concurrently-contended test's own symptom**, not this failure's cause — disclosed, not asserted: my repro reproduced `has_focus` failing with zero other tests running, so that error cannot be this failure's root cause. Its own actual cause was not separately investigated (out of this issue's scope).

## Fix

An **unbounded** condition-wait (`_settle_until`), duplicated from `test_textual_chat_intervention_panel_3299.py`'s own helper of the same name — #4751's own docstring already names that file as this test's model, but this one test never adopted its wait pattern. Two settle points, matching the two real deferral stages:
1. `tabs.active != ""` (the tab activation itself, needed before `_active_pane()` can even resolve — `TabbedContent.get_pane("")` raises otherwise, confirmed directly)
2. `radio.has_focus` (the `call_after_refresh`-deferred focus call)

**A fixed pump count (e.g. two `await pilot.pause()` calls — the sibling file's own occasional shape) was explicitly rejected in review**: it's a duration floor wearing a different unit — covers today's two-stage chain but reintroduces the same failure class the day a third deferral stage is added. The ceiling stays CI's own `--timeout=120` (pytest-timeout); no sleep or timeout marker written into the test itself.

## Verification

- **Same contention setup that reproduced the race, post-fix**: 20/20 passed (was 1/8 failed pre-fix).
- Ambient environment (3.12): this file + its model sibling, 29/29 passed.
- Full local suite (Python 3.11, `-n auto`, matching CI's own invocation): `test_4751` is **not** among the failures. 15 unrelated failures present (process-registry/stall-dump/mcp-import-chain/rag-pipeline/journal — all local-environment-sensitive, out of #5705's scope, not touched here) — disclosed per this repo's own "local full suite is CI-only" caution, not silently omitted.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_4751_intervention_panel_hotkeys.py`
- [x] `python scripts/verify_module_docstrings.py tests/interfaces/test_4751_intervention_panel_hotkeys.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- [x] Contention repro (accept criterion) — 20/20 passed post-fix vs 1/8 failed pre-fix, same setup
- [x] Full local suite (Python 3.11, `-n auto --timeout=120`) — `test_4751` not among the 15 unrelated failures
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51