### PR TITLE
feat(#5588): shrink-flow progress becomes a single flowview entry, with a real spinner

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
+++ b/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
@@ -86,7 +86,25 @@ ELAPSED_SECS_KEY = "_elapsed_secs"
 #: state instead of the latest frame's text.
 PIPELINE_RUN_KEY = "_pipeline_run_id"
 
+#: #5588: marks a row as the ONE shrink-flow (compaction/overflow-recovery)
+#: progress entry for the attached session's CURRENT recovery episode —
+#: mirrors :data:`PIPELINE_RUN_KEY`'s own shape exactly (a presence-only
+#: marker the presenter dispatches on, never a run/episode identity value
+#: itself; the entry is looked up by ``app.py``'s own single
+#: ``self._compaction_progress_entry`` reference, not by a keyed dict, since
+#: only ONE shrink flow can be in flight for an attached session at a time).
+#: :data:`RUNNING_SINCE_KEY`/:data:`ELAPSED_SECS_KEY` (above) drive this
+#: row's own spinner/settled-elapsed exactly as they already do for a tool
+#: call — no new spinner vocabulary. The progress FIGURES themselves
+#: (spill_done/spill_total/call_count/is_compacting/terminal) live under
+#: this SAME row's other, integer/bool/str-only meta keys — see
+#: ``presenter.py``'s own render function for the exact set: "the numbers
+#: are what the row is actually about" (:data:`PIPELINE_RUN_KEY`'s own
+#: docstring precedent — never parsed back out of rendered text).
+COMPACTION_PROGRESS_KEY = "_compaction_progress"
+
 __all__ = [
+    "COMPACTION_PROGRESS_KEY",
     "ELAPSED_SECS_KEY",
     "PIPELINE_RUN_KEY",
     "ORPHANED_RESULT_KIND",

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -93,11 +93,7 @@ from .chrome import (
     status_line_text,
 )
 from .compact import compact_caps
-from .compaction_progress import (
-    CompactionProgressRow,
-    CompactionProgressSnapshot,
-    compaction_progress_lines,
-)
+from .compaction_progress import compaction_failure_text
 from .completion import CompletionPopup, CompletionState, compute_completion
 from .gutter import (
     _RUNNING_FRAME_PERIOD,
@@ -108,6 +104,7 @@ from .gutter import (
 from .intervention_panel import InterventionPanel
 from .loop_probe import LoopTripwire
 from .presenter import (
+    _COMPACTION_PROGRESS_KEY,
     _RESULT_KIND_KEY,
     _RESULT_META_KEY,
     _RUNNING_SINCE_KEY,
@@ -1498,6 +1495,22 @@ class TextualChatApp(App):
         #: One row per pipeline RUN, keyed by ``run_id`` — every step frame for
         #: that run folds into it (:meth:`_coalesce_pipeline_step`).
         self._pipeline_runs: "dict[str, Entry[OutboxMessage]]" = {}
+        #: #5588: the ONE row for the attached session's current shrink-flow
+        #: episode — a plain reference, not a dict keyed by episode number
+        #: (:meth:`_coalesce_pipeline_step`'s own precedent), since only one
+        #: episode can be in flight for an attached session at a time.
+        #: ``None`` whenever no episode is running (mirrors ``_pipeline_
+        #: runs`` NOT holding a settled run's entry any more).
+        self._compaction_progress_entry: "Entry[OutboxMessage] | None" = None
+        #: The session's own ``compaction_progress_raw()["terminal_seq"]``
+        #: value at the moment :attr:`_compaction_progress_entry` was
+        #: created — read again at settle time to tell "a NEW unrecovered
+        #: failure fired during THIS entry's lifetime" apart from "the
+        #: field still holds an older episode's stale value" (the counter
+        #: is durable/never episode-joined in ``session.py``, precisely so
+        #: it survives long enough to be read here; see that field's own
+        #: docstring).
+        self._compaction_progress_terminal_baseline: int = 0
         # ALL pending interventions' flow entries (#3299 P2 — was single-slot
         # in P1, overwritten by a second concurrent pending intervention, an
         # architect self-review finding: ``outstanding_interventions`` is a
@@ -1955,12 +1968,12 @@ class TextualChatApp(App):
             )
             if config_warning is not None:
                 yield ConfigWarningLine(config_warning, id="config-warning")
-            # #5588: always composed (matching ActivityRow's own "created
-            # hidden, shown/hidden live via a reactive attribute" shape) —
-            # never conditionally yielded like ConfigWarningLine above,
-            # since whether compaction is running can change many times
-            # within one session, unlike a config-key count fixed at boot.
-            yield CompactionProgressRow(id="compaction-progress")
+            # #5588: shrink-flow progress no longer lives in a standalone
+            # chrome row here (owner: "今の表示だと分からん... 開始〜終了は
+            # 単一 flowview entry or group にして") — it is now ONE flowview
+            # entry (:meth:`_refresh_compaction_progress`,
+            # ``self._compaction_progress_entry``), same family as a
+            # RUNNING tool-call row, not a chrome sibling of MenuBar.
             # Bottom chrome: a focusable menu row that also carries the slim
             # status-values segment (#3326: MenuBar owns placing StatusLine on
             # whichever row has room, collapsing the two previously-separate rows
@@ -4945,6 +4958,18 @@ class TextualChatApp(App):
         if kind == "status" and meta.get("source") == "pipeline":
             if self._coalesce_pipeline_step(msg):
                 return
+        # #5588: a shrink-flow episode's own started/completed/failed
+        # markers (``lifecycle_forwarder``'s own ``compaction_episode_
+        # marker`` tag) absorb into the SAME single flowview entry the
+        # episode's progress lives on, TUI-local — the source emission is
+        # UNCHANGED (other surfaces with no episode-entry mechanism, e.g.
+        # AG-UI, still receive these frames exactly as before). Absorbed
+        # only while an entry is actually open; a marker arriving with no
+        # open entry (a REMOTE reconnect mid-episode, or the entry already
+        # settled) falls through and appends as its own row rather than
+        # being silently dropped.
+        if meta.get("compaction_episode_marker") and self._compaction_progress_entry is not None:
+            return
         op_id = meta.get("op_id")
         if kind in ("tool_call_completed", "tool_call_failed") and op_id is not None:
             started = self._running_tools.pop(op_id, None)
@@ -6812,36 +6837,148 @@ class TextualChatApp(App):
         menubar.update_status(self._status_text(snap))
 
     def _refresh_compaction_progress(self, snap: "dict | None | object" = _UNSET) -> None:
-        """#5588: re-render the shrink-flow progress chrome row from a fresh
-        snapshot (or the already-read ``snap``) — the "down" trigger for
-        :class:`CompactionProgressRow`'s own ``reactive`` ``lines``
-        attribute, matching :meth:`_refresh_status`'s own shape exactly.
+        """#5588 (owner: "今の表示だと分からん... 開始〜終了は単一 flowview
+        entry or group にして"): create/update/settle the ONE flowview
+        entry for the attached session's CURRENT shrink-flow episode, from
+        a fresh snapshot (or the already-read ``snap``) — matches
+        :meth:`_refresh_status`'s own per-frame, event-driven trigger (see
+        ``_refresh_live_chrome``'s own docstring: this runs on every
+        arriving frame, DISPLAY or audit-EVENT alike, never a fixed-
+        interval poll).
+
+        Mirrors :meth:`_coalesce_pipeline_step`/:meth:`_settle_pipeline_
+        run`'s own "one row folds a whole multi-event episode" shape
+        exactly (the precedent lead-coder's #5588 review pointed at,
+        rather than a new mechanism) — :meth:`_ensure_compaction_progress_
+        entry` creates the row once and starts its spinner
+        (:meth:`_begin_running_indicator`'s own live-spinner convention,
+        never a new visual vocabulary), each call while running re-derives
+        the row's body from the CURRENT snapshot's numbers (never text —
+        see ``presenter.py``'s own ``_compaction_progress_body``), and
+        :meth:`_settle_compaction_progress` stops the spinner and gives the
+        row a terminal state exactly once (success or failure, never
+        zero — owner's own real-machine report that ``compaction_failed``
+        firing is something they rely on seeing).
+
         Absent snapshot key (a REMOTE connection, which does not report
         this yet — see ``status.py``'s own #5588 comment) degrades to
-        ``is_compacting=False``, never a fabricated value."""
-        try:
-            row = self.query_one(CompactionProgressRow)
-        except Exception:
-            return  # not yet mounted
+        ``is_compacting=False`` and settles any open entry as SUCCESS
+        (never a fabricated failure) — never a spinner left running for a
+        fact this connection cannot see.
+        """
         snapshot = self._snapshot() if snap is _UNSET else snap
         snapshot = snapshot or {}
         if not snapshot.get("compaction_progress_reported", True):
-            row.lines = ["compaction progress not reported on this connection"]
+            self._settle_compaction_progress(terminal_text=None)
             return
         raw = snapshot.get("compaction_progress_raw") or {}
-        row.lines = compaction_progress_lines(
-            CompactionProgressSnapshot(
-                is_compacting=raw.get("is_compacting", False),
-                spill_done=(
-                    raw["raw_middle_total"] - raw["raw_middle_remaining"]
-                    if raw.get("raw_middle_total") is not None
-                    and raw.get("raw_middle_remaining") is not None
-                    else None
-                ),
-                spill_total=raw.get("raw_middle_total"),
-                call_count=raw.get("upstream_recovery_call_count"),
-            )
+        is_compacting = bool(raw.get("is_compacting", False))
+        meta = {
+            "is_compacting": is_compacting,
+            "spill_done": (
+                raw["raw_middle_total"] - raw["raw_middle_remaining"]
+                if raw.get("raw_middle_total") is not None
+                and raw.get("raw_middle_remaining") is not None
+                else None
+            ),
+            "spill_total": raw.get("raw_middle_total"),
+            "call_count": raw.get("upstream_recovery_call_count"),
+        }
+        if is_compacting:
+            self._ensure_compaction_progress_entry(raw)
+            entry = self._compaction_progress_entry
+            if entry is None:
+                return
+            try:
+                entry.set_item(replace(entry.item, meta={**entry.item.meta, **meta}))
+            except Exception:
+                logger.exception("textual chat: could not update compaction progress row")
+            return
+        # #5588 acceptance ③: a NEW terminal_seq since this entry was
+        # created is the ONLY thing that makes this an ERROR settle — a
+        # stale (already-baselined) terminal value from an EARLIER episode
+        # must never re-fail a episode that actually just succeeded.
+        terminal_text = None
+        terminal_seq = raw.get("terminal_seq")
+        terminal = raw.get("terminal")
+        if (
+            isinstance(terminal_seq, int)
+            and terminal_seq > self._compaction_progress_terminal_baseline
+            and terminal is not None
+        ):
+            try:
+                from reyn.services.compaction.engine import RetryLoopTerminal as _RLT
+                terminal_text = compaction_failure_text(_RLT(terminal))
+            except Exception:
+                logger.exception("textual chat: could not resolve compaction terminal text")
+        self._settle_compaction_progress(terminal_text=terminal_text, meta=meta)
+
+    def _ensure_compaction_progress_entry(self, raw: dict) -> None:
+        """#5588: create the shrink-flow-episode row ONCE (idempotent — a
+        no-op while :attr:`_compaction_progress_entry` is already set) and
+        start its spinner, mirroring :meth:`_begin_running_indicator`'s own
+        two-step shape (stamp :data:`_RUNNING_SINCE_KEY`, register the
+        per-entry ``animate_entry`` timer) rather than
+        :meth:`_coalesce_pipeline_step`'s own ``start_entry_animation``
+        call — that method does not exist on the installed
+        ``textual_flowview`` (confirmed: its own ``try``/``except`` swallows
+        the ``AttributeError`` every time, so a pipeline run's row never
+        actually spins today — a real, pre-existing, OUT-OF-SCOPE bug for
+        THIS issue, disclosed rather than silently copied into new code)."""
+        if self._compaction_progress_entry is not None:
+            return
+        from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
+        item = OutboxMessage(
+            kind="system",
+            text="",  # #5588: body is meta-driven (_compaction_progress_body)
+            meta={
+                _COMPACTION_PROGRESS_KEY: True,
+                _RUNNING_SINCE_KEY: self._clock(),
+                "is_compacting": True,
+            },
         )
+        try:
+            entry = self.conversation.append(item)
+            entry.set_state(EntryState.RUNNING)
+            self._flow.animate_entry(entry, 1.0 / self.RUNNING_BODY_FPS, lambda e: e.update())
+        except Exception:
+            logger.exception("textual chat: could not start compaction progress row")
+            return
+        self._compaction_progress_entry = entry
+        self._compaction_progress_terminal_baseline = raw.get("terminal_seq") or 0
+
+    def _settle_compaction_progress(
+        self, *, terminal_text: "str | None", meta: "dict | None" = None,
+    ) -> None:
+        """#5588 acceptance ③: stop the spinner and give the row a terminal
+        state EXACTLY ONCE — a no-op when no entry is open (already
+        settled, or never started), so a caller may call this
+        unconditionally every refresh cycle while ``is_compacting`` reads
+        False. *terminal_text* is ``None`` for a success settle (architect:
+        keep the EXISTING ``[↑ N turns compacted]`` marker as the success
+        text elsewhere — this row's own text never duplicates it, only its
+        gutter state flips to SUCCESS) or the resolved ``RetryLoopTerminal``
+        sentence for a genuine unrecovered failure."""
+        entry = self._compaction_progress_entry
+        if entry is None:
+            return
+        try:
+            self._flow.stop_entry_animation(entry)
+        except Exception:
+            logger.exception("textual chat: could not stop compaction progress indicator")
+        merged = {k: v for k, v in entry.item.meta.items() if k != _RUNNING_SINCE_KEY}
+        if meta:
+            merged.update(meta)
+        merged["is_compacting"] = False
+        if terminal_text is not None:
+            merged["terminal_text"] = terminal_text
+        try:
+            entry.set_item(replace(entry.item, meta=merged))
+        except Exception:
+            logger.exception("textual chat: could not settle compaction progress row")
+        entry.set_state(EntryState.ERROR if terminal_text is not None else EntryState.SUCCESS)
+        self._compaction_progress_entry = None
 
     def watch__destination(self, old_value: "_Destination", new_value: "_Destination") -> None:
         """#5131: the App is now showing a DIFFERENT agent (init or a real

--- a/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
+++ b/src/reyn/interfaces/inline/textual_chat/compaction_progress.py
@@ -1,6 +1,16 @@
 """Shrink-flow (compaction/overflow-recovery) progress display — pure render
 layer (#5588).
 
+#5588 owner follow-up (real-machine: "スピナーになってないね"／"進捗も見え
+ない"／"開始〜終了までスピナー対応して...開始〜進捗〜終了は単一 flowview
+entry or group にして"): this module went from feeding a standalone chrome
+row (``CompactionProgressRow``, now REMOVED) to feeding ONE flowview entry
+spanning the whole shrink-flow episode (created/updated/settled by
+``app.py``'s own entry-lifecycle methods, rendered by ``presenter.py``'s
+``_compaction_progress_body``). Still a pure render layer — every function
+here takes a snapshot/enum member and returns text, no ``Session``/registry
+reach of its own.
+
 Two readers, one display, three layered lines (architect design, #5588
 issue thread — quoted verbatim in this module's own docstrings below):
 
@@ -50,9 +60,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-
-from textual.reactive import reactive
-from textual.widgets import Static
 
 if TYPE_CHECKING:
     from reyn.services.compaction.engine import RetryLoopTerminal
@@ -177,6 +184,65 @@ def compaction_progress_lines(snap: CompactionProgressSnapshot) -> "list[str]":
     return lines
 
 
+def compaction_progress_entry_lines(
+    snap: CompactionProgressSnapshot, *, terminal_text: "str | None" = None,
+) -> "list[str]":
+    """#5588 (owner: "開始〜進捗〜終了は単一 flowview entry or group にして") —
+    like :func:`compaction_progress_lines`, but for the ONE flowview entry
+    that spans a whole shrink-flow episode start-to-finish, never just
+    ``[]`` the instant ``is_compacting`` goes False: a settled entry still
+    shows its last-known progress (the same "still there after settling"
+    contract a completed tool-call row already has), plus, only once, the
+    reason it stopped.
+
+    *terminal_text* (from :func:`compaction_failure_text`, or ``None`` on
+    success — architect: success keeps the EXISTING ``[↑ N turns
+    compacted]`` marker unchanged, this line never duplicates that text)
+    is appended as its own line ONLY when given; never fabricated from
+    ``snap`` itself.
+    """
+    lines = (
+        ["⟳ 文脈を縮めています（自動で終わります）"] if snap.is_compacting
+        else ["文脈を縮めました" if terminal_text is None else "✗ 文脈を縮められませんでした"]
+    )
+
+    if snap.waiting_for is not None:
+        target = {"summary": "要約", "main_call": "本文"}.get(snap.waiting_for, snap.waiting_for)
+        elapsed = ""
+        if snap.waiting_elapsed_s is not None:
+            elapsed = f" {int(snap.waiting_elapsed_s)}秒"
+        lines.append(f"  {target}の応答を待っています{elapsed}")
+
+    rung_parts = []
+    if snap.spill_done is not None and snap.spill_total is not None:
+        call_suffix = "" if snap.call_count is None else f"  呼び出し {snap.call_count}"
+        rung_parts.append(f"① 退避 {snap.spill_done}/{snap.spill_total}{call_suffix}")
+    if snap.slice_len is not None:
+        rung_parts.append(f"② 分割 {snap.slice_len}")
+    if snap.head_available is not None or snap.tail_available is not None:
+        avail = []
+        if snap.head_available:
+            avail.append("head")
+        if snap.tail_available:
+            avail.append("tail")
+        rung_parts.append(f"③ 補充 {'/'.join(avail) if avail else '—'}")
+    if snap.budget_halvings_done is not None and snap.budget_halvings_max is not None:
+        rung_parts.append(f"④ 予算 {snap.budget_halvings_done}/{snap.budget_halvings_max}")
+
+    if rung_parts:
+        line3 = "  " + "  ".join(rung_parts)
+        if snap.lap is not None:
+            line3 += f"  · 周回 {snap.lap}"
+        if snap.active_rung is not None and snap.active_rung in _RUNG_LABELS:
+            line3 += f"     ← 今 {_RUNG_LABELS[snap.active_rung]}"
+        lines.append(line3)
+
+    if terminal_text is not None:
+        lines.append(f"  {terminal_text}")
+
+    return lines
+
+
 #: architect's own exact wording (#5588 issue thread) — never derived from
 #: RetryLoopTerminal's own member NAME/value string (that would be the same
 #: "parse the reason text" pattern this design explicitly forbids elsewhere;
@@ -193,38 +259,3 @@ def compaction_failure_text(terminal: "RetryLoopTerminal") -> str:
         _T.MID_FLOOR: "1つのやり取りが単独で大きすぎます",
         _T.ROOM_FLOOR: "最新のメッセージだけで窓に入りません",
     }[terminal]
-
-
-class CompactionProgressRow(Static):
-    """The chrome widget half of #5588 — a plain top-level sibling of
-    ``MenuBar`` in the app's compose order (same placement family as
-    :class:`~.chrome.ConfigWarningLine`), rendering whatever
-    :func:`compaction_progress_lines` returns.
-
-    #5131 "down" discipline: the App writes :attr:`lines` (a ``reactive``
-    attribute) from its own periodic snapshot read — this widget never
-    queries ``Session``/the registry itself (Gate A: this module does not,
-    and must not, import ``reyn.interfaces.transport``/``reyn.runtime.
-    registry``). :meth:`watch_lines` is the ONE place that reacts, matching
-    ``ActivityRow``'s own established shape for a conditionally-visible
-    chrome row: absent (``display = False``) whenever there is nothing to
-    show, never an empty visible row occupying the layout slot."""
-
-    DEFAULT_CSS = """
-    CompactionProgressRow {
-        height: auto;
-        padding: 0 1;
-    }
-    """
-
-    can_focus = False
-
-    lines: "reactive[list[str]]" = reactive(list, always_update=True)
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__("", **kwargs)
-        self.display = False
-
-    def watch_lines(self, new_lines: "list[str]") -> None:
-        self.display = bool(new_lines)
-        self.update("\n".join(new_lines))

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -38,6 +38,7 @@ from reyn.interfaces.repl.renderer import (
     summarize_tool_result,
 )
 
+from ._meta_keys import COMPACTION_PROGRESS_KEY as _COMPACTION_PROGRESS_KEY
 from ._meta_keys import EXPANDED_KEY as _EXPANDED_KEY
 from ._meta_keys import ORPHANED_RESULT_KIND as _ORPHANED_RESULT_KIND
 from ._meta_keys import PIPELINE_RUN_KEY as _PIPELINE_RUN_KEY
@@ -219,6 +220,48 @@ def _pipeline_row(meta: dict) -> "RenderableType":
         Text(kind, style=_CC_DIM),
     )
     return row
+
+
+def _compaction_progress_body(meta: dict, *, spinner_frame: "str | None") -> "RenderableType":
+    """#5588: the ONE shrink-flow-episode entry's body — built from the
+    INTEGER/bool/str figures in ``meta`` (never parsed back out of a
+    forwarder's own composed sentence — same discipline :func:`_pipeline_row`
+    already established: "the numbers are what the row is actually about").
+
+    Reconstructs a ``CompactionProgressSnapshot`` from ``meta`` and renders
+    it via :func:`~.compaction_progress.compaction_progress_entry_lines` —
+    the ONE place that line-building logic lives, so this presenter and any
+    other future reader never drift apart on wording.
+
+    *spinner_frame* (the current braille glyph, or ``None`` when settled)
+    replaces line 1's static "⟳" — the SAME advance-rate/character set the
+    RUNNING tool-call row already uses (:data:`_SPINNER`/:data:`_SPINNER_
+    SPEED`), so "is this animating" reads identically across every live row
+    in the flow, no new visual vocabulary.
+    """
+    from .compaction_progress import CompactionProgressSnapshot, compaction_progress_entry_lines
+
+    snap = CompactionProgressSnapshot(
+        is_compacting=bool(meta.get("is_compacting")),
+        waiting_for=meta.get("waiting_for"),
+        waiting_elapsed_s=meta.get("waiting_elapsed_s"),
+        spill_done=meta.get("spill_done"),
+        spill_total=meta.get("spill_total"),
+        slice_len=meta.get("slice_len"),
+        head_available=meta.get("head_available"),
+        tail_available=meta.get("tail_available"),
+        budget_halvings_done=meta.get("budget_halvings_done"),
+        budget_halvings_max=meta.get("budget_halvings_max"),
+        active_rung=meta.get("active_rung"),
+        lap=meta.get("lap"),
+        call_count=meta.get("call_count"),
+    )
+    terminal_text = meta.get("terminal_text")
+    lines = compaction_progress_entry_lines(snap, terminal_text=terminal_text)
+    if spinner_frame is not None and lines:
+        lines[0] = f"{spinner_frame}{lines[0][1:]}" if lines[0].startswith("⟳") else lines[0]
+    style = _CC_ERR if terminal_text is not None and not snap.is_compacting else _CC_TEXT
+    return Text("\n".join(lines), style=style)
 
 
 def _tool_head(msg: "OutboxMessage") -> Text:
@@ -551,6 +594,11 @@ def _body_and_background(
         return body, None
     if meta.get(_PIPELINE_RUN_KEY) is not None:
         return _pipeline_row(meta), None
+    if meta.get(_COMPACTION_PROGRESS_KEY) is not None:
+        frame = None
+        if meta.get(_RUNNING_SINCE_KEY) is not None and now is not None:
+            frame = _SPINNER[int(now * _SPINNER_SPEED) % len(_SPINNER)]
+        return _compaction_progress_body(meta, spinner_frame=frame), None
     # kind == "intervention" is intercepted earlier, in ``ReynPresenter.present``
     # (the pending/resolved placeholder — #3299 P1), so it never reaches here.
     if kind == "tool_call_started":

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -190,23 +190,28 @@ class ChatLifecycleForwarder:
         finding names: the event was emitted (``engine.py``'s
         ``compact()``), nothing in ``src/reyn/interfaces/`` ever consumed it.
 
-        Deliberately independent of #5618/#5630's `is_compacting`/
-        `recovery_episode` progress-row gate — that is STATE a polling
-        consumer reads each frame; this is an EDGE, a one-line transcript
-        marker for the moment compaction begins, the same shape
-        ``on_compaction_completed``/``on_compaction_failed`` already use for
-        their own edges. Neither replaces the other: the progress row answers
-        "is it running right now", this marker answers "something just
-        started" for a reader who was not watching the row at that instant.
+        #5588 correction: this marker is no longer independent of #5618/
+        #5630's `is_compacting`/`recovery_episode` state — owner's own
+        "開始〜終了は単一 flowview entry or group にして" ruled that a
+        `compact()` call inside an already-running shrink-flow episode
+        (#5719's own shrink-retry ladder can call `compact()` more than
+        once per episode) must NOT scatter its own edge marker into the
+        conv pane as a separate line. This handler still ALWAYS emits —
+        ``meta["compaction_episode_marker"]`` is what lets ``app.py``'s
+        ``_ingest_frame`` ABSORB the frame into the single open episode
+        entry (TUI-local; the frame still reaches the outbox unchanged,
+        so a surface with no episode-entry mechanism of its own, e.g.
+        AG-UI, still gets this marker exactly as before).
 
         ``new_turn_count`` mirrors ``on_compaction_completed``'s own field
         name for the same count (this pass's target, not its result) —
         absent degrades to a generic marker, never a fabricated count."""
         count = data.get("new_turn_count")
+        meta = {"compaction_episode_marker": True}
         if isinstance(count, int) and count > 0:
-            self._enqueue(f"[⟳ compacting {count} turn{'s' if count != 1 else ''}]")
+            self._enqueue(f"[⟳ compacting {count} turn{'s' if count != 1 else ''}]", meta=meta)
         else:
-            self._enqueue("[⟳ compacting history]")
+            self._enqueue("[⟳ compacting history]", meta=meta)
 
     def on_compaction_failed(self, data: dict) -> None:
         """Surface a ``[✗ compaction failed: <reason>]`` error marker.
@@ -218,7 +223,42 @@ class ChatLifecycleForwarder:
         context pressure continues unrelieved.
         """
         reason = str(data.get("error") or "unknown error")
-        self._enqueue(f"[✗ compaction failed: {reason}]")
+        self._enqueue(
+            f"[✗ compaction failed: {reason}]",
+            meta={"compaction_episode_marker": True},
+        )
+
+    def on_router_context_overflow_unrecovered(self, data: dict) -> None:
+        """Surface a ``[✗ shrink flow failed: <impossibility>]`` marker —
+        the TRUE end-of-episode failure, distinct from :meth:`on_compaction_
+        failed` above (a single ``compact()`` call raising, which #5719's
+        own shrink-retry ladder may still recover from within the SAME
+        episode — this event fires only once the whole ladder is
+        exhausted).
+
+        Names WHICH impossibility fired via the ``RetryLoopTerminal``
+        member itself (#5588 architect ruling: "reason 文字列を解析しない
+        こと") — never a parse of ``error``'s own ``repr()`` text. A plain
+        ``ContextOverflowError`` (the window itself is too small — no
+        ladder-terminal distinction at all) carries no ``terminal`` field
+        (never fabricated) and degrades to a generic marker.
+
+        The 2-line mapping is a SMALL, deliberate duplicate of
+        ``compaction_progress.py``'s own ``compaction_failure_text`` —
+        that module is INTERFACES-layer (imports ``textual``); this one is
+        RUNTIME-layer, so importing it here would invert the dependency
+        direction (same reasoning this module's own ``_compact_token_
+        count`` docstring already gives for not importing ``gutter.py``).
+        """
+        terminal = data.get("terminal")
+        text = {
+            "mid_floor": "1つのやり取りが単独で大きすぎます",
+            "room_floor": "最新のメッセージだけで窓に入りません",
+        }.get(str(terminal))
+        if text is not None:
+            self._enqueue(f"[✗ shrink flow failed: {text}]")
+        else:
+            self._enqueue("[✗ shrink flow failed]")
 
     def on_summary_resummarize_failed(self, data: dict) -> None:
         """Surface a ``[✗ summary re-compress failed: <reason>]`` error marker.
@@ -267,7 +307,12 @@ class ChatLifecycleForwarder:
         if isinstance(cost, (int, float)):
             text += f" · ${cost:.2f}"
         text += "]"
-        self._enqueue(text)
+        # #5588: same absorption tag as on_compaction_started/failed above
+        # — a shrink-flow episode can call compact() more than once (#5719's
+        # own shrink-retry ladder), so this must not scatter either, even
+        # though its OWN text is architect's explicitly-unchanged success
+        # format (still built exactly as before this PR).
+        self._enqueue(text, meta={"compaction_episode_marker": True})
 
     # ── Router cap / iteration limit ─────────────────────────────────────
     # Two distinct ``limit_denied`` sources:
@@ -401,10 +446,20 @@ class ChatLifecycleForwarder:
         # Fire-and-forget: lifecycle markers are advisory, never block the
         # session loop. Uses ``kind="system"`` so the conv pane's
         # ``_render_system_message`` path styles it as a dim marker line.
-        # ``meta`` (#4380): optional — carries ``lifecycle_bundle_key`` for
-        # the ONE marker kind (``permission_denied``) the conv pane
-        # coalesces consecutive repeats of; every other caller omits it
-        # (``None`` -> ``{}``, byte-identical to every pre-#4380 marker).
+        # ``meta`` (#4380): optional — ``on_permission_denied`` (below)
+        # still stamps ``lifecycle_bundle_key`` on every call. #5588
+        # correction: the conv-pane consumer that once coalesced consecutive
+        # repeats keyed on it was ITSELF removed as unreachable (``fix
+        # (#4380): remove the unreachable permission_denied ×N bundling`` —
+        # re-measured, no live trigger ever produced two adjacent
+        # occurrences). The write here is now INERT — no reader consumes
+        # this key anywhere in the tree (verified: `git grep
+        # lifecycle_bundle_key` finds only this write site) — kept
+        # (not removed) because whether to also drop it is a separate,
+        # out-of-scope decision from the one #5588 needed to make (CLAUDE.md:
+        # a doc/comment goes stale the moment the mechanism it describes
+        # changes; fixed here in the same PR that found it, per that rule —
+        # the writer itself is untouched).
         try:
             self.outbox.put_nowait(OutboxMessage(kind="system", text=text, meta=meta or {}))
         except asyncio.QueueFull:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10771,6 +10771,29 @@ class Session:
                 # ended, which is exactly when the Ctx pane's "folded" row
                 # (#5619) shows it. Episode-joining it would blank a fact that
                 # is still correct — the opposite of what the join is for.
+        elif event.type == "router_context_overflow_unrecovered":
+            # #5588: deliberately NOT episode-joined, same reasoning as
+            # ``persisted_covers_through_seq`` above — a genuine failure IS
+            # the moment ``is_compacting``/``recovery_episode`` flip back to
+            # "not running", so an episode-joined field would be wiped on
+            # the very next read (episode is None -> the join clears every
+            # IN_FLIGHT key), before any reader could ever observe it. A
+            # DURABLE cache alone would still leak a stale old failure into
+            # a LATER successful episode's own read, so ``terminal_seq``
+            # (a plain, always-incrementing counter — never cleared, never
+            # reset) is what a caller actually compares against: "did a NEW
+            # unrecovered failure fire since I started watching" is a
+            # question a monotonic counter answers correctly regardless of
+            # whether ``terminal``'s own VALUE happens to repeat (e.g. two
+            # separate episodes both ending in MID_FLOOR) — the caller's own
+            # baseline-vs-current comparison, not this cache, is what tells
+            # "new" apart from "stale".
+            terminal = event.data.get("terminal")
+            if terminal is not None:
+                self._compaction_progress_state["terminal"] = terminal
+                self._compaction_progress_state["terminal_seq"] = (
+                    self._compaction_progress_state.get("terminal_seq") or 0
+                ) + 1
 
     def compaction_progress_raw(self) -> dict:
         """#5588: ``is_compacting`` plus the latest #5592 observability
@@ -10796,7 +10819,15 @@ class Session:
         watermark is a durable fact about a fold that happened, still true —
         and still displayed by the Ctx pane's "folded" row (#5619) — long after
         the episode that produced it ended. Blanking it between episodes would
-        hide a correct answer, which is the opposite of the join's purpose."""
+        hide a correct answer, which is the opposite of the join's purpose.
+
+        ``terminal``/``terminal_seq`` are likewise NOT joined, for the same
+        reason plus one more (see :meth:`_on_compaction_progress_event`'s
+        own comment): a genuine failure IS the moment the episode ends, so
+        joining would erase the field before any reader could see it. The
+        caller compares ``terminal_seq`` against its own remembered
+        baseline to tell "a NEW failure fired" apart from "this is an old
+        cached value" — this method never makes that call itself."""
         figures = dict(self._compaction_progress_state)
         episode = self._recovery_episode()
         if episode is None or episode != self._compaction_progress_episode:

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -1,19 +1,36 @@
-"""Tier 2: #5588 — the shrink-flow progress row, mounted in a REAL
+"""Tier 2: #5588 — the shrink-flow progress ROW is a single flowview entry
+(``TextualChatApp._compaction_progress_entry``), mounted in a REAL
 ``TextualChatApp`` and driven from a REAL ``Session``'s own snapshot (the
 production ``interfaces/repl/status.py::_snapshot_for_session()`` seam, not
 a hand-typed dict).
+
+owner (real-machine, 2026-09-02/03): "スピナーになってないね"／"進捗も見え
+ない"／"開始〜終了までスピナー対応して...開始〜進捗〜終了は単一 flowview
+entry or group にして" — this file replaces its own prior generation
+(``CompactionProgressRow``, a standalone chrome ``Static`` sibling of
+``MenuBar``, REMOVED by this same PR) with tests against the flowview entry
+that took its place: one ``Entry[OutboxMessage]``, created once, its
+``meta`` updated in place while running (never re-created), spinning via
+the SAME live-indicator convention a RUNNING tool-call row already uses,
+and settled to a terminal ``EntryState`` exactly once.
 
 Real ``Session``/``AgentRegistry``/``EventLog`` throughout. Driving via a
 direct ``session._audit_events.emit(...)`` call for
 ``compaction_shrink_recovered``/``llm_request`` is the same legitimate
 "arrange, not assert" pattern established across #5557/#5588's own prior
-tests: this file's claim is "the chrome row renders what the snapshot
-carries", not "production fires these events in scenario X" (that belongs
-to tests/services/test_5592_observability_fields.py). Setting
+tests: this file's claim is "the entry renders what the snapshot carries",
+not "production fires these events in scenario X" (that belongs to
+tests/services/test_5592_observability_fields.py). Setting
 ``session._compaction_controller._compacting`` directly (no public setter
 exists — see ``CompactionController.is_compacting``'s own read-only
 property) is the same class of legitimate scenario-arrangement, not an
 assertion on private state.
+
+Assertions read ``entry.item.meta`` (the INTEGER/bool/str figures the row
+is built from — same public-surface precedent ``presenter.py``'s own
+``_pipeline_row`` established: "the numbers are what the row is actually
+about", never a parse of rendered text/pixels) and ``entry.state``
+(``EntryState`` — a public flowview attribute, not private state).
 
 ``_MutableSnapshotReadModel``/``_EventOnlyTransport`` mirror
 ``test_3338_tui_status_chrome_liveness.py``'s own classes of the same name
@@ -29,7 +46,6 @@ import pytest
 
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.textual_chat import TextualChatApp
-from reyn.interfaces.inline.textual_chat.compaction_progress import CompactionProgressRow
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.repl.status import _snapshot_for_session
 from reyn.interfaces.transport.client_transport import ClientTransportStub
@@ -37,6 +53,7 @@ from reyn.interfaces.transport.frames import EventFrame
 from reyn.runtime.registry import AgentRegistry
 from reyn.schemas.models import Event
 from tests._support.agent_session import make_session
+from tests._support.events import settle
 
 
 class _MutableSnapshotReadModel(ChatReadModel):
@@ -138,43 +155,65 @@ async def _make_app_with_real_session(tmp_path: Path):
     return app, session, reg
 
 
+def _open_compaction_entry(app: TextualChatApp):
+    """Tier 2's own public-surface read of "is there a shrink-flow-episode
+    entry open right now" — never ``app._compaction_progress_entry``
+    (private state; the AST gate correctly flags a syntactic position, not
+    just an assertion on it — testing.md: "naming a syntactic position only
+    moves the read one line up"). ``app.conversation.entries`` (a public
+    ``FlowModel`` property) is the SAME surface :func:`presenter.py`'s own
+    ``_pipeline_row`` precedent reads ("the numbers are what the row is
+    actually about") — scanning it for the ONE entry tagged
+    :data:`_COMPACTION_PROGRESS_KEY` is genuinely public, not a renamed
+    private read."""
+    from reyn.interfaces.inline.textual_chat._meta_keys import COMPACTION_PROGRESS_KEY
+
+    for entry in app.conversation.entries:
+        if entry.item.meta.get(COMPACTION_PROGRESS_KEY) is not None:
+            return entry
+    return None
+
+
 @pytest.mark.asyncio
-async def test_row_absent_while_not_compacting(tmp_path: Path) -> None:
-    """Tier 2: accept/deny — the row is mounted but hidden (the issue's
-    own deny criterion: never a persistently-visible row)."""
+async def test_no_entry_while_not_compacting(tmp_path: Path) -> None:
+    """Tier 2: accept/deny — no flowview entry exists while nothing is
+    compacting (the issue's own deny criterion: never a persistently-
+    visible row)."""
     app, _session, _reg = await _make_app_with_real_session(tmp_path)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        row = app.query_one(CompactionProgressRow)
-        assert row.display is False
+        assert _open_compaction_entry(app) is None
 
 
 @pytest.mark.asyncio
-async def test_row_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
+async def test_entry_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
     """Tier 2: accept — a CONTROLLER-driven compaction (the threshold pass /
-    force_compact_now) mounts the row and renders line 1, end-to-end from
-    Session through the App's own refresh cycle to the rendered widget rather
+    force_compact_now) creates the flowview entry, RUNNING, from the App's
+    own refresh cycle end-to-end from Session through to the entry rather
     than the pure render layer in isolation.
 
     #5618 narrowed what this can claim. The rung figures
     (raw_middle_remaining, upstream_recovery_call_count) are measured by the
     retry LADDER and are now joined against the recovery episode they were
     measured in — a controller compaction is a different operation and runs
-    in no episode, so those figures correctly read unknown here and line 3
-    does not render. The arrangement below (controller flag up, ladder events
-    on the log, no episode) is one production cannot produce at all: the
-    engine emits those events from inside retry_loop, which only runs inside
-    an episode.
+    in no episode, so those figures correctly read unknown here and the
+    entry's own meta does not carry them. The arrangement below (controller
+    flag up, ladder events on the log, no episode) is one production cannot
+    produce at all: the engine emits those events from inside retry_loop,
+    which only runs inside an episode.
 
-    So this asserts the controller path's real contract — the row appears and
-    says the honest thing — and, as the deny half, that it does NOT print rung
-    numbers it never measured.
+    So this asserts the controller path's real contract — the entry appears
+    and says the honest thing — and, as the deny half, that it does NOT
+    carry rung numbers it never measured.
 
     Accept sibling (architect, #5630): the figures ARE rendered on the path
     that measures them — ``test_the_measured_figures_are_reported_while_their_
     episode_runs`` in tests/runtime/test_5618_recovery_episode_gate.py, which
     drives the real ladder end-to-end. Without that sibling, this test's deny
-    half would be satisfied by a pane that never shows the figures at all."""
+    half would be satisfied by an entry that never carries the figures at
+    all."""
+    from reyn.interfaces.inline.textual_chat._meta_keys import RUNNING_SINCE_KEY
+
     app, session, reg = await _make_app_with_real_session(tmp_path)
     session._compaction_controller._compacting = True  # arrange: no public setter
     session._audit_events.emit(
@@ -197,13 +236,188 @@ async def test_row_shows_real_events_driven_snapshot(tmp_path: Path) -> None:
         app._refresh_compaction_progress()
         await pilot.pause()
 
-        row = app.query_one(CompactionProgressRow)
-        assert row.display is True
-        assert row.lines[0] == "⟳ 文脈を縮めています（自動で終わります）"
-        blob = "\n".join(row.lines)
-        assert "① 退避" not in blob, (
-            f"the row printed ladder rung figures during a controller-driven "
-            f"compaction, which measures none of them — those numbers would "
-            f"be another operation's, shown as this one's progress:\n{blob}"
+        entry = _open_compaction_entry(app)
+        assert entry is not None
+        from textual_flowview import EntryState
+        assert entry.state is EntryState.RUNNING
+        meta = entry.item.meta
+        assert meta.get("is_compacting") is True
+        assert meta.get(RUNNING_SINCE_KEY) is not None, "expected the spinner to be running"
+        assert meta.get("spill_done") is None, (
+            f"a controller-driven compaction measures no ladder rung figures — "
+            f"those numbers would be another operation's, shown as this one's "
+            f"progress: {meta!r}"
         )
-        assert "呼び出し" not in blob, blob
+        assert meta.get("call_count") is None, meta
+
+
+@pytest.mark.asyncio
+async def test_entry_settles_success_when_compaction_stops_with_no_new_failure(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5588 acceptance ③ — the entry settles to SUCCESS exactly
+    once when ``is_compacting`` goes back to False with no NEW
+    router_context_overflow_unrecovered since it started (a genuine
+    resolve, not a fabricated failure)."""
+    from textual_flowview import EntryState
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        entry = _open_compaction_entry(app)
+        assert entry is not None, "arrange: entry must exist before it can settle"
+
+        session._compaction_controller._compacting = False
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+
+        # The entry stays in the flow (a settled row, matching a completed
+        # tool call's own "still there after settling" contract) — the
+        # public witness for "settled" is its OWN state, not disappearance.
+        assert _open_compaction_entry(app) is entry
+        assert entry.state is EntryState.SUCCESS
+        assert entry.item.meta.get("terminal_text") is None, (
+            "a success settle must never carry a failure sentence"
+        )
+
+
+@pytest.mark.asyncio
+async def test_entry_settles_error_with_the_real_retry_loop_terminal_text(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5588 acceptance ③ — a NEW router_context_overflow_
+    unrecovered fired since the entry was created settles it ERROR, with
+    the resolved RetryLoopTerminal sentence (never a parsed reason
+    string)."""
+    from textual_flowview import EntryState
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        entry = _open_compaction_entry(app)
+        assert entry is not None
+
+        session._audit_events.emit(
+            "router_context_overflow_unrecovered",
+            error="UnrecoveredError(...)", terminal="mid_floor",
+        )
+        await settle(session._audit_events)  # dispatch is queued under a real event loop
+        session._compaction_controller._compacting = False
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+
+        assert _open_compaction_entry(app) is entry, "the settled row stays in the flow"
+        assert entry.state is EntryState.ERROR
+        assert entry.item.meta.get("terminal_text") == "1つのやり取りが単独で大きすぎます"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_terminal_from_before_the_entry_started_is_never_reused(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: deny side (acceptance ③'s own load-bearing property) — a
+    terminal_seq that was already at its baseline WHEN the entry was
+    created must never make a genuinely-successful episode settle as
+    ERROR. Without the baseline comparison, an old failure from a
+    PREVIOUS episode would leak into this one's own settle."""
+    from textual_flowview import EntryState
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    # An OLDER episode's own failure, already on the log before this
+    # entry is ever created.
+    session._audit_events.emit(
+        "router_context_overflow_unrecovered", error="old", terminal="room_floor",
+    )
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        entry = _open_compaction_entry(app)
+        assert entry is not None
+
+        # No NEW failure this time — the episode genuinely resolves.
+        session._compaction_controller._compacting = False
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+
+        assert entry.state is EntryState.SUCCESS, (
+            "a terminal_seq already at baseline when the entry was created "
+            "must never be read as a NEW failure"
+        )
+
+
+@pytest.mark.asyncio
+async def test_compaction_episode_marker_frame_absorbs_into_the_open_entry(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5588 — a lifecycle_forwarder marker tagged
+    ``compaction_episode_marker`` (on_compaction_started/completed/failed)
+    is absorbed into the single open episode entry rather than appended
+    as its own conv-pane row, TUI-locally, while an entry is open."""
+    from reyn.runtime.outbox import OutboxMessage
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        assert _open_compaction_entry(app) is not None
+
+        before = list(app.conversation.entries)
+        result = app._ingest_frame(OutboxMessage(
+            kind="system", text="[⟳ compacting 3 turns]",
+            meta={"compaction_episode_marker": True},
+        ))
+        after = list(app.conversation.entries)
+
+        assert result is None, "an absorbed frame creates no new entry"
+        assert len(after) == len(before), (
+            f"expected the marker to absorb (no new row) — root count grew "
+            f"{len(before)} -> {len(after)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_compaction_episode_marker_frame_appends_normally_with_no_open_entry(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: deny side — with NO open episode entry (a REMOTE reconnect
+    mid-episode, or the entry already settled), a tagged marker falls
+    through and appends as its own row rather than being silently
+    dropped."""
+    from reyn.runtime.outbox import OutboxMessage
+
+    app, _session, _reg = await _make_app_with_real_session(tmp_path)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert _open_compaction_entry(app) is None
+
+        before = list(app.conversation.entries)
+        result = app._ingest_frame(OutboxMessage(
+            kind="system", text="[⟳ compacting 3 turns]",
+            meta={"compaction_episode_marker": True},
+        ))
+        after = list(app.conversation.entries)
+
+        assert result is not None, "no open entry to absorb into -- must append"
+        assert len(after) == len(before) + 1

--- a/tests/runtime/test_5588_compaction_progress_session_wiring.py
+++ b/tests/runtime/test_5588_compaction_progress_session_wiring.py
@@ -156,3 +156,78 @@ def test_no_covers_through_seq_outcome_does_not_move_the_watermark(tmp_path):
         covers_through_seq=0,
     )
     assert session.compaction_progress_raw()["persisted_covers_through_seq"] is None
+
+
+# ── #5588: the TRUE end-of-episode failure (terminal/terminal_seq) ─────────
+
+
+def test_terminal_caches_the_real_retry_loop_terminal_value(tmp_path):
+    """Tier 2: a real router_context_overflow_unrecovered event's own
+    ``terminal`` field (already a plain str — RetryLoopTerminal's own
+    ``.value``, see router_loop_driver.py's own emit) lands in the cache
+    verbatim, and terminal_seq starts counting from 1."""
+    session = _make_session(tmp_path)
+    session._audit_events.emit(
+        "router_context_overflow_unrecovered",
+        error="UnrecoveredError(...)", terminal="mid_floor",
+    )
+    raw = session.compaction_progress_raw()
+    assert raw["terminal"] == "mid_floor"
+    assert raw["terminal_seq"] == 1
+
+
+def test_terminal_seq_is_monotonic_and_never_resets(tmp_path):
+    """Tier 2: acceptance ③'s own load-bearing property — a caller (the
+    TUI's flowview entry) tells "a NEW failure fired since I started
+    watching" apart from "this is an old cached value" by comparing
+    terminal_seq against its own remembered baseline. That comparison
+    only works if the counter never resets and always increments,
+    regardless of whether the SAME terminal value repeats across two
+    separate episodes (two MID_FLOOR failures in a row must still bump
+    the counter, or the second failure would look like a stale read)."""
+    session = _make_session(tmp_path)
+    session._audit_events.emit(
+        "router_context_overflow_unrecovered", error="e1", terminal="mid_floor",
+    )
+    session._audit_events.emit(
+        "router_context_overflow_unrecovered", error="e2", terminal="mid_floor",
+    )
+    raw = session.compaction_progress_raw()
+    assert raw["terminal_seq"] == 2, "the SAME terminal value twice must still bump the counter"
+
+
+def test_terminal_without_a_terminal_field_does_not_cache_or_bump(tmp_path):
+    """Tier 2: deny side — a plain ContextOverflowError (no ladder-terminal
+    distinction, never fabricated — router_loop_driver.py's own comment:
+    "omitted... for a plain ContextOverflowError") must not be cached as
+    a real terminal, and must not bump the counter (a caller comparing
+    against terminal_seq must never see progress that did not happen)."""
+    session = _make_session(tmp_path)
+    session._audit_events.emit(
+        "router_context_overflow_unrecovered", error="ContextOverflowError(...)",
+    )
+    raw = session.compaction_progress_raw()
+    assert raw.get("terminal") is None
+    assert raw.get("terminal_seq") is None
+
+
+def test_terminal_is_never_episode_joined(tmp_path):
+    """Tier 2: unlike raw_middle_remaining/raw_middle_total/upstream_
+    recovery_call_count (_IN_FLIGHT_PROGRESS_KEYS, episode-joined),
+    terminal/terminal_seq stay readable with no live recovery episode —
+    the same durable-cache shape persisted_covers_through_seq already
+    has, and for the same reason: a genuine failure IS the moment the
+    episode ends, so an episode-joined field would be wiped on the very
+    next read before any caller could ever observe it."""
+    session = _make_session(tmp_path)
+    # Public-surface witness that no real ladder is running in this test
+    # (never session._recovery_episode() — private state): is_compacting
+    # is the OR of the controller flag and the episode check, so a False
+    # read here proves both are inactive.
+    assert session.is_compacting is False, "arrange: no real ladder ran in this test"
+    session._audit_events.emit(
+        "router_context_overflow_unrecovered", error="e", terminal="room_floor",
+    )
+    raw = session.compaction_progress_raw()
+    assert raw["terminal"] == "room_floor"
+    assert raw["terminal_seq"] == 1

--- a/tests/runtime/test_chat_lifecycle_forwarder.py
+++ b/tests/runtime/test_chat_lifecycle_forwarder.py
@@ -471,6 +471,94 @@ def test_compaction_failed_missing_error_uses_fallback() -> None:
     assert "unknown error" in only.text
 
 
+# ── #5588: started/completed/failed carry the episode-marker absorption tag ──
+
+
+def test_compaction_started_carries_the_episode_marker_meta() -> None:
+    """Tier 2: #5588 — app.py's own single shrink-flow-episode entry absorbs
+    this marker (TUI-local) via ``meta["compaction_episode_marker"]``; the
+    frame itself is UNCHANGED for a surface with no absorption mechanism
+    (e.g. AG-UI)."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_started", data={"new_turn_count": 3}))
+    (only,) = _drain(q)
+    assert only.meta.get("compaction_episode_marker") is True
+    assert only.text == "[⟳ compacting 3 turns]", "the marker text itself is unchanged"
+
+
+def test_compaction_completed_carries_the_episode_marker_meta() -> None:
+    """Tier 2: same tag on the success marker — architect's own "existing
+    [↑ N turns compacted] text unchanged" ruling means only meta is added,
+    never the text."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_completed", data={"new_turn_count": 5}))
+    (only,) = _drain(q)
+    assert only.meta.get("compaction_episode_marker") is True
+    assert only.text == "[↑ 5 turns compacted]"
+
+
+def test_compaction_failed_carries_the_episode_marker_meta() -> None:
+    """Tier 2: same tag on the (per-compact()-call) failure marker — a
+    single failed attempt inside an active episode may still be recovered
+    by #5719's own shrink-retry ladder, so it absorbs into the episode
+    entry too rather than scattering its own line."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(type="compaction_failed", data={"error": "boom"}))
+    (only,) = _drain(q)
+    assert only.meta.get("compaction_episode_marker") is True
+
+
+# ── #5588: router_context_overflow_unrecovered (the TRUE end-of-episode failure) ──
+
+
+def test_router_context_overflow_unrecovered_names_mid_floor() -> None:
+    """Tier 2: #5588 architect ruling — the true end-of-ladder failure is
+    named via the RetryLoopTerminal member itself, never a parse of
+    error's own repr() text."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="router_context_overflow_unrecovered",
+        data={"error": "UnrecoveredError(...)", "terminal": "mid_floor"},
+    ))
+    (only,) = _drain(q)
+    assert only.kind == "system"
+    assert "1つのやり取りが単独で大きすぎます" in only.text
+    assert "shrink flow failed" in only.text
+
+
+def test_router_context_overflow_unrecovered_names_room_floor() -> None:
+    """Tier 2: the OTHER RetryLoopTerminal member gets its own distinct
+    text — the two are never collapsed into one."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="router_context_overflow_unrecovered",
+        data={"error": "ContextOverflowError(...)", "terminal": "room_floor"},
+    ))
+    (only,) = _drain(q)
+    assert "最新のメッセージだけで窓に入りません" in only.text
+
+
+def test_router_context_overflow_unrecovered_without_terminal_degrades_gracefully() -> None:
+    """Tier 2: a plain ContextOverflowError (no ladder-terminal distinction
+    at all — never fabricated) still emits a marker, generic rather than
+    naming an impossibility it was never told."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="router_context_overflow_unrecovered",
+        data={"error": "ContextOverflowError(...)"},
+    ))
+    (only,) = _drain(q)
+    assert only.text == "[✗ shrink flow failed]"
+    # Never absorbed — this is the ONE terminal signal, always its own line.
+    assert only.meta.get("compaction_episode_marker") is None
+
+
 # ── limit_denied (router cap) ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
**[tui-coder]** — Closes #5588

## What changed

The shrink-flow (compaction / overflow-recovery) progress display is rewired from a persistent chrome widget (`CompactionProgressRow`, deleted) into a single `textual_flowview` `Entry` per episode — matching the acceptance criteria restated by lead-coder on the issue:

1. **Single entry per episode**, not per `compact()` call. `lifecycle_forwarder.py`'s existing per-call markers (`on_compaction_started`/`_completed`/`_failed`) now carry `meta["compaction_episode_marker"] = True`; `app.py::_ingest_frame` absorbs any such frame while an episode entry is already open, so they no longer scatter into their own flowview rows. `router_context_overflow_unrecovered`'s own marker is deliberately NOT tagged — it stays the one always-visible terminal line (`on_router_context_overflow_unrecovered`, new handler).
2. **A real spinner**, reusing the *already-live* `_begin_running_indicator` convention (`RUNNING_SINCE_KEY` meta + `FlowView.animate_entry`, a genuine viewport-gated Textual timer — confirmed present via direct `dir(FlowView)` introspection) rather than the `_coalesce_pipeline_step` precedent, whose own `self._flow.append`/`self._flow.start_entry_animation` calls do not exist on the installed `textual_flowview` (see disclosure below).
3. **Progress as "levers left," never a %/bar** — `spill_done/spill_total`, `call_count` land as typed `meta` integers, rendered by a new `_compaction_progress_body` in `presenter.py` (dispatches on `meta[COMPACTION_PROGRESS_KEY]`, ahead of any `kind` branching, so no new `OutboxMessage.kind` was needed — `"system"` already covers this per `outbox.py`'s own docstring).
4. **Never fabricated** — `Session.is_compacting`'s existing docstring posture is preserved; the entry only ever renders real cached figures from `Session.compaction_progress_raw()`.
5. **Never polls** — the App is the only reader, driven off the same real audit-event subscriptions already in place (`_refresh_compaction_progress`).
6. **Terminal fires exactly once per episode, never zero** — settle happens in `_settle_compaction_progress` the moment `is_compacting` goes False; a genuinely NEW failure (vs. a stale cached one from an older episode) is distinguished via a monotonic, never-reset `terminal_seq` counter compared against a baseline captured at entry-creation time (mirrors the existing `persisted_covers_through_seq` durable-cache shape in `session.py`) — a bare value comparison would be insufficient since the same `RetryLoopTerminal` member can legitimately repeat across two distinct failed episodes.

## Disclosure: two pre-existing, unrelated bugs found while surveying the precedent

While confirming `_coalesce_pipeline_step`/`_settle_pipeline_run` (app.py ~5190-5238) as the precedent to mirror, direct introspection of the **installed** `textual_flowview` package (not just source-reading) showed:
- `self._flow.append(item)` — `FlowView` has no `append` method (the real one is `FlowModel.append`). This call is **unguarded**, so it would raise `AttributeError` outright.
- `self._flow.start_entry_animation(entry)` — also does not exist (the real name is `animate_entry`). This call **is** wrapped in a swallowing `try/except`, so it silently no-ops today.

Net effect: pipeline-run rows likely never actually get created as flowview entries, and never animate, in production today. Left untouched here (different feature, out of scope for #5588) — flagging separately over broker as its own finding.

## Test plan

- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 57/57, 0 errors (after fixing 6 private-state flags: `app._compaction_progress_entry` → public `app.conversation.entries` scan helper; `session._recovery_episode()` → public `session.is_compacting`)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — 201 findings, unchanged baseline
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK, no new entries
- [x] `pytest` scoped to the diff (`-k "5588 or 5605 or 5618 or lifecycle_forwarder"`) — green
- [x] Truncate-falsify on the `terminal_seq` baseline comparison — confirmed `test_a_stale_terminal_from_before_the_entry_started_is_never_reused` goes red when the comparison is weakened, nothing else breaks
- [x] (skipped — no new `AUDIT_EVENT_KINDS` entry needed: `router_context_overflow_unrecovered` was already declared from #5588's earlier skeleton PR #5595)
- [ ] 👁️ Visual — real spinner glyph confirmed via an actual rendered screenshot (`app.export_screenshot()`, controller-driven fixture): running state shows `⠙ 文脈を縮めています（自動で終わります）`, settled state shows the static `文脈を縮めました`. **Not yet seen by the owner** — per standing waiver this does not block merge, but flagging per lead-coder's explicit request for a real capture before arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)