### PR TITLE
fix(#5732): textual chat pump — surface swallowed frame-ingest exceptions

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -203,6 +203,7 @@ presentation_load_failed
 presented
 process_marker_reaped
 project_context_changed
+pump_exception_swallowed
 recovery_summary_persisted
 repo_ingest_files_skipped
 resource_cap_exceeds_budget_trigger
@@ -733,6 +734,29 @@ readers ran `live_processes` first would otherwise destroy the evidence
 | Kind | Trigger | Key payload |
 |------|---------|-------------|
 | `process_marker_reaped` | #5358: a confirmed-dead PID's marker is about to be reaped (unlinked) — the marker was the ONLY record that PID ever ran, since the process itself never got to say it was stopping (a graceful exit's own `atexit` handler would have already removed it). Emitted from the reading CALLER's process, but under the DEAD process's OWN project (`reyn_root` resolved by walking up from the marker's own `cwd` field, never the caller's cwd — a `reyn doctor` run from project A must not misattribute a reap for a process that ran in project B). Best-effort: an emit failure (no `.reyn/` reachable from the marker's cwd, or any other error) logs a warning and never blocks the reap itself. Detection, not diagnosis — carries no information about WHY the process stopped (crash / SIGKILL / power loss / OOM are indistinguishable from here). #5709: `marker` now also carries `last_loop_beat_at` (absent/`None` if the process's own turn loop never armed the beat driver, e.g. it died before `Session.run()` ever started) — together with `observed_at` this is the ONE place `[last_loop_beat_at, observed_at]` — the tightened death window #5709 exists to produce — is readable, and it lands in the dead session's own `.reyn/events`, the same place a post-mortem reader already looks. | `marker` (the dead process's own full recorded content: `pid`/`ppid`/`cwd`/`subcommand`/`started_at`/`sessions` (#5714 — a collection of hosted-session identity entries, replacing the pre-#5714 singular `agent_name`/`broker_session_id` pair)/`last_loop_beat_at`), `observed_at` (an UPPER BOUND on the stop time — the real stop happened sometime between the marker's `last_loop_beat_at` (or `started_at`, if the beat never armed) and this timestamp, never asserted as the exact moment) |
+
+## Textual chat pump
+
+`TextualChatApp._pump_frames` (`src/reyn/interfaces/inline/textual_chat/app.py`)
+wraps each of its 3 per-message-kind handlers (`/rewind` sentinel,
+`__open_artifact__` sentinel, `_ingest_frame`) in its own
+`try`/`except Exception` — the pump must survive one bad frame, since a
+single unhandled exception there would end the whole chat loop. #5732
+(architect ruling, real-machine incident #5731 — `_coalesce_pipeline_step`
+raised `AttributeError` on EVERY `"status"`-kind frame, shipped, undetected:
+tests stayed green and nothing surfaced it to a human): keeping the catch
+is correct — the defect was that a swallowed exception reached nowhere but
+one `logger.exception` line, with no operator-visible signal. `reyn.
+interfaces.inline.textual_chat.app.PumpSwallowStats.count` (also folded
+into the status line via `chrome.status_line_text`'s `pump_swallow_count`
+param — `"draw failed: N — see log · "`, only when `N > 0`, never a
+transient toast) is the COMPLETE read: it increments on every swallowed
+occurrence, from every one of the 3 handlers, with no gating. This event is
+a deliberately BOUNDED companion, not a duplicate of that count.
+
+| Kind | Trigger | Key payload |
+|------|---------|-------------|
+| `pump_exception_swallowed` | One of the pump's 3 `except Exception` blocks caught an exception. Fires only on the FIRST time a given `(frame_kind, exception type)` pair is seen this process (`PumpSwallowStats.record`) — a broken call site fails on every frame, so a durable record per OCCURRENCE would flood `.reyn/events` with thousands of rows for one defect; the bounded count above already carries the complete tally. Never carries the exception's own message or traceback — `logger.exception` (unchanged, already called at all 3 sites) already covers the free-text half; this event carries only the structured facts a post-mortem reader queries by. Best-effort (`emit_cli_event`, matching `install_asyncio_exception_handler`'s own posture for `reyn chat` — a single-invocation, single-cwd CLI entrypoint, unlike a long-lived multi-project server): an emit failure here is logged and swallowed, never propagated into the pump. | `frame_kind` (the pump message's own `kind` — `__rewind_list__` \| `__open_artifact__` \| the `_ingest_frame` frame's `kind`), `exception_type` (`type(exc).__name__`) |
 
 ## Replay
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -738,8 +738,8 @@ readers ran `live_processes` first would otherwise destroy the evidence
 ## Textual chat pump
 
 `TextualChatApp._pump_frames` (`src/reyn/interfaces/inline/textual_chat/app.py`)
-wraps each of its 3 per-message-kind handlers (`/rewind` sentinel,
-`__open_artifact__` sentinel, `_ingest_frame`) in its own
+wraps each of its 4 per-message-kind handlers (`/copy` sentinel, `/rewind`
+sentinel, `__open_artifact__` sentinel, `_ingest_frame`) in its own
 `try`/`except Exception` — the pump must survive one bad frame, since a
 single unhandled exception there would end the whole chat loop. #5732
 (architect ruling, real-machine incident #5731 — `_coalesce_pipeline_step`
@@ -751,12 +751,12 @@ interfaces.inline.textual_chat.app.PumpSwallowStats.count` (also folded
 into the status line via `chrome.status_line_text`'s `pump_swallow_count`
 param — `"draw failed: N — see log · "`, only when `N > 0`, never a
 transient toast) is the COMPLETE read: it increments on every swallowed
-occurrence, from every one of the 3 handlers, with no gating. This event is
+occurrence, from every one of the 4 handlers, with no gating. This event is
 a deliberately BOUNDED companion, not a duplicate of that count.
 
 | Kind | Trigger | Key payload |
 |------|---------|-------------|
-| `pump_exception_swallowed` | One of the pump's 3 `except Exception` blocks caught an exception. Fires only on the FIRST time a given `(frame_kind, exception type)` pair is seen this process (`PumpSwallowStats.record`) — a broken call site fails on every frame, so a durable record per OCCURRENCE would flood `.reyn/events` with thousands of rows for one defect; the bounded count above already carries the complete tally. Never carries the exception's own message or traceback — `logger.exception` (unchanged, already called at all 3 sites) already covers the free-text half; this event carries only the structured facts a post-mortem reader queries by. Best-effort (`emit_cli_event`, matching `install_asyncio_exception_handler`'s own posture for `reyn chat` — a single-invocation, single-cwd CLI entrypoint, unlike a long-lived multi-project server): an emit failure here is logged and swallowed, never propagated into the pump. | `frame_kind` (the pump message's own `kind` — `__rewind_list__` \| `__open_artifact__` \| the `_ingest_frame` frame's `kind`), `exception_type` (`type(exc).__name__`) |
+| `pump_exception_swallowed` | One of the pump's 4 `except Exception` blocks caught an exception. Fires only on the FIRST time a given `(frame_kind, exception type)` pair is seen this process (`PumpSwallowStats.record`) — a broken call site fails on every frame, so a durable record per OCCURRENCE would flood `.reyn/events` with thousands of rows for one defect; the bounded count above already carries the complete tally. Never carries the exception's own message or traceback — `logger.exception` (unchanged, already called at all 4 sites) already covers the free-text half; this event carries only the structured facts a post-mortem reader queries by. Best-effort (`emit_cli_event`, matching `install_asyncio_exception_handler`'s own posture for `reyn chat` — a single-invocation, single-cwd CLI entrypoint, unlike a long-lived multi-project server): an emit failure here is logged and swallowed, never propagated into the pump. | `frame_kind` (the pump message's own `kind` — `__copy_last_reply__` \| `__rewind_list__` \| `__open_artifact__` \| the `_ingest_frame` frame's `kind`), `exception_type` (`type(exc).__name__`) |
 
 ## Replay
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -547,8 +547,9 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "process_marker_reaped",
     "project_context_changed",
     # #5732 (architect ruling): the textual chat pump's own bounded
-    # diagnostic for a swallowed per-frame exception (/rewind sentinel,
-    # __open_artifact__ sentinel, _ingest_frame) -- one event per FIRST
+    # diagnostic for a swallowed per-frame exception (/copy sentinel,
+    # /rewind sentinel, __open_artifact__ sentinel, _ingest_frame) --
+    # one event per FIRST
     # occurrence of a (frame_kind, exception type) pair, never per
     # occurrence (a broken call site fails every frame; the running
     # count is exposed separately via PumpSwallowStats.count, which is

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -546,6 +546,14 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "presented",
     "process_marker_reaped",
     "project_context_changed",
+    # #5732 (architect ruling): the textual chat pump's own bounded
+    # diagnostic for a swallowed per-frame exception (/rewind sentinel,
+    # __open_artifact__ sentinel, _ingest_frame) -- one event per FIRST
+    # occurrence of a (frame_kind, exception type) pair, never per
+    # occurrence (a broken call site fails every frame; the running
+    # count is exposed separately via PumpSwallowStats.count, which is
+    # complete -- this event is bounded, not a duplicate of the count).
+    "pump_exception_swallowed",
     "recovery_summary_persisted",
     "repo_ingest_files_skipped",
     "resource_cap_exceeds_budget_trigger",

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4982,7 +4982,7 @@ class TextualChatApp(App):
 
         Never includes the exception's own message/traceback — that is
         `logger.exception`'s own job (already called at every one of
-        this method's 3 call sites, unchanged); the audit-event carries
+        this method's 4 call sites, unchanged); the audit-event carries
         only ``frame_kind``/``exception_type`` (named ``frame_kind``,
         not ``kind`` — ``emit_cli_event``'s own first positional
         parameter is itself named ``kind``, the audit-event's own kind
@@ -6797,8 +6797,9 @@ class TextualChatApp(App):
                     elif msg.kind == "__copy_last_reply__":
                         try:
                             await self._handle_copy_request(msg.text)
-                        except Exception:
+                        except Exception as exc:
                             logger.exception("textual chat: /copy sentinel failed")
+                            self._record_pump_swallow("__copy_last_reply__", exc)
                     elif msg.kind == "__rewind_list__":
                         try:
                             await self._handle_rewind_request(msg)

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import deque
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Callable
 
 from textual import events
@@ -155,6 +155,55 @@ logger = logging.getLogger(__name__)
 # currently empty — kept (not deleted) as the documented extension point for
 # a future control sentinel that needs skipping here.
 _SKIP_KINDS: "frozenset[str]" = frozenset()
+
+
+@dataclass
+class PumpSwallowStats:
+    """#5732 (architect ruling, real-machine incident #5731 — a broken
+    call site inside ``_ingest_frame`` raised ``AttributeError`` on
+    EVERY frame, silently, and shipped that way undetected): the pump's
+    own per-sentinel/per-frame ``except Exception`` blocks (:meth:`_pump_
+    frames`) are the correct scope — a single bad frame must never take
+    down the whole chat loop — but a caught exception used to become
+    nothing more than one ``logger.exception`` line, visible only to
+    someone already reading the log. This is the live counter that
+    closes that: mirrors :class:`~reyn.interfaces.inline.textual_chat.
+    stray_output.StrayOutputStats`'s own shape exactly (a plain,
+    App/widget-free dataclass the App reads at each status-line
+    refresh) — no new visibility vocabulary, the SAME "one persistent
+    number, prepended to the always-visible status line, never a
+    per-occurrence toast" precedent #5168 already established.
+
+    ``count`` is the TOTAL swallowed occurrences across every kind and
+    exception type — the number an operator sees ("N frames failed to
+    draw"), always complete regardless of how many distinct call sites
+    are broken. ``record`` ALSO gates a separate, bounded concern: a
+    broken call site fails on EVERY frame it's given (#5731's own
+    measured shape), so recording one audit-event per occurrence would
+    turn a single defect into thousands of durable records (charter Q1
+    — "who stops this if it repeats" — nobody, if nothing bounds it).
+    ``record``'s own return value is that bound: True only the FIRST
+    time a given ``(kind, exception type)`` pair is seen, so the caller
+    emits an audit-event on that transition alone. The COUNT still
+    reflects every occurrence — only the EVENT population is bounded,
+    never the number an operator or a test reads."""
+
+    count: int = 0
+    _seen: "set[tuple[str, str]]" = field(default_factory=set)
+
+    def record(self, kind: str, exc: BaseException) -> bool:
+        """Record one swallowed exception for *kind*. Returns True iff
+        this exact ``(kind, type(exc).__name__)`` pair has never been
+        recorded before — the caller's own signal to emit the bounded,
+        once-per-pair audit-event; a repeat of an already-seen pair
+        still increments :attr:`count` but returns False."""
+        self.count += 1
+        key = (kind, type(exc).__name__)
+        if key in self._seen:
+            return False
+        self._seen.add(key)
+        return True
+
 
 # Turn-end event types (#72): when one of these lands on the EVENT-tag frame
 # path, any tool row still RUNNING is a confirmed ORPHAN — its completion frame
@@ -1321,6 +1370,10 @@ class TextualChatApp(App):
         # TextualChatApp(...) in a test), in which case _status_text's own
         # diagnostics_count read stays 0, byte-identical to before #5168.
         self._stray_output_stats: "StrayOutputStats | None" = None
+        # #5732: unlike _stray_output_stats above (only set inside
+        # run_textual_chat's own capture window), this pump ALWAYS runs
+        # for every App instance — always constructed, never None.
+        self._pump_swallow_stats = PumpSwallowStats()
         # #5149: the two halves of "current location" are seeded TOGETHER,
         # one ``_Destination`` construction — see that class's own
         # docstring for why they can no longer be seeded (or later updated)
@@ -2226,7 +2279,13 @@ class TextualChatApp(App):
         ``None`` whenever this App wasn't constructed inside
         :func:`run_textual_chat`'s own ``capture_stray_output`` window (a
         bare ``TextualChatApp(...)`` in a test, for instance), in which case
-        the count is always 0 — byte-identical status text to before #5168."""
+        the count is always 0 — byte-identical status text to before #5168.
+
+        #5732: ``pump_swallow_count`` reads ``self._pump_swallow_stats``
+        (always constructed, unlike ``_stray_output_stats`` above) — the
+        SAME "prepend, don't replace" segment shape #5168 established,
+        applied to a different failure class (a pump call site raising,
+        not a stray stdout/stderr write)."""
         snapshot = self._snapshot() if snap is _UNSET else snap
         warn_percent = getattr(
             getattr(self._config, "tui", None),
@@ -2240,6 +2299,7 @@ class TextualChatApp(App):
             attach_state=self._attach_state(),
             warn_percent=warn_percent,
             diagnostics_count=diagnostics_count,
+            pump_swallow_count=self._pump_swallow_stats.count,
         )  # type: ignore[arg-type]
 
     async def _watch_loop_responsiveness(self) -> None:
@@ -4900,6 +4960,54 @@ class TextualChatApp(App):
             # never a candidate for this collapse in the first place.
             entry.collapse()
 
+    def _record_pump_swallow(self, kind: str, exc: BaseException) -> None:
+        """#5732: the ONE call site every ``except Exception`` block in
+        :meth:`_pump_frames` routes through — bumps :attr:`_pump_swallow_
+        stats` (the always-complete count) and, only on the first time
+        THIS ``(kind, exception type)`` pair is seen, durably records a
+        ``pump_exception_swallowed`` audit-event (architect ruling: bounded
+        by the pair, never by the occurrence — a broken call site fails
+        every frame, so 1-event-per-occurrence would flood ``.reyn/events``
+        with thousands of records for a single defect).
+
+        ``emit_cli_event`` (cwd-derived project root), not ``emit_direct_
+        event`` with an explicit root: unlike a long-lived multi-project
+        server (``reyn web``, #5714's own case for why cwd is wrong
+        there), this is a single-invocation, single-cwd CLI entrypoint —
+        the SAME shape ``asyncio_diagnostics.py``'s own ``install_asyncio_
+        exception_handler`` already uses for ``reyn chat``. Best-effort:
+        an emit failure here must never propagate into the pump — logged,
+        swallowed, matching this module's own posture for every other
+        diagnostic-only write.
+
+        Never includes the exception's own message/traceback — that is
+        `logger.exception`'s own job (already called at every one of
+        this method's 3 call sites, unchanged); the audit-event carries
+        only ``frame_kind``/``exception_type`` (named ``frame_kind``,
+        not ``kind`` — ``emit_cli_event``'s own first positional
+        parameter is itself named ``kind``, the audit-event's own kind
+        string; passing this method's ``kind`` argument under that same
+        name collides with it), the structured facts a post-mortem
+        reader queries by, not the free-text a log grep already
+        answers."""
+        first_occurrence = self._pump_swallow_stats.record(kind, exc)
+        if not first_occurrence:
+            return
+        try:
+            from reyn.core.events.events import emit_cli_event
+
+            emit_cli_event(
+                "pump_exception_swallowed",
+                frame_kind=kind,
+                exception_type=type(exc).__name__,
+            )
+        except Exception:
+            logger.exception(
+                "textual chat: failed to emit pump_exception_swallowed "
+                "for kind=%r (diagnostic-only, does not block the pump)",
+                kind,
+            )
+
     def _ingest_frame(self, msg: "OutboxMessage") -> "Entry[OutboxMessage] | None":
         """Fold one display frame into the retained model — appending a new entry,
         or COALESCING a correlated tool result into its RUNNING started entry.
@@ -6694,21 +6802,24 @@ class TextualChatApp(App):
                     elif msg.kind == "__rewind_list__":
                         try:
                             await self._handle_rewind_request(msg)
-                        except Exception:
+                        except Exception as exc:
                             logger.exception("textual chat: /rewind sentinel failed")
+                            self._record_pump_swallow("__rewind_list__", exc)
                     elif msg.kind == "__open_artifact__":
                         try:
                             await self._handle_open_artifact_request(msg.text)
-                        except Exception:
+                        except Exception as exc:
                             logger.exception("textual chat: /open sentinel failed")
+                            self._record_pump_swallow("__open_artifact__", exc)
                     elif msg.kind not in _SKIP_KINDS:
                         try:
                             self._ingest_frame(msg)
-                        except Exception:
+                        except Exception as exc:
                             logger.exception(
                                 "textual chat: frame ingest failed for kind=%r",
                                 msg.kind,
                             )
+                            self._record_pump_swallow(msg.kind, exc)
                 # F5b + #3338: refresh the live chrome (the always-visible
                 # status-values line, plus whichever drawer pane is OPEN) on EVERY
                 # frame — DISPLAY **and** EVENT alike. This used to sit inside the

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1912,6 +1912,7 @@ def status_line_text(
     warn_percent: int = CTX_WARN_PERCENT,
     diagnostics_count: int = 0,
     diagnostics_log_path: "str | None" = None,
+    pump_swallow_count: int = 0,
 ) -> str:
     """The Telemetry segment (#4542: ``model · agent    $cost  ctx%``, no
     ``│``/``|`` separators — position and text-style carry the grouping
@@ -1966,6 +1967,19 @@ def status_line_text(
     LAST, after every other branch (``connecting``/``failed``/HALTED/base)
     — diagnostics can coexist with any of those, so it is not folded into
     any single branch's own return.
+
+    #5732: ``pump_swallow_count`` (default 0, byte-identical text when
+    unset) PREPENDS a further ``draw failed: N — see log`` segment, the
+    SAME shape as ``diagnostics_count`` immediately above (never a
+    traceback, never a transient toast — architect ruling: an operator
+    needs "something failed to draw, N times" and where to look, not the
+    exception itself) — a pump call site (frame ingest, ``/rewind``,
+    ``/open``) raised and was caught to keep the chat loop alive
+    (:meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+    _record_pump_swallow`); this is the operator-facing half of that
+    fact, never shown when the count is 0. Ordered ahead of
+    ``diagnostics_count`` (leftmost = most recently added) — no
+    dependency between the two, an arbitrary but stable order.
     """
     if attach_state == "connecting":
         text = f"connecting… · agent {agent_name}"
@@ -2001,6 +2015,8 @@ def status_line_text(
         )
     if diagnostics_count:
         text = f"diagnostics: {diagnostics_count} — {diagnostics_log_path or '.reyn/logs/reyn.log'} · {text}"
+    if pump_swallow_count:
+        text = f"draw failed: {pump_swallow_count} — see log · {text}"
     return text
 
 

--- a/tests/interfaces/test_5732_pump_swallow_visibility.py
+++ b/tests/interfaces/test_5732_pump_swallow_visibility.py
@@ -1,0 +1,403 @@
+"""Tier 2: #5732 (architect ruling, real-machine incident #5731 —
+``_coalesce_pipeline_step`` raised ``AttributeError`` on EVERY ``"status"``-
+kind frame, shipped, undetected: tests stayed green and nothing surfaced it
+to a human) — ``TextualChatApp._pump_frames``'s 3 sibling ``except
+Exception`` blocks (``/rewind`` sentinel, ``__open_artifact__`` sentinel,
+``_ingest_frame``) must keep the app alive (unchanged) AND make the
+swallowed failure legible: a complete, public ``PumpSwallowStats.count``,
+a status-line segment once it is nonzero, and a bounded
+``pump_exception_swallowed`` audit-event (one per first-seen
+``(frame_kind, exception type)`` pair, never one per occurrence).
+
+Architect's own 8-point acceptance (issuecomment on #5732), verbatim:
+  ① all 3 sibling catches treated alike
+  ② deliberately breaking ``_ingest_frame`` makes a test go RED
+  ③ production behaviour unchanged (catch stays, loop survives)
+  ④ no test-only branch (behaviour does not vary by environment)
+  ⑤ the same ``(kind, exception type)`` failing 100x is 1 event, count 100
+  ⑥ a DIFFERENT ``(kind, exception type)`` counts separately
+  ⑦ no traceback on the operator surface; nothing shown at 0
+  ⑧ the indicator does not disappear (not a transient toast)
+
+No mocks: real ``PumpSwallowStats``, real ``TextualChatApp`` + ``run_test()``
+pilot (mirrors ``tests/interfaces/test_5168_tui_stdio_capture.py``'s own
+end-to-end idiom), real ``emit_cli_event`` + a real ``.reyn/events`` read-back
+(mirrors ``tests/core/test_asyncio_diagnostics.py``'s own idiom) for the
+audit-event witnesses. ``_ingest_frame`` is broken by monkeypatching the
+method itself to raise (② above) — not by editing source — since the point
+under test is the PUMP's own reaction to a broken handler, not the handler's
+own internals.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat.app import PumpSwallowStats
+from reyn.interfaces.inline.textual_chat.chrome import status_line_text
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+# ---------------------------------------------------------------------------
+# PumpSwallowStats — unit level (real instance, no App needed)
+# ---------------------------------------------------------------------------
+
+
+def test_record_returns_true_only_on_the_first_occurrence_of_a_pair() -> None:
+    """Tier 2: acceptance ⑤'s dedup-gate witness — the SAME (kind,
+    exception type) pair returns True once, then False on every further
+    occurrence, regardless of how many times it recurs."""
+    stats = PumpSwallowStats()
+    first = stats.record("status", ValueError("boom"))
+    second = stats.record("status", ValueError("boom again"))
+    third = stats.record("status", ValueError("boom a third time"))
+    assert first is True
+    assert second is False
+    assert third is False
+
+
+def test_count_grows_every_occurrence_even_while_dedup_gates_the_event() -> None:
+    """Tier 2: acceptance ⑤'s "count 100" half — the public count is
+    COMPLETE (every occurrence), independent of the event-emission gate
+    the ``record()`` return value drives."""
+    stats = PumpSwallowStats()
+    for _ in range(5):
+        stats.record("status", ValueError("boom"))
+    assert stats.count == 5
+
+
+def test_a_different_exception_type_for_the_same_kind_is_a_separate_pair() -> None:
+    """Tier 2: acceptance ⑥ — (kind, exception type) is the KEY, not kind
+    alone. A second, DIFFERENT exception type for the same frame kind must
+    get its own first-occurrence True, not be folded into the first pair's
+    dedup."""
+    stats = PumpSwallowStats()
+    first = stats.record("status", ValueError("boom"))
+    second = stats.record("status", AttributeError("different failure class"))
+    assert first is True
+    assert second is True, (
+        "a different exception TYPE for the same kind must not be treated "
+        "as a repeat of the first pair"
+    )
+
+
+def test_a_different_kind_for_the_same_exception_type_is_a_separate_pair() -> None:
+    """Tier 2: acceptance ⑥, the other axis — kind is also part of the key,
+    not just the exception type."""
+    stats = PumpSwallowStats()
+    first = stats.record("status", ValueError("boom"))
+    second = stats.record("__open_artifact__", ValueError("boom"))
+    assert first is True
+    assert second is True, (
+        "a different frame kind with the same exception type must not be "
+        "treated as a repeat of the first pair"
+    )
+
+
+# ---------------------------------------------------------------------------
+# status_line_text — pure-function level
+# ---------------------------------------------------------------------------
+
+
+def test_status_line_unaffected_when_pump_swallow_count_is_zero() -> None:
+    """Tier 2: acceptance ⑦'s "nothing shown at 0" half — the default is
+    byte-identical to the pre-#5732 text."""
+    text_before = status_line_text({"model_active_class": "opus"}, "alpha")
+    text_default = status_line_text(
+        {"model_active_class": "opus"}, "alpha", pump_swallow_count=0,
+    )
+    assert text_before == text_default
+    assert "draw failed" not in text_default
+
+
+def test_status_line_prepends_draw_failed_segment_when_count_is_nonzero() -> None:
+    """Tier 2: acceptance ⑦'s "N — see log" half; acceptance ⑧ — the
+    segment names a count, never a traceback or exception message."""
+    text = status_line_text(
+        {"model_active_class": "opus"}, "alpha", pump_swallow_count=3,
+    )
+    assert text.startswith("draw failed: 3 — see log"), text
+    assert "opus" in text, "the ordinary status text must still follow"
+    assert "Traceback" not in text
+    assert "Error" not in text
+
+
+def test_status_line_pump_swallow_coexists_with_diagnostics_segment() -> None:
+    """Tier 2: two independently-gated segments (#5168's diagnostics_count,
+    #5732's pump_swallow_count) must not silently swallow each other when
+    both are nonzero at once."""
+    text = status_line_text(
+        {"model_active_class": "opus"}, "alpha",
+        diagnostics_count=1, pump_swallow_count=2,
+    )
+    assert "draw failed: 2" in text
+    assert "diagnostics: 1" in text
+
+
+# ---------------------------------------------------------------------------
+# _record_pump_swallow — real emit_cli_event, real .reyn/events read-back
+# ---------------------------------------------------------------------------
+
+
+def _read_events_of_kind(events_dir: Path, kind: str) -> "list[dict]":
+    found: "list[dict]" = []
+    if not events_dir.exists():
+        return found
+    for path in events_dir.rglob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            if rec.get("type") == kind:
+                found.append(rec)
+    return found
+
+
+class _StubTransport(ClientTransportStub):
+    """Mirrors ``test_5168_tui_stdio_capture.py``'s own ``_StubTransport`` —
+    no attach machinery needed, just an app that mounts and stays running."""
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def has_session(self) -> bool:
+        return True
+
+    def attach_failed(self) -> bool:
+        return False
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        import asyncio
+        await asyncio.Event().wait()
+        return
+        yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
+
+    async def submit_user_text(self, text: str) -> str:
+        return "msg-1"
+
+    async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str, *, intervention_id=None) -> bool:
+        return False
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+class _StubReadModel(ChatReadModel):
+    @property
+    def capabilities(self):
+        return LOCAL_CHAT_READ_CAPABILITIES
+
+    def snapshot(self, config=None):
+        return {"model_active_class": "opus"}
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self):
+        return Path("/tmp/reyn_5732_history")
+
+    def conversation_history(self, *, limit=None):
+        return []
+
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
+
+def test_record_pump_swallow_emits_a_real_event_with_no_parameter_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: REAL regression witness for the ``emit_cli_event(kind=...)``
+    collision this PR fixed (``emit_cli_event``'s own first positional
+    parameter is ALSO named ``kind`` — passing the frame kind under that
+    same name raises ``TypeError: emit_cli_event() got multiple values for
+    argument 'kind'``). Calling the real, unmocked path end to end is the
+    only way this class of bug is caught — a mocked ``emit_cli_event``
+    would not raise on a bad keyword the mock itself accepts anything for."""
+    from reyn.interfaces.inline.textual_chat.app import TextualChatApp
+
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    app = TextualChatApp(transport=_StubTransport(), read_model=_StubReadModel())
+    app._record_pump_swallow("status", AttributeError("no attribute 'append'"))
+
+    events = _read_events_of_kind(reyn_dir / "events", "pump_exception_swallowed")
+    [event] = events
+    assert event["data"]["frame_kind"] == "status"
+    assert event["data"]["exception_type"] == "AttributeError"
+
+
+def test_record_pump_swallow_emits_once_for_a_repeated_pair_but_keeps_counting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: acceptance ⑤ end to end — the SAME (kind, exception type)
+    failing repeatedly (the #5731 shape: a broken call site fails every
+    frame) durably records exactly ONE audit-event, while the public count
+    keeps growing."""
+    from reyn.interfaces.inline.textual_chat.app import TextualChatApp
+
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    app = TextualChatApp(transport=_StubTransport(), read_model=_StubReadModel())
+    stats = PumpSwallowStats()
+    app._pump_swallow_stats = stats  # mirrors test_5168's own app._stray_output_stats wiring
+    for _ in range(5):
+        app._record_pump_swallow("status", AttributeError("append"))
+
+    events = _read_events_of_kind(reyn_dir / "events", "pump_exception_swallowed")
+    [event] = events  # exactly one event captured — unpack raises otherwise
+    assert event["data"]["exception_type"] == "AttributeError"
+    assert stats.count == 5
+
+
+def test_record_pump_swallow_emits_separately_for_a_different_exception_type(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: acceptance ⑥ end to end — a second, different (kind,
+    exception type) pair gets its own durable event."""
+    from reyn.interfaces.inline.textual_chat.app import TextualChatApp
+
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    app = TextualChatApp(transport=_StubTransport(), read_model=_StubReadModel())
+    app._record_pump_swallow("status", AttributeError("append"))
+    app._record_pump_swallow("status", ValueError("a different failure class"))
+
+    events = _read_events_of_kind(reyn_dir / "events", "pump_exception_swallowed")
+    [event_a, event_b] = events  # exactly two events captured — unpack raises otherwise
+    assert {event_a["data"]["exception_type"], event_b["data"]["exception_type"]} == {
+        "AttributeError", "ValueError",
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — a real TextualChatApp, real run_test() pilot, a genuinely
+# broken _ingest_frame (the #5731 shape) driving a real frame through the
+# pump.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_broken_ingest_frame_is_visible_in_the_status_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: acceptance ② — the PR's own "body". Deliberately breaking
+    ``_ingest_frame`` (mirrors #5731's real ``AttributeError`` on every
+    "status"-kind frame) must turn THIS test red were the #5732 fix ever
+    reverted: with the fix in place, the swallowed failure surfaces on the
+    status line; strip :meth:`TextualChatApp._record_pump_swallow`'s call
+    site (or revert it to a bare ``except Exception:``) and this assertion
+    fails — exactly the gap #5731 shipped through undetected."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    transport = _StubTransport()
+    app = TextualChatApp(transport=transport, read_model=_StubReadModel())
+
+    def _broken_ingest(self, msg):
+        raise AttributeError("'_CursorFlowView' object has no attribute 'append'")
+
+    monkeypatch.setattr(TextualChatApp, "_ingest_frame", _broken_ingest)
+
+    async def _one_status_frame() -> "AsyncIterator[DisplayFrame]":
+        yield DisplayFrame(OutboxMessage(kind="status", text="thinking"))
+        import asyncio
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(transport, "frames", _one_status_frame)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        # Public read, per the architect's own design ("count は公開の読みに
+        # 載る") — the status line, not a private ._pump_swallow_stats access.
+        status_text = str(app.query_one(StatusLine).render())
+        assert "draw failed: 1" in status_text, (
+            f"a swallowed ingest failure did not surface on the status "
+            f"line: {status_text!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_pump_survives_a_broken_ingest_frame_and_keeps_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: acceptance ③ — production behaviour is UNCHANGED: the catch
+    stays, and a broken frame handler does not end the pump's own loop. A
+    SECOND, ordinary frame after the broken one must still be ingested."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    transport = _StubTransport()
+    app = TextualChatApp(transport=transport, read_model=_StubReadModel())
+
+    real_ingest = TextualChatApp._ingest_frame
+    call_kinds: "list[str]" = []
+
+    def _fails_once_then_delegates(self, msg):
+        call_kinds.append(msg.kind)
+        if msg.kind == "status":
+            raise AttributeError("'_CursorFlowView' object has no attribute 'append'")
+        return real_ingest(self, msg)
+
+    monkeypatch.setattr(TextualChatApp, "_ingest_frame", _fails_once_then_delegates)
+
+    async def _two_frames() -> "AsyncIterator[DisplayFrame]":
+        yield DisplayFrame(OutboxMessage(kind="status", text="thinking"))
+        yield DisplayFrame(OutboxMessage(kind="agent", text="hello"))
+        import asyncio
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(transport, "frames", _two_frames)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert call_kinds == ["status", "agent"], (
+            "the pump must keep draining frames after one handler raised — "
+            f"got {call_kinds!r}"
+        )
+        # Public read, mirrors the sibling test above — only the broken
+        # (status) frame should have been recorded, not the ordinary one.
+        status_text = str(app.query_one(StatusLine).render())
+        assert "draw failed: 1" in status_text, (
+            f"only the broken (status) frame should have been recorded: "
+            f"{status_text!r}"
+        )

--- a/tests/interfaces/test_5732_pump_swallow_visibility.py
+++ b/tests/interfaces/test_5732_pump_swallow_visibility.py
@@ -1,16 +1,26 @@
 """Tier 2: #5732 (architect ruling, real-machine incident #5731 —
 ``_coalesce_pipeline_step`` raised ``AttributeError`` on EVERY ``"status"``-
 kind frame, shipped, undetected: tests stayed green and nothing surfaced it
-to a human) — ``TextualChatApp._pump_frames``'s 3 sibling ``except
-Exception`` blocks (``/rewind`` sentinel, ``__open_artifact__`` sentinel,
-``_ingest_frame``) must keep the app alive (unchanged) AND make the
-swallowed failure legible: a complete, public ``PumpSwallowStats.count``,
-a status-line segment once it is nonzero, and a bounded
-``pump_exception_swallowed`` audit-event (one per first-seen
+to a human) — ``TextualChatApp._pump_frames``'s 4 sibling ``except
+Exception`` blocks (``/copy`` sentinel, ``/rewind`` sentinel,
+``__open_artifact__`` sentinel, ``_ingest_frame``) must keep the app alive
+(unchanged) AND make the swallowed failure legible: a complete, public
+``PumpSwallowStats.count``, a status-line segment once it is nonzero, and
+a bounded ``pump_exception_swallowed`` audit-event (one per first-seen
 ``(frame_kind, exception type)`` pair, never one per occurrence).
 
-Architect's own 8-point acceptance (issuecomment on #5732), verbatim:
-  ① all 3 sibling catches treated alike
+The ``/copy`` sentinel (``__copy_last_reply__``) was NOT in the architect's
+own original 3-item enumeration below (nor lead-coder's brief) — e2e-coder
+disclosed it as a 4th, identically-shaped sibling on the original PR;
+lead-coder independently re-read the window their own census used, found
+it excluded ``/copy`` by construction, and BLOCKED on folding it in now
+rather than leaving "one catch still silent" open (the architect's own
+"1 つだけ直すと残り 2 つが黙ったまま残ります" ruling holds at 3-of-4 too).
+
+Architect's own 8-point acceptance (issuecomment on #5732), verbatim below
+— written against 3 siblings; this PR applies the same ① at 4:
+  ① all sibling catches treated alike (originally worded "3"; now 4 — see
+     the ``/copy`` disclosure above)
   ② deliberately breaking ``_ingest_frame`` makes a test go RED
   ③ production behaviour unchanged (catch stays, loop survives)
   ④ no test-only branch (behaviour does not vary by environment)


### PR DESCRIPTION
**[e2e-coder]** —

`TextualChatApp._pump_frames` wraps 4 sibling handlers (`/copy` sentinel, `/rewind` sentinel, `__open_artifact__` sentinel, `_ingest_frame`) in their own `except Exception`, correctly keeping the pump alive on a single bad frame — but the failure reached nowhere but one `logger.exception` line. #5731 shipped an `AttributeError` on every `"status"`-kind frame, undetected, because nothing surfaced it to a human and no test could go red on it. (#5731's own underlying bug was independently fixed in #5733 — this PR is the visibility mechanism, not that fix.)

Architect design: issue #5732's own comment.

**Update (post lead-coder-30 BLOCKING review):** acceptance ① ("all sibling catches treated alike") was originally written against 3 handlers — the architect's own enumeration and lead-coder-30's independent census both drew a grep window that put `__copy_last_reply__` (textually adjacent, identically shaped) just outside it. e2e-coder had disclosed this on the original PR as a gap; lead-coder-30 re-read it, confirmed the census miss, and BLOCKED on folding it in now — the architect's own "one catch left silent" ruling holds at 3-of-4 too. `/copy` is now the 4th sibling, wired identically to the other 3. Everything below reflects the corrected count of 4.

## What changed

- `PumpSwallowStats`: a public `count` (every swallowed occurrence, from all 4 handlers) plus a `record()` gate that returns `True` only on the first occurrence of a `(kind, exception type)` pair — a broken call site fails every frame, so the durable audit-event is bounded by the pair, never the occurrence count.
- `_record_pump_swallow`: the one call site all 4 handlers route through. Wired identically to all 4 (no partial fix).
- `status_line_text` gains `pump_swallow_count` → `"draw failed: N — see log · "` prepended when nonzero, absent at 0, no traceback — mirrors #5168's own `diagnostics_count` segment.
- New audit-event kind `pump_exception_swallowed`, registered in both `AUDIT_EVENT_KINDS` and `docs/reference/runtime/events.md` (new "Textual chat pump" section).
- No test-only branch anywhere — production behaviour is unchanged (the catch stays, the loop survives); tests drive the real path via a monkeypatched-raising `_ingest_frame`, never an environment flag.

Real bug caught by this PR's own diligence: my first draft called `emit_cli_event("pump_exception_swallowed", kind=kind, ...)` — `emit_cli_event`'s own first positional parameter is *also* named `kind`, so this collided (`TypeError: got multiple values for argument 'kind'`). A pyright `reportCallIssue` diagnostic caught it before any test ran; fixed by naming the payload field `frame_kind`. A new test (`test_record_pump_swallow_emits_a_real_event_with_no_parameter_collision`) exercises the real, unmocked path so this class of bug can't silently regress.

Strip-falsified: removing the `_record_pump_swallow` call from the `_ingest_frame` branch turns `test_a_broken_ingest_frame_is_visible_in_the_status_line` RED (confirmed by real execution, then restored) — the PR's own body per the architect's ruling. The `/copy` wiring was separately strip-falsified with a standalone real call (bumps the count) rather than a new pytest, per lead-coder-30's own guidance that the existing kind-axis dedup tests already generalize.

## Test plan

- [x] `ruff check`
- [x] `test_tier_audit.py --strict` (12/12 OK, 0 Tier 4 violations)
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `mkdocs build --strict` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py`
- [x] `pytest` scoped to the diff (`test_5732_pump_swallow_visibility.py`, plus sibling `test_5168`/`test_textual_chat_*`/`test_5731_pipeline_flowview_entry.py` + the audit-event-vocabulary doc-sync tests) — full suite left to CI
- [ ] 👁️ Visual — owner verifies on a real TTY, cannot be judged headless (standing waiver; not fabricated)

Closes #5732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
