### PR TITLE
**[coder-smith]** — fix pipeline flowview entry path (Closes #5731)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -5234,12 +5234,13 @@ class TextualChatApp(App):
         entry = self._pipeline_runs.get(run_id)
         item = replace(msg, meta={**meta, _PIPELINE_RUN_KEY: run_id})
         if entry is None:
-            entry = self._flow.append(item)
+            # ``_flow`` is the view; new entries belong to its model, just like
+            # every other entry-creating path. Reuse the established running
+            # indicator helper so pipeline rows receive the same viewport-gated
+            # animation as other live rows.
+            entry = self.conversation.append(item)
             self._pipeline_runs[run_id] = entry
-            try:
-                self._flow.start_entry_animation(entry)
-            except Exception:
-                logger.exception("textual chat: could not start pipeline animation")
+            self._begin_running_indicator(entry)
             return True
         try:
             entry.set_item(item)

--- a/tests/interfaces/test_5731_pipeline_flowview_entry.py
+++ b/tests/interfaces/test_5731_pipeline_flowview_entry.py
@@ -1,0 +1,103 @@
+"""Tier 2: pipeline progress frames create and animate a visible flow entry.
+
+The pipeline coalescer must append through the FlowModel owned by the view and
+use the same live-entry animation seam as tool rows. A real Textual test app
+and real textual-flowview objects provide the observation surface.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _PipelineTransport(ClientTransportStub):
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[DisplayFrame]" = asyncio.Queue()
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._queue.get()
+
+    async def push(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def submit_user_text(self, text: str) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def attach_failed(self) -> bool:
+        return False
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: OutboxMessage) -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        return False
+
+
+def _pipeline_message(index: int = 0) -> OutboxMessage:
+    return OutboxMessage(
+        kind="status",
+        text="[pipeline step]",
+        meta={
+            "source": "pipeline",
+            "run_id": "run-5731",
+            "pipeline_name": "probe",
+            "step_index": index,
+            "total_steps": 2,
+            "step_kind": "transform",
+            "step_event": "pipeline_step_started",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_frame_creates_one_flow_entry() -> None:
+    """Tier 2: a reached pipeline frame is retained as a visible flow entry."""
+    transport = _PipelineTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await transport.push(_pipeline_message())
+        await pilot.pause()
+        await pilot.pause()
+        entries = app.query_one(FlowView).entries
+
+    entry = next(
+        entry for entry in entries if entry.item.meta.get("run_id") == "run-5731"
+    )
+    assert entry.item.meta["step_index"] == 0

--- a/tests/interfaces/test_5731_pipeline_flowview_entry.py
+++ b/tests/interfaces/test_5731_pipeline_flowview_entry.py
@@ -13,6 +13,7 @@ import pytest
 from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat._meta_keys import RUNNING_SINCE_KEY
 from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
@@ -101,3 +102,6 @@ async def test_pipeline_frame_creates_one_flow_entry() -> None:
         entry for entry in entries if entry.item.meta.get("run_id") == "run-5731"
     )
     assert entry.item.meta["step_index"] == 0
+    assert entry.item.meta.get(RUNNING_SINCE_KEY) is not None, (
+        "expected the pipeline row animation to be running"
+    )


### PR DESCRIPTION
**[coder-smith]** — #5731 の pipeline TUI 行生成を修理します。

- `FlowView` に存在しない `append` を `FlowModel` (`self.conversation`) の append に変更
- `start_entry_animation` を、実際に動作している `_begin_running_indicator` 経路へ変更
- 実TUIで到達・entry生成を確認する Tier 2 テストを追加

検証:
- scoped pytest: `1 passed`
- `ruff check`: passed
- `test_tier_audit.py --strict`: passed
- `verify_module_docstrings.py`: passed
- `git diff --check`: passed

part of #5731


---

**[lead-coder]** — 本文に閉じ語を追加しました（題が `part of` のままで、残務の記載も無かったため。この PR は #5731 の 2 箇所を両方直しています）。

Closes #5731
