### PR TITLE
fix(#5720): a reactive spill's durable record carries the real turn's seq, not a silently-defaulted one

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -904,8 +904,15 @@ class RouterLoopDriver:
                             self._router_main_call_for_retry,
                             loop=loop, user_text=user_text,
                         ),
+                        # #5720 ②: the fold callback (below) already
+                        # receives seq_by_id — the spill callback did not,
+                        # so mid's own seq_fn (_mid_seq_of) silently fell
+                        # back to a default instead of the turn's real
+                        # provenance (architect ruling: "provenance is not
+                        # structurally absent, only unwired").
                         spill_fn=_partial(
-                            self._spill_batch_for_retry, chain_id=chain_id,
+                            self._spill_batch_for_retry,
+                            chain_id=chain_id, seq_by_id=payload.seq_by_id,
                         ),
                         on_summary_used=_partial(
                             self._persist_recovery_fold, seq_by_id=payload.seq_by_id,
@@ -971,18 +978,44 @@ class RouterLoopDriver:
                     # recovering THIS turn's overflow).
                     await self._compaction_controller.force_compact_now(
                         spill_fn=_partial(
-                            self._spill_batch_for_retry, chain_id=chain_id,
+                            self._spill_batch_for_retry,
+                            chain_id=chain_id, seq_by_id=payload.seq_by_id,
                         ),
                     )
                 raise
         return _shim.usage
 
     @staticmethod
-    def _mid_seq_of(_idx: int, turn: dict) -> int:
-        """Pre-#5592 mid convention: the turn's own ``seq``, else 1. A named
-        function rather than the lambda this used to be (#5631) — it captures
-        nothing, and the closure count is the gate."""
-        return turn.get("seq", 1)
+    def _mid_seq_of(_idx: int, turn: dict, *, seq_by_id: "dict[int, int]") -> int:
+        """#5720 ② (architect ruling): mid's own wire dicts carry no ``seq``
+        field at all (``SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ``) — the
+        pre-#5720 ``turn.get("seq", 1)`` therefore ALWAYS fell to the
+        default, silently. The real per-turn seq was never structurally
+        absent: it already sits one keyword away, in ``on_summary_used``'s
+        own ``seq_by_id`` (``_persist_recovery_fold``'s own param, same
+        ``decompose_history_for_retry``-derived ``id(wire_dict) -> real
+        seq`` map) — the spill callback simply never received it. Passed
+        explicitly here (#5631's own discipline: no closures) rather than
+        threaded through a new instance attribute.
+
+        ``.get(id(turn), 1)`` keeps the SAME 1-fallback the old code had —
+        this is genuinely defensive now (every candidate handed to spill
+        originates from the SAME decomposition ``seq_by_id`` was built
+        from, so a miss should not occur in practice), not a silent
+        "provenance unresolved, looks resolved" default the way the
+        pre-#5720 unconditional fallback was.
+
+        This value feeds `save_tool_result`'s own `seq=` — that field is
+        the store's naming ORDINAL (head/tail's `idx + 1` genuinely is
+        just position, unaffected, unchanged by this fix) and, via
+        `spill_turn_content`'s own `SPILL_TARGET_SEQ_META_KEY`, the spill
+        record's own PROVENANCE (which real history turn this offload
+        target was) — for mid specifically these were always meant to be
+        the SAME value (the turn's real seq), never two competing facts
+        sharing one field; the pre-#5720 bug was that the shared value was
+        wrong for mid, not that mid needed a second, parallel field.
+        """
+        return seq_by_id.get(id(turn), 1)
 
     async def _persist_recovery_fold(
         self,
@@ -1036,11 +1069,18 @@ class RouterLoopDriver:
         )
 
     def _spill_batch_for_retry(
-        self, candidates: "list[dict]", *, chain_id: str,
+        self, candidates: "list[dict]", *,
+        chain_id: str, seq_by_id: "dict[int, int]",
     ) -> "list[tuple[int, dict]]":
         """#5531 §10 rung①: the spill batch retry_loop is handed. Was a closure
         in ``_run_with_shrink``; ``chain_id`` is the one value it captured and
         is now passed explicitly (#5631).
+
+        ``seq_by_id`` (#5720 ②): the SAME ``decompose_history_for_retry``-
+        derived ``id(wire_dict) -> real seq`` map ``on_summary_used``'s own
+        ``_persist_recovery_fold`` already receives from this method's own
+        callers — threaded through to :meth:`_mid_seq_of` (see its own
+        docstring for why this was previously silently unwired).
         """
         # #5531 §10 rung① / #9.6: injected into retry_loop, not
         # imported by it — matches ``context_budget_advisor.py``'s
@@ -1071,9 +1111,10 @@ class RouterLoopDriver:
         _edits = self._spill_batch_within_face(
             candidates, chain_id=chain_id,
             granularity=self._compaction.spill_granularity,
-            # Pre-#5592 mid convention: the turn's own ``seq``
-            # field, falling back to 1 — unchanged.
-            seq_fn=self._mid_seq_of,
+            # #5720 ②: the turn's own REAL seq, resolved via seq_by_id —
+            # see _mid_seq_of's own docstring for why the pre-#5720
+            # `turn.get("seq", 1)` always fell to the fallback.
+            seq_fn=_partial(self._mid_seq_of, seq_by_id=seq_by_id),
         )
         if _edits:
             return _edits

--- a/tests/runtime/test_5720_spill_carries_real_turn_provenance.py
+++ b/tests/runtime/test_5720_spill_carries_real_turn_provenance.py
@@ -1,0 +1,170 @@
+"""Tier 2: #5720 ② — a reactive (mid) spill's durable ``spill_record`` now
+carries the REAL history turn it targeted, not a silently-defaulted ``1``.
+
+architect's own naming of the defect: the fold callback
+(``RouterLoopDriver._persist_recovery_fold``) already receives ``seq_by_id``
+(``decompose_history_for_retry``'s own ``id(wire_dict) -> real seq`` map —
+the ONLY way to recover a real seq from a wire dict, which structurally
+carries none, ``SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ``). The spill
+callback (``_spill_batch_for_retry``) sits in the SAME call block and did
+not — its own ``_mid_seq_of`` fell back to ``turn.get("seq", 1)``, which
+for a wire dict is ALWAYS the default. Provenance was never structurally
+absent; it was one keyword away and unwired.
+
+``seq`` itself (``MediaStore.save_tool_result``'s own kwarg) is NOT
+repurposed — it is still the store's naming ordinal (head/tail's
+``idx + 1`` is untouched, unaffected by this fix). For the mid path
+specifically, that ordinal was ALWAYS meant to carry the turn's real seq
+(mid has no positional convention the way head/tail do) — fixing
+``_mid_seq_of`` to genuinely resolve it via ``seq_by_id`` corrects both
+the store's own filename uniqueness for mid entries AND the pre-existing,
+dedicated provenance field this record already carries
+(``SPILL_TARGET_SEQ_META_KEY`` — a real field, not one this PR invents).
+
+Real ``RouterLoopDriver`` + real ``RouterHistoryBuffer`` + real
+``MediaStore``; the only stand-ins are the collaborators
+``test_slash_model_router_integration.py``'s own real-driver test already
+tolerates as fakes (``RouterHostAdapter``, budget tracker) — none of which
+``_spill_batch_for_retry``'s own code path reads.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.chat_message import SPILL_TARGET_SEQ_META_KEY, ChatMessage
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from reyn.runtime.services.router_loop_driver import RouterLoopDriver
+from tests._support.events import collect_events
+
+
+class _FakeRouterHost:
+    """Minimal stand-in — ``_spill_batch_for_retry``'s own code path never
+    reads it (same tolerance ``test_slash_model_router_integration.py``'s
+    own real-driver test already establishes for this exact collaborator)."""
+
+    def _set_cancel_event(self, event):
+        pass
+
+
+class _FakeBudget:
+    def check_and_increment_router_cap(self, text):
+        pass
+
+    def extend_router_cap(self, n):
+        pass
+
+    def add_router_usage(self, **kwargs):
+        pass
+
+
+class _FakeBudgetAdvisor:
+    async def enforce_new_msg_budget(self, **kwargs):
+        pass
+
+
+async def _noop_limit_checkpoint(**kwargs):
+    from types import SimpleNamespace
+    return SimpleNamespace(allow_continue=True, extension=1)
+
+
+def _make_real_driver(tmp_path, *, history: "list"):
+    from reyn.config.chat import SafetyConfig
+    from reyn.data.workspace.media_store import MediaStore
+    store = MediaStore(
+        project_root=tmp_path, agent_name="t-agent", session_id="t-session",
+    )
+    events = EventLog()
+    compaction_cfg = CompactionConfig(use_chars4_estimate=True)
+    history_buffer = RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=compaction_cfg,
+        compaction_controller=None,
+        model_fn=lambda: "test-model",
+        events=events,
+        media_store=store,
+        router_host=None,
+        universal_wrappers_enabled=False,
+        non_interactive=True,
+        history_appender=history.append,
+    )
+    driver = RouterLoopDriver(
+        router_host=_FakeRouterHost(),
+        safety=SafetyConfig(),
+        router_max_iterations=1,
+        budget_tracker=_FakeBudget(),
+        non_interactive=True,
+        exclude_tools=set(),
+        budget=_FakeBudget(),
+        resolver=None,
+        compaction=compaction_cfg,
+        compaction_controller=None,
+        token_learner=None,
+        events=events,
+        model_override_fn=lambda: None,
+        history_buffer=history_buffer,
+        budget_advisor=_FakeBudgetAdvisor(),
+        limit_checkpoint_fn=_noop_limit_checkpoint,
+        next_seq_fn=lambda: 0,
+        append_history_fn=history.append,
+    )
+    return driver, events
+
+
+def _big_wire_turn(seq: int) -> dict:
+    """A mid-face wire dict — role+content only, structurally NO ``seq``
+    field (the exact shape ``decompose_history_for_retry`` hands
+    ``retry_loop``, ``SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ``'s own
+    subject) — ``seq`` here names the REAL history turn only via the
+    ``seq_by_id`` map a caller supplies out of band, never via a key on
+    this dict itself."""
+    return {"role": "tool", "content": "Y" * 50_000, "spillability": "first_choice"}
+
+
+def test_spill_record_carries_the_real_turn_seq_not_a_defaulted_one(tmp_path):
+    """Tier 2: #5720 ② — spilling a mid candidate with a REAL, distinct
+    seq_by_id entry produces a durable spill_record whose
+    SPILL_TARGET_SEQ_META_KEY is that real seq — never the pre-#5720
+    default of 1."""
+    history: "list[ChatMessage]" = []
+    driver, events = _make_real_driver(tmp_path, history=history)
+    collect_events(events)
+
+    turn = _big_wire_turn(seq=77)
+    seq_by_id = {id(turn): 77}
+
+    edits = driver._spill_batch_for_retry(
+        [turn], chain_id="c1", seq_by_id=seq_by_id,
+    )
+
+    assert edits, "expected a real spill edit — the candidate is large and eligible"
+    records = [m for m in history if m.role == "spill_record"]
+    assert records, "expected a durable spill_record entry"
+    assert records[-1].meta.get(SPILL_TARGET_SEQ_META_KEY) == 77, (
+        f"expected the real turn seq (77), got "
+        f"{records[-1].meta.get(SPILL_TARGET_SEQ_META_KEY)!r}"
+    )
+
+
+def test_spill_record_falls_back_to_1_only_when_provenance_is_genuinely_unavailable(
+    tmp_path,
+):
+    """Tier 2: falsify pair (deny side) — when the candidate's own id is
+    genuinely absent from seq_by_id (provenance truly could not be
+    resolved, not merely unwired), the defensive fallback still produces
+    a record rather than crashing — same shape the pre-#5720 code had,
+    now reached only in the genuinely-unresolvable case instead of
+    always."""
+    history: "list[ChatMessage]" = []
+    driver, events = _make_real_driver(tmp_path, history=history)
+    collect_events(events)
+
+    turn = _big_wire_turn(seq=77)
+    empty_seq_by_id: "dict[int, int]" = {}
+
+    edits = driver._spill_batch_for_retry(
+        [turn], chain_id="c1", seq_by_id=empty_seq_by_id,
+    )
+
+    assert edits, "expected a real spill edit regardless of provenance resolution"
+    records = [m for m in history if m.role == "spill_record"]
+    assert records[-1].meta.get(SPILL_TARGET_SEQ_META_KEY) == 1


### PR DESCRIPTION
**[tui-coder]** #5720 ② (partial GO, architect ruling) — a reactive spill's durable `spill_record` now carries the REAL history turn it targeted, not a silently-defaulted `1`. **Part of #5720** — ① is still open, reported separately below as a measurement, not this PR.

## The defect (architect's own naming)

The fold callback (`RouterLoopDriver._persist_recovery_fold`) already receives `seq_by_id` — `decompose_history_for_retry`'s own `id(wire_dict) -> real seq` map, the ONLY way to recover a real seq from a wire dict (which structurally carries none, `SeqUnavailable.WIRE_DICTS_CARRY_NO_SEQ`). The spill callback (`_spill_batch_for_retry`) sits in the exact same call block and never received it:

```python
spill_fn=_partial(self._spill_batch_for_retry, chain_id=chain_id),                    # no seq_by_id
on_summary_used=_partial(self._persist_recovery_fold, seq_by_id=payload.seq_by_id),   # has it
```

`_mid_seq_of` therefore always fell back to `turn.get("seq", 1)` — a wire dict never has that key, so this was **always** the default. Provenance was never structurally absent — it was one keyword away and unwired.

## The fix

Threaded `seq_by_id` into `_spill_batch_for_retry` (both real call sites) and `_mid_seq_of`, which now resolves `seq_by_id.get(id(turn), 1)`. `SeqUnavailable` is not needed.

`MediaStore.save_tool_result`'s own `seq=` kwarg is **unchanged in meaning** — still the store's naming ordinal (head/tail's `idx + 1` usage is untouched, unaffected). For the mid path specifically, that ordinal was always intended to carry the turn's real seq (mid has no positional convention the way head/tail do) — fixing it corrects both the store's own filename uniqueness for mid entries AND the pre-existing, dedicated provenance field the resulting `spill_record` already carries (`SPILL_TARGET_SEQ_META_KEY` — a real field already in `chat_message.py`, not one this PR invents).

## Test / falsify

New `tests/runtime/test_5720_spill_carries_real_turn_provenance.py` (2 tests, real `RouterLoopDriver` + real `RouterHistoryBuffer` + real `MediaStore`): a spill with a real, distinct `seq_by_id` entry produces a `spill_record` whose `SPILL_TARGET_SEQ_META_KEY` is that real seq; the deny-side pair confirms the defensive `1`-fallback still fires (no crash) when a candidate's id is genuinely absent from `seq_by_id`. Falsify-verified (Edit-break-then-restore): reverting `_mid_seq_of` to `turn.get("seq", 1)` turns the accept-side test red.

## Scope

- ② GO — this PR.
- ③ GO — no code change (`artifacts_referenced` stays an LLM-output echo, not repurposed as a carry mechanism).
- ① — **still open.** Reported separately as a measurement (per architect's own go/no-go condition and lead-coder's instruction not to mix it with this implementation) — see the accompanying report.

## Verification status

- **Confirmed via synthetic tests here**: new test file 2/2 pass; scoped spill/retry_loop sweep (183 tests) passes; falsify-verified; all local gates (ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`) pass. No new audit-event kinds introduced.
- Per standing instruction, full pytest was NOT run locally — scoped only; CI runs the full suite.

## Test plan

- [x] `pytest tests/runtime/test_5720_spill_carries_real_turn_provenance.py` — 2/2 pass
- [x] Scoped spill/retry_loop sweep — 183 passed, 4 skipped (unrelated missing extras)
- [x] Falsify: reverted `_mid_seq_of` to the old default — accept-side test failed (restored)
- [x] (skipped — full suite is CI's responsibility)

part of #5720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
