### PR TITLE
fix(#5703): sub_loop_memo_key.py docstring names two nonexistent classes

### DIFF
--- a/src/reyn/core/kernel/sub_loop_memo_key.py
+++ b/src/reyn/core/kernel/sub_loop_memo_key.py
@@ -1,10 +1,20 @@
 """Sub-loop LLM-call memo-key computation (ADR-0025).
 
-The stable args-hash that keys ``RouterLoop`` sub-loop memoization — used by the
-phase memo path (``LLMCallRecorder.make_phase_memo_provider`` +
-``PhaseRouterHost.compute_memo_key``) and as the chat-router fallback when the host
-provides no ``compute_memo_key``. A pure function over the inputs that drive
-deterministic LLM output; no I/O, no persistence.
+The stable args-hash that keys ``RouterLoop`` sub-loop memoization — used as
+the chat-router fallback when the host provides no ``compute_memo_key``
+(``router_loop.py``'s own ``getattr(self.host, "compute_memo_key", None)``
+seam). A pure function over the inputs that drive deterministic LLM output;
+no I/O, no persistence.
+
+#5703 (doc-sync): this module docstring used to also name the phase-axis
+consumer of that seam (``LLMCallRecorder.make_phase_memo_provider`` +
+``PhaseRouterLoopHost.compute_memo_key``, both introduced by #1092). Neither
+exists in this repo any more — the whole phase engine, including both, was
+deleted by #2434/#2438's clean-break arc (same removal #5701 traced for the
+sibling ``record_force_close`` seam). The chat-router fallback role this
+module plays is unaffected either way — no host in this repo implements
+``compute_memo_key`` today, so ``RouterLoop``'s own memo key is always this
+module's output.
 """
 from __future__ import annotations
 

--- a/tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py
+++ b/tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py
@@ -118,11 +118,12 @@ _ALLOWLIST = {
     ),
     "compute_memo_key": (
         "src/reyn/core/kernel/sub_loop_memo_key.py's own module docstring — "
-        "\"used by the phase memo path (...`PhaseRouterHost.compute_memo_"
-        "key`) and as the chat-router fallback when the host provides no "
-        "`compute_memo_key`\" (explicitly documented as an optional "
-        "phase-host-only seam; this pure-function module IS the "
-        "documented fallback for hosts that omit it)."
+        "\"used as the chat-router fallback when the host provides no "
+        "`compute_memo_key`\" (#5703: the docstring used to also name the "
+        "phase-axis consumer, deleted by #2434/#2438 along with the rest of "
+        "the phase engine — corrected there, not a live implementer; this "
+        "pure-function module IS the documented fallback for a host that "
+        "omits the seam, which is every host in this repo today)."
     ),
 }
 


### PR DESCRIPTION
**[e2e-coder]** Closes #5703

## Confirming lead-coder-30's own correction

The real defect here is doc drift, not a dead branch — `getattr(self.host, "compute_memo_key", None)` is a documented, currently-unimplemented optional host seam (same shape #5701 found for the sibling `record_force_close` seam), not a defect to remove.

## Traced both halves of the stale parenthetical to their origin

`sub_loop_memo_key.py`'s docstring said: *"used by the phase memo path (`LLMCallRecorder.make_phase_memo_provider` + `PhaseRouterHost.compute_memo_key`) and as the chat-router fallback..."*

- **`PhaseRouterHost.compute_memo_key`** — always a typo/abbreviation for `PhaseRouterLoopHost` (#1092 PR-C-2.6; `dd3aea96e`'s own diff confirms the real method lived on `PhaseRouterLoopHost`, never a class literally named `PhaseRouterHost`). Deleted along with the entire phase engine by #2434/#2438's clean-break arc — the same removal #5701 already traced for `record_force_close`.
- **`LLMCallRecorder.make_phase_memo_provider`** — a **second** dead reference the issue's own body didn't flag (read as still-real because it's named in the same sentence as `compute_memo_key`). Verified directly: zero definitions of either `LLMCallRecorder` or `make_phase_memo_provider` anywhere under `src/`, and `RouterLoop`'s own `memo_provider` param has **zero callers passing it** anywhere in the repo today (`src/` or `tests/`).

## Fix

Rewrote the docstring to describe what's actually live — the getattr-guarded chat-router fallback, unaffected by either deletion — without naming either dead class.

## Doc-sync

The SAME quoted excerpt (verbatim, ellipsis-abbreviated) appears in `tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py`'s own allowlist justification for this literal (landed hours earlier, #5706) — updated to match, so the allowlist's own quote stays a real quote of the current docstring rather than freezing the stale wording it was copied from.

Full-repo sweep (`docs/` + `src/` + `tests/`): no other file references either dead identifier. The remaining `PhaseRouterLoopHost` mentions repo-wide are already correctly past-tense ("was deleted in #2438") or live inside a dated design record (`docs/deep-dives/decisions/0036`, kept verbatim per this repo's own precedent for historical records) — both left untouched.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py` — 6/6 OK
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/kernel/sub_loop_memo_key.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- [x] `pytest tests/scripts/test_5685_router_loop_host_getattr_literal_gate.py` — 6/6 passed
- [x] Full local suite (`-n auto --timeout=120`) — 15 unrelated failures present (process-registry/stall-dump/mcp-import-chain/rag-pipeline/denial-hint/journal — same class seen in #5705's own full run, local-environment-sensitive, out of scope, disclosed not omitted); nothing in the changed files' own scope
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51