### PR TITLE
fix(#5720): wire seq_by_id through /compact's own real spill call -- main was red

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -372,7 +372,17 @@ class CompactionController:
 
     async def force_compact_now(
         self, *,
-        spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]]",
+        # #5726: widened from Callable[[list[dict]], ...] -- the real
+        # production spill_fn (RouterLoopDriver._spill_batch_for_retry,
+        # bound via functools.partial(..., chain_id=...)) requires a
+        # seq_by_id kwarg _spill_fn_adapted (below) now always supplies,
+        # freshly computed per shrink attempt (see that function's own
+        # comment for why it cannot be pre-bound the way chain_id is).
+        # `...` (not a stricter Protocol) matches this file's own existing
+        # understated-type precedent for this parameter (chain_id was
+        # ALREADY invisible to the declared type, bound via partial,
+        # before this widening).
+        spill_fn: "Callable[..., list[tuple[int, dict]]]",
         spill_capability_present: bool = True,
     ) -> ForceCompactResult:
         """Synchronous force-trigger — single pass (#1128 PR-c).
@@ -604,7 +614,9 @@ class CompactionController:
         candidates: list[ChatMessage],
         previous_summary: ChatMessage | None,
         *,
-        spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]]",
+        # #5726: widened -- see force_compact_now's own comment on this
+        # same parameter name above.
+        spill_fn: "Callable[..., list[tuple[int, dict]]]",
         spill_capability_present: bool = True,
     ) -> None:
         """Call the compaction engine and persist the resulting summary entry."""
@@ -734,7 +746,29 @@ class CompactionController:
                 {**item, "content": item.get("text", ""), "spillability": _spillability_by_index[i]}
                 for i, item in enumerate(offered)
             ]
-            edits = spill_fn(content_shaped)
+            # #5720/#5725 -> #5726: RouterLoopDriver._spill_batch_for_retry
+            # (spill_fn's real production implementation, bound via
+            # functools.partial(..., chain_id="manual-compact") in
+            # session.py's own _compact_now_for_op) made seq_by_id a
+            # REQUIRED kwarg — #5725 wired it for retry_loop's own
+            # reactive spill_fn partial (built with the real seq_by_id
+            # already in hand at THAT construction time), but left this
+            # (operator-driven /compact) call site unwired -> TypeError,
+            # the 5th instance of #5712's own "reactive protected /
+            # operator-driven bare" asymmetry this arc keeps finding.
+            #
+            # Unlike the reactive path, seq_by_id cannot be baked into
+            # session.py's own partial at construction time — content_
+            # shaped is rebuilt fresh, per shrink attempt, only here.
+            # But `_turn_to_compactor_input` (the wire-shape builder that
+            # produced `item` before this adapter ever saw it) already
+            # stamps a real `"seq"` field on every turn (this repo's own
+            # `new_turns` shape, `{role, text, seq, ...}`) — no side
+            # channel is needed the way the reactive path's own decompose
+            # step required one; the real seq is already sitting on each
+            # dict, unlike `decompose_history_for_retry`'s wire dicts.
+            seq_by_id = {id(d): d["seq"] for d in content_shaped}
+            edits = spill_fn(content_shaped, seq_by_id=seq_by_id)
             return [
                 (idx, {**offered[idx], "text": replacement.get("content", offered[idx].get("text", ""))})
                 for idx, replacement in edits

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -976,10 +976,27 @@ class RouterLoopDriver:
                     # own retry_loop call above already used (this
                     # fallback pass is still semantically part of
                     # recovering THIS turn's overflow).
+                    #
+                    # #5726: `seq_by_id` is deliberately NOT bound here
+                    # (unlike the retry_loop call above, this call site's
+                    # own `payload.seq_by_id` would be STALE for what
+                    # `force_compact_now` actually offers — a fresh
+                    # `_run_compaction` candidate read from disk, not
+                    # `payload`'s own wire dicts). `compaction_controller.
+                    # py`'s own `_spill_fn_adapted` now computes a fresh,
+                    # correct `seq_by_id` from the wire dicts it actually
+                    # builds and calls this partial with it explicitly —
+                    # binding one here too would collide (`got multiple
+                    # values for keyword argument 'seq_by_id'`), the exact
+                    # class of bug #5725 introduced for the OTHER
+                    # force_compact_now caller (session.py, unwired
+                    # entirely) — this caller was wired, just to a value
+                    # that would now double-bind rather than one that
+                    # would ever have matched `_run_compaction`'s own
+                    # fresh candidates in the first place.
                     await self._compaction_controller.force_compact_now(
                         spill_fn=_partial(
-                            self._spill_batch_for_retry,
-                            chain_id=chain_id, seq_by_id=payload.seq_by_id,
+                            self._spill_batch_for_retry, chain_id=chain_id,
                         ),
                     )
                 raise

--- a/tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py
+++ b/tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py
@@ -187,7 +187,13 @@ def _spilling_one_content_shaped_candidate_at_a_time(
     were OFFERED on each call (``spill_calls``), so a test can assert on
     call count without pinning an internal iteration count."""
 
-    def _spill_fn(offered: "list[dict]") -> "list[tuple[int, dict]]":
+    def _spill_fn(
+        offered: "list[dict]", *, seq_by_id: "dict[int, int] | None" = None,
+    ) -> "list[tuple[int, dict]]":
+        # #5726: force_compact_now's own real spill_fn contract now also
+        # passes seq_by_id (compaction_controller.py's own _spill_fn_
+        # adapted always supplies one) — accepted and ignored here, this
+        # fixture's own subject is spill engagement, not provenance.
         spill_calls.append(len(offered))
         for idx, item in enumerate(offered):
             if item.get("spillability") == "never":
@@ -258,7 +264,11 @@ async def test_mid_floor_records_that_spill_was_offered():
     engine = _OverflowsUntilFewEnoughEngine(events, fits_at_or_below_chars=0)
     ctrl, _collected, _hist = _make_controller(history=history, engine=engine, events=events)
 
-    def _never_spillable(_offered: "list[dict]") -> "list[tuple[int, dict]]":
+    def _never_spillable(
+        _offered: "list[dict]", *, seq_by_id: "dict[int, int] | None" = None,
+    ) -> "list[tuple[int, dict]]":
+        # #5726: accepted and ignored -- see _spilling_one_content_shaped_
+        # candidate_at_a_time's own comment for why.
         return []  # every real spill_fn answer is "nothing eligible"
 
     result = await ctrl.force_compact_now(spill_fn=_never_spillable)
@@ -330,7 +340,11 @@ async def test_falls_through_to_halving_when_nothing_is_spillable():
     engine = _OverflowsUntilFewEnoughEngine(events, fits_at_or_below_chars=810)
     ctrl, _collected, hist = _make_controller(history=history, engine=engine, events=events)
 
-    def _never_spillable(_offered: "list[dict]") -> "list[tuple[int, dict]]":
+    def _never_spillable(
+        _offered: "list[dict]", *, seq_by_id: "dict[int, int] | None" = None,
+    ) -> "list[tuple[int, dict]]":
+        # #5726: accepted and ignored -- see _spilling_one_content_shaped_
+        # candidate_at_a_time's own comment for why.
         return []
 
     result = await ctrl.force_compact_now(spill_fn=_never_spillable)


### PR DESCRIPTION
**[e2e-coder]** part of #5720

## Why main was red

#5725 made `seq_by_id` a REQUIRED kwarg on `RouterLoopDriver._spill_batch_for_retry`
and correctly wired the retry_loop-reactive caller, but left the
operator-driven `/compact` caller (`session.py`'s own
`_compact_now_for_op` → `force_compact_now` → `compaction_controller.py`'s
own `_spill_fn_adapted` → the bare `functools.partial(_spill_batch_for_
retry, chain_id="manual-compact")`) unwired — a real `TypeError` the
moment `/compact`'s own shrink ladder needed to spill. **The 5th
instance of #5712's own named class this arc keeps finding**: a
reactive path protected, an operator-driven one bare.

Confirmed genuinely broken on a clean `origin/main` before this fix:
`test_5712_compact_shares_shrink_ladder_with_spill.py::test_session_
wiring_drives_the_real_router_loop_driver_spill_implementation` failed
(the final shrink attempt never fit — spill silently never engaged).

## Fix

Unlike the reactive path (whose `seq_by_id` is known up front, at
partial-construction time), `/compact`'s own wire dicts are rebuilt
fresh per shrink attempt inside `_spill_fn_adapted` — but
`_turn_to_compactor_input` already stamps a real `"seq"` field on every
turn it builds (the `new_turns` wire shape), so no side-channel map is
needed the way the reactive path's own decompose step required one.
`_spill_fn_adapted` now builds `{id(d): d["seq"] for d in
content_shaped}` and passes it through explicitly.

## A second, independent bug this surfaced

`router_loop_driver.py`'s OWN 2nd `force_compact_now` caller (the
post-retry_loop-exhaustion fallback pass) pre-bound
`seq_by_id=payload.seq_by_id` via partial — but `force_compact_now`
reads FRESH candidates from disk, not from `payload`, so those `id()`
keys never matched anything real even before this PR (a silent no-op,
not merely a collision this PR would have introduced). Removed that
pre-binding; `_spill_fn_adapted`'s own fresh computation now serves
BOTH `force_compact_now` callers uniformly — one computation, not two,
matching the arc's own "no second mechanism" discipline.

## Type widening + 3 test doubles fixed

`spill_fn`'s own declared type widened
(`Callable[[list[dict]], ...]` → `Callable[..., ...]`) to reflect the
real contract — the 3 test-double `spill_fn` implementations in
`test_5712`'s own suite broke under the stricter single-arg call once
`_spill_fn_adapted` started always passing `seq_by_id` (a real
regression this PR's own gates caught, not merely inherited); they now
accept and ignore `seq_by_id`, matching production's own real spill_fn
shape.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5712_compact_shares_shrink_ladder_with_spill.py` — 7/7 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- [x] (skipped — docs not touched, no doc gate applies)
- [x] `pytest` scoped to the diff — a 124-test compaction/spill sibling sweep, all green; `test_5712`'s own previously-red witness (`test_session_wiring_drives_the_real_router_loop_driver_spill_implementation`) confirmed green
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
