### PR TITLE
fix(#5720): main LLM learns spilled content is reachable, deterministically

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -1820,6 +1820,17 @@ class MediaStore:
     # ── Introspection ─────────────────────────────────────────────────
 
     @property
+    def project_root(self) -> Path:
+        """Resolved absolute path of this store's own project root — the
+        SAME boundary every path-ref block this store returns is already
+        rendered relative to (e.g. :meth:`save_tool_result`'s own
+        ``"path"``). #5720: exposed so a caller deriving a directory-level
+        listing instruction (rather than a single path-ref block) can
+        render it in the SAME project-relative shape, instead of leaking
+        this process's own absolute filesystem layout onto the wire."""
+        return self._project_root
+
+    @property
     def media_dir(self) -> Path:
         """Absolute path of the image storage directory."""
         return self._media_dir

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -768,7 +768,16 @@ class RouterHistoryBuffer:
         if m.role == "summary":
             from reyn.services.compaction.engine import wrap_summary_as_message
             structured = (m.meta or {}).get("structured")
-            return wrap_summary_as_message(structured if isinstance(structured, dict) else {})
+            # #5720: this IS a genuine wire-egress point (the SAME shape
+            # `wrap_summary_as_message`'s own docstring names) — a real,
+            # FRESHLY-derived snapshot every call, never one persisted
+            # onto `structured` (see that function's own docstring for
+            # why a persisted value would ride through the summarizing
+            # LLM on the next fold and become its own judgment call).
+            return wrap_summary_as_message(
+                structured if isinstance(structured, dict) else {},
+                spill_reachability=self.spill_reachability_snapshot(),
+            )
 
         # Legacy "agent" stragglers (= migrated entries that somehow bypassed
         # _migrate_legacy_chat_message) → normalise on read.
@@ -1236,6 +1245,68 @@ class RouterHistoryBuffer:
         spill axis is compared as "did a candidate get consumed", never
         by re-measuring wire bytes for either."""
         return self._compaction_watermark()
+
+    def spill_reachability_snapshot(self) -> "tuple[int, str] | None":
+        """#5720 (architect ruling): a FRESH ``(count, directory)`` read
+        of this session's own ``.reyn/memory/history-content/<agent>/
+        <session_id>/`` directory — the one :meth:`_serialise_turn`'s
+        summary branch (and, via ``RouterLoopDriver``'s own injection,
+        ``RecoveryLadder._advance_state_after_fold``) passes to
+        :func:`~reyn.services.compaction.engine.wrap_summary_as_message`
+        as its ``spill_reachability`` value, EVERY time either is
+        called — never cached, never derived from anything a prior fold
+        wrote into ``structured`` (see that function's own docstring for
+        why: a persisted value would ride through the summarizing LLM
+        on the next fold and become that LLM's own judgment call, the
+        same failure ``artifacts_referenced`` already has).
+
+        Deliberately a plain directory LISTING, not scoped to any one
+        fold's own covered turns: this session's history-content
+        directory holds every reactive-spill / write-time-cap dump this
+        store has EVER written for THIS session, and nothing removes an
+        entry from it once a turn carrying its reference gets folded
+        away (eviction is a separate, storage-cap-driven policy —
+        :meth:`MediaStore._evict_history_content_over_cap` — not a
+        fold-time GC) — so "everything currently on disk for this
+        session" and "everything reachable behind the current summary"
+        coincide in practice, without needing to parse a filename's own
+        encoded ``seq`` (which, per #5720's own architect correction,
+        means two DIFFERENT things depending on which spill path wrote
+        it — a store-side naming position for the head/tail path, the
+        turn's real seq for the mid path — not a uniform provenance
+        field a listing could filter on).
+
+        Returns ``None`` when there is nothing to report — no
+        ``agent_name`` (a legacy/read-only store construction), no
+        directory yet (nothing spilled this session), or an empty one —
+        so a caller can pass this straight through as
+        ``wrap_summary_as_message``'s own ``spill_reachability`` kwarg
+        without a separate zero-check."""
+        if self._media_store is None:
+            return None
+        try:
+            directory = self._media_store.history_content_dir
+        except ValueError:
+            # #5364: MediaStore.save_tool_result's own directory requires
+            # a real agent_name; a legacy/read-only construction (4 of 5
+            # production MediaStore call sites) has none — nothing this
+            # store could have written under a session directory either.
+            return None
+        if not directory.is_dir():
+            return None
+        count = sum(1 for p in directory.iterdir() if p.is_file())
+        if count == 0:
+            return None
+        # #5720: project-relative, matching the SAME shape every
+        # individual spill's own read_file(path=...) marker already uses
+        # (tool_result_cap.py's `_build_preview`, MediaStore.save_tool_
+        # result's own "Convert absolute path_ref to project-relative
+        # path for the block" comment) — an absolute path here would be
+        # the one inconsistency between this section and the markers it
+        # is meant to explain, and would leak this process's own
+        # filesystem layout onto the wire besides.
+        relative = directory.relative_to(self._media_store.project_root)
+        return count, str(relative)
 
     def is_already_spilled(self, content: str) -> bool:
         """#5364 §1.6: True if ``content`` IS a previously-produced spill

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -917,6 +917,14 @@ class RouterLoopDriver:
                         on_summary_used=_partial(
                             self._persist_recovery_fold, seq_by_id=payload.seq_by_id,
                         ),
+                        # #5720: the SAME snapshot _serialise_turn's own
+                        # summary branch uses — RouterHistoryBuffer's
+                        # spill_reachability_snapshot is the ONE
+                        # implementation both wire-egress points share
+                        # (never a private copy that could drift).
+                        spill_reachability_fn=(
+                            self._history_buffer.spill_reachability_snapshot
+                        ),
                         # #5531 §10: no `max_iterations=` any more —
                         # retry_loop abolished its iteration-count bound
                         # (see its own "Bounded termination proof"

--- a/src/reyn/runtime/session_pure.py
+++ b/src/reyn/runtime/session_pure.py
@@ -82,12 +82,44 @@ def merge_memory_indexes(
     return {"status": "ok", "content": "\n\n".join(parts).strip() + "\n"}
 
 
-def render_summary_for_storage(structured: dict) -> str:
+def render_summary_for_storage(
+    structured: dict,
+    *,
+    spill_reachability: "tuple[int, str] | None" = None,
+) -> str:
     """Render a chat_summary structured dict to a quick-display text blob.
 
     Stored in ChatMessage.text so REPL traces and audit dumps don't need
-    to re-render the structured form. The slicer prefers the structured
-    form for LLM consumption — this is for human consumption only.
+    to re-render the structured form.
+
+    #5720 (architect correction, issuecomment-5525827176): the prior
+    docstring here said "the slicer prefers the structured form for LLM
+    consumption — this is for human consumption only," read by two
+    people in the SAME hour as opposite claims about which LLM. Both
+    readings were partly right: for the COMPACTION LLM (``compact()``'s
+    own call, which JSON-dumps the whole message dict as its input),
+    the structured keys genuinely ride along — "for LLM consumption"
+    is true there. For the MAIN LLM (``main_call`` — the one the owner
+    meant by "何を覚えてるか聞いてみた"), this rendered TEXT is the ONE
+    form that reaches the wire at all (``engine.py``'s own
+    ``wrap_summary_as_message``, verbatim: "this rendered form is the
+    ONE the wire actually sends") — never the structured dict, never
+    ``meta``. "For human consumption only" was accurate for that
+    reader, not for this one.
+
+    ``spill_reachability``, when given, is a PRE-COMPUTED ``(count,
+    directory)`` pair — this function stays pure (no store access) and
+    never reads a decision out of *structured* for it: baking a
+    deterministic count into ``structured`` would make it ride through
+    the summarizing LLM on the NEXT fold and become that LLM's own
+    judgment whether to keep it, echo it, or drop it — the exact
+    failure mode ``artifacts_referenced`` (an LLM-output field) already
+    has, measured directly in #5720 (a real fold discarding it). The
+    caller is expected to derive a FRESH value from the store every
+    time this function is called (a summary message is re-rendered on
+    every turn, not once at fold time), never persist it into
+    ``structured``, and pass ``None`` when there is nothing to report
+    (zero spilled bodies is a normal answer, not an omitted section).
     """
     parts: list[str] = []
     # #1092 PR-F2a: a force-close handoff consolidation carries its (free-text)
@@ -106,4 +138,22 @@ def render_summary_for_storage(structured: dict) -> str:
             continue
         parts.append(f"[{key}]")
         parts.extend(f"  - {item}" for item in items)
+    if spill_reachability is not None:
+        # #5720: fixed-length section — 3 lines regardless of how many
+        # bodies were spilled (charter Q1's own bound: wire cost must
+        # not scale with N). Names the COUNT and a LOCATE instruction,
+        # never every path — answers the owner's own two questions
+        # ("is there a spill file at all" / "I didn't know how to get
+        # it") without re-introducing the per-path enumeration this
+        # section deliberately avoids.
+        count, directory = spill_reachability
+        parts.append("[spilled_content]")
+        parts.append(
+            f"  - {count} tool result(s) from this conversation were "
+            f"offloaded to disk and are not shown above"
+        )
+        parts.append(
+            f'  - list them: glob(path="{directory}/*"); '
+            f'then read one: read_file(path="<listed path>")'
+        )
     return "\n".join(parts)

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -507,7 +507,9 @@ def wire_role(role: str) -> str:
     return role
 
 
-def wrap_summary_as_message(summary: dict) -> dict:
+def wrap_summary_as_message(
+    summary: dict, *, spill_reachability: "tuple[int, str] | None" = None,
+) -> dict:
     """#5531 condition④ — a previously-compacted summary is JUST a message
     in :attr:`HistoryChunkToCompact.messages`, distinguished only by
     :data:`SUMMARY_MESSAGE_ROLE`. This is the ONE place that wrapping
@@ -529,8 +531,20 @@ def wrap_summary_as_message(summary: dict) -> dict:
     from the wire; (2) it lets every site that places a summary directly
     into a message list (this function's own callers) skip carrying a
     SEPARATE decoration step — the content IS the decoration, so there is
-    no second place a caller could decide whether/how to splice it in."""
-    rendered = render_summary_for_storage(summary)
+    no second place a caller could decide whether/how to splice it in.
+
+    ``spill_reachability`` (#5720): passed straight through to
+    :func:`~reyn.runtime.session_pure.render_summary_for_storage` — see
+    that function's own docstring. Only the 2 callers whose ``content``
+    genuinely reaches the MAIN LLM's wire (``RouterHistoryBuffer.
+    _serialise_turn``, ``RecoveryLadder._advance_state_after_fold``)
+    pass a real value; ``CompactionController``'s own re-wrap of a PRIOR
+    summary as ``compact()``'s own INPUT (never main_call's wire) is
+    unaffected by this parameter's default and does not need one — that
+    call's own summary gets its section applied fresh the NEXT time
+    ``_serialise_turn`` renders it for an actual wire send, same as any
+    other fold."""
+    rendered = render_summary_for_storage(summary, spill_reachability=spill_reachability)
     return {
         "role": SUMMARY_MESSAGE_ROLE,
         **summary,
@@ -2872,6 +2886,7 @@ async def retry_loop(
     main_call: Callable[..., Awaitable[Any]],
     spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]] | None" = None,
     on_summary_used: "Callable[[ChatSummary, list[dict]], Awaitable[None]] | None" = None,
+    spill_reachability_fn: "Callable[[], tuple[int, str] | None] | None" = None,
 ) -> Any:
     """Bounded shrink loop for context overflow recovery (PR-N6).
 
@@ -2906,6 +2921,7 @@ async def retry_loop(
         SP=SP, payload=payload, cfg=cfg, model=model, engine=engine,
         learner=learner, main_call=main_call, spill_fn=spill_fn,
         on_summary_used=on_summary_used,
+        spill_reachability_fn=spill_reachability_fn,
     )
     return await ladder.run()
 
@@ -3118,6 +3134,21 @@ class RecoveryLadder:
         anything — trusting ``ChatSummary.covers_through_seq`` off this
         path would silently persist 0 (#5498's own load-bearing warning,
         re-confirmed by this change).
+    spill_reachability_fn:
+        #5720 — optional zero-arg callable returning a FRESH ``(count,
+        directory)`` snapshot of what is currently recoverable from
+        this session's own spill store, or ``None`` when there is
+        nothing to report. Called EVERY time :meth:`_advance_state_
+        after_fold` wraps a fresh summary — never cached across calls,
+        never read back from anything a prior fold wrote (a persisted
+        value would ride through the summarizing LLM on the NEXT fold
+        and become its own judgment call, the exact failure
+        ``artifacts_referenced`` already has). ``None`` (the default)
+        preserves this class's pre-#5720 shape byte-for-byte — see
+        :func:`~reyn.runtime.session_pure.render_summary_for_storage`'s
+        own docstring for the full rationale and the OTHER wire-egress
+        point (``RouterHistoryBuffer._serialise_turn``) that shares the
+        SAME snapshot implementation.
     """
 
     def __init__(
@@ -3132,6 +3163,7 @@ class RecoveryLadder:
         main_call: Callable[..., Awaitable[Any]],
         spill_fn: "Callable[[list[dict]], list[tuple[int, dict]]] | None" = None,
         on_summary_used: "Callable[[ChatSummary, list[dict]], Awaitable[None]] | None" = None,
+        spill_reachability_fn: "Callable[[], tuple[int, str] | None] | None" = None,
     ) -> None:
         self._SP = SP
         self.head = payload.head
@@ -3145,6 +3177,12 @@ class RecoveryLadder:
         self._main_call = main_call
         self._spill_fn = spill_fn
         self._on_summary_used = on_summary_used
+        # #5720: zero-arg, called FRESH at every fold this episode makes
+        # (never cached across calls) — the caller's own snapshot of
+        # "how many spilled bodies are reachable right now, and where."
+        # None (the default) preserves this class's pre-#5720 shape byte-
+        # for-byte for any caller that doesn't wire one.
+        self._spill_reachability_fn = spill_reachability_fn
 
         from reyn.llm.llm import note_upstream_recovery_call_attempt
         from reyn.llm.model_budget import get_max_input_tokens
@@ -3787,7 +3825,21 @@ class RecoveryLadder:
         # ``max_iterations`` no longer exists as a backstop.)
         self.head = [
             t for t in self.head if t.get("role") != SUMMARY_MESSAGE_ROLE
-        ] + [wrap_summary_as_message(chat_summary.to_dict())]
+        ] + [
+            wrap_summary_as_message(
+                chat_summary.to_dict(),
+                # #5720: this wrap's own `content` goes straight into
+                # `self.head`, which `main_call` receives DIRECTLY (see
+                # this method's own module-level docstring) — one of the
+                # 2 genuine wire-egress points, so a real snapshot (not
+                # None) is passed whenever the caller wired one.
+                spill_reachability=(
+                    self._spill_reachability_fn()
+                    if self._spill_reachability_fn is not None
+                    else None
+                ),
+            )
+        ]
         # Only the ATTEMPTED slice is compacted — a smaller
         # remainder (if any) stays in raw_middle for a later
         # iteration. #5531 §10 (architect/owner correction,

--- a/tests/runtime/test_5720_spill_reachability_in_summary.py
+++ b/tests/runtime/test_5720_spill_reachability_in_summary.py
@@ -1,0 +1,472 @@
+"""Tier 2: #5720 (architect's confirmed spec, issuecomment-5533959117) —
+the MAIN LLM (``main_call``) learns, from every summary message's own
+``content``, that spilled tool-result bodies are recoverable, WITHOUT that
+knowledge ever riding through a summarizing LLM's own judgment.
+
+owner's real-machine incident: "compact 成功しました。ただし、その後何を覚え
+てるか聞いてみたところ、ほとんどのことを忘れてました" / "spill out ファイル
+あるか聞いたけど、知らないていうてたよ" — measured (issue #5720's own thread,
+e2e-coder, real execution, no mocks) in two stages: (1) a spilled turn's own
+``read_file(path=...)`` marker IS on the wire for that turn, but (2) once
+that turn is folded into a summary, the marker vanishes — survival of ANY
+reference past a fold depends entirely on whether the summarizing LLM's own
+JSON response happens to echo it into ``artifacts_referenced``, which has no
+deterministic guarantee at all.
+
+Architect's confirmed acceptance (verbatim, issuecomment-5533959117):
+  - [ ] render された text に実在する (structured への追加だけでは不十分)
+  - [ ] 毎回 store から導出される — structured に保存されていない
+  - [ ] ★ 2 回 fold しても残る — persisted-via-LLM carry would be invisible
+        to a single-fold test; this is the witness that closes that gap
+  - [ ] section の長さが spill 件数に依存しない (wire cost O(1), charter Q1)
+  - [ ] spill 0 件で section が出ない ("no spills" is a normal answer)
+  - [ ] artifacts_referenced に決定論的な値を書いていない (2 つの出所を持たせない)
+
+Real ``CompactionController`` + real ``RouterHistoryBuffer`` + real
+``MediaStore`` + real ``RetryLoop``/``RecoveryLadder`` throughout — the ONLY
+stand-in anywhere in this file is the compaction LLM's own ``compact()``
+call (the one LLM-call boundary every sibling compaction test in this repo
+already stubs, ``test_5719``/``test_5721``'s own idiom), and it is a
+CAPTURING stub, never a mock (no assertions on call count/args beyond what
+`compact()`'s own real signature requires).
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.data.workspace.media_store import MediaStore
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.compaction_controller import CompactionController
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from reyn.runtime.session_pure import render_summary_for_storage
+from reyn.services.compaction.engine import (
+    ChatSummary,
+    CompactionEngine,
+    ComputedBudgets,
+    CoversThrough,
+    HistoryChunkToCompact,
+    RetryPayload,
+    retry_loop,
+)
+
+_STUB_BUDGETS = ComputedBudgets(
+    main_pool=100_000, head_budget=50, body_budget=5_000, tail_budget=50,
+    new_msg_budget=10_000, B_M=80_000, main_M_room=150_000, effective_trigger=150_000,
+    section_caps={},
+)
+
+
+class _CapturingEngine(CompactionEngine):
+    """Stands in for the LLM-call boundary only — same idiom as
+    ``test_5719``'s own ``_SucceedingEngine`` / ``test_5721``'s own
+    ``_CapturingEngine``. Never asked about spill reachability at all —
+    that section is composed entirely OUTSIDE this stub's own output,
+    which is exactly the property under test."""
+
+    def __init__(self) -> None:
+        self._model = ""
+        self._events = EventLog()
+        self._budgets = _STUB_BUDGETS
+
+    async def compact(
+        self, input_chunk: "HistoryChunkToCompact", *, covers_through: "CoversThrough",
+    ) -> "ChatSummary":
+        seqs = [int(t.get("seq", 0)) for t in input_chunk.messages if isinstance(t, dict)]
+        return ChatSummary(topic_arc="stub summary", covers_through_seq=max(seqs, default=0))
+
+
+def _history(n: int, *, start: int = 1) -> "list[ChatMessage]":
+    return [
+        ChatMessage(role="user" if i % 2 else "assistant", content="x" * 200, seq=i)
+        for i in range(start, start + n)
+    ]
+
+
+def _make_controller(
+    *, history: "list[ChatMessage]", engine: "CompactionEngine",
+) -> CompactionController:
+    return CompactionController(
+        event_log=engine._events,
+        config=CompactionConfig(use_chars4_estimate=True),
+        history_from_disk=lambda after_seq: (
+            [m for m in history if m.seq == 0 or m.seq > after_seq], False,
+        ),
+        latest_summary=lambda: None,
+        compaction_engine_factory=lambda: engine,
+        history_appender=history.append,
+        make_summary_message=lambda rendered, structured, covers: ChatMessage(
+            role="summary", content=rendered, seq=0,
+            meta={"structured": structured, "covers_through_seq": covers},
+        ),
+        render_summary=render_summary_for_storage,
+    )
+
+
+def _make_history_buffer(
+    *, history: "list[ChatMessage]", media_store: "MediaStore",
+) -> RouterHistoryBuffer:
+    return RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(use_chars4_estimate=True),
+        compaction_controller=None,
+        model_fn=lambda: "test-model",
+        events=EventLog(),
+        media_store=media_store,
+        router_host=None,
+        universal_wrappers_enabled=False,
+        non_interactive=True,
+        history_appender=history.append,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RouterHistoryBuffer.spill_reachability_snapshot — unit level
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_is_none_when_nothing_was_ever_spilled(tmp_path: Path) -> None:
+    """Tier 2: acceptance "spill 0 件で section が出ない" — the pure-count
+    witness. A store that has written nothing yields None, not a
+    zero-count tuple (the caller distinguishes "nothing to report" from
+    "report a count of zero" — the former omits the section entirely)."""
+    store = MediaStore(project_root=tmp_path, agent_name="a", session_id="s")
+    hb = _make_history_buffer(history=[], media_store=store)
+    assert hb.spill_reachability_snapshot() is None
+
+
+def test_snapshot_reports_the_real_count_and_a_project_relative_directory(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a real spilled body makes the snapshot non-None, with the
+    EXACT count and a directory rendered project-relative — the SAME
+    shape every individual spill's own read_file(path=...) marker
+    already uses (tool_result_cap.py's _build_preview), not this
+    process's own absolute filesystem layout."""
+    store = MediaStore(project_root=tmp_path, agent_name="a", session_id="s")
+    store.save_tool_result("Y" * 50_000, chain_id="c1", tool="tool", seq=5)
+    store.save_tool_result("Z" * 50_000, chain_id="c1", tool="tool", seq=9)
+    hb = _make_history_buffer(history=[], media_store=store)
+
+    snapshot = hb.spill_reachability_snapshot()
+
+    assert snapshot is not None
+    count, directory = snapshot
+    assert count == 2
+    assert not directory.startswith("/"), (
+        f"directory must be project-relative, got an absolute-looking "
+        f"path: {directory!r}"
+    )
+    assert directory == ".reyn/memory/history-content/a/s"
+
+
+def test_snapshot_is_none_for_a_store_with_no_agent_identity(tmp_path: Path) -> None:
+    """Tier 2: falsify pair (deny side) — a legacy/read-only MediaStore
+    construction (no agent_name, 4 of 5 production call sites per
+    MediaStore's own docstring) has no session directory to report;
+    the snapshot degrades to None rather than raising."""
+    store = MediaStore(project_root=tmp_path, session_id="s")
+    hb = _make_history_buffer(history=[], media_store=store)
+    assert hb.spill_reachability_snapshot() is None
+
+
+def test_snapshot_is_none_when_media_store_itself_is_none(tmp_path: Path) -> None:
+    """Tier 2: falsify pair — RouterHistoryBuffer's own media_store param
+    is documented ``MediaStore | None``; this method must degrade the
+    same way _materialise_path_ref_content already does."""
+    hb = _make_history_buffer(history=[], media_store=None)
+    assert hb.spill_reachability_snapshot() is None
+
+
+# ---------------------------------------------------------------------------
+# render_summary_for_storage / wrap_summary_as_message — section shape
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_omits_the_section_when_spill_reachability_is_none() -> None:
+    """Tier 2: byte-identical to pre-#5720 when there is nothing to
+    report — the default parameter value changes nothing for every
+    existing caller/test of this function."""
+    structured = {"topic_arc": "x"}
+    before = render_summary_for_storage(structured)
+    after = render_summary_for_storage(structured, spill_reachability=None)
+    assert before == after
+    assert "spilled_content" not in after
+
+
+def test_render_summary_section_length_does_not_scale_with_spill_count() -> None:
+    """Tier 2: acceptance "section の長さが spill 件数に依存しない" — charter
+    Q1's own O(1) wire-cost bound. The rendered [spilled_content] block
+    stays a fixed 2 lines whether count is 1 or 5000 — only the digit
+    inside those 2 lines changes, never a per-path enumeration."""
+    structured = {"topic_arc": "x"}
+    small = render_summary_for_storage(
+        structured, spill_reachability=(1, ".reyn/memory/history-content/a/s"),
+    )
+    huge = render_summary_for_storage(
+        structured, spill_reachability=(5000, ".reyn/memory/history-content/a/s"),
+    )
+    small_block = small.split("[spilled_content]", 1)[1]
+    huge_block = huge.split("[spilled_content]", 1)[1]
+    assert small_block.count("\n") == huge_block.count("\n"), (
+        "the section's own line count must not grow with the spill count"
+    )
+    # The only byte-length delta allowed is the digit string itself
+    # ("1" vs "5000") — never a per-path listing riding along.
+    assert len(huge_block) - len(small_block) == len("5000") - len("1")
+
+
+def test_render_summary_never_writes_into_artifacts_referenced() -> None:
+    """Tier 2: acceptance "artifacts_referenced に決定論的な値を書いていない"
+    — the architect's own rejected-alternative check. A caller that
+    (incorrectly) tried folding this into artifacts_referenced would
+    give it two provenances (LLM output AND this deterministic write);
+    this asserts the real render path never does."""
+    structured = {"topic_arc": "x", "artifacts_referenced": ["a-real-llm-value"]}
+    rendered = render_summary_for_storage(
+        structured, spill_reachability=(3, ".reyn/memory/history-content/a/s"),
+    )
+    assert "a-real-llm-value" in rendered, "the LLM's own value must still render"
+    # The deterministic count must never appear as a bullet UNDER
+    # [artifacts_referenced] — only under its own, separate section.
+    artifacts_block = rendered.split("[artifacts_referenced]", 1)[1].split("[", 1)[0]
+    assert "3 tool result" not in artifacts_block
+
+
+# ---------------------------------------------------------------------------
+# RouterHistoryBuffer._serialise_turn — the normal (build_history) wire path
+# ---------------------------------------------------------------------------
+
+
+def test_serialise_turn_omits_the_section_with_no_spills(tmp_path: Path) -> None:
+    """Tier 2: acceptance "spill 0 件で section が出ない", exercised through
+    the real wire-egress point (not the pure renderer directly)."""
+    store = MediaStore(project_root=tmp_path, agent_name="a", session_id="s")
+    hb = _make_history_buffer(history=[], media_store=store)
+    m = ChatMessage(
+        role="summary", content="", seq=0,
+        meta={"structured": {"topic_arc": "x"}},
+    )
+    wire = hb._serialise_turn(m)
+    assert "spilled_content" not in wire["content"]
+
+
+def test_serialise_turn_includes_the_section_when_something_was_spilled(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance "render された text に実在する" — the ACTUAL wire
+    dict main_call/build_history receive, not an intermediate value."""
+    store = MediaStore(project_root=tmp_path, agent_name="a", session_id="s")
+    store.save_tool_result("Y" * 50_000, chain_id="c1", tool="tool", seq=5)
+    hb = _make_history_buffer(history=[], media_store=store)
+    m = ChatMessage(
+        role="summary", content="", seq=0,
+        meta={"structured": {"topic_arc": "x"}},
+    )
+    wire = hb._serialise_turn(m)
+    assert '1 tool result(s)' in wire["content"]
+    assert 'glob(path=".reyn/memory/history-content/a/s/*")' in wire["content"]
+    assert "read_file(path=" in wire["content"]
+
+
+def test_the_stored_structured_dict_never_carries_the_derived_value(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance "毎回 store から導出される — structured に保存され
+    ていない", exercised behaviourally (not a static git-grep): after a
+    real render with a real spill present, the meta['structured'] dict
+    this ChatMessage carries must be untouched — the ONLY place the
+    value exists is the rendered `content` string, which is REBUILT
+    fresh on the next _serialise_turn call, never read back FROM this
+    dict."""
+    store = MediaStore(project_root=tmp_path, agent_name="a", session_id="s")
+    store.save_tool_result("Y" * 50_000, chain_id="c1", tool="tool", seq=5)
+    hb = _make_history_buffer(history=[], media_store=store)
+    structured = {"topic_arc": "x"}
+    m = ChatMessage(role="summary", content="", seq=0, meta={"structured": structured})
+
+    hb._serialise_turn(m)
+
+    assert "spilled_content" not in structured
+    assert set(structured.keys()) == {"topic_arc"}, (
+        "rendering must never write back into the caller's own "
+        "structured dict"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ★ The central witness — 2 REAL folds, no persisted carry
+# ---------------------------------------------------------------------------
+
+
+def test_two_real_folds_each_render_a_fresh_section_never_a_stale_one(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ★ architect's own named central witness ("2 回 fold しても
+    残る") — a test exercising only ONE fold cannot distinguish "derived
+    fresh every time" from "persisted once and carried through the
+    summarizing LLM," the exact failure class ``artifacts_referenced``
+    already has (measured directly in #5720's own investigation: a real
+    fold discarding an unprotected reference).
+
+    Drives 2 REAL ``CompactionController._run_compaction`` calls in
+    sequence (the 2nd's own ``previous_summary`` is the 1st's real
+    persisted ``ChatMessage`` — genuine fold-over-fold, not two
+    independent compactions), with MORE spills added between them, then
+    re-serialises the FINAL summary the same way ``build_history``
+    would. If the count were being carried via ``structured`` (the
+    ①-rejected design), it would read stale from fold 1; instead it
+    reflects the CURRENT total after fold 2."""
+    store = MediaStore(project_root=tmp_path, agent_name="a", session_id="s")
+    engine = _CapturingEngine()
+    history: "list[ChatMessage]" = []
+    ctrl = _make_controller(history=history, engine=engine)
+    hb = _make_history_buffer(history=history, media_store=store)
+
+    store.save_tool_result("Y" * 50_000, chain_id="c1", tool="tool", seq=1)
+
+    history.extend(_history(10, start=1))
+    asyncio.run(ctrl._run_compaction(list(history), previous_summary=None, spill_fn=lambda _c: []))
+    summary_1 = [m for m in history if m.role == "summary"][-1]
+
+    structured_1 = (summary_1.meta or {}).get("structured", {})
+    assert "spilled_content" not in structured_1, (
+        "fold 1 must not persist the derived value into structured"
+    )
+
+    wire_after_fold_1 = hb._serialise_turn(summary_1)
+    assert "1 tool result(s)" in wire_after_fold_1["content"]
+
+    # 2 MORE spills happen between the two folds.
+    store.save_tool_result("Z" * 50_000, chain_id="c2", tool="tool", seq=15)
+    store.save_tool_result("W" * 50_000, chain_id="c2", tool="tool", seq=16)
+
+    history.extend(_history(10, start=11))
+    asyncio.run(
+        ctrl._run_compaction(list(history), previous_summary=summary_1, spill_fn=lambda _c: []),
+    )
+    summary_2 = [m for m in history if m.role == "summary"][-1]
+    assert summary_2 is not summary_1, "fold 2 must produce its own summary entry"
+
+    structured_2 = (summary_2.meta or {}).get("structured", {})
+    assert "spilled_content" not in structured_2, (
+        "fold 2 must not persist the derived value into structured either"
+    )
+
+    wire_after_fold_2 = hb._serialise_turn(summary_2)
+    assert "3 tool result(s)" in wire_after_fold_2["content"], (
+        f"the section after fold 2 must reflect the CURRENT total (3), "
+        f"not fold 1's stale count (1) or an empty one — got: "
+        f"{wire_after_fold_2['content']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The retry_loop / RecoveryLadder wire-egress point (#5732-adjacent path,
+# the SAME injection shape ``on_summary_used``/``spill_fn`` already use)
+# ---------------------------------------------------------------------------
+
+
+def test_retry_loop_fold_wires_spill_reachability_straight_into_main_calls_wire(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the RETRY-driven fold path (context-overflow recovery,
+    ``RecoveryLadder._advance_state_after_fold``) is a SEPARATE
+    wire-egress point from ``RouterHistoryBuffer._serialise_turn`` — its
+    own ``wrap_summary_as_message`` call feeds ``main_call``'s ``head``
+    DIRECTLY (``_router_main_call_for_retry``'s own docstring: "bypassing
+    _serialise_turn"). Falsified without the ``spill_reachability_fn``
+    injection: this test would see no [spilled_content] section in
+    main_call's own received head at all."""
+    received_heads: "list[list[dict]]" = []
+    attempt = [0]
+
+    async def _main_call(**kwargs):
+        attempt[0] += 1
+        received_heads.append(list(kwargs.get("head", [])))
+        if attempt[0] == 1:
+            from reyn.services.compaction.engine import ContextOverflowError
+            raise ContextOverflowError("simulated overflow")
+        from types import SimpleNamespace
+        return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=1000), choices=[])
+
+    with tempfile.TemporaryDirectory() as td:
+        from reyn.runtime.services.token_multiplier_learner import TokenMultiplierLearner
+
+        learner = TokenMultiplierLearner(storage_path=Path(td) / "m.json")
+        raw_middle = [
+            {"role": "user", "content": "x" * 500, "seq": i} for i in range(1, 30)
+        ]
+        asyncio.run(retry_loop(
+            SP="sp",
+            payload=RetryPayload(
+                head=[], raw_middle=raw_middle,
+                tail=[{"role": "user", "content": "tail", "seq": 99}],
+                new_msg={"role": "user", "content": "hi", "seq": 100},
+                seq_by_id={},
+            ),
+            cfg=CompactionConfig(use_chars4_estimate=True),
+            model="test-model",
+            engine=_CapturingEngine(),
+            learner=learner,
+            main_call=_main_call,
+            spill_reachability_fn=lambda: (7, ".reyn/memory/history-content/x/y"),
+        ))
+
+    # exactly 2 attempts: the overflow, then the recovered retry — unpack
+    # raises otherwise, so this also pins the count without a bare len().
+    [_overflowed_head, _recovered_head] = received_heads
+    for i, head in enumerate(received_heads):
+        summary_entries = [t for t in head if t.get("role") == "summary"]
+        assert summary_entries, f"attempt {i + 1}'s head carried no fold at all"
+        assert "7 tool result(s)" in summary_entries[0]["content"], (
+            f"attempt {i + 1}'s own fold did not carry the injected "
+            f"spill_reachability_fn's value onto main_call's wire"
+        )
+
+
+def test_retry_loop_fold_omits_the_section_when_no_fn_is_injected() -> None:
+    """Tier 2: falsify pair (deny side) — a caller that wires no
+    spill_reachability_fn at all (the pre-#5720 shape, and every
+    OTHER existing retry_loop test in this repo) is byte-unaffected;
+    the new parameter's default preserves prior behaviour exactly."""
+    received_heads: "list[list[dict]]" = []
+    attempt = [0]
+
+    async def _main_call(**kwargs):
+        attempt[0] += 1
+        received_heads.append(list(kwargs.get("head", [])))
+        if attempt[0] == 1:
+            from reyn.services.compaction.engine import ContextOverflowError
+            raise ContextOverflowError("simulated overflow")
+        from types import SimpleNamespace
+        return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=1000), choices=[])
+
+    with tempfile.TemporaryDirectory() as td:
+        from reyn.runtime.services.token_multiplier_learner import TokenMultiplierLearner
+
+        learner = TokenMultiplierLearner(storage_path=Path(td) / "m.json")
+        raw_middle = [
+            {"role": "user", "content": "x" * 500, "seq": i} for i in range(1, 30)
+        ]
+        asyncio.run(retry_loop(
+            SP="sp",
+            payload=RetryPayload(
+                head=[], raw_middle=raw_middle,
+                tail=[{"role": "user", "content": "tail", "seq": 99}],
+                new_msg={"role": "user", "content": "hi", "seq": 100},
+                seq_by_id={},
+            ),
+            cfg=CompactionConfig(use_chars4_estimate=True),
+            model="test-model",
+            engine=_CapturingEngine(),
+            learner=learner,
+            main_call=_main_call,
+        ))
+
+    summary_entries = [t for t in received_heads[-1] if t.get("role") == "summary"]
+    assert summary_entries
+    assert "spilled_content" not in summary_entries[0]["content"]


### PR DESCRIPTION
**[e2e-coder]** —

owner incident: "compact 成功しました。ただし、その後何を覚えてるか聞いてみたところ、ほとんどのことを忘れてました" / "spill out ファイルあるか聞いたけど、知らないていうてたよ". Measured (real execution, no mocks, issue #5720's own thread): a spilled turn's `read_file(path=...)` marker IS on the wire for that turn, but once folded into a summary, survival depends entirely on whether the summarizing LLM's own JSON response happens to echo it into `artifacts_referenced` — no deterministic guarantee at all.

Confirmed spec: architect, [issuecomment-5533959117](https://github.com/tya5/reyn/issues/5720#issuecomment-5533959117).

## What changed

1. **`content` only.** The main LLM never sees `structured`/`meta` (`engine.py:538`'s own "this rendered form is the ONE the wire actually sends") — the new section rides in `render_summary_for_storage`'s own rendered output, nowhere else.
2. **Never persisted.** Every wire-egress render derives a FRESH `(count, directory)` snapshot from the store; nothing is written into `structured` — a persisted value could ride through the summarizing LLM on the next fold and become its own judgment call, the exact failure `artifacts_referenced` already has.
3. **Count + a locate instruction only**, never a per-path listing — wire cost O(1) regardless of spill count (charter Q1). Absent entirely at 0 spills.

### Implementation

- `render_summary_for_storage` (`session_pure.py`) gains `spill_reachability: (count, directory) | None` — stays a pure function, no store access. Also corrects its own docstring's "for human consumption only" claim (architect's own retraction: true for the COMPACTION LLM's input, false for the MAIN LLM the owner's own incident is about — the docstring named neither, which is why 2 people read it in opposite directions the same hour).
- `wrap_summary_as_message` (`engine.py`) threads the same value through.
- `RouterHistoryBuffer.spill_reachability_snapshot()`: a fresh directory listing of this session's own history-content dir (deliberately NOT scoped to one fold's own turns — nothing removes an entry once its turn folds away, so "on disk now" and "reachable behind the current summary" coincide, without parsing a filename-encoded `seq` whose meaning differs between the head/tail and mid spill paths). Wired at the TWO genuine wire-egress points: `RouterHistoryBuffer._serialise_turn` (the normal `build_history`/`decompose_history_for_retry` path — already held `self._media_store`) and `RecoveryLadder._advance_state_after_fold` via a new injected `spill_reachability_fn` (retry_loop's own overflow-recovery fold, which bypasses `_serialise_turn` entirely and feeds `main_call`'s wire directly — `router_loop_driver.py` wires it from the SAME `RouterHistoryBuffer` instance, one implementation, never two that could drift). `CompactionController`'s own re-wrap of a prior summary as `compact()`'s OWN input is deliberately left untouched — that content never reaches `main_call`'s wire (`build_history` always re-derives via `_serialise_turn` before any wire send), so it needs no snapshot.
- `MediaStore` gains a `project_root` property so the directory renders project-relative, matching the SAME shape every individual spill's own `read_file(path=...)` marker already uses.

Strip-falsified (real execution, then restored): removing either wiring site's own `spill_reachability` argument turns its dedicated test red.

**Central witness** (architect's own explicit ask — a single-fold test cannot distinguish "derived fresh" from "persisted and carried through the summarizing LLM," the exact failure class this PR closes): 2 REAL `CompactionController._run_compaction` folds in sequence, with more spills between them — the section after fold 2 reflects the CURRENT total (3), never fold 1's stale count (1), and `structured` never carries the value at either fold.

## Test plan

- [x] `ruff check`
- [x] `test_tier_audit.py --strict` (13/13 OK, 0 Tier 4 violations)
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `pytest` scoped to the diff (`test_5720_spill_reachability_in_summary.py`, plus `test_5720_spill_carries_real_turn_provenance.py`, `test_pr_n6_compaction_overflow_retry.py`, `test_session_router_history_slicing.py`, `test_5628_spill_supersede_map_incremental.py`, `test_build_history_producer_calls_2939.py`, `test_family6b_history_compaction_bundle_wiring.py`, `test_5564_history_content_spill_origin_agnostic.py`, `test_slash_model_router_integration.py`) — full suite left to CI
- [x] (skipped — no docs/ touched, no new audit-event kind)

Closes #5720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51