### PR TITLE
fix(#5712): /compact shares the reactive spill+halve shrink ladder, not a bare unprotected call

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -34,7 +34,10 @@ from reyn.core.events.events import EventLog
 from reyn.runtime.chat_message import is_compaction_eligible
 from reyn.services.compaction.engine import (
     CompactionEngine,
+    CompactionOverflowError,
     HistoryChunkToCompact,
+    classify_compact_overflow,
+    shrink_pool_after_overflow,
     trim_head,
     trim_tail,
     wrap_summary_as_message,
@@ -338,8 +341,20 @@ class CompactionController:
             and t.seq > prev_cover
         ]
 
-    async def force_compact_now(self) -> ForceCompactResult:
+    async def force_compact_now(
+        self, *, spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]]",
+    ) -> ForceCompactResult:
         """Synchronous force-trigger — single pass (#1128 PR-c).
+
+        #5712 (owner ruling, "operator の compact 要求は spill 含む縮小
+        フローだから"): ``spill_fn`` is now REQUIRED — no path through
+        this method may run the mid-side shrink ladder without rung①
+        (spill) genuinely available (acceptance ②: no ``None`` left at
+        this boundary). Both real callers (``Session._compact_now_for_
+        op``, ``RouterLoopDriver``'s own post-``retry_loop``-exhaustion
+        fallback) pass the SAME concrete spill implementation
+        (``RouterLoopDriver._spill_batch_for_retry``) — one real
+        implementation, reused, never a second copy for this path.
 
         #5528: the pre-frame guard that used to call this proactively, on
         an ESTIMATE, is gone — this is now reached only reactively (a real
@@ -447,7 +462,7 @@ class CompactionController:
         self._compacting = True
         failed = False
         try:
-            await self._run_compaction(candidates, latest)
+            await self._run_compaction(candidates, latest, spill_fn=spill_fn)
         except Exception:
             # #5633 (lead-coder review): NOT re-raised, and NOT re-emitted
             # here — whatever `_run_compaction` raises has already had its
@@ -543,6 +558,8 @@ class CompactionController:
         self,
         candidates: list[ChatMessage],
         previous_summary: ChatMessage | None,
+        *,
+        spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]]",
     ) -> None:
         """Call the compaction engine and persist the resulting summary entry."""
         cfg = self._config
@@ -607,7 +624,6 @@ class CompactionController:
             self._events.emit("compaction_failed", error=str(exc))
             raise
 
-        new_turn_count = len(candidates)
         # #5475 (architect ruling): compaction_started now emits at
         # CompactionEngine.compact()'s own entry — the one real entry both
         # of its callers (this method, and retry_loop's own internal
@@ -617,20 +633,105 @@ class CompactionController:
         # rejected). This caller's own real `seq` (`candidates[-1].seq` —
         # unlike retry_loop's wire-dict turns, `_turn_to_compactor_input`
         # keeps `seq` per turn) is passed through explicitly.
-        # #5633 (lead-coder review): deliberately OUTSIDE any try/except in
-        # THIS method — a compact() failure is already fully handled at its
-        # own origin (CompactionEngine.compact()'s own except emits
-        # `compaction_failed` and re-raises; see its own docstring). Nothing
-        # here may also catch it: which side emits for a given failure is
-        # decided STRUCTURALLY, by which try/except block the failure
-        # physically raises inside, never by a caller re-inspecting the
-        # exception for a marker.
-        chat_summary = await self._engine.compact(
-            input_chunk, covers_through=candidates[-1].seq,
+        # #5712 (owner ruling, "operator の compact 要求は spill 含む縮小
+        # フローだから"): #5633's own "deliberately OUTSIDE any try/except"
+        # structure below is UNCHANGED in spirit — a compact() failure is
+        # still fully handled at its own origin (CompactionEngine.
+        # compact()'s own except emits `compaction_failed` and re-raises)
+        # — this loop only adds the SAME rung①(spill)+rung②(halve) shrink
+        # retry `RecoveryLadder` already runs on a compact()-origin
+        # OVERFLOW (`engine.classify_compact_overflow`/`shrink_pool_
+        # after_overflow`, #5712 — the ONE shared implementation, not a
+        # second copy). A FATAL/RETRYABLE classification still propagates
+        # bare, immediately, exactly as it always did (`classify_compact_
+        # overflow`'s own `raise exc` for those, uncaught here). Only a
+        # genuinely shrinkable OVERFLOW gets a shrink-and-retry; the loop
+        # itself never swallows or re-emits anything `compact()`'s own
+        # `except` did not already emit.
+        #
+        # `pool` is the FULL wire-dict list `input_chunk` already built
+        # (summary-then-candidates, #5531 condition③'s own ordering,
+        # unchanged) — the shared function mutates it in place via spill.
+        # `_n_summary` messages never shrink via halving (this caller's
+        # own candidate selection already excluded head/tail; the prior
+        # summary, if any, is the one thing NOT drawn from `candidates`)
+        # — attempt_len only ever trims from the CANDIDATE side, matching
+        # `covers_through`'s own derivation below.
+        pool = input_chunk.messages
+        _n_summary = len(_summary_messages)
+        attempt_len = len(pool)
+        _last_saw_byte_limit = False
+        # #5712 (found while wiring this in, not assumed): `_turn_to_
+        # compactor_input`'s own wire shape (`text`, no `spillability`)
+        # is a DIFFERENT convention from the one `spill_fn`'s real
+        # implementation (`RouterLoopDriver._spill_batch_for_retry` ->
+        # `_spill_batch_within_face`) expects (`content` + `spillability`
+        # — retry_loop's own wire-dict turns already carry both, via
+        # `decompose_history_for_retry`). Passing this caller's own
+        # `text`-shaped dicts to it directly would make EVERY candidate
+        # look ineligible (`t.get("content")` always `None`) — spill
+        # would silently never fire, the exact silent-half-fix #5712
+        # itself is about. `_turn_to_compactor_input`'s own output shape
+        # stays UNCHANGED (existing tests assert exact dict equality on
+        # it, `test_compaction_controller_tool_aware.py`) — this adapter
+        # translates at the boundary instead: builds a `content`+
+        # `spillability`-shaped VIEW for the real spill_fn, then
+        # translates any returned edit back into this caller's own
+        # `text` field before `shrink_pool_after_overflow` applies it to
+        # `pool`.
+        _spillability_by_index = (
+            [""] * _n_summary + [c.spillability.value for c in candidates]
         )
+
+        def _spill_fn_adapted(offered: "list[dict]") -> "list[tuple[int, dict]]":
+            content_shaped = [
+                {**item, "content": item.get("text", ""), "spillability": _spillability_by_index[i]}
+                for i, item in enumerate(offered)
+            ]
+            edits = spill_fn(content_shaped)
+            return [
+                (idx, {**offered[idx], "text": replacement.get("content", offered[idx].get("text", ""))})
+                for idx, replacement in edits
+            ]
+        while True:
+            offered = pool[:attempt_len]
+            _offered_chunk = HistoryChunkToCompact(
+                messages=offered, section_token_caps=input_chunk.section_token_caps,
+            )
+            # `covers_through` names the LAST candidate actually offered
+            # this attempt — never `candidates[-1].seq` unconditionally
+            # (#5531 condition③'s own contract holds only for a full,
+            # un-shrunk attempt; a shrunk one covers a genuine PREFIX,
+            # same shape `RecoveryLadder`'s own partial-fold-then-continue
+            # already has for the reactive path — a later `/compact` call
+            # covers the remainder, this method staying "single pass").
+            _n_candidates_offered = max(attempt_len - _n_summary, 0)
+            _covers_through = (
+                candidates[_n_candidates_offered - 1].seq
+                if _n_candidates_offered > 0 else candidates[0].seq
+            )
+            try:
+                chat_summary = await self._engine.compact(
+                    _offered_chunk, covers_through=_covers_through,
+                )
+                break
+            except Exception as exc:
+                try:
+                    classify_compact_overflow(exc)
+                except CompactionOverflowError as _overflow_exc:
+                    _last_saw_byte_limit = (
+                        getattr(_overflow_exc.__cause__, "status_code", None) == 413
+                    )
+                    attempt_len = shrink_pool_after_overflow(
+                        pool, offered, attempt_len,
+                        spill_fn=_spill_fn_adapted, saw_byte_limit=_last_saw_byte_limit,
+                    )
+                    continue
+                raise  # FATAL/RETRYABLE — bare, unchanged (#5633)
+        new_turn_count = _n_candidates_offered
         try:
             structured = chat_summary.to_dict()
-            covers = chat_summary.covers_through_seq or candidates[-1].seq
+            covers = chat_summary.covers_through_seq or _covers_through
             # #1820 Part1: frame the rendered summary with a static reference-only
             # preamble (Hermes SUMMARY_PREFIX analog) so the model treats the summary as
             # history — NOT a fresh instruction — and does not re-execute `pending` work

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -964,7 +964,16 @@ class RouterLoopDriver:
                 # everything durably available — so the second call onward
                 # is a no-op, not a repeated summarization.
                 if self._compaction.fold_persist_policy == "next_turn":
-                    await self._compaction_controller.force_compact_now()
+                    # #5712: `force_compact_now` now requires a real
+                    # spill_fn — reuse the SAME `chain_id` this method's
+                    # own retry_loop call above already used (this
+                    # fallback pass is still semantically part of
+                    # recovering THIS turn's overflow).
+                    await self._compaction_controller.force_compact_now(
+                        spill_fn=_partial(
+                            self._spill_batch_for_retry, chain_id=chain_id,
+                        ),
+                    )
                 raise
         return _shim.usage
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10838,7 +10838,34 @@ class Session:
 
         effective_trigger, before = self._budget_advisor._free_window_now()
         prev_cover = _cover()
-        compaction_outcome = await self._compaction_controller.force_compact_now()
+        # #5712 (owner ruling, "operator の compact 要求は spill 含む縮小
+        # フローだから"): `force_compact_now` now requires a real spill_fn
+        # — reuses `RouterLoopDriver._spill_batch_for_retry` (the SAME
+        # concrete implementation the reactive retry_loop path already
+        # calls, via `RouterLoopDriver`'s own `spill_fn=` wiring for
+        # `retry_loop`) rather than a second copy for this on-demand
+        # path. `chain_id="manual-compact"` (never a real turn's chain —
+        # `/compact` is not attached to any in-flight turn) is a plain
+        # manifest/audit label with a documented empty-string default
+        # (`RouterHistoryBuffer.spill_turn_content`); using a descriptive
+        # literal instead of leaving it blank distinguishes an on-demand
+        # spill from a reactive one in the spill audit trail for free.
+        from functools import partial as _partial
+        # `_spill_batch_for_retry` is `RouterLoopDriver`-specific, not
+        # part of the `ExecutionDriver` Protocol every driver satisfies
+        # (`execution_driver.py`) — a test/alternate driver that omits it
+        # degrades to a genuine no-op spill (never a crash), the same
+        # graceful-absence shape `force_compact_now`'s own REQUIRED
+        # spill_fn contract still honors: "nothing real to spill" is a
+        # valid answer, "None entirely" is not (#5712 acceptance ②).
+        _spill_impl = getattr(self._loop_driver, "_spill_batch_for_retry", None)
+        _spill_fn = (
+            _partial(_spill_impl, chain_id="manual-compact")
+            if _spill_impl is not None else (lambda _candidates: [])
+        )
+        compaction_outcome = await self._compaction_controller.force_compact_now(
+            spill_fn=_spill_fn,
+        )
         _, after = self._budget_advisor._free_window_now()
         new_cover = _cover()
 

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1433,10 +1433,12 @@ def is_shrinkable_overflow(exc: BaseException) -> bool:
 class CompactionOverflowError(Exception):
     """The compaction LLM call itself exceeded its B_M budget.
 
-    Raised when the compaction call (= the inner ``engine.compact()`` call
-    inside retry_loop) returns a context-length error.  Triggers the same
-    escalation path as ContextOverflowError: shrink raw_middle/tail/head and
-    retry.
+    Raised when the compaction call (= the inner ``engine.compact()`` call)
+    returns a context-length error — from either of its two callers:
+    ``RecoveryLadder``'s reactive ``retry_loop`` path, or
+    ``CompactionController``'s on-demand ``/compact`` path (#5712).  Both
+    route this through ``shrink_pool_after_overflow`` to shrink the offered
+    pool (spill, then halve) and retry.
     """
 
 
@@ -1530,10 +1532,21 @@ class UnrecoveredError(Exception):
 
     def __init__(
         self, reason: str, *, terminal: RetryLoopTerminal, saw_byte_limit: bool = False,
+        spill_was_offered: bool = False,
     ) -> None:
         self.reason = reason
         self.terminal = terminal
         self.saw_byte_limit = saw_byte_limit
+        # #5712 acceptance ③: whether spill (rung①) was actually given a
+        # chance at the content before this MID_FLOOR raise — a real
+        # record that the shared shrink loop tried the FIRST rung, not an
+        # inference from `terminal` alone (MID_FLOOR is defined in terms
+        # of "spilling it did not resolve the overflow either", ADR-0044
+        # §4 — this field is what makes that clause checkable). Default
+        # `False` so a pre-#5712 raise site that never threads this
+        # through (there should be none left, but the field must not
+        # silently claim spill ran when nobody asked it to).
+        self.spill_was_offered = spill_was_offered
         super().__init__(reason)
 
 
@@ -2852,6 +2865,92 @@ async def retry_loop(
 _LADDER_CONTINUE = object()
 
 
+def classify_compact_overflow(exc: Exception) -> "None":
+    """#5712: the ONE classification site every ``compact()``-call failure
+    goes through, shared by :class:`RecoveryLadder` (reactive) and
+    :class:`~reyn.runtime.services.compaction_controller.CompactionController`
+    (on-demand, ``/compact``) — moved out of
+    :class:`RecoveryLadder`'s own (already fully stateless) ``_classify_
+    and_wrap_compact_failure`` body verbatim; that method now delegates
+    here instead of owning a private copy. See the original method's own
+    (still-current) docstring, preserved on :class:`RecoveryLadder` for
+    the FATAL/RETRYABLE/OVERFLOW rationale — nothing about the
+    classification logic itself changed, only where it lives.
+
+    Always raises — never returns normally. FATAL/RETRYABLE re-raise
+    *exc* bare; OVERFLOW wraps it as :class:`CompactionOverflowError`.
+    """
+    if classify_llm_failure(exc) is not LLMFailureClass.OVERFLOW:
+        raise exc
+    raise CompactionOverflowError(str(exc)) from exc
+
+
+def shrink_pool_after_overflow(
+    pool: "list[dict]",
+    offered: "list[dict]",
+    attempt_len: int,
+    *,
+    spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]]",
+    saw_byte_limit: bool,
+) -> int:
+    """ADR-0044's mid-side ladder — rung① (spill) then rung② (halve) — as
+    ONE shared unit (#5712, owner ruling: "operator の compact 要求は
+    spill 含む縮小フローだから"). :class:`RecoveryLadder` (reactive) and
+    :class:`CompactionController` (on-demand, ``/compact``) both reach
+    this SAME function after a single failed ``compact()`` attempt at
+    *attempt_len* over *pool* — this is the ONE place either rung's
+    arithmetic exists; neither caller keeps a private copy.
+
+    *pool* is mutated IN PLACE via ``spill_fn``'s returned ``(index,
+    replacement)`` edits — the caller's own list (``RecoveryLadder.
+    raw_middle`` for the reactive path), so a caller tracking that list
+    sees spill's effect directly, no second copy step.
+
+    ``spill_fn`` is REQUIRED here, never optional (#5712 acceptance ②:
+    no path at this shared boundary may pass ``None`` — a caller with
+    nothing real to spill passes a no-op ``lambda offered: []``, so rung①
+    always genuinely runs, even when it can never make progress).
+
+    Rung① (spill) always runs BEFORE rung② (halve) — #5712 acceptance ①.
+    If spilling *offered* returns any edit, applies them all and returns
+    *attempt_len* UNCHANGED (the caller retries the SAME length against
+    the now-smaller pool next attempt). Otherwise halves *attempt_len*
+    (floor 1) and returns the new value — UNLESS *attempt_len* was
+    already 1, in which case spilling a single candidate alone still not
+    resolving the overflow IS the mid floor: raises
+    :class:`UnrecoveredError` with ``terminal=RetryLoopTerminal.MID_FLOOR``
+    and ``spill_was_offered=True`` (#5712 acceptance ③ — this raise is
+    reached ONLY after rung① was tried on this exact candidate, on the
+    SAME line that computed ``edits``, so the record is structural, not
+    inferred).
+
+    This is the ONLY terminal this function can ever raise —
+    ``ROOM_FLOOR`` needs ``main_call``/``SP``/``new_msg``/``head``/
+    ``tail``, none of which this function is given; a caller with no
+    room-side ladder (``/compact``) cannot reach it BY CONSTRUCTION, not
+    by a runtime check that could be forgotten.
+    """
+    edits = spill_fn(offered) if offered else []
+    if edits:
+        for idx, replacement in edits:
+            pool[idx] = replacement
+        return attempt_len
+    if attempt_len <= 1:
+        raise UnrecoveredError(
+            (
+                "HTTP 413 (a request-BODY-BYTE limit) recurred "
+                if saw_byte_limit
+                else "shrinking recurred "
+            ) + "compacting a single candidate alone — mid cannot be "
+            "split any further (the turn-count floor), and spilling it "
+            "did not resolve this either.",
+            terminal=RetryLoopTerminal.MID_FLOOR,
+            saw_byte_limit=saw_byte_limit,
+            spill_was_offered=True,
+        )
+    return max(attempt_len // 2, 1)
+
+
 class RecoveryLadder:
     """The bounded shrink ladder for ONE context-overflow recovery episode
     (#5631 candidate 1 — Fowler's Replace Function with Command, applied
@@ -3068,45 +3167,6 @@ class RecoveryLadder:
             self.new_msg, self._model, use_chars4=self._use_chars4,
         )
 
-    def _spill_batch_from_offered(self, offered: "list[dict]") -> int:
-        """#5592 (owner ruling, superseding the withdrawn #5531 §10 "one
-        candidate at a time" AND this PR's own withdrawn doubling-batch
-        draft) — rung①: spill as many candidates from *offered* as
-        ``spill_fn`` decides to hand back in ONE call, apply them all,
-        return the count applied.
-
-        ``offered`` — #5592 (owner ruling, correcting #9.6's own "never a
-        slice" claim): the population is "the range THIS request is about
-        to send" — ``raw_middle[:_attempt_len]`` at the call site below,
-        which coincides with ``raw_middle`` entirely on the first attempt
-        (``_compact_attempt_len is None``) and is the OFFERED SLICE only
-        once rung② has halved at least once. #9.6's docstring text is
-        stale as of this change; see the call site's own comment.
-
-        ``spill_fn`` now returns ``list[tuple[int, dict]]`` (was
-        ``tuple[int, dict] | None``) — a whole BATCH to apply this call,
-        not one candidate. This function stays Spillability-agnostic
-        either way (``spill_fn`` owns all tier/order/granularity
-        decisions — this module never imports ``Spillability``, matching
-        ``tool_result_cap.cap_tool_result_content``'s own ``save_fn``-
-        injection style).
-
-        #9.5's own "no cursor" rule still holds: every call re-scans the
-        CURRENT ``offered`` fresh via ``spill_fn(offered)`` — no persisted
-        position on this side either.
-
-        Never reads wire bytes to decide progress (#5364 §1.6: a
-        ``raw_middle`` spill cannot move wire bytes by construction,
-        elided out of ``estimate_wire_bytes``; reading bytes here would
-        discard every mid spill outright) — progress is "how many edits
-        did ``spill_fn`` return," full stop."""
-        if self._spill_fn is None or not offered:
-            return 0
-        edits = self._spill_fn(offered)
-        for idx, replacement in edits:
-            self.raw_middle[idx] = replacement
-        return len(edits)
-
     def _stage_refill_phase1(self) -> bool:
         """ADR-0044 refill, Phase 1: if ``tail`` still holds non-summary
         content above ``_tail_min_tokens``, trim half of it (skipping any
@@ -3169,91 +3229,6 @@ class RecoveryLadder:
         # stays valid.
         self._compact_attempt_len = None
         return True
-
-    def _stage_spill(self) -> bool:
-        """ADR-0044 rung① — spill. #5531 §10 (owner ruling, "spill is the
-        ladder's first rung"): try spilling before touching
-        ``_compact_attempt_len`` at all. Looping via ``_LADDER_CONTINUE``
-        (was bare ``continue``) re-runs ``compact()`` on the SAME
-        ``_attempt_len`` slice (unchanged by a spill — only the CONTENT
-        of the spilled candidates shrank) — #9.5's own no-cursor rule:
-        each call re-scans fresh, so this naturally keeps consuming
-        candidates until either the overflow resolves or the population
-        is exhausted.
-
-        #5592 (owner ruling, superseding this PR's own withdrawn
-        doubling-batch draft — real-machine incident: 2469 raw_middle
-        candidates meant 2469 compact() calls at ~6s each, ~4.1 hours;
-        see issue #5592 for the full incident trace): ``spill_fn`` now
-        decides, in ONE call, how many candidates to hand back — this
-        rung just applies whatever it returns and retries.
-        ``chat.compaction.spill_granularity`` (the caller's own config,
-        this function stays agnostic to it) controls ``spill_fn``'s own
-        batch size: ``tier`` (default) returns every eligible candidate
-        sharing the SAME ``Spillability`` tier in one shot (O(1) calls
-        per overflow regardless of N); ``turn`` reproduces the
-        pre-#5592 one-candidate-at-a-time behavior exactly (O(N) calls)
-        — a config escape hatch, explicitly documented as NOT the safe
-        default (``docs/reference/config/reyn-yaml.md``).
-
-        #5592 (owner ruling, correcting #9.6): the population for THIS
-        spill attempt is ``raw_middle[:_attempt_len]`` — the SAME slice
-        this iteration's own ``compact()`` call just sent and had
-        rejected, not ``raw_middle`` in its entirety. These coincide on
-        the very first attempt (``_attempt_len == len(raw_middle)`` when
-        ``_compact_attempt_len`` is still ``None``); they diverge only
-        after rung② has halved at least once, and it is the SENT slice
-        that must be offered to spill, not the untried remainder sitting
-        past it.
-
-        Returns whether any candidate was actually spilled — the caller
-        (:meth:`_run_one_iteration`) returns :data:`_LADDER_CONTINUE`
-        when it does (rung① exhausted, or no ``spill_fn`` at all, falls
-        through to :meth:`_stage_halve_slice`)."""
-        return self._spill_batch_from_offered(self.raw_middle[:self._attempt_len]) > 0
-
-    def _stage_halve_slice(self) -> None:
-        """ADR-0044 rung② — halve the slice. Only reached once rung①
-        (:meth:`_stage_spill`) is exhausted (or no ``spill_fn`` at all).
-        #5531 §10 (architect/owner correction, 2026-08-30): "fail →
-        halve, succeed → double" — a genuine binary search, not the old
-        one-way ratchet. A SUCCESS's own doubling happens at the success
-        site itself (inside :meth:`_stage_fold`, right after
-        ``raw_middle = raw_middle[_attempt_len:]`` — the only place that
-        knows "this attempt just succeeded"), never here; this method
-        only ever HALVES, because reaching it means the LAST attempt at
-        the current ``_attempt_len`` just failed.
-
-        Terminal (mid floor): raises :class:`UnrecoveredError` when a
-        single turn offered alone still overflows AND spilling it (just
-        tried by the caller) did not resolve it either — halving further
-        cannot produce a smaller nonzero slice. #5531 §3 item 12:
-        mode-independent (a floor is a floor regardless of which HTTP
-        shape triggered the overflow)."""
-        _current_attempt = (
-            self._compact_attempt_len if self._compact_attempt_len is not None
-            else len(self.raw_middle)
-        )
-        if _current_attempt <= 1:
-            raise UnrecoveredError(
-                (
-                    "retry_loop: HTTP 413 (a request-BODY-BYTE limit) "
-                    if self._last_recover_is_byte_limit
-                    else "retry_loop: shrinking "
-                ) + "recurred compacting a single raw_middle turn "
-                "alone — mid cannot be split any further (the "
-                "turn-count floor), and spilling every available "
-                "candidate in raw_middle did not resolve this "
-                "either." + (
-                    _learned_byte_limit_clause(
-                        last_accepted_wire_bytes=self._last_accepted_wire_bytes,
-                        last_rejected_wire_bytes=self._last_rejected_wire_bytes,
-                    ) if self._last_recover_is_byte_limit else ""
-                ),
-                terminal=RetryLoopTerminal.MID_FLOOR,
-                saw_byte_limit=self._last_recover_is_byte_limit,
-            )
-        self._compact_attempt_len = max(_current_attempt // 2, 1)
 
     def _stage_halve_room(self) -> None:
         """ADR-0044 — halve the room. Reached once ``raw_middle`` is
@@ -3425,10 +3400,17 @@ class RecoveryLadder:
         own 2 sites import it from here unchanged. Only the 3rd site's
         OWN discriminator stays the bare ``classify_llm_failure`` check
         it always was — 2 deliberately different discriminators for 2
-        deliberately different blast radii, not a drift."""
-        if classify_llm_failure(exc) is not LLMFailureClass.OVERFLOW:
-            raise
-        raise CompactionOverflowError(str(exc)) from exc
+        deliberately different blast radii, not a drift.
+
+        #5712: the body itself moved to the module-level
+        :func:`classify_compact_overflow` (verbatim — this method was
+        already fully stateless, reading only *exc*) so
+        :class:`~reyn.runtime.services.compaction_controller.
+        CompactionController`'s own on-demand path shares the SAME
+        classification instead of a private copy. This method stays as
+        the documented call site for :meth:`_stage_fold`'s own
+        ``except``; only the implementation is now shared."""
+        classify_compact_overflow(exc)
 
     async def _stage_fold(self) -> "object | None":
         """ADR-0044 -- fold. Compacts ``raw_middle`` (or the first
@@ -3907,11 +3889,53 @@ class RecoveryLadder:
 
         # Shrink escalation: reduce context size monotonically.
         if self.raw_middle:
-            # ADR-0044: rung① (spill) then rung② (halve_slice) -- see
-            # each method's own docstring for the full rationale.
-            if self._stage_spill():
-                return _LADDER_CONTINUE
-            self._stage_halve_slice()
+            # ADR-0044: rung① (spill) then rung② (halve) -- #5712, both
+            # now the SAME shared function `/compact` also calls (see
+            # its own docstring for the full rationale and the MID_FLOOR
+            # terminal). `_last_recover_is_byte_limit`'s own #4954(b)
+            # wire-bytes-clause augmentation stays HERE (RecoveryLadder-
+            # only: needs SP/head/tail/new_msg, which the shared
+            # function is never given) -- the shared function's own
+            # raise carries the base message; this catches ONLY that
+            # one raise shape and re-raises with the extra clause
+            # appended, never swallowing or altering anything else.
+            _current_attempt = (
+                self._compact_attempt_len if self._compact_attempt_len is not None
+                else len(self.raw_middle)
+            )
+            _offered_for_shrink = self.raw_middle[:_current_attempt]
+            try:
+                self._compact_attempt_len = shrink_pool_after_overflow(
+                    self.raw_middle, _offered_for_shrink, _current_attempt,
+                    spill_fn=self._spill_fn or (lambda _offered: []),
+                    saw_byte_limit=self._last_recover_is_byte_limit,
+                )
+            except UnrecoveredError as _mid_floor_exc:
+                # #5712: the shared function's own message says "a single
+                # candidate alone" (caller-neutral wording); RecoveryLadder
+                # keeps its OWN pre-#5712 wording ("raw_middle turn") byte-
+                # identical here — existing tests pin that exact substring
+                # (test_4947_stage1_floor_names_413_when_it_is_a_byte_limit)
+                # — plus the byte-limit wire-bytes clause this class alone
+                # can compute (needs SP/head/tail/new_msg).
+                raise UnrecoveredError(
+                    (
+                        "HTTP 413 (a request-BODY-BYTE limit) recurred "
+                        if self._last_recover_is_byte_limit
+                        else "shrinking recurred "
+                    ) + "compacting a single raw_middle turn alone — mid "
+                    "cannot be split any further (the turn-count floor), "
+                    "and spilling every available candidate in raw_middle "
+                    "did not resolve this either." + (
+                        _learned_byte_limit_clause(
+                            last_accepted_wire_bytes=self._last_accepted_wire_bytes,
+                            last_rejected_wire_bytes=self._last_rejected_wire_bytes,
+                        ) if self._last_recover_is_byte_limit else ""
+                    ),
+                    terminal=_mid_floor_exc.terminal,
+                    saw_byte_limit=_mid_floor_exc.saw_byte_limit,
+                    spill_was_offered=_mid_floor_exc.spill_was_offered,
+                ) from None
         elif self._stage_refill_phase1():
             pass
         elif self._stage_refill_phase2():

--- a/tests/core/test_4883_compaction_schema_validation.py
+++ b/tests/core/test_4883_compaction_schema_validation.py
@@ -242,7 +242,7 @@ def test_raise_does_not_confirm_covered_range(monkeypatch) -> None:
         monkeypatch, scripted_responses=["{}"], history=_history(30),
     )
 
-    asyncio.run(ctrl.force_compact_now())  # must not raise to the caller
+    asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))  # must not raise to the caller
 
     assert [e for e in collected if e.type == "compaction_failed"], (
         "engine exhaustion must surface as compaction_failed, not swallowed silently"
@@ -265,7 +265,7 @@ def test_raise_does_not_confirm_covered_range(monkeypatch) -> None:
     ctrl2, collected2, _ = _controller_with_real_engine(
         monkeypatch, scripted_responses=["{}"], history=list(hist),
     )
-    asyncio.run(ctrl2.force_compact_now())
+    asyncio.run(ctrl2.force_compact_now(spill_fn=lambda _candidates: []))
     started = [e for e in collected2 if e.type == "compaction_started"]
     assert started, "the retried candidates must still be seen as compactable"
     assert started[0].data.get("covers_through_seq") == 21, (

--- a/tests/dev/test_5382_llm_stub_compaction_selectivity.py
+++ b/tests/dev/test_5382_llm_stub_compaction_selectivity.py
@@ -79,7 +79,7 @@ def test_raise_for_compaction_leaves_the_main_router_call_untouched_end_to_end(
     session.subscribe_audit_events(events.append)
 
     async def _drive() -> bool:
-        await session._compaction_controller.force_compact_now()
+        await session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: [])
         # #4961 C: dispatch to `events` runs on a background consumer
         # task — settle() before the synchronous read below, right at
         # the spot that depends on delivery having already happened.

--- a/tests/llm/test_chat_compaction_engine_11axis.py
+++ b/tests/llm/test_chat_compaction_engine_11axis.py
@@ -854,7 +854,7 @@ def test_force_compact_now_single_pass_no_race_recovery() -> None:
         render_summary=lambda s: str(s),
     )
 
-    asyncio.run(ctrl.force_compact_now())
+    asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))
 
     assert engine.compact_call_count == 1, (
         f"force_compact_now must run exactly one pass, got {engine.compact_call_count}"

--- a/tests/runtime/test_5513_media_followup_tool_call_id_survives_reordering.py
+++ b/tests/runtime/test_5513_media_followup_tool_call_id_survives_reordering.py
@@ -102,7 +102,7 @@ def test_tool_call_id_disambiguates_two_same_tool_followups_after_a_real_compact
     _push(session, "user", _followup_text("tc2"))
     _push(session, "assistant", "both done")
 
-    asyncio.run(session._compaction_controller.force_compact_now())
+    asyncio.run(session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: []))
 
     history = session._history_buffer.build_history()
     texts = [str(m.get("content", "")) for m in history]

--- a/tests/runtime/test_5597_compaction_llm_call_timeout.py
+++ b/tests/runtime/test_5597_compaction_llm_call_timeout.py
@@ -96,7 +96,7 @@ def test_compaction_call_inherits_mains_own_timeout(
     stub = LLMStub()
     stub.install()
     try:
-        asyncio.run(session._compaction_controller.force_compact_now())
+        asyncio.run(session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: []))
         asyncio.run(settle(session))
     finally:
         stub.restore()
@@ -129,7 +129,7 @@ def test_compaction_llm_call_seconds_override_wins_when_set(
     stub = LLMStub()
     stub.install()
     try:
-        asyncio.run(session._compaction_controller.force_compact_now())
+        asyncio.run(session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: []))
         asyncio.run(settle(session))
     finally:
         stub.restore()
@@ -205,7 +205,7 @@ def test_funnel_resolved_timeout_genuinely_reaches_litellm_acompletion(
             return await _orig(*args, **kwargs)
 
         monkeypatch.setattr(litellm, "acompletion", _spy)
-        asyncio.run(session._compaction_controller.force_compact_now())
+        asyncio.run(session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: []))
         asyncio.run(settle(session))
     finally:
         stub.restore()

--- a/tests/runtime/test_5699_compaction_window_fold_parity.py
+++ b/tests/runtime/test_5699_compaction_window_fold_parity.py
@@ -122,7 +122,7 @@ async def test_force_compact_now_folds_a_model_visible_backlog(tmp_path, monkeyp
 
     s._audit_events.emit = _capture
 
-    await s._compaction_controller.force_compact_now()
+    await s._compaction_controller.force_compact_now(spill_fn=lambda _candidates: [])
 
     (check,) = [kw for kind, kw in events if kind == "compaction_check"]
     assert check["outcome"] == "forced_sync"

--- a/tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py
+++ b/tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py
@@ -1,0 +1,322 @@
+"""Tier 2: #5712 — ``/compact`` (``CompactionController.force_compact_now``
+-> ``_run_compaction``) runs its ``compact()`` call through the SAME
+rung①(spill)+rung②(halve) shrink ladder ``RecoveryLadder`` (the reactive
+``retry_loop`` path) already runs on an overflow, instead of a bare,
+unprotected single call.
+
+owner real-machine incident: the recorded exception was ``context_length_
+exceeded`` — the compaction LLM call ITSELF exceeded its own budget.
+``force_compact_now``'s ``except Exception: pass`` (closed by #5708) swallowed
+this every time, so ``/compact`` rendered "Nothing was compacted this pass"
+forever; the compaction call that was SUPPOSED to shrink history was itself
+too big to send. #5712 fixes the CAUSE #5708 could only report accurately.
+
+owner ruling (2026-09-03, verbatim): "operator の compact 要求は spill 含む
+縮小フローだから" — ``/compact`` must run spill (rung①), not just halving
+(rung②) alone. architect's own witness for "genuinely the same shared logic,
+not a second copy": stripping either rung's arithmetic must turn BOTH the
+reactive-path test AND this file's own new test red — a shared boundary that
+only one side's test can reach would mean two implementations, not one.
+
+Fixtures are built so a SINGLE, full-size ``compact()`` call genuinely
+overflows and MULTIPLE spill rounds (never one) are needed before it fits —
+per lead-coder's own explicit review note: "1 回の呼びで通ってしまう
+fixture では、段①(spill) が効いた証拠になりません." Real
+``CompactionController``/real ``EventLog`` — the engine and spill_fn are the
+two collaborators this suite is free to fake (the same class of "the
+provider LLM/network boundary" every other compaction test here fakes, per
+the testing policy's `LLMReplay`-or-real-instance rule; no ``MagicMock``/
+``patch`` anywhere).
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.compaction_controller import CompactionController
+from reyn.services.compaction.engine import (
+    SUMMARY_MESSAGE_ROLE,
+    ChatSummary,
+    CompactionEngine,
+    ComputedBudgets,
+    CoversThrough,
+    HistoryChunkToCompact,
+    RetryLoopTerminal,
+    UnrecoveredError,
+)
+from tests._support.events import collect_events, settle
+
+_STUB_BUDGETS = ComputedBudgets(
+    main_pool=100_000, head_budget=50, body_budget=5_000,
+    tail_budget=50, new_msg_budget=10_000,
+    B_M=80_000, main_M_room=65_000, effective_trigger=65_000,
+)
+
+
+def _emit_compaction_started(
+    events: EventLog, input_chunk: HistoryChunkToCompact, covers_through: CoversThrough,
+) -> None:
+    """Mirrors ``CompactionEngine.compact()``'s own real entry emit — see
+    ``test_compaction_controller_invariants.py``'s identically-named
+    helper; duplicated here (not imported) so this file stays a
+    self-contained fixture, matching this suite's own convention of not
+    bare-importing names across sibling test modules."""
+    _summary_messages = [
+        m for m in input_chunk.messages if m.get("role") == SUMMARY_MESSAGE_ROLE
+    ]
+    events.emit(
+        "compaction_started",
+        new_turn_count=len(input_chunk.messages) - len(_summary_messages),
+        covers_through_seq=covers_through if isinstance(covers_through, int) else None,
+        covers_through_unavailable_reason=(
+            None if isinstance(covers_through, int) else covers_through.value
+        ),
+        had_previous=bool(_summary_messages),
+    )
+
+
+class _ContextLengthExceeded(Exception):
+    """Stands in for the provider's own real exception (owner real-machine
+    record: ``context_length_exceeded``) — a PLAIN exception with no
+    FATAL/RETRYABLE-matching shape (no ``status_code``, no reyn-internal
+    bug type), so ``classify_llm_failure`` falls through to its
+    documented OVERFLOW default — the same classification a genuine
+    context-length error gets. What actually raises is irrelevant to the
+    property under test (mirrors ``test_5126_pump_sse_exception_not_
+    swallowed.py``'s own reasoning for a plain stand-in exception)."""
+
+
+class _OverflowsUntilFewEnoughEngine(CompactionEngine):
+    """``compact()`` genuinely overflows whenever the TOTAL char length of
+    the offered messages' ``text`` exceeds ``fits_at_or_below_chars`` —
+    char length, not message COUNT, since spill only ever shrinks
+    CONTENT (never removes an item — the wire dict stays, its text
+    becomes a small placeholder), and halving only ever shrinks COUNT.
+    Gating on count would make spill invisible (it never changes count,
+    so a count-only gate could never distinguish "spill helped" from
+    "spill did nothing") — the fixture shape lead-coder's own review
+    demanded: a single full-size attempt must NOT already fit (or
+    spill's own contribution could never be distinguished from "it
+    happened to work anyway")."""
+
+    def __init__(self, events: EventLog, *, fits_at_or_below_chars: int) -> None:
+        self._model = ""
+        self._events = events
+        self._budgets = _STUB_BUDGETS
+        self._fits_at_or_below_chars = fits_at_or_below_chars
+        self.attempt_sizes: "list[int]" = []
+        self.attempt_char_totals: "list[int]" = []
+
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
+    ) -> ChatSummary:
+        _emit_compaction_started(self._events, input_chunk, covers_through)
+        self.attempt_sizes.append(len(input_chunk.messages))
+        _chars = sum(len(t.get("text", "")) for t in input_chunk.messages if isinstance(t, dict))
+        self.attempt_char_totals.append(_chars)
+        if _chars > self._fits_at_or_below_chars:
+            self._events.emit("compaction_failed", error="context_length_exceeded")
+            raise _ContextLengthExceeded("context_length_exceeded")
+        seqs = [int(t.get("seq", 0)) for t in input_chunk.messages if isinstance(t, dict)]
+        return ChatSummary(topic_arc="stub", covers_through_seq=max(seqs) if seqs else 0)
+
+
+def _history(n: int) -> "list[ChatMessage]":
+    return [
+        ChatMessage(role="user" if i % 2 == 1 else "assistant", content="x" * 200, seq=i)
+        for i in range(1, n + 1)
+    ]
+
+
+def _make_controller(
+    *, history: "list[ChatMessage]", engine: CompactionEngine, events: EventLog,
+) -> "tuple[CompactionController, list, list[ChatMessage]]":
+    collected = collect_events(events)
+
+    def _latest_summary():
+        for m in reversed(history):
+            if m.role == "summary":
+                return m
+        return None
+
+    ctrl = CompactionController(
+        event_log=events,
+        config=CompactionConfig(use_chars4_estimate=True),
+        history_from_disk=lambda after_seq: (
+            [m for m in history if m.seq == 0 or m.seq > after_seq], False,
+        ),
+        latest_summary=_latest_summary,
+        compaction_engine_factory=lambda: engine,
+        history_appender=history.append,
+        make_summary_message=lambda rendered, structured, covers: ChatMessage(
+            role="summary", content=rendered, seq=0,
+            meta={"structured": structured, "covers_through_seq": covers},
+        ),
+        render_summary=lambda s: str(s),
+    )
+    return ctrl, collected, history
+
+
+def _spilling_one_content_shaped_candidate_at_a_time(
+    spill_calls: "list[int]",
+) -> "Callable[[list[dict]], list[tuple[int, dict]]]":
+    """A real, working spill_fn contract (content+spillability-shaped
+    input, ``(index, replacement)`` edits out) that spills EXACTLY ONE
+    eligible candidate per call — ADR §3's own "one candidate at a time"
+    (lead-coder's explicit review note: this is the acceptance for
+    proving spill genuinely engages, not a fixture that resolves the
+    whole overflow in a single spill call). Records how many candidates
+    were OFFERED on each call (``spill_calls``), so a test can assert on
+    call count without pinning an internal iteration count."""
+
+    def _spill_fn(offered: "list[dict]") -> "list[tuple[int, dict]]":
+        spill_calls.append(len(offered))
+        for idx, item in enumerate(offered):
+            if item.get("spillability") == "never":
+                continue
+            if item.get("content", "").startswith("[spilled]"):
+                continue
+            return [(idx, {**item, "content": "[spilled]"})]
+        return []
+
+    return _spill_fn
+
+
+@pytest.mark.asyncio
+async def test_spill_alone_resolves_the_overflow_no_halving_needed():
+    """Tier 2: acceptance ① (spill runs BEFORE halving) — a population
+    that genuinely overflows at full size, but where EVERY candidate is
+    spillable, must be resolved by spill rounds alone: every recorded
+    compact() attempt size stays the FULL candidate count (halving never
+    shrank the offered slice), while multiple spill calls fire.
+
+    Falsify pair (deny side) lives in the next test — a population with
+    NOTHING spillable, where the exact same shape must fall through to
+    halving instead."""
+    events = EventLog()
+    history = _history(6)  # -> 4 middle candidates (head=[t1], tail=[t6])
+    engine = _OverflowsUntilFewEnoughEngine(events, fits_at_or_below_chars=400)
+    # 5 raw chars ("x"*200 * 4 candidates) overflows at full size; each
+    # spill round shrinks ONE candidate's content to "[spilled]" (9
+    # chars) — after enough rounds the wire is small enough. The COUNT
+    # of messages offered never changes via spill (only content does),
+    # so `fits_at_or_below` here gates on total wire size via a second
+    # engine variant below is unnecessary — this engine's own count-based
+    # gate already proves "no halving happened" via `attempt_sizes`
+    # staying constant; a real byte-based gate is exercised by the
+    # spill-driven engine variant in the next test file section.
+    ctrl, collected, hist = _make_controller(history=history, engine=engine, events=events)
+    spill_calls: "list[int]" = []
+
+    result = await ctrl.force_compact_now(
+        spill_fn=_spilling_one_content_shaped_candidate_at_a_time(spill_calls),
+    )
+    await settle(events)
+
+    assert engine.attempt_sizes, "compact() was never called"
+    assert all(n == engine.attempt_sizes[0] for n in engine.attempt_sizes), (
+        f"the offered SIZE must never shrink via halving in this all-"
+        f"spillable fixture — got attempt sizes {engine.attempt_sizes!r}"
+    )
+    assert spill_calls[1:], (
+        f"expected multiple spill rounds (ADR §3 'one candidate at a "
+        f"time') before the overflow resolved — got {spill_calls!r}"
+    )
+    assert not result.failed, f"expected eventual success, got failed result: {result!r}"
+    summaries = [m for m in hist if m.role == "summary"]
+    assert summaries, "a successful shrink-and-retry must still append a summary"
+
+
+@pytest.mark.asyncio
+async def test_mid_floor_records_that_spill_was_offered():
+    """Tier 2: acceptance ③ — when NOTHING is spillable (every candidate
+    ``spillability == "never"``) and the overflow persists all the way
+    down to a single candidate, the resulting MID_FLOOR
+    ``UnrecoveredError`` must carry ``spill_was_offered=True`` — spill
+    (rung①) was genuinely tried on that final candidate, not skipped."""
+    events = EventLog()
+    history = _history(6)
+    # Never satisfiable — even a single candidate overflows.
+    engine = _OverflowsUntilFewEnoughEngine(events, fits_at_or_below_chars=0)
+    ctrl, _collected, _hist = _make_controller(history=history, engine=engine, events=events)
+
+    def _never_spillable(_offered: "list[dict]") -> "list[tuple[int, dict]]":
+        return []  # every real spill_fn answer is "nothing eligible"
+
+    result = await ctrl.force_compact_now(spill_fn=_never_spillable)
+
+    assert result.failed, f"expected the MID_FLOOR raise to surface as failed, got {result!r}"
+    # The raised UnrecoveredError itself is swallowed by force_compact_now
+    # (#5633/#5708) — reach it directly via a fresh, equivalent call to
+    # confirm the STRUCTURED fact the swallow discards, mirroring how
+    # test_5708's own tests read `compaction_failed`/`failed` without
+    # needing the exception object itself.
+    from reyn.services.compaction.engine import shrink_pool_after_overflow
+    pool = [{"content": "x", "spillability": "never"}]
+    with pytest.raises(UnrecoveredError) as excinfo:
+        shrink_pool_after_overflow(
+            pool, pool, 1, spill_fn=_never_spillable, saw_byte_limit=False,
+        )
+    assert excinfo.value.terminal is RetryLoopTerminal.MID_FLOOR
+    assert excinfo.value.spill_was_offered is True
+
+
+@pytest.mark.asyncio
+async def test_falls_through_to_halving_when_nothing_is_spillable():
+    """Tier 2: falsify pair (deny side) for the spill-alone test above —
+    an otherwise-identical overflow with NOTHING spillable must fall
+    through to halving (rung②): the offered SIZE shrinks across
+    attempts, proving halving genuinely engages when spill cannot help,
+    not that this fixture accidentally never needed it."""
+    events = EventLog()
+    history = _history(10)  # -> 8 middle candidates
+    engine = _OverflowsUntilFewEnoughEngine(events, fits_at_or_below_chars=810)
+    ctrl, _collected, hist = _make_controller(history=history, engine=engine, events=events)
+
+    def _never_spillable(_offered: "list[dict]") -> "list[tuple[int, dict]]":
+        return []
+
+    result = await ctrl.force_compact_now(spill_fn=_never_spillable)
+    await settle(events)
+
+    assert engine.attempt_sizes[1:], "expected multiple shrink-and-retry attempts"
+    assert engine.attempt_sizes[0] > engine.attempt_sizes[-1], (
+        f"the offered SIZE must shrink via halving when spill cannot "
+        f"help — got attempt sizes {engine.attempt_sizes!r}"
+    )
+    assert not result.failed
+    summaries = [m for m in hist if m.role == "summary"]
+    assert summaries, "eventual success via halving must still append a summary"
+
+
+@pytest.mark.asyncio
+async def test_on_demand_compaction_never_touches_recovery_episode():
+    """Tier 2: acceptance ④ — ``/compact``'s own episode is recorded
+    distinctly from the reactive path's, never co-mingled. The concrete,
+    checkable form: ``force_compact_now``'s own ``compaction_started``
+    call never opens or reads ``RouterLoopDriver``'s
+    ``_recovery_episode_scope`` — this test's own controller has no
+    ``RouterLoopDriver`` wired at all, and compaction still runs to
+    completion, proving the on-demand path's success does not depend on
+    (and therefore cannot silently share) that reactive-only concept."""
+    events = EventLog()
+    history = _history(6)
+    engine = _OverflowsUntilFewEnoughEngine(events, fits_at_or_below_chars=400)
+    ctrl, _collected, hist = _make_controller(history=history, engine=engine, events=events)
+    spill_calls: "list[int]" = []
+
+    result = await ctrl.force_compact_now(
+        spill_fn=_spilling_one_content_shaped_candidate_at_a_time(spill_calls),
+    )
+
+    assert not result.failed
+    assert [m for m in hist if m.role == "summary"], (
+        "on-demand compaction completed with no RouterLoopDriver/"
+        "recovery_episode concept present at all — the on-demand path "
+        "does not depend on it, so it cannot silently share it with the "
+        "reactive path either"
+    )

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -195,7 +195,7 @@ def test_force_compact_no_candidates_emits_forced_sync_no_started():
     """
     ctrl, collected, _, events = _make_controller(history=_history(2), engine_factory=_AbortingEngine)
 
-    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(spill_fn=lambda _candidates: []), events))
 
     emitted = collected
     forced = [e for e in emitted if e.type == "compaction_check"
@@ -217,7 +217,7 @@ def test_force_compact_with_candidates_appends_summary():
     """
     ctrl, collected, hist, events = _make_controller(history=_history(7), engine_factory=_SucceedingEngine)
 
-    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(spill_fn=lambda _candidates: []), events))
 
     emitted = collected
     assert [e for e in emitted if e.type == "compaction_started"], "expected compaction_started"
@@ -237,7 +237,7 @@ def test_force_compact_engine_failure_emits_failed():
     rather than propagating it to the caller)."""
     ctrl, collected, _, events = _make_controller(history=_history(7), engine_factory=_AbortingEngine)
 
-    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))  # must not raise
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(spill_fn=lambda _candidates: []), events))  # must not raise
 
     assert [e for e in collected if e.type == "compaction_failed"], (
         "engine failure during force_compact_now must emit compaction_failed"
@@ -277,7 +277,7 @@ def test_force_compact_pre_compact_setup_failure_emits_failed():
     ]
     ctrl, collected, _, events = _make_controller(history=history, engine_factory=_SucceedingEngine)
 
-    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))  # must not raise
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(spill_fn=lambda _candidates: []), events))  # must not raise
 
     kinds = [e.type for e in collected]
     assert "compaction_started" not in kinds, (
@@ -336,7 +336,7 @@ def test_is_compacting_true_only_during_a_pass():
 
     assert ctrl.is_compacting is False, "must read False before any pass starts"
 
-    asyncio.run(_run_and_settle(ctrl.force_compact_now(), events))
+    asyncio.run(_run_and_settle(ctrl.force_compact_now(spill_fn=lambda _candidates: []), events))
 
     (engine,) = engine_box
     assert engine.observed_during_compact is True, (

--- a/tests/runtime/test_compaction_summary_preamble_1820.py
+++ b/tests/runtime/test_compaction_summary_preamble_1820.py
@@ -78,7 +78,7 @@ def test_summary_leads_with_reference_only_preamble():
     """Tier 2: the rendered summary leads with the reference-only preamble carrying
     the source-of-truth + discard-pending-on-reverse-signal directives."""
     ctrl, hist = _make_controller(_history(7))
-    asyncio.run(ctrl.force_compact_now())
+    asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))
     summaries = [m for m in hist if m.role == "summary"]
     assert summaries, "force_compact_now must append a summary"
     text = summaries[-1].text
@@ -91,7 +91,7 @@ def test_preamble_is_prepended_not_replacing_summary():
     """Tier 2: (non-regression) the preamble is PREPENDED — the original rendered
     summary content still follows it (the summary is not replaced)."""
     ctrl, hist = _make_controller(_history(7))
-    asyncio.run(ctrl.force_compact_now())
+    asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))
     text = [m for m in hist if m.role == "summary"][-1].text
     assert "--- summary follows ---" in text, "delimiter between preamble and summary"
     assert "STUB_ARC" in text, "the original rendered summary content must survive the prepend"

--- a/tests/services/test_4703_compaction_spend_visible.py
+++ b/tests/services/test_4703_compaction_spend_visible.py
@@ -148,7 +148,7 @@ def test_compaction_completed_event_carries_the_usage_end_to_end(monkeypatch) ->
     ctrl, collected, _, events = _make_controller(history=_history(7), engine_factory=_build_engine)
 
     async def _run() -> None:
-        await ctrl.force_compact_now()
+        await ctrl.force_compact_now(spill_fn=lambda _candidates: [])
         await settle(events)
 
     asyncio.run(_run())

--- a/tests/services/test_5475_compaction_started_moved_to_engine.py
+++ b/tests/services/test_5475_compaction_started_moved_to_engine.py
@@ -75,7 +75,7 @@ async def test_controller_path_carries_a_real_seq(tmp_path, monkeypatch):
             session._append_history(
                 _msg(f"filler turn {i} " * 40, seq=i + 1),
             )
-        await session._compaction_controller.force_compact_now()
+        await session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: [])
         await settle(session)
     finally:
         stub.restore()

--- a/tests/services/test_5498_retry_loop_covers_zero_never_persisted.py
+++ b/tests/services/test_5498_retry_loop_covers_zero_never_persisted.py
@@ -47,7 +47,7 @@ async def test_controller_summary_lands_in_history_but_retry_loop_summary_does_n
     stub = LLMStub()
     stub.install()
     try:
-        await ctrl_session._compaction_controller.force_compact_now()
+        await ctrl_session._compaction_controller.force_compact_now(spill_fn=lambda _candidates: [])
         await settle(ctrl_session)
     finally:
         stub.restore()


### PR DESCRIPTION
**[tui-coder]** #5712 — `/compact` (on-demand compaction) now shares the SAME rung①(spill)+rung②(halve) shrink ladder the reactive `retry_loop` path (`RecoveryLadder`) already runs when its own inner `compact()` call overflows, instead of calling `compact()` bare and unprotected.

## Root cause (this is what #5708 could only report accurately)

The owner's real-machine incident recorded `context_length_exceeded` — the compaction LLM call **itself** (inside `/compact`'s own `force_compact_now` → `_run_compaction` → `CompactionEngine.compact()`) exceeded its own context budget. `RecoveryLadder`'s reactive path already protects its own inner `compact()` call with ADR-0044's mid-side ladder (spill, then halve). `CompactionController`'s on-demand path had no such protection — the overflow surfaced as a swallowed exception, which #5708 fixed the *reporting* of but could not fix, since the cause was structural.

owner ruling (verbatim, cited twice): "ADR44が最新の縮小フローの神様であって、過去の技術負債を残すような方向に進まないでよ" and "operatorのcompact要求はspill含む縮小フローだから" — `/compact` must share BOTH rungs (spill + halve), not halving alone (reversing an earlier, narrower ruling).

## Implementation shape (architect left this to my judgment — recorded here per that request)

Extracted `classify_compact_overflow` / `shrink_pool_after_overflow` as **module-level functions** in `engine.py` — reused in place ("上置き"), not lifted into a new class. This is the ONE real implementation both callers reach:

- `RecoveryLadder` (reactive `retry_loop`) still owns spill-interleaving/fold-orchestration/doubling-on-success/refill/room-halving — it now calls the shared function for its own mid-side shrink step instead of keeping a private copy of the halving/spill arithmetic.
- `CompactionController` (`/compact`, on-demand) is a brand-new, simple shrink-retry loop around the same shared function — it has no `main_call`/`new_msg`/`head`/`tail`/`recovery_episode` concept at all, so it structurally cannot reach `ROOM_FLOOR` or touch `RouterLoopDriver`'s recovery episode; only `MID_FLOOR` is reachable on this path.

I chose reuse-in-place over a lift because both callers converge on the exact same "one failed `compact()` attempt over a pool, try spill then halve" unit — there was no meaningful third abstraction to lift into, and a lift would have added an indirection layer neither caller needed.

`spill_fn` is a **required** kwarg at the shared boundary (never optional, never `None`) — `RecoveryLadder` passes its own `spill_fn or (lambda _offered: [])`; `CompactionController`'s callers (`Session._compact_now_for_op`, `RouterLoopDriver`'s post-exhaustion fold path) build a real adapter over `RouterLoopDriver._spill_batch_for_retry` when one is wired, or a no-op lambda otherwise — so rung① always genuinely runs, even when nothing is actually spillable.

A real wire-shape incompatibility was found and fixed along the way: `CompactionController`'s own candidate serialization (`{"role", "text", "seq", ...}`) is not the same shape `RouterLoopDriver`'s real spill implementation expects (`{"content", "spillability", ...}`, `retry_loop`'s own convention). A translation adapter (`_spill_fn_adapted`) sits at the `_run_compaction` call boundary rather than changing either side's existing wire shape (several tests assert on `CompactionController`'s output shape via exact dict equality).

## Acceptance criteria (cumulative, from architect/lead-coder)

- [x] Halving arithmetic exists in exactly ONE `git grep`-able site (`shrink_pool_after_overflow`) — falsified: stripping it hangs (infinite loop) both a `retry_loop`-family sweep test and this PR's own halving-fallback test
- [x] Same witness for spill — falsified: a no-op `spill_fn` makes the spill-alone test fail, correctly falling through to halving instead (`attempt_sizes` shrinks 4→2)
- [x] Existing `retry_loop`-family tests (#5592/#5612/#5296 PR-2/#3783/PR-N6) pass with ZERO line changes
- [x] `/compact`'s path terminal is MID_FLOOR only — no `main_call`/`new_msg` params exist on that path
- [x] `/compact`'s path never advances/borrows `recovery_episode` — `test_on_demand_compaction_never_touches_recovery_episode`
- [x] `spill_fn=None` structurally impossible at the shared boundary — every call site either passes a real adapter or an explicit no-op lambda; falsify-verified `RecoveryLadder`'s own call always passes `self._spill_fn or (lambda _offered: [])`
- [x] MID_FLOOR raises record `spill_was_offered=True` — `test_mid_floor_records_that_spill_was_offered`
- [x] `docs/deep-dives/decisions/0044-overflow-recovery-ladder.md` has ZERO diff lines (verified via `git diff --stat`)
- [x] `CompactionOverflowError`'s docstring updated (was false: claimed the raise only happens "inside retry_loop"); the `#:` comment near `seq`'s origin (`SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ`) re-read in full — still accurate, no change needed (it already distinguished retry_loop's no-seq wire dicts from the controller's real-seq path, and #5712 doesn't change that distinction)
- [x] One PR, not split
- [x] Test fixtures genuinely require MULTIPLE spill rounds (gated on total candidate char length, not count — spill only ever shrinks content, never count) and reproduce "the `compact()` call itself overflows" specifically

## Verification status — please read this split carefully

- **Confirmed via synthetic tests here**: all 4 new tests in `tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py` pass; the scoped compaction/retry_loop sweep (313 tests) passes; falsify-then-restore performed on both the spill and halving witnesses (Edit-break-then-restore, no `git checkout`/`git stash`); all local gates (ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`) pass.
- **NOT YET verified on the real machine** — that is the owner's own hand, and the owner is deliberately preserving that incident state for post-fix verification. A successful compaction is PERMANENT/irreversible per ADR-0044's own wording, so this fix has NOT been run against the real held-open reproduction yet.

## Test plan

- [x] `pytest tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py` — 4/4 pass
- [x] Scoped compaction/retry_loop sweep — 313 passed, 4 skipped (unrelated missing extras)
- [x] Falsify: stripped halving arithmetic — hangs both a `retry_loop`-family test and this PR's own halving-fallback test (restored)
- [x] Falsify: no-op `spill_fn` — spill-alone test correctly fails, falls through to halving (restored)
- [x] (skipped — real-machine verification is explicitly deferred to the owner, per lead-coder's standing instruction for this ticket)

Closes #5712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7

