### PR TITLE
closes #5708: /compact names its own cause instead of hedging

### DIFF
--- a/src/reyn/interfaces/slash/compact.py
+++ b/src/reyn/interfaces/slash/compact.py
@@ -56,44 +56,109 @@ async def compact_cmd(ctx: "SlashContext", args: str) -> None:
     # number for chat regardless: how many older turns were summarised and
     # the raw->bridge token compression.
     n = result.get("summarized_turns", 0)
-    if n <= 0:
-        free_after = result.get("free_window_after")
-        # #5579 (owner's real machine, 2026-08-30): ``summarized_turns == 0``
-        # has THREE possible causes — genuinely nothing to fold, an attempt
-        # that folded nothing, or a watermark that failed to advance — and
-        # this function has no way to tell them apart (``force_compact_now``
-        # returns nothing; see session.py's own ``_compact_now_for_op``).
-        # The PREVIOUS wording asserted "already fits the window"
-        # unconditionally on ``n <= 0`` — true only for the first cause. The
-        # owner's own machine showed the contradiction directly: "already
-        # fits the window. Free window: ~0 tokens." in the SAME line.
-        # ``free_window_after`` (``max(0, effective_trigger - after)``,
-        # already computed, no new threshold needed) is the one number that
-        # actually says whether the window fits: `> 0` means room remains,
-        # `== 0` means it does not — regardless of why ``n`` came back 0.
-        if free_after is not None and free_after <= 0:
-            await reply(
-                ctx,
-                "Nothing was compacted this pass, and the window is still "
-                "full (~0 tokens free) — /compact did not free any room. "
-                "This may mean there was nothing eligible to fold, or an "
-                "attempt folded nothing; either way, running /compact "
-                "again right now is unlikely to help further.",
-            )
-            return
-        tail = f" Free window: ~{free_after} tokens." if free_after is not None else ""
+    free_after = result.get("free_window_after")
+    free_tail = f" Free window: ~{free_after} tokens." if free_after is not None else ""
+
+    if n > 0:
+        compressed = result.get("compressed_tokens", 0)
+        bridge = result.get("bridge_tokens", 0)
+        word = "turn" if n == 1 else "turns"
         await reply(
             ctx,
-            "✓ Nothing to compact right now — recent history already fits the "
-            "window." + tail,
+            f"✓ Compacted — summarised {n} older {word} (~{compressed} tokens) into a "
+            f"~{bridge}-token summary bridge.",
         )
         return
 
-    compressed = result.get("compressed_tokens", 0)
-    bridge = result.get("bridge_tokens", 0)
-    word = "turn" if n == 1 else "turns"
+    # #5708 (owner real-machine incident, #5579's own follow-up): `n == 0`
+    # used to collapse THREE distinct causes into one hedged sentence — the
+    # owner's own machine showed the contradiction directly ("already fits
+    # the window. Free window: ~0 tokens." in the same line). `force_compact_
+    # now` (via `Session._compact_now_for_op`) now RETURNS which of its 4
+    # outcomes actually fired, so each gets its own, non-hedged wording —
+    # never "may mean X or Y". `free_window`/`free_after` is an ORTHOGONAL
+    # fact (#5708 acceptance ③): appended where it adds information, never
+    # used to infer WHY nothing was summarised.
+    outcome = result.get("compaction_outcome")
+    candidate_count = result.get("compaction_candidate_count", 0)
+
+    if outcome == "already_running":
+        await reply(
+            ctx,
+            "Another compaction pass is already running — try /compact "
+            "again once it finishes." + free_tail,
+        )
+        return
+
+    if outcome == "compaction_input_gap_invariant_violated":
+        # A defensive invariant, not a routine outcome (compaction_
+        # controller.py's own comment on this branch) — an operator seeing
+        # this has hit something unexpected, not "nothing to do".
+        await reply_error(
+            ctx,
+            "compaction could not run: an internal consistency check "
+            "failed (compaction_input_gap_invariant_violated). This is "
+            "unexpected — please report it.",
+        )
+        return
+
+    if outcome == "forced_sync" and candidate_count > 0:
+        # #5708 acceptance ②: distinguishes THIS case (candidates were
+        # selected, an attempt ran) from `forced_sync_no_turns`/
+        # `candidate_count == 0` below (nothing was ever selected) — the
+        # exact distinction `summarized_turns == 0` alone could not make.
+        count_word = f"{candidate_count} candidate{'s' if candidate_count != 1 else ''}"
+        if result.get("compaction_failed"):
+            # #5708 acceptance ④: `_run_compaction` raised (swallowed,
+            # #5633 — the exception itself never reaches this caller,
+            # only the fact that it happened does). State it plainly —
+            # no "may indicate", the caller asked for a fact, not a
+            # guess.
+            await reply_error(
+                ctx,
+                f"Compaction failed while processing {count_word} — no "
+                "summary was persisted. Check the audit log for "
+                "compaction_failed for details.",
+            )
+            return
+        # No exception, but the watermark still did not advance — a
+        # genuinely unresolved case (this IS the honest limit of what
+        # `force_compact_now` currently reports back); the hedge stays
+        # here, narrowed to only this one residual unknown rather than
+        # spread across every `n <= 0` result the way it used to be.
+        await reply(
+            ctx,
+            f"An attempt to compact ran ({count_word}), but it did not "
+            "advance — no summary was persisted, though no failure was "
+            "recorded either. Check the audit log for compaction_check/"
+            "recovery_summary_persisted for detail." + free_tail,
+        )
+        return
+
+    # outcome in {"forced_sync_no_turns", "forced_sync" with candidate_
+    # count == 0} (or an old-shaped result with no `compaction_outcome` at
+    # all — a legacy caller) — genuinely nothing eligible to fold (no
+    # candidates were ever selected), the one case the pre-#5708 wording
+    # was actually correct for.
+    #
+    # #5579 (acceptance ③, kept unchanged): `free_window_after` is an
+    # ORTHOGONAL fact from WHY nothing was selected — a genuinely-empty
+    # candidate set can still coincide with a window that has NOT
+    # recovered any room (`free_after <= 0`, the owner's own observed
+    # contradiction: "already fits the window. Free window: ~0 tokens."
+    # in the same line). Keep the two wordings distinct here, exactly as
+    # #5579 fixed them — this branch only decides "nothing was eligible",
+    # never "the window has room".
+    if free_after is not None and free_after <= 0:
+        await reply(
+            ctx,
+            "Nothing was compacted this pass, and the window is still "
+            "full (~0 tokens free) — /compact did not free any room. "
+            "There was nothing eligible to fold.",
+        )
+        return
     await reply(
         ctx,
-        f"✓ Compacted — summarised {n} older {word} (~{compressed} tokens) into a "
-        f"~{bridge}-token summary bridge.",
+        "✓ Nothing to compact right now — recent history already fits the "
+        "window." + free_tail,
     )

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -26,6 +26,7 @@ delegates via :meth:`force_compact_now` (P3).
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
 from reyn.config import CompactionConfig
@@ -60,6 +61,52 @@ if TYPE_CHECKING:
     from reyn.services.compaction.engine import ChatSummary
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ForceCompactResult:
+    """#5708 (owner real-machine incident): what :meth:`CompactionController.
+    force_compact_now` actually did — the SAME ``outcome`` the ``compaction_
+    check`` audit-event already carries at each of its 4 exit points, now
+    also RETURNED instead of discarded. Before this, the caller
+    (``Session._compact_now_for_op``) had no way to tell "genuinely nothing
+    eligible" apart from "an attempt ran but folded nothing" apart from "a
+    watermark that failed to advance" — all three produced the identical
+    ``summarized_turns == 0`` (derived from a before/after ``covers_
+    through_seq`` delta, the only signal it had), and ``/compact``'s own
+    message had to hedge between causes it could not distinguish (the exact
+    defect this closes).
+
+    ``outcome`` is one of the 4 literal strings ``force_compact_now``'s own
+    ``self._events.emit("compaction_check", outcome=...)`` calls use —
+    passed through the SAME variable at each call site (see that method's
+    body), never re-typed, so this type and the audit trail cannot drift
+    apart. Deliberately NOT a single boolean (architect's #5699 ruling,
+    cited again for this issue): the caller's possible questions differ —
+    "should I retry now" (``already_running``), "is there really nothing
+    to fold" (``forced_sync_no_turns``), "did the internal invariant hold"
+    (``compaction_input_gap_invariant_violated``), "did an attempt run,
+    and if so on how many candidates" (``forced_sync`` + ``candidate_
+    count``) — collapsing them into one true/false would re-lose exactly
+    the distinction this type exists to carry.
+
+    ``failed`` (#5708 acceptance ④, added mid-fix on lead-coder review):
+    ``_run_compaction`` raising is
+    deliberately still swallowed here (#5633 — its own ``compaction_
+    failed`` audit event already fired at its origin, and re-raising
+    would propagate an exception past this method's own established
+    no-throw contract). But "the event was emitted" is not "the caller
+    was told" — audit is the observability plane, a return value is the
+    control plane, and this field is what closes THAT gap: the CALLER
+    (``/compact``) gets the fact "an attempt genuinely failed", never the
+    exception itself, so it can say so instead of the pre-#5708 "Nothing
+    was compacted this pass" a swallowed failure used to render as.
+    """
+
+    outcome: str
+    candidate_count: int = 0
+    batch_truncated: bool = False
+    failed: bool = False
 
 
 def _estimate_tokens(text: str) -> int:
@@ -291,7 +338,7 @@ class CompactionController:
             and t.seq > prev_cover
         ]
 
-    async def force_compact_now(self) -> None:
+    async def force_compact_now(self) -> ForceCompactResult:
         """Synchronous force-trigger — single pass (#1128 PR-c).
 
         #5528: the pre-frame guard that used to call this proactively, on
@@ -300,6 +347,13 @@ class CompactionController:
         ``router_loop_driver.py``'s byte-limit recovery path) or on-demand
         (``/compact`` / the ``compact`` op). Emits ``compaction_check``
         with ``outcome="forced_sync"``.
+
+        #5708: RETURNS a :class:`ForceCompactResult` naming which of the 4
+        outcomes fired, instead of ``None`` — every exit point below both
+        emits the audit event AND returns the matching result from the
+        SAME outcome literal (never two separately-typed copies of the
+        same fact). See that class's own docstring for why the caller
+        needs the full outcome, not a collapsed boolean.
 
         #1128 PR-c: collapsed from the former Option-B race-recovery loop
         (``max_passes`` re-measure + ``ForceCompactRaceUnrecoveredError``) to a
@@ -318,8 +372,9 @@ class CompactionController:
         Cross-driver turn serialization is the shared per-agent lock's job (PR-b).
         """
         if self._compacting:
-            self._events.emit("compaction_check", outcome="already_running")
-            return
+            outcome = "already_running"
+            self._events.emit("compaction_check", outcome=outcome)
+            return ForceCompactResult(outcome=outcome)
 
         latest = self._latest_summary()
         prev_cover = (latest.meta or {}).get("covers_through_seq", 0) if latest else 0
@@ -356,8 +411,9 @@ class CompactionController:
         # rather than re-derived, so this can never drift from them again.
         turns = [m for m in history if is_compaction_eligible(m)]
         if not turns:
-            self._events.emit("compaction_check", outcome="forced_sync_no_turns")
-            return
+            outcome = "forced_sync_no_turns"
+            self._events.emit("compaction_check", outcome=outcome)
+            return ForceCompactResult(outcome=outcome)
         # #4472 architect review, point ③: NOT a normal branch — a defensive
         # invariant, not a routine outcome. The durable read always starts
         # its batch immediately after `prev_cover` (only the END of the
@@ -372,37 +428,48 @@ class CompactionController:
         # itself was.
         resident_seqs = [t.seq for t in turns if t.seq > 0]
         if resident_seqs and min(resident_seqs) > prev_cover + 1:
-            self._events.emit(
-                "compaction_check", outcome="compaction_input_gap_invariant_violated",
-            )
-            return
+            outcome = "compaction_input_gap_invariant_violated"
+            self._events.emit("compaction_check", outcome=outcome)
+            return ForceCompactResult(outcome=outcome)
         candidates = self._select_candidates(turns, prev_cover)
 
+        outcome = "forced_sync"
         self._events.emit(
-            "compaction_check", outcome="forced_sync",
+            "compaction_check", outcome=outcome,
             batch_truncated=batch_truncated,
             candidate_count=len(candidates),
         )
         if not candidates:
-            return
+            return ForceCompactResult(
+                outcome=outcome, candidate_count=0, batch_truncated=batch_truncated,
+            )
 
         self._compacting = True
+        failed = False
         try:
             await self._run_compaction(candidates, latest)
         except Exception:
-            # #5633 (lead-coder review): NOT re-emitted here. Whatever
-            # `_run_compaction` raises has already had its own
-            # `compaction_failed` emitted at its own origin —
-            # `CompactionEngine.compact()`'s own except for a compact()
+            # #5633 (lead-coder review): NOT re-raised, and NOT re-emitted
+            # here — whatever `_run_compaction` raises has already had its
+            # own `compaction_failed` emitted at its own origin
+            # (`CompactionEngine.compact()`'s own except for a compact()
             # failure, or `_run_compaction`'s own post-processing
-            # `try`/`except` for anything after `compact()` returns (see
+            # `try`/`except` for anything after `compact()` returns; see
             # `_run_compaction`'s own comment for why those two `try`
-            # blocks never overlap). This bare catch exists only so a
-            # compaction failure never propagates past `force_compact_now`
-            # to ITS OWN caller.
-            pass
+            # blocks never overlap). Swallowing the exception itself
+            # stays correct (`force_compact_now`'s own no-throw contract
+            # is intentional, #5633) — #5708's own finding is narrower:
+            # "the event was emitted" is not "the caller was told", so
+            # `failed` below carries the ONE bit of fact the caller
+            # actually needs (an attempt genuinely failed) without
+            # propagating the exception object itself.
+            failed = True
         finally:
             self._compacting = False
+        return ForceCompactResult(
+            outcome=outcome, candidate_count=len(candidates),
+            batch_truncated=batch_truncated, failed=failed,
+        )
 
     async def persist_recovery_summary(
         self, chat_summary: "ChatSummary", *, covers_through_seq: int,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10810,6 +10810,14 @@ class Session:
         kept for the op contract shared with the phase axis (where it is
         the real control_ir shrink); callers front the compression numbers
         for chat regardless of what ``freed_tokens`` reads.
+
+        #5708: also carries ``compaction_outcome``/``compaction_candidate_
+        count``, threaded straight from ``force_compact_now``'s own
+        ``ForceCompactResult`` (never re-derived from the before/after
+        ``covers_through_seq`` delta, which cannot distinguish WHY
+        ``summarized_turns`` came back 0). ``/compact`` reads these to
+        name the actual cause instead of hedging between causes it used
+        to have no way to tell apart.
         """
         import json as _json
 
@@ -10830,7 +10838,7 @@ class Session:
 
         effective_trigger, before = self._budget_advisor._free_window_now()
         prev_cover = _cover()
-        await self._compaction_controller.force_compact_now()
+        compaction_outcome = await self._compaction_controller.force_compact_now()
         _, after = self._budget_advisor._free_window_now()
         new_cover = _cover()
 
@@ -10858,6 +10866,19 @@ class Session:
             "summarized_turns": len(middle),
             "compressed_tokens": sum(_est(m.text) for m in middle),
             "bridge_tokens": _est(bridge_text) if summary is not None else 0,
+            # #5708: threaded through from `force_compact_now`'s own
+            # `ForceCompactResult` — see that class's docstring. Lets a
+            # caller (``/compact``) distinguish "genuinely nothing
+            # eligible" from "an attempt ran but folded/advanced nothing"
+            # from "already running" from "internal invariant violated",
+            # all of which otherwise looked identical (``summarized_turns
+            # == 0``) from this dict alone.
+            "compaction_outcome": compaction_outcome.outcome,
+            "compaction_candidate_count": compaction_outcome.candidate_count,
+            # #5708 acceptance ④: the one bit `_run_compaction` raising
+            # left with no way to reach this caller — the exception itself
+            # stays swallowed (intentional, #5633), only the FACT survives.
+            "compaction_failed": compaction_outcome.failed,
         }
 
     def reasoning_continuity_section(self) -> str:

--- a/tests/interfaces/test_slash_compact_cmd.py
+++ b/tests/interfaces/test_slash_compact_cmd.py
@@ -2,7 +2,18 @@
 
 `compact_cmd` has four distinct paths based on whether the compaction engine
 is wired, whether it raises, and the `summarized_turns` value in its result.
-"""
+
+#5708 (owner real-machine incident): before this, EVERY `summarized_turns
+<= 0` result rendered as one of two hedged messages regardless of WHY
+nothing was summarised — `force_compact_now` had no way to tell the caller
+"already_running" apart from "genuinely nothing eligible" apart from "an
+attempt ran but did not advance" apart from "an internal invariant was
+violated", so `/compact` could not either (its own comment, verbatim,
+named the defect: "this function has no way to tell them apart"). The 4
+tests below (`test_compact_*_outcome_*`) pin that each of the `compaction_
+outcome` values `Session._compact_now_for_op` now threads through from
+`CompactionController.ForceCompactResult` produces its OWN, non-hedged
+wording — the acceptance-item-① witness."""
 from __future__ import annotations
 
 import pytest
@@ -156,3 +167,119 @@ async def test_compact_success_plural_turns_word() -> None:
     await compact_cmd(_ctx(session), "")
     text = session.reply_text()
     assert "turns" in text, f"plural not used; got: {text!r}"
+
+
+# --- #5708: outcome-specific wording (the acceptance-① witness) -----------
+
+
+@pytest.mark.asyncio
+async def test_compact_outcome_already_running_names_the_cause() -> None:
+    """Tier 2: `already_running` gets its own wording — "try again", not
+    "nothing to compact" (a DIFFERENT actionable next step)."""
+    async def _running():
+        return {"summarized_turns": 0, "compaction_outcome": "already_running"}
+
+    session = _FakeSession(compact_now=_running)
+    await compact_cmd(_ctx(session), "")
+    text = session.reply_text()
+    assert "already running" in text.lower(), f"got: {text!r}"
+    assert "already fits" not in text.lower()
+    assert not session.error_text()
+
+
+@pytest.mark.asyncio
+async def test_compact_outcome_invariant_violated_is_an_error_not_a_hedge() -> None:
+    """Tier 2: `compaction_input_gap_invariant_violated` is a genuine
+    internal anomaly (compaction_controller.py's own comment: "a defensive
+    invariant, not a routine outcome") — must surface as an error, not a
+    quiet "nothing to compact"."""
+    async def _violated():
+        return {
+            "summarized_turns": 0,
+            "compaction_outcome": "compaction_input_gap_invariant_violated",
+        }
+
+    session = _FakeSession(compact_now=_violated)
+    await compact_cmd(_ctx(session), "")
+    assert session.error_text(), "expected an error reply for an invariant violation"
+    assert "invariant" in session.error_text().lower()
+    assert not session.reply_text()
+
+
+@pytest.mark.asyncio
+async def test_compact_outcome_forced_sync_with_candidates_but_no_progress() -> None:
+    """Tier 2: acceptance ② — `forced_sync` WITH candidates selected but
+    `summarized_turns == 0` (the watermark never advanced) must read
+    DIFFERENTLY from `forced_sync_no_turns`/`candidate_count == 0` below —
+    an attempt genuinely ran and did not complete, not "nothing eligible"."""
+    async def _stalled():
+        return {
+            "summarized_turns": 0,
+            "compaction_outcome": "forced_sync",
+            "compaction_candidate_count": 7,
+        }
+
+    session = _FakeSession(compact_now=_stalled)
+    await compact_cmd(_ctx(session), "")
+    text = session.reply_text()
+    assert "7" in text, f"candidate count not surfaced; got: {text!r}"
+    assert "did not complete" in text.lower() or "attempt" in text.lower(), (
+        f"got: {text!r}"
+    )
+    assert "already fits" not in text.lower(), (
+        "must not be conflated with the genuinely-nothing-eligible case"
+    )
+    assert "nothing eligible" not in text.lower(), (
+        "must not be conflated with the genuinely-nothing-eligible case"
+    )
+    assert not session.error_text()
+
+
+@pytest.mark.asyncio
+async def test_compact_outcome_forced_sync_failed_says_so_plainly() -> None:
+    """Tier 2: acceptance ④ — `compaction_failed=True` (an exception the
+    swallow in `force_compact_now` caught) must state the fact PLAINLY, as
+    an error, not hedge with "may indicate a compaction failure" the way
+    the unconfirmed-stall case does. (423 here is an arbitrary test value,
+    not a claim about any specific real-machine incident.)"""
+    async def _failed():
+        return {
+            "summarized_turns": 0,
+            "compaction_outcome": "forced_sync",
+            "compaction_candidate_count": 423,
+            "compaction_failed": True,
+        }
+
+    session = _FakeSession(compact_now=_failed)
+    await compact_cmd(_ctx(session), "")
+    err = session.error_text()
+    assert err, f"expected an error reply for a confirmed failure, got reply: {session.reply_text()!r}"
+    assert "423" in err, f"candidate count not surfaced; got: {err!r}"
+    assert "failed" in err.lower()
+    assert "may indicate" not in err.lower(), (
+        "a CONFIRMED failure must not be hedged the same way the "
+        "unconfirmed-stall case is"
+    )
+    assert not session.reply_text()
+
+
+@pytest.mark.asyncio
+async def test_compact_outcome_forced_sync_no_turns_still_says_nothing_eligible() -> None:
+    """Tier 2: acceptance ② deny side — `forced_sync_no_turns` (or
+    `forced_sync` with `candidate_count == 0`) is the ONE case the
+    pre-#5708 "already fits" wording was correct for; it must stay
+    distinct from the stalled-attempt case above (same `summarized_turns
+    == 0`, different `compaction_outcome`)."""
+    async def _no_turns():
+        return {
+            "summarized_turns": 0,
+            "compaction_outcome": "forced_sync_no_turns",
+            "free_window_after": 12000,
+        }
+
+    session = _FakeSession(compact_now=_no_turns)
+    await compact_cmd(_ctx(session), "")
+    text = session.reply_text()
+    assert "already fits" in text.lower(), f"got: {text!r}"
+    assert "did not complete" not in text.lower()
+    assert not session.error_text()


### PR DESCRIPTION
**[tui-coder]** — Closes #5708

受入④(圧縮が例外で落ちたことを`/compact`が伝える)を含めています——根拠はコード上の事実のみです(force_compact_nowがNoneを返しexcept: passが例外を飲み込むため、圧縮が何で落ちても/compactは"Nothing was compacted this pass"と出す)。lead-coderが実機ログのtail -3から「今日の失敗」と読んだ分は時刻未確認で取り消されており、本PRはそれを根拠にしていません。

## 中身

`force_compact_now(self) -> None` → `ForceCompactResult(outcome, candidate_count, batch_truncated, failed)`。既存4つのaudit outcomeリテラルをそのままreturn値にも使う(2重管理なし)。`_run_compaction`の例外は引き続きswallow(#5633の意図どおり)だが、`failed`フィールドで「起きた」という事実だけ呼び手に届く。

`/compact`は5パターンに分岐: already_running / invariant違反(error) / forced_sync+失敗(error、断定) / forced_sync+停滞だが未失敗(hedge残す、唯一の本当に不明な残余ケース) / genuinely nothing eligible(既存free_window still full経路も保持)。

## Test plan

- [x] `tests/interfaces/test_slash_compact_cmd.py`(5本追加、13本): 4 outcome + failed/stalled区別
- [x] falsify: already_running分岐・failed分岐をEditで無効化→赤確認→復元
- [x] 関連compaction test 95 green
- [x] `ruff check .` / `test_tier_audit.py --strict` 13/13 / `verify_module_docstrings.py` / `mypy_ratchet.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — all green
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7

