### PR TITLE
fix(#5719): compact() folds only the shortfall, not everything between head and tail

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -37,6 +37,8 @@ from reyn.services.compaction.engine import (
     CompactionOverflowError,
     HistoryChunkToCompact,
     classify_compact_overflow,
+    estimate_tokens_for_any_turn,
+    select_fold_candidates_for_shortfall,
     shrink_pool_after_overflow,
     trim_head,
     trim_tail,
@@ -308,16 +310,34 @@ class CompactionController:
         turns: "list[ChatMessage]",
         prev_cover: int,
     ) -> "list[ChatMessage]":
-        """Select compaction candidates using token-budget-derived HEAD/TAIL boundaries.
+        """Select compaction candidates: token-budget HEAD/TAIL protect,
+        the SHORTFALL against ``main_M_room`` selects.
 
-        #1128 step 3: replaces the old seq-arithmetic on cfg.head_size/tail_size
-        with token-budget trimming via the engine's ComputedBudgets.  Candidates
-        are the turns strictly between the head (trim_head) and tail (trim_tail)
-        slices that also have seq > prev_cover (= not yet covered by the latest
-        summary).
+        #5719 (architect ruling, real-machine incident: #5712's own fix
+        compacted 1.6M raw_middle chars to a ~3K summary against a 950K
+        window — needing only a ~650K reduction, 600x less than what
+        actually folded). head/tail (unchanged since #1128 step 3 —
+        token-budget trimming via the engine's ``ComputedBudgets``)
+        answer ONE question: is this turn protected. Everything strictly
+        between them, with ``seq > prev_cover`` (not yet covered by the
+        latest summary), used to become a fold CANDIDATE unconditionally
+        — collapsing "not protected" and "must be folded" onto one
+        predicate (architect's own naming of the defect). They are now
+        two separate steps: the unprotected-and-uncovered set is
+        computed exactly as before, then :func:`select_fold_candidates_
+        for_shortfall` selects only as much of it (oldest first, group-
+        aware) as is needed to bring the REMAINING unprotected middle
+        back under ``main_M_room`` — never "all of it" by default. See
+        that function's own docstring for the selection algorithm and
+        why no slack constant is added here.
 
-        Falls back to a quarter of get_max_input_tokens when budgets are None
-        (engine not yet initialised — highly unlikely in production but safe).
+        Falls back to a quarter of get_max_input_tokens when budgets are
+        None (engine not yet initialised — highly unlikely in
+        production but safe); ``main_M_room`` has no real formula to
+        fall back to in that branch (it needs T_SP/new_msg_budget, which
+        this fallback never had), so it re-derives the same "room after
+        head+tail" shape the real formula uses, from values already in
+        scope here.
         """
         budgets = getattr(self._engine, "budgets", None)
         model = getattr(self._engine, "_model", "")
@@ -325,21 +345,30 @@ class CompactionController:
         if budgets is not None:
             head_budget = budgets.head_budget
             tail_budget = budgets.tail_budget
+            main_M_room = budgets.main_M_room
         else:
             from reyn.llm.model_budget import get_max_input_tokens
             fallback = get_max_input_tokens(model) if model else 100_000
             head_budget = tail_budget = fallback // 4
+            main_M_room = fallback - head_budget - tail_budget
 
         head_turns = trim_head(turns, head_budget, model, use_chars4=use_chars4)
         tail_turns = trim_tail(turns, tail_budget, model, use_chars4=use_chars4)
         head_id_set = {id(t) for t in head_turns}
         tail_id_set = {id(t) for t in tail_turns}
-        return [
+        unprotected = [
             t for t in turns
             if id(t) not in head_id_set
             and id(t) not in tail_id_set
             and t.seq > prev_cover
         ]
+        unprotected_tokens = sum(
+            estimate_tokens_for_any_turn(t, model, use_chars4=use_chars4) for t in unprotected
+        )
+        shortfall = unprotected_tokens - main_M_room
+        return select_fold_candidates_for_shortfall(
+            unprotected, shortfall, model, use_chars4=use_chars4,
+        )
 
     async def force_compact_now(
         self, *, spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]]",

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1856,6 +1856,60 @@ def trim_tail(
     return [t for group in reversed(kept_reversed) for t in group]
 
 
+def select_fold_candidates_for_shortfall(
+    turns: list,
+    shortfall_tokens: int,
+    model: str = "",
+    *,
+    use_chars4: bool = False,
+) -> list:
+    """#5719 (architect ruling, real-machine incident: #5712's own fix
+    compacted 1.6M raw_middle chars down to a ~3K summary against a 950K
+    window — 600x more than the ~650K shortfall actually needed).
+
+    ``CompactionController._select_candidates`` used to treat
+    head/tail's OWN boundary as the fold selector too: "everything
+    strictly between head and tail" became "everything to fold",
+    collapsing "is this turn protected" and "does this turn need
+    folding" onto one predicate. head/tail stay exactly what they always
+    were — the protection boundary, computed by the caller before this
+    function ever runs. This function answers the SEPARATE question:
+    of the turns head/tail leave unprotected, how many actually need to
+    fold to close *shortfall_tokens* — never "all of them" by default.
+
+    ``shortfall_tokens <= 0`` (the unprotected middle already fits the
+    window) returns ``[]`` — folding zero turns is a valid, common
+    answer this function did not have before #5719; the caller (#4472's
+    own contract) already treats an empty candidate list as "nothing to
+    compact" correctly, no new outcome needed.
+
+    Oldest-first (``turns`` is already chronological — the caller reads
+    straight from ``history.jsonl``), group-aware (:func:`_group_tool_
+    cycles` — same discipline :func:`trim_head`/:func:`trim_tail` use;
+    a tool_call and its results never split across the fold boundary),
+    accumulating until the running total reaches *shortfall_tokens* —
+    the LAST group that crosses the threshold is folded WHOLE (never
+    split), so the actual amount folded can overshoot the shortfall by
+    at most one group's own size, never by design margin. No "fold a
+    bit extra just in case" constant here (owner ruling, relayed via
+    lead-coder: invent it later as a RE-OPEN TRIGGER if a real machine
+    ever shows repeated near-immediate re-compaction after a
+    shortfall-sized fold — not preemptively, unmeasured, today).
+    """
+    if shortfall_tokens <= 0:
+        return []
+    selected: list = []
+    total = 0
+    for group in _group_tool_cycles(turns):
+        if total >= shortfall_tokens:
+            break
+        selected.extend(group)
+        total += sum(
+            estimate_tokens_for_any_turn(t, model, use_chars4=use_chars4) for t in group
+        )
+    return selected
+
+
 def hard_truncate_summary(
     summary_text: str,
     body_budget: int,

--- a/tests/core/test_4883_compaction_schema_validation.py
+++ b/tests/core/test_4883_compaction_schema_validation.py
@@ -210,13 +210,19 @@ def _history(n: int) -> "list[ChatMessage]":
     # Large enough (count × per-turn size) that, at the real
     # CompactionEngine's token budgets (head_budget/tail_budget computed
     # against the real model catalog, not a synthetic stub), a middle band
-    # of candidates survives head/tail trimming — the sibling
-    # controller-invariants suite uses a stub engine with tiny synthetic
-    # budgets instead; this test needs the REAL engine (to exercise the
-    # real compact() loop), so it sizes the history up instead of shrinking
-    # budgets down. n=30 turns of ~2000 tokens each leaves seq 1..21 as the
-    # middle candidate band at this model's fallback 128K-token budgets
-    # (verified directly against ComputedBudgets, not assumed).
+    # SURVIVES head/tail trimming AND exceeds main_M_room by enough to
+    # force a genuine shortfall-driven fold (#5719 — head/tail no longer
+    # doubles as the fold selector; the sibling controller-invariants
+    # suite uses a stub engine with tiny synthetic budgets instead; this
+    # test needs the REAL engine, to exercise the real compact() loop, so
+    # it sizes the history up instead of shrinking budgets down). n=90
+    # turns of ~2000 tokens each leaves seq 7..40 as the SELECTED
+    # (oldest-first, shortfall-covering) candidate band at this model's
+    # fallback 128K-token budgets (head_budget=12800/tail_budget=19200/
+    # main_M_room=83200 — verified directly against ComputedBudgets, not
+    # assumed; the full unprotected middle is seq 7..81, but only its
+    # oldest ~34 turns are needed to close the shortfall against
+    # main_M_room, so seq 41..81 stays un-folded).
     return [
         ChatMessage(
             role="user" if i % 2 == 1 else "assistant", content="x " * 4000, seq=i,
@@ -239,7 +245,7 @@ def test_raise_does_not_confirm_covered_range(monkeypatch) -> None:
     compaction attempt.
     """
     ctrl, collected, hist = _controller_with_real_engine(
-        monkeypatch, scripted_responses=["{}"], history=_history(30),
+        monkeypatch, scripted_responses=["{}"], history=_history(90),
     )
 
     asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))  # must not raise to the caller
@@ -268,7 +274,7 @@ def test_raise_does_not_confirm_covered_range(monkeypatch) -> None:
     asyncio.run(ctrl2.force_compact_now(spill_fn=lambda _candidates: []))
     started = [e for e in collected2 if e.type == "compaction_started"]
     assert started, "the retried candidates must still be seen as compactable"
-    assert started[0].data.get("covers_through_seq") == 21, (
+    assert started[0].data.get("covers_through_seq") == 40, (
         "the same original candidate range must still be up for compaction — "
         "the failed attempt must not have narrowed or consumed it"
     )

--- a/tests/llm/test_chat_compaction_engine_11axis.py
+++ b/tests/llm/test_chat_compaction_engine_11axis.py
@@ -786,10 +786,15 @@ class _CountingEngine(CompactionEngine):
         self._use_chars4 = True
         self._T_comp_SP = 10
         self._system_prompt_provider = None
+        # #5719: main_M_room=0 — this test is about single-pass/no-race-
+        # recovery behavior, not the shortfall-selection algorithm (that
+        # has its own dedicated tests), so main_M_room always produces a
+        # shortfall for any nonempty middle, matching this test's
+        # pre-#5719 "the whole middle is a candidate" fixture shape.
         self._budgets = ComputedBudgets(
             main_pool=100_000, head_budget=10_000, body_budget=5_000,
             tail_budget=15_000, new_msg_budget=10_000,
-            B_M=80_000, main_M_room=65_000, effective_trigger=50_000,
+            B_M=80_000, main_M_room=0, effective_trigger=0,
         )
         self.compact_call_count = 0
 

--- a/tests/runtime/test_3704_seq_assigned_to_every_role.py
+++ b/tests/runtime/test_3704_seq_assigned_to_every_role.py
@@ -76,10 +76,19 @@ def test_assistant_and_tool_turns_are_not_excluded_from_compaction_candidates(
     # slices — the actual "candidate" zone _select_candidates filters by
     # seq. With the large default t_max, 3 tiny turns fit entirely inside
     # head+tail and nothing is ever a "middle" candidate regardless of seq.
+    #
+    # #5719: candidate selection is no longer "everything outside head/
+    # tail" — it is only as much of that unprotected middle as is needed
+    # to close the shortfall against main_M_room (measured directly:
+    # main_M_room=13000 at this t_max). 200 turns (vs. the pre-#5719 40)
+    # ensures the unprotected middle genuinely EXCEEDS main_M_room after
+    # head/tail's own ~38-turn carve-out, so this test's actual subject —
+    # whether assistant/tool turns reach the SELECTED set at all — stays
+    # exercised regardless of how much of the middle needs to fold.
     session = _make_session(tmp_path, monkeypatch=monkeypatch, t_max=20_000)
 
     filler = "middle turn padding text " * 20
-    for i in range(40):
+    for i in range(200):
         role = "user" if i % 3 == 0 else ("assistant" if i % 3 == 1 else "tool")
         session._append_history(
             ChatMessage(role=role, content=f"{filler} #{i}", ts=f"t{i}")

--- a/tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py
+++ b/tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py
@@ -50,10 +50,16 @@ from reyn.services.compaction.engine import (
 )
 from tests._support.events import collect_events, settle
 
+# #5719: main_M_room=0 — this file's own tests are about the shrink-retry
+# ladder (spill/halving) downstream of candidate selection, not the #5719
+# shortfall-selection algorithm itself (that has its own dedicated tests
+# in test_5719_..._shortfall_selection.py), so main_M_room always produces
+# a shortfall for any nonempty middle, matching this file's pre-#5719
+# "everything between head/tail is initially offered" fixture shape.
 _STUB_BUDGETS = ComputedBudgets(
     main_pool=100_000, head_budget=50, body_budget=5_000,
     tail_budget=50, new_msg_budget=10_000,
-    B_M=80_000, main_M_room=65_000, effective_trigger=65_000,
+    B_M=80_000, main_M_room=0, effective_trigger=0,
 )
 
 

--- a/tests/runtime/test_5719_compact_folds_only_the_shortfall.py
+++ b/tests/runtime/test_5719_compact_folds_only_the_shortfall.py
@@ -1,0 +1,258 @@
+"""Tier 2: #5719 — ``CompactionController._select_candidates`` folds only as
+much of the unprotected middle as is needed to close the shortfall against
+``main_M_room``, never "everything between head and tail" unconditionally.
+
+owner real-machine incident (relayed via lead-coder, architect's own naming
+of the defect): #5712's fix let a real compaction succeed, but it compacted
+1.6M raw_middle chars down to a ~3K summary against a 950K window — the
+shortfall was only ~650K, so ~600x more was folded than the window ever
+needed freed. head/tail (unchanged since #1128 step 3 — a token-budget
+PROTECTION boundary) had been doing double duty as the fold SELECTOR too:
+"not protected" and "must be folded" were one predicate. They are now two
+steps — head/tail still answer "is this turn protected"; a separate,
+shortfall-derived selection (:func:`select_fold_candidates_for_shortfall`,
+oldest-first, group-aware, no added slack constant — see that function's
+own docstring) answers "of the unprotected turns, how many actually need
+to fold".
+
+Real ``CompactionController`` + real ``ChatMessage``/``EventLog``/
+``CompactionConfig`` throughout; only the engine (the LLM-call boundary
+every other compaction test here also stubs) is a stand-in, and it is
+never actually invoked by the tests that assert zero candidates — proving
+the shortfall gate short-circuits BEFORE any LLM call would be spent.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.compaction_controller import CompactionController
+from reyn.services.compaction.engine import (
+    SUMMARY_MESSAGE_ROLE,
+    ChatSummary,
+    CompactionEngine,
+    ComputedBudgets,
+    CoversThrough,
+    HistoryChunkToCompact,
+    select_fold_candidates_for_shortfall,
+)
+from tests._support.events import collect_events, settle
+
+# head fits 1 turn (50 tokens, "x"*200 via chars4), tail fits 1 turn,
+# main_M_room fits exactly 3 turns (150 tokens) of the unprotected middle —
+# the shortfall only ever needs to be measured against SOMETHING nonzero,
+# not left at 0 the way the sibling suites (whose subject is unrelated to
+# this shortfall math) deliberately do.
+_STUB_BUDGETS = ComputedBudgets(
+    main_pool=100_000, head_budget=50, body_budget=5_000, tail_budget=50,
+    new_msg_budget=10_000, B_M=80_000, main_M_room=150, effective_trigger=150,
+)
+
+
+class _NeverCalledEngine(CompactionEngine):
+    """A stand-in whose ``compact()`` fails the test outright if invoked —
+    used by the "shortfall is zero" tests, where the gate must short-
+    circuit before any LLM call would be spent."""
+
+    def __init__(self) -> None:
+        self._model = ""
+        self._events = EventLog()
+        self._budgets = _STUB_BUDGETS
+
+    async def compact(self, input_chunk, *, covers_through):  # noqa: ANN001
+        raise AssertionError(
+            "compact() must never be called when the shortfall is <= 0 — "
+            "nothing needed folding"
+        )
+
+
+def _emit_compaction_started(
+    events: EventLog, input_chunk: HistoryChunkToCompact, covers_through: CoversThrough,
+) -> None:
+    """Mirrors ``CompactionEngine.compact()``'s own real entry emit — same
+    helper shape as the sibling test files in this directory."""
+    _summary_messages = [
+        m for m in input_chunk.messages if m.get("role") == SUMMARY_MESSAGE_ROLE
+    ]
+    events.emit(
+        "compaction_started",
+        new_turn_count=len(input_chunk.messages) - len(_summary_messages),
+        covers_through_seq=covers_through if isinstance(covers_through, int) else None,
+        covers_through_unavailable_reason=(
+            None if isinstance(covers_through, int) else covers_through.value
+        ),
+        had_previous=bool(_summary_messages),
+    )
+
+
+class _SucceedingEngine(CompactionEngine):
+    def __init__(self, events: EventLog) -> None:
+        self._model = ""
+        self._events = events
+        self._budgets = _STUB_BUDGETS
+
+    async def compact(
+        self, input_chunk: HistoryChunkToCompact, *, covers_through: CoversThrough,
+    ) -> ChatSummary:
+        _emit_compaction_started(self._events, input_chunk, covers_through)
+        seqs = [int(t.get("seq", 0)) for t in input_chunk.messages if isinstance(t, dict)]
+        return ChatSummary(topic_arc="stub", covers_through_seq=max(seqs) if seqs else 0)
+
+
+def _history(n: int) -> "list[ChatMessage]":
+    return [
+        ChatMessage(role="user" if i % 2 == 1 else "assistant", content="x" * 200, seq=i)
+        for i in range(1, n + 1)
+    ]
+
+
+def _make_controller(
+    *, history: "list[ChatMessage]", engine: CompactionEngine, events: EventLog,
+) -> "tuple[CompactionController, list, list[ChatMessage]]":
+    collected = collect_events(events)
+    ctrl = CompactionController(
+        event_log=events,
+        config=CompactionConfig(use_chars4_estimate=True),
+        history_from_disk=lambda after_seq: (
+            [m for m in history if m.seq == 0 or m.seq > after_seq], False,
+        ),
+        latest_summary=lambda: None,
+        compaction_engine_factory=lambda: engine,
+        history_appender=history.append,
+        make_summary_message=lambda rendered, structured, covers: ChatMessage(
+            role="summary", content=rendered, seq=0,
+            meta={"structured": structured, "covers_through_seq": covers},
+        ),
+        render_summary=lambda s: str(s),
+    )
+    return ctrl, collected, history
+
+
+# ---------------------------------------------------------------------------
+# select_fold_candidates_for_shortfall — the shared function directly
+# ---------------------------------------------------------------------------
+
+
+def test_shortfall_at_or_below_zero_selects_nothing():
+    """Tier 2: acceptance — a shortfall of exactly 0 (or negative) means the
+    unprotected middle already fits the window; the correct answer is to
+    fold ZERO turns, not "all of them" (the pre-#5719 behavior)."""
+    turns = _history(5)
+    assert select_fold_candidates_for_shortfall(turns, 0, "", use_chars4=True) == []
+    assert select_fold_candidates_for_shortfall(turns, -1, "", use_chars4=True) == []
+
+
+def test_selection_is_oldest_first_and_stops_once_the_shortfall_is_covered():
+    """Tier 2: acceptance ① — oldest-first, stopping at the FIRST point the
+    running total reaches the shortfall (never continuing past it, never
+    stopping short of it). Each turn here is exactly 50 tokens (chars4);
+    a shortfall of 120 needs 3 turns (50+50+50=150 >= 120), not 2
+    (50+50=100 < 120) and not 4."""
+    turns = _history(6)  # seq 1..6, oldest first
+    selected = select_fold_candidates_for_shortfall(turns, 120, "", use_chars4=True)
+    assert [t.seq for t in selected] == [1, 2, 3], (
+        f"expected the oldest 3 turns (just enough to cover a 120-token "
+        f"shortfall at 50 tokens/turn) — got seqs {[t.seq for t in selected]!r}"
+    )
+
+
+def test_selection_never_splits_a_tool_cycle_even_mid_shortfall():
+    """Tier 2: group-aware, matching trim_head/trim_tail's own discipline —
+    an assistant-with-tool_calls turn and its tool-result turns are ONE
+    atomic unit; a shortfall boundary landing inside that unit must still
+    take the whole group, never split it (a split would reach the wire as
+    a dangling call / orphan result)."""
+    turns = [
+        ChatMessage(role="user", content="x" * 40, seq=1),  # 10 tokens
+        ChatMessage(  # 10 tokens, starts a tool cycle
+            role="assistant", content="x" * 40, seq=2,
+            tool_calls=[{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+        ),
+        ChatMessage(role="tool", content="x" * 400, seq=3, tool_call_id="c1"),  # 100 tokens
+        ChatMessage(role="user", content="x" * 40, seq=4),  # 10 tokens
+    ]
+    # Shortfall of 15 lands INSIDE the tool cycle (10 from seq1, then the
+    # 2-turn cycle worth 110 crosses it) — the whole cycle must be taken,
+    # never just seq2 alone.
+    selected = select_fold_candidates_for_shortfall(turns, 15, "", use_chars4=True)
+    assert [t.seq for t in selected] == [1, 2, 3], (
+        f"a shortfall boundary inside a tool cycle must take the WHOLE "
+        f"cycle, never split it — got seqs {[t.seq for t in selected]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CompactionController._select_candidates — head/tail protection unaffected,
+# integrated through the real controller
+# ---------------------------------------------------------------------------
+
+
+def test_head_and_tail_still_protected_even_with_a_large_shortfall():
+    """Tier 2: acceptance ② — head/tail's own protection role is untouched
+    by #5719: regardless of how large the shortfall is, the newest tail
+    turn and the oldest head turn never appear in the candidate set."""
+    history = _history(6)  # head=[t1] (50 tok fits head_budget=50), tail=[t6]
+    engine = _SucceedingEngine(EventLog())
+    ctrl, _collected, _hist = _make_controller(history=history, engine=engine, events=engine._events)
+
+    candidates = ctrl._select_candidates(history, prev_cover=0)
+
+    candidate_seqs = {t.seq for t in candidates}
+    assert 1 not in candidate_seqs, "head turn (seq 1) must never be a fold candidate"
+    assert 6 not in candidate_seqs, "tail turn (seq 6) must never be a fold candidate"
+
+
+def test_middle_that_already_fits_the_window_folds_nothing():
+    """Tier 2: acceptance ① — the real-machine incident's own shape: a
+    middle band that already fits main_M_room must produce ZERO candidates
+    and never call compact() at all (the pre-#5719 code folded it anyway).
+    """
+    history = _history(4)  # head=[t1], tail=[t4], middle=[t2,t3]=100 tok < 150
+    engine = _NeverCalledEngine()
+    ctrl, collected, _hist = _make_controller(history=history, engine=engine, events=engine._events)
+
+    result = asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))
+
+    assert result.candidate_count == 0
+    assert not result.failed
+    started = [e for e in collected if e.type == "compaction_started"]
+    assert not started, "compact() must never be reached when the shortfall is <= 0"
+
+
+def test_only_the_oldest_shortfall_covering_turns_fold_the_rest_survive():
+    """Tier 2: acceptance ① end-to-end — the real-machine shape reproduced
+    through ``force_compact_now`` itself, not just the selector function
+    directly: a middle band LARGER than main_M_room folds only its oldest
+    turns (just enough to close the shortfall) — the newer, un-folded
+    middle turns remain individually in history, never swept into the
+    summary just because they were "between head and tail"."""
+    # head=[t1] (50 tok), tail=[t10] (50 tok), middle=t2..t9 (8 turns, 400
+    # tok) vs. main_M_room=150 -> shortfall=250 -> needs ceil(250/50)=5
+    # oldest middle turns (t2..t6, 250 tok) to close it; t7..t9 survive.
+    history = _history(10)
+    events = EventLog()
+    engine = _SucceedingEngine(events)
+    ctrl, collected, hist = _make_controller(history=history, engine=engine, events=events)
+
+    result = asyncio.run(ctrl.force_compact_now(spill_fn=lambda _candidates: []))
+    asyncio.run(settle(events))
+
+    assert not result.failed
+    assert result.candidate_count == 5, (
+        f"expected exactly the oldest 5 middle turns to close a 250-token "
+        f"shortfall at 50 tokens/turn — got {result.candidate_count}"
+    )
+    started = [e for e in collected if e.type == "compaction_started"]
+    assert started, "expected a real compact() call"
+    assert started[0].data.get("covers_through_seq") == 6, (
+        "the summary must cover only through the oldest folded turn (seq "
+        f"6) — got {started[0].data.get('covers_through_seq')!r}"
+    )
+    # t7..t9 (never folded, never covered) must still be present as
+    # individual turns in history — never silently dropped.
+    surviving_seqs = {m.seq for m in hist if m.role not in ("summary",)}
+    assert {7, 8, 9} <= surviving_seqs, (
+        f"turns beyond the shortfall must survive un-folded — got {surviving_seqs!r}"
+    )

--- a/tests/runtime/test_compaction_controller_invariants.py
+++ b/tests/runtime/test_compaction_controller_invariants.py
@@ -45,10 +45,15 @@ async def _run_and_settle(coro, log):
 
 # Synthetic budgets: head/tail each fit ~one 50-token turn ("x"*200 via chars4),
 # so a 7-turn history yields head=[t1], tail=[t7], middle=[t2..t6] = candidates.
+# #5719: main_M_room=0 — these tests are about is_compacting/failure/summary-
+# append behavior, not the shortfall-selection algorithm itself (that has its
+# own dedicated tests), so main_M_room is set to always produce a shortfall
+# for any nonempty middle, matching the pre-#5719 "select everything between
+# head and tail" shape byte-for-byte for this file's own fixtures.
 _STUB_BUDGETS = ComputedBudgets(
     main_pool=100_000, head_budget=50, body_budget=5_000,
     tail_budget=50, new_msg_budget=10_000,
-    B_M=80_000, main_M_room=65_000, effective_trigger=65_000,
+    B_M=80_000, main_M_room=0, effective_trigger=0,
 )
 
 

--- a/tests/runtime/test_compaction_summary_preamble_1820.py
+++ b/tests/runtime/test_compaction_summary_preamble_1820.py
@@ -25,9 +25,14 @@ from reyn.services.compaction.engine import (
     HistoryChunkToCompact,
 )
 
+# #5719: main_M_room=0 — this file's own tests are about the rendered
+# preamble, not the shortfall-selection algorithm itself (that has its own
+# dedicated tests), so main_M_room always produces a shortfall for any
+# nonempty middle, matching this file's pre-#5719 "everything between
+# head/tail is a candidate" fixture shape.
 _STUB_BUDGETS = ComputedBudgets(
     main_pool=100_000, head_budget=50, body_budget=5_000, tail_budget=50,
-    new_msg_budget=10_000, B_M=80_000, main_M_room=65_000, effective_trigger=65_000,
+    new_msg_budget=10_000, B_M=80_000, main_M_room=0, effective_trigger=0,
 )
 
 


### PR DESCRIPTION
**[tui-coder]** #5719 (A) — `CompactionController._select_candidates` now folds only as much of the unprotected middle as the shortfall against `main_M_room` requires, never "everything between head and tail" unconditionally.

## The defect (architect's own naming, relayed via lead-coder)

Real-machine incident: #5712's own fix let a real compact() call succeed on the owner's machine, but it folded **1.6M raw_middle chars down to a ~3K summary against a 950K window** — the actual shortfall was only ~650K, roughly **600x less** than what was folded. Fold is permanent and irreversible (ADR-0044: "compact — many turns → one summary; permanent"), so over-folding is not merely wasteful — it destroys detail the conversation may still need.

> head/tail are the boundary that answers "what is protected", but were also being used as the selector for "what gets folded". "not protected" and "must be folded" were collapsed into one predicate.

## The fix

head/tail are **unchanged** — still the token-budget protection boundary from #1128 step 3. A separate step now decides how much of the resulting unprotected-and-uncovered middle actually needs to fold: the **shortfall against `main_M_room`**, oldest-first, group-aware (a tool_call and its results never split across the fold boundary — same discipline `trim_head`/`trim_tail` already use), stopping the moment the running total covers the shortfall.

New module-level `select_fold_candidates_for_shortfall` (`engine.py`, next to `trim_head`/`trim_tail`, reusing the same `_group_tool_cycles` helper) is the ONE place this selection logic exists. `_select_candidates` computes the unprotected set exactly as before, measures its total token size, and derives the shortfall from `main_M_room` — already read from the same `ComputedBudgets` it already consults for `head_budget`/`tail_budget`, no new threshold invented.

## Acceptance (lead-coder's own enumeration)

- [x] ① Fold amount derived from the shortfall — oldest-first, stops where it fits
- [x] ② head/tail remain the protection boundary — role not stripped, unchanged code path
- [x] ③ No "fold extra just in case" constant added — `shortfall_tokens <= 0` selects zero candidates; a slack margin is explicitly deferred as a re-open trigger (named in the function's own docstring) rather than invented unmeasured today
- [x] ④ `force_compact_now` is the only caller into this selection logic — no branching added

## Test fixtures updated (not the retry_loop-family zero-diff set)

Six `CompactionController`-level test fixtures relied on "everything between head and tail is a candidate" as their own setup shape, independent of what each test actually verifies (`is_compacting` transitions, failure handling, summary rendering, seq-assignment reach, spill/halving ladder). Updated each to genuinely need a fold: `main_M_room=0` for tests unrelated to the shortfall math itself (matching the pre-#5719 shape byte-for-byte for their own purposes), or a real, measured shortfall for the two using a real `CompactionEngine` (values verified directly against `ComputedBudgets`, not assumed — same discipline those files' own comments already establish).

New `tests/runtime/test_5719_compact_folds_only_the_shortfall.py` (6 tests): the selection function directly (shortfall ≤ 0 → `[]`, oldest-first stop-at-threshold, tool-cycle group-awareness) and through the real `CompactionController` end-to-end (head/tail still protected under a large shortfall; a middle that already fits folds nothing and never calls `compact()`; a middle over budget folds only its oldest shortfall-covering turns and the rest survive un-folded in history).

Docs checked (`docs/concepts/data-retrieval/chat-compaction.md`, `docs/reference/runtime/events.md`) for a stale "everything between head/tail folds" claim — found none; both describe the general head/body/tail shape and `retry_loop`'s own separate mid-ladder, neither of which asserted `CompactionController`'s specific selection behavior.

## Verification status

- **Confirmed via synthetic tests here**: new test file 6/6 pass; scoped compaction/retry_loop sweep (321 tests) passes; falsify-verified (Edit-break-then-restore) — removing the stop condition turns exactly the 3 tests that depend on it red; all local gates (ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`) pass.
- Per standing instruction, full pytest was NOT run locally — scoped only; CI runs the full suite.
- **NOT verified on the real machine** — the owner has left for the day; no urgency was asked for, correctness was prioritized over speed per explicit instruction.

## Test plan

- [x] `pytest tests/runtime/test_5719_compact_folds_only_the_shortfall.py` — 6/6 pass
- [x] Scoped compaction/retry_loop sweep — 321 passed, 4 skipped (unrelated missing extras)
- [x] Falsify: removed the shortfall stop condition — exactly the 3 dependent tests failed (restored)
- [x] (skipped — full suite is CI's responsibility)

Closes #5719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
