### PR TITLE
feat(#5736): remote client sees an unattached session's status change immediately

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -492,6 +492,22 @@ remote client has not attached. `turn_active`/`iv_waiting` are carried as
 2 INDEPENDENT booleans, never collapsed into a status enum: a turn can be
 dispatched and ALSO waiting on an intervention answer at once, and that
 combination is the one an operator most needs to see.
+
+**A change on an unattached session reaches this channel immediately**
+(#5736), not only at this connection's own frame cadence. `endpoint.py`'s
+`_SessionFrameSource` stays bound to exactly ONE session (unchanged,
+#5729's own "1 session bound" contract) — a SEPARATE, connection-scoped
+`_StatusFrameSource` subscribes `AgentRegistry.add_status_listener`
+(registry-wide) and pushes a payload-free `StatusPingFrame` onto that
+SAME ordered queue, coalesced to at most one unconsumed ping at a time
+(a busy fleet's transitions never grow the queue past O(1) per
+connection). `AgUiEmitter.stream()` reacts to that frame kind by
+re-projecting the CURRENT status and emitting a `STATE_DELTA` if
+anything changed — the identical `StatusModel.delta` path every other
+status change already uses. `remove_status_listener` is called on
+disconnect, matching `_SessionFrameSource`'s own `remove_attach_listener`
+teardown — a remote connection's own subscription lifetime, unlike the
+process-lifetime local TUI consumer, must not outlive the connection.
 - `STATE_DELTA` — emitted **on change**, carrying only the changed keys. An idle
   stream emits no deltas.
 

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -1084,6 +1084,25 @@ class RemoteReadModel(ChatReadModel):
     def capabilities(self) -> ChatReadModelCapabilities:
         return REMOTE_CHAT_READ_CAPABILITIES
 
+    def add_status_listener(self, callback: "Callable[[str, str, bool, bool, int], None]") -> None:
+        """#5736: the real REMOTE wiring — was the base class's no-op
+        default (issue #5736's own residual from #5734: values were
+        already correct over the wire, but nothing woke this read model's
+        ONE consumer for a session other than the currently-attached one).
+        Delegates to :meth:`AgUiTransport.add_status_listener` when this
+        read model's own transport implements it (it does, in production);
+        a transport that does not (e.g. a bare ``ClientTransportStub`` in a
+        test with no status wiring of its own) degrades to the base
+        class's no-op via ``getattr``, never raising."""
+        add = getattr(self._transport, "add_status_listener", None)
+        if callable(add):
+            add(callback)
+
+    def remove_status_listener(self, callback: "Callable[[str, str, bool, bool, int], None]") -> None:
+        remove = getattr(self._transport, "remove_status_listener", None)
+        if callable(remove):
+            remove(callback)
+
     def snapshot(self, config=None):
         # ``transport.status`` is the RemoteStatusView the AgUiTransport updates as
         # it decodes STATE_* frames; read it live each render tick.

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -158,6 +158,18 @@ class AgUiTransport(ClientTransport):
         # server's own per-connection binding (``_CONNECTION_RETARGET_HUB``,
         # #5116) has already forgotten it.
         self._pump_died = False
+        # #5736: RemoteReadModel's real add_status_listener/remove_status_
+        # listener wiring — see those methods' own docstrings. Fired from
+        # _consume_block whenever a decoded STATE_DELTA touches
+        # all_sessions_status; ChatReadModel.add_status_listener's OWN
+        # consumer (TextualChatApp._on_session_status_delta) ignores every
+        # argument but "something changed" (re-reads a fresh snapshot
+        # itself), so a client-local counter here is a legitimate seq —
+        # there is no per-key server seq for this side to relay in the
+        # first place (the wire already carries a value-level diff,
+        # StatusModel.delta's own coalescing, not a per-row sequence).
+        self._status_listeners: "list[Callable[[str, str, bool, bool, int], None]]" = []
+        self._status_listener_seq = 0
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -185,6 +197,52 @@ class AgUiTransport(ClientTransport):
     def status(self) -> RemoteStatusView:
         """The remote status read-model view (reflects the server's STATE_*)."""
         return self._status
+
+    def add_status_listener(
+        self, callback: "Callable[[str, str, bool, bool, int], None]",
+    ) -> None:
+        """#5736: the real ``RemoteReadModel.add_status_listener`` wiring —
+        fired synchronously from :meth:`_consume_block` whenever a decoded
+        ``STATE_DELTA`` touches ``all_sessions_status`` (server ⑤: the SAME
+        function, ``AgentRegistry.all_sessions_status()``, already gates
+        both the snapshot and this delta — this side adds no second
+        visibility check). Mirrors ``AgentRegistry.add_status_listener``'s
+        own shape exactly so ``ChatReadModel``'s ONE consumer
+        (``TextualChatApp._on_session_status_delta``) works unchanged
+        against either read model."""
+        self._status_listeners.append(callback)
+
+    def remove_status_listener(
+        self, callback: "Callable[[str, str, bool, bool, int], None]",
+    ) -> None:
+        """Undo :meth:`add_status_listener`. A no-op if already removed."""
+        if callback in self._status_listeners:
+            self._status_listeners.remove(callback)
+
+    def _dispatch_status_listeners(self, delta: dict) -> None:
+        """#5736: fire every registered status listener for each row in a
+        decoded ``all_sessions_status`` delta. A no-op (never even reads
+        the delta's other keys) when the delta did not touch that key —
+        this STATE_DELTA channel also carries unrelated status fields
+        (cost, ctx, queue, …) that must not spuriously trigger an agent-
+        tab refresh."""
+        if not self._status_listeners:
+            return
+        rows = delta.get("all_sessions_status")
+        if not isinstance(rows, list):
+            return
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            self._status_listener_seq += 1
+            for listener in list(self._status_listeners):
+                listener(
+                    str(row.get("agent", "")),
+                    str(row.get("sid", "")),
+                    bool(row.get("turn_active", False)),
+                    bool(row.get("iv_waiting", False)),
+                    self._status_listener_seq,
+                )
 
     # -- frame production ---------------------------------------------------
 
@@ -219,6 +277,7 @@ class AgUiTransport(ClientTransport):
                     self._status.apply_snapshot(decoded.snapshot)
                 if decoded.delta is not None:
                     self._status.apply_delta(decoded.delta)
+                    self._dispatch_status_listeners(decoded.delta)
                 # #5050 ③: either kind of STATE_* update means the status
                 # side-channel now reflects at least one genuine server
                 # update — see :meth:`state_ready`'s own docstring for why

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -59,6 +59,12 @@ from reyn.interfaces.transport.agui.protocol import (
 from reyn.interfaces.transport.agui.state import StatusModel, project_status
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
 
+# #5736: not part of the shared local/remote ``Frame`` union (``frames.py``)
+# — this is an AG-UI-server-internal signal, never produced by
+# InProcessTransport, so it stays a forward reference imported lazily
+# inside ``stream()`` rather than widening that shared module's own
+# vocabulary for a mechanism the local transport never has.
+
 # WaitingOn label derivation off the audit-event stream — a lightweight, local
 # mirror of the renderer's ``_WAITING_ON_BY_EVENT`` table + turn lifecycle, kept
 # here so the emitter need not import the inline app (which pulls the renderer).
@@ -162,6 +168,11 @@ class AgUiEmitter:
         ]
 
     async def stream(self) -> AsyncIterator[str]:
+        # #5736: imported here (not at module level) — endpoint.py already
+        # imports AgUiEmitter FROM this module at ITS OWN module level, so
+        # a module-level import the other direction would be circular.
+        from reyn.interfaces.transport.agui.endpoint import StatusPingFrame
+
         # Reconnect snapshots first (A4): backlog display, then full status —
         # ``self._initial_status``, paired with ``self._backlog`` at the
         # SAME instant the caller captured both (#5179), not a fresh read.
@@ -172,6 +183,23 @@ class AgUiEmitter:
             yield chunk
 
         async for frame in self._frames:
+            if isinstance(frame, StatusPingFrame):
+                # #5736: no DisplayFrame/EventFrame encoding at all for
+                # this kind — re-project the CURRENT status (a fresh
+                # ``status_provider()`` read, always live —
+                # ``AgentRegistry.all_sessions_status()``'s own "no
+                # stored copy" ruling) through the SAME
+                # ``StatusModel.delta`` diff every OTHER status change
+                # already goes through below (the per-frame delta at
+                # the bottom of this loop), never a second, parallel
+                # diff/encode implementation. Emits nothing when the
+                # ping turns out to have been redundant (e.g. the
+                # change already got picked up by an ordinary frame's
+                # own delta check before this ping was drained).
+                delta = self._model.delta(self._project())
+                if delta:
+                    yield to_sse(encode_state_delta(delta))
+                continue
             # Control sentinels in CONTROL_FILTER_KINDS are NOT forwarded on the
             # AG-UI wire — the explicit per-entry allowlist (protocol.py), not the
             # negation of any forward-set. It holds only ``__end__`` (the stream

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -607,6 +607,32 @@ def _merged_delta_frame(run: list):
     return EventFrame(last.model_copy(update={"data": {**(last.data or {}), "text": text}}))
 
 
+@dataclass(frozen=True)
+class StatusPingFrame:
+    """#5736: a lightweight "re-check status now" signal — NOT a
+    :class:`DisplayFrame`/:class:`EventFrame`, carries no payload at all.
+    Pushed onto :class:`_SessionFrameSource`'s own ordered queue by a
+    SEPARATE, connection-scoped :class:`_StatusFrameSource` (architect
+    ruling, issue #5736: "status は connection 単位の第 2 source として置
+    く" — the frame SOURCE that reads one session's outbox/audit-events
+    stays exactly that; this rides the SAME ordered queue as a different
+    frame kind instead of opening a second stream/connection).
+
+    ``AgUiEmitter.stream()`` reacts to this by re-projecting the CURRENT
+    status (``status_provider()``, always a fresh registry read — see
+    ``AgentRegistry.all_sessions_status()``'s own "no stored copy"
+    ruling) and emitting a ``STATE_DELTA`` if anything actually changed —
+    the SAME ``StatusModel.delta`` code path every OTHER status change
+    already goes through (frame-cadence deltas included), never a second,
+    parallel diff/encode implementation. Carries no ``(name, sid, ...)``
+    payload of its own because none is needed: the eventual re-read is
+    always of the CURRENT, whole ``all_sessions_status()`` list, so
+    coalescing multiple pings into "at most one pending" (see
+    :meth:`_SessionFrameSource.push_status_ping`) loses nothing — the
+    drain always picks up every change accumulated since the last one,
+    never a stale slice."""
+
+
 class _SessionFrameSource:
     """Per-connection unified frame stream off a session (server analogue of
     :class:`InProcessTransport`): fan out ``session.outbox`` as DisplayFrames and
@@ -707,6 +733,10 @@ class _SessionFrameSource:
         self._switch_signal: "asyncio.Queue[tuple[str, str]]" = asyncio.Queue()
         self._listening_for = ""
         self._connection_id = ""
+        # #5736: at most one unconsumed StatusPingFrame in self._q at a
+        # time — see that class's own docstring for why a coalesced,
+        # payload-free ping loses nothing.
+        self._status_ping_pending = False
         self._bind(session)
         if self._registry is not None and self._agent_name:
             self._registry.add_attach_listener(self._agent_name, self._on_attach_announced)
@@ -724,6 +754,21 @@ class _SessionFrameSource:
         """#5116: the ONE read path for "which session is this connection
         looking at right now" — see :meth:`current_agent_name`."""
         return self._session
+
+    def push_status_ping(self) -> None:
+        """#5736: called by a SEPARATE, connection-scoped
+        :class:`_StatusFrameSource` (never by this class itself — this
+        source still only ever READS from one session's own outbox_hub/
+        audit_events, unchanged; it merely accepts an out-of-band wake
+        the same way :attr:`_switch_signal` already does from
+        ``registry.add_attach_listener``, #4534 PR-2b). Coalesced: a
+        second call while one :class:`StatusPingFrame` is already sitting
+        unconsumed in :attr:`_q` is a no-op — see that class's own
+        docstring for why nothing is lost."""
+        if self._status_ping_pending:
+            return
+        self._status_ping_pending = True
+        self._q.put_nowait(StatusPingFrame())
 
     def listen_for_retarget(self, connection_id: str) -> None:
         """#5116: subscribe this source to :data:`_CONNECTION_RETARGET_HUB`
@@ -952,6 +997,18 @@ class _SessionFrameSource:
     async def frames(self):
         while True:
             frame = await self._q.get()
+            if isinstance(frame, StatusPingFrame):
+                # #5736: cleared the MOMENT this ping is taken off the
+                # queue (not when the caller finishes processing it) —
+                # a listener firing between now and the caller's own
+                # re-read must be able to enqueue its own fresh ping
+                # rather than assume this drain will still see it (the
+                # eventual re-read always reflects whatever is CURRENT
+                # at read time regardless, so no ordering is lost).
+                self._status_ping_pending = False
+                await suspend_between_frames()
+                yield frame
+                continue
             # #5259: whatever else is ALREADY waiting is collected here, and a
             # run of consecutive ``agent_delta`` frames leaves as one. The
             # window is however long the consumer took to come back for the
@@ -1034,6 +1091,69 @@ class _SessionFrameSource:
         return _merged_delta_frame(run), held
 
 
+class _StatusFrameSource:
+    """#5736 (architect ruling, issue #5736): the connection-scoped SECOND
+    source status rides — deliberately a SEPARATE object from
+    :class:`_SessionFrameSource`, not a widened responsibility on it.
+    ``_SessionFrameSource`` stays bound to exactly one session's own
+    outbox/audit-events (its own docstring's "bound to ONE session
+    object" claim would become misleading the moment it also subscribed
+    registry-wide); this class owns the registry-wide subscription and
+    pushes a :class:`StatusPingFrame` onto that SAME source's ordered
+    queue (:meth:`_SessionFrameSource.push_status_ping`) — one stream,
+    two producers, never a second connection.
+
+    **Lifetime is the CONNECTION, not the attached session** (architect's
+    own point ②): constructed once per ``agui_events`` call, alongside
+    ``_SessionFrameSource``, and never re-subscribed on a ``/session
+    switch`` or cross-agent ``/attach`` — those re-point WHICH session
+    ``_SessionFrameSource`` reads display/event frames from; the status
+    universe (every loaded session, owner ruling B) does not change, so
+    there is nothing to re-subscribe.
+
+    Identifiers stay in the callback's own ARGUMENTS, never a captured
+    closure variable (#5729 ①'s own named trap, architect's explicit
+    "この形を変えないでください") — :meth:`_on_status_changed` reads
+    nothing from ``self`` but the sink it pushes to."""
+
+    def __init__(self, registry, sink: "_SessionFrameSource") -> None:
+        self._registry = registry
+        self._sink = sink
+        self._subscribed = False
+
+    def start(self) -> None:
+        self._registry.add_status_listener(self._on_status_changed)
+        self._subscribed = True
+
+    def close(self) -> None:
+        # #5736 (architect ruling ⑥, real gap measured on origin/main
+        # before #5734 merged): a remote connection is per-CONNECTION,
+        # unlike the single process-lifetime local TUI consumer #5729
+        # never needed to unsubscribe — omitting this leaks one listener
+        # per connection AND fires a callback into a dead connection's
+        # now-closed queue. Idempotent (`_subscribed` guards a double
+        # `close()`, e.g. the construction-window try/except in
+        # ``agui_events`` racing this method's own normal call in
+        # ``gen()``'s ``finally``).
+        if self._subscribed:
+            self._registry.remove_status_listener(self._on_status_changed)
+            self._subscribed = False
+
+    def _on_status_changed(
+        self, agent_name: str, sid: str, turn_active: bool, iv_waiting: bool, seq: int,
+    ) -> None:
+        # #5736: the 5 identifiers arrive as arguments (AgentRegistry's own
+        # contract, #5729 ①) and are UNUSED here — the eventual re-read
+        # (AgUiEmitter.stream()'s reaction to the pushed StatusPingFrame)
+        # always re-derives the CURRENT, whole all_sessions_status() list
+        # fresh, never carries a per-event payload forward. Naming them in
+        # the signature (not `*args`) keeps this callback's own shape
+        # identical to every other AgentRegistry.add_status_listener
+        # consumer, so a reader comparing the two sees one contract, not
+        # two that happen to agree today.
+        self._sink.push_status_ping()
+
+
 @router.get("/agui/chat/{agent_name}/events")
 async def agui_events(request: Request):
     """SSE stream of the session's frames as AG-UI events (server→client).
@@ -1077,6 +1197,12 @@ async def agui_events(request: Request):
     _ensure_fail_close_driver(agent_name, manager, registry)
 
     source = _SessionFrameSource(session, registry=registry, agent_name=agent_name)
+    # #5736: the connection-scoped SECOND source — see its own class
+    # docstring. Constructed/closed alongside ``source`` in this SAME
+    # try/except/finally window (below) for the identical reason #5119
+    # names for ``source`` itself: an exception anywhere in this window
+    # must not leave a registry-wide listener subscribed forever.
+    status_source = _StatusFrameSource(registry, sink=source)
     # #5119 (architect co-vet on #5118, issuecomment-5380501066, item ④):
     # everything from here through the ``AgUiEmitter`` construction below
     # runs BEFORE ``gen()``'s own ``try``/``finally`` (which is where
@@ -1097,6 +1223,7 @@ async def agui_events(request: Request):
     try:
         source.listen_for_retarget(connection_id)  # #5116: cross-agent /attach
         source.start()
+        status_source.start()
 
         def _status_provider():
             # #5094: read status off THIS connection's own resolved session
@@ -1164,6 +1291,7 @@ async def agui_events(request: Request):
             initial_status=initial_status,
         )
     except Exception:
+        status_source.close()
         source.close()
         raise
 
@@ -1172,6 +1300,7 @@ async def agui_events(request: Request):
             async for chunk in emitter.stream():
                 yield chunk
         finally:
+            status_source.close()
             source.close()
             now2 = monotonic()
             manager.detach(connection_id, now2)

--- a/tests/interfaces/test_5736_remote_status_reactive.py
+++ b/tests/interfaces/test_5736_remote_status_reactive.py
@@ -1,0 +1,540 @@
+"""Tier 2: #5736 — a remote (AG-UI) client learns, IMMEDIATELY, that an
+UNATTACHED session's ``turn_active``/``iv_waiting`` changed — the remote
+counterpart to #5734's local wiring. owner's own request (verbatim): "各
+agent の状態を reactive で表示してほしい…local/remote 両方対応してね."
+Owner ruling B (2026-09-04, verbatim "B だよ"): a remote client MAY see the
+status of a same-process session it has not attached to — this PR is about
+HOW that reaches the wire promptly, not whether it is allowed.
+
+Values were ALREADY correct before this PR (``AgentRegistry.all_sessions_
+status()`` is computed fresh, and ``project_status`` folds it into the SAME
+projection both local and remote read) — the gap was purely a wake channel:
+nothing told an open AG-UI SSE stream to re-check status when the change
+belonged to a session OTHER than the one its own frame source follows.
+
+Architect's confirmed design (issuecomment-5533964539), 6 points this file's
+own test names map onto 1:1:
+  ① _SessionFrameSource stays bound to exactly ONE session (unchanged) —
+     status rides a SEPARATE, connection-scoped _StatusFrameSource.
+  ② the same ordered queue/stream, a different frame kind (StatusPingFrame)
+     — never a second transport connection.
+  ③ subscription lifetime is the CONNECTION, never the attached session —
+     a /session switch must not re-subscribe/unsubscribe.
+  ④ coalesced per key (here: at most one pending ping at all, since the
+     wire payload is never per-key — see StatusPingFrame's own docstring).
+  ⑤ snapshot + delta share the SAME visibility function (this PR adds NO
+     new one — both already read AgentRegistry.all_sessions_status()).
+  ⑥ remove_status_listener is called on disconnect (real gap on origin/main
+     before #5734 merged; #5734 landed the removal method itself).
+
+Real AgentRegistry/Session/InterventionRegistry throughout — the end-to-end
+tests drive a real _SessionFrameSource/_StatusFrameSource/AgUiEmitter chain
+(mirrors test_4534_pr2b_switch_follow_e2e.py's own Frame-level idiom for
+exercising the real wire mechanism directly, without a full HTTP server).
+The intervention dispatch/answer cycle is the SAME
+cheap, real, LLM-free status-transition drive test_5729_status_registry_
+wiring.py already established. No mocks anywhere in this file.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.repl.read_model import RemoteReadModel
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.endpoint import (
+    StatusPingFrame,
+    _SessionFrameSource,
+    _StatusFrameSource,
+)
+from reyn.interfaces.transport.agui.protocol import parse_sse_blocks
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.user_intervention import UserIntervention
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _two_agent_registry(tmp_path: Path, monkeypatch) -> AgentRegistry:
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        s = make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create("alpha")
+    reg.create("beta")
+    return reg
+
+
+
+async def _dispatch_intervention(session: Session) -> "tuple[UserIntervention, asyncio.Task]":
+    """The SAME cheap, real, LLM-free ``iv_waiting`` transition
+    test_5729_status_registry_wiring.py already established."""
+    iv = UserIntervention(kind="ask_user", prompt="Q?")
+    task = asyncio.ensure_future(session.interventions.dispatch(iv))
+    await asyncio.sleep(0)
+    return iv, task
+
+
+# ---------------------------------------------------------------------------
+# Unit level — real AgentRegistry, no HTTP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_source_pushes_a_ping_for_an_unattached_sessions_change(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: ①②'s own direct witness — a frame source bound to session
+    "alpha" observes a real status change on the UNRELATED session "beta"
+    (never attached to this connection) as a StatusPingFrame on its own
+    ordered queue — the SAME queue frames() already drains, never a second
+    stream."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    session_beta = reg.get_or_load("beta")
+
+    source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+    status_source = _StatusFrameSource(reg, sink=source)
+    source.start()
+    status_source.start()
+    try:
+        frames_iter = source.frames()
+
+        iv, task = await _dispatch_intervention(session_beta)
+        await asyncio.sleep(0)
+
+        frame = await asyncio.wait_for(frames_iter.__anext__(), timeout=5)
+        assert isinstance(frame, StatusPingFrame), (
+            f"expected a StatusPingFrame off session alpha's own frame "
+            f"source after session beta's (unattached) status changed — "
+            f"got {frame!r}"
+        )
+
+        await session_beta.interventions.deliver_answer(iv, "ok")
+        await task
+    finally:
+        status_source.close()
+        source.close()
+
+
+@pytest.mark.asyncio
+async def test_multiple_changes_before_drain_coalesce_to_fewer_pings(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: ★④ — N real status transitions on the SAME unattached
+    session, none drained in between, must not produce N separate pings —
+    ``push_status_ping``'s own coalescing collapses them (the eventual
+    drain always re-reads the CURRENT, whole status, so nothing is lost)."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    session_beta = reg.get_or_load("beta")
+
+    source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+    status_source = _StatusFrameSource(reg, sink=source)
+    source.start()
+    status_source.start()
+    try:
+        transitions = 5
+        for _ in range(transitions):
+            iv, task = await _dispatch_intervention(session_beta)
+            await asyncio.sleep(0)
+            await session_beta.interventions.deliver_answer(iv, "ok")
+            await task
+
+        # Terminate the collection deterministically: push a real __end__
+        # DisplayFrame after the (coalesced) pings, and collect until it.
+        source._q.put_nowait(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+
+        pings = 0
+        async for frame in source.frames():
+            if isinstance(frame, StatusPingFrame):
+                pings += 1
+            if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
+                break
+
+        assert pings < transitions, (
+            f"{transitions} real status transitions produced {pings} "
+            f"pings — expected coalescing to keep this below the "
+            f"transition count"
+        )
+        assert pings >= 1, "at least one ping must still have been produced"
+    finally:
+        status_source.close()
+        source.close()
+
+
+@pytest.mark.asyncio
+async def test_close_unsubscribes_the_status_listener(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: ★⑥ — the disconnect-time teardown witness. Public
+    ``status_listener_count()`` (added alongside ``remove_status_listener``
+    in #5734) proves the subscription is actually gone, not merely that
+    ``close()`` ran without raising."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    before = reg.status_listener_count()
+
+    source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+    status_source = _StatusFrameSource(reg, sink=source)
+    status_source.start()
+    assert reg.status_listener_count() == before + 1
+
+    status_source.close()
+    assert reg.status_listener_count() == before
+    source.close()
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: falsify pair — the construction-window try/except in
+    ``agui_events`` can race a normal ``close()`` in ``gen()``'s own
+    ``finally``; a second ``close()`` must not double-decrement (or raise)."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    before = reg.status_listener_count()
+
+    source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+    status_source = _StatusFrameSource(reg, sink=source)
+    status_source.start()
+    status_source.close()
+    status_source.close()  # must not raise or go negative
+    assert reg.status_listener_count() == before
+    source.close()
+
+
+@pytest.mark.asyncio
+async def test_two_connect_disconnect_cycles_never_leak_a_listener(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: ★⑥'s own explicit acceptance phrasing — "接続→切断を2回して
+    listener 数が増えない" — 2 full start/close cycles must return to the
+    SAME baseline, not accumulate."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    before = reg.status_listener_count()
+
+    for _ in range(2):
+        source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+        status_source = _StatusFrameSource(reg, sink=source)
+        status_source.start()
+        status_source.close()
+        source.close()
+
+    assert reg.status_listener_count() == before
+
+
+@pytest.mark.asyncio
+async def test_session_switch_does_not_resubscribe_the_status_listener(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: ★③ — a real ``registry.attach_session`` switch-follow (the
+    SAME mechanism ``_SessionFrameSource`` reacts to via
+    ``add_attach_listener``) must leave the status subscription COUNT
+    unchanged, twice, proving lifetime tracks the CONNECTION, never the
+    currently-attached session."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    sid_b = reg.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)
+
+    source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+    status_source = _StatusFrameSource(reg, sink=source)
+    source.start()
+    status_source.start()
+    try:
+        after_start = reg.status_listener_count()
+
+        await reg.attach_session("alpha", sid_b)
+        await asyncio.sleep(0)
+        assert reg.status_listener_count() == after_start, (
+            "a same-agent session switch must not touch the status "
+            "subscription count"
+        )
+
+        await reg.attach_session("alpha", "main")
+        await asyncio.sleep(0)
+        assert reg.status_listener_count() == after_start, (
+            "switching back must not touch it either"
+        )
+    finally:
+        status_source.close()
+        source.close()
+
+
+# ---------------------------------------------------------------------------
+# Emitter level — a real AgUiEmitter, no HTTP
+# ---------------------------------------------------------------------------
+
+
+async def _one_shot_frames(*items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_emitter_emits_state_delta_when_a_status_ping_arrives() -> None:
+    """Tier 2: ★①②⑤ at the emitter level — a StatusPingFrame (never
+    encoded as a DisplayFrame/EventFrame) causes the SAME
+    ``StatusModel.delta``/``encode_state_delta`` path every other status
+    change already uses to fire, with the CURRENT ``status_provider()``
+    value (never a payload carried BY the ping itself, since it carries
+    none — see that class's own docstring)."""
+    calls = [0]
+
+    def _status_provider():
+        calls[0] += 1
+        # First call (the connect-time reconnect snapshot) sees an empty
+        # roster; the second (triggered by the ping) sees beta.
+        if calls[0] == 1:
+            return {"all_sessions_status": []}
+        return {
+            "all_sessions_status": [
+                {"agent": "beta", "sid": "main", "turn_active": False, "iv_waiting": True},
+            ],
+        }
+
+    emitter = AgUiEmitter(_one_shot_frames(StatusPingFrame()), _status_provider)
+    chunks = [chunk async for chunk in emitter.stream()]
+    sse_text = "".join(chunks)
+    events = parse_sse_blocks(sse_text.split("\n"))
+
+    deltas = [ev for ev in events if ev.type == "STATE_DELTA"]
+    assert deltas, f"expected a STATE_DELTA after the status ping — events: {events!r}"
+    assert deltas[0].data["delta"]["all_sessions_status"] == [
+        {"agent": "beta", "sid": "main", "turn_active": False, "iv_waiting": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_emitter_emits_nothing_for_a_redundant_status_ping() -> None:
+    """Tier 2: falsify pair (deny side) — a ping that arrives after the
+    change it was for was ALREADY picked up (e.g. by an ordinary frame's
+    own per-frame delta check) must not manufacture a second, empty
+    STATE_DELTA."""
+    def _status_provider():
+        return {"all_sessions_status": []}
+
+    emitter = AgUiEmitter(_one_shot_frames(StatusPingFrame()), _status_provider)
+    chunks = [chunk async for chunk in emitter.stream()]
+    sse_text = "".join(chunks)
+    events = parse_sse_blocks(sse_text.split("\n"))
+
+    deltas = [ev for ev in events if ev.type == "STATE_DELTA"]
+    assert deltas == []
+
+
+# ---------------------------------------------------------------------------
+# ★ End-to-end — a real _SessionFrameSource/_StatusFrameSource/AgUiEmitter
+# chain (mirrors test_4534_pr2b_switch_follow_e2e.py's own Frame-level
+# idiom for exercising the real wire mechanism without a full HTTP server;
+# owner ruling B's own witness: an UNATTACHED session's change reaches the
+# wire immediately)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_client_sees_an_unattached_sessions_change_without_a_frame_of_its_own(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: ★ the central, owner-facing witness. Connects a real
+    ``_SessionFrameSource``/``_StatusFrameSource`` pair bound to agent
+    "alpha" (mirrors what ``agui_events`` wires per-connection), then
+    drives a REAL ``iv_waiting`` transition on agent "beta" — a session
+    this connection never attached to and which produces NO frame on
+    alpha's own outbox/audit-event stream. The change must still reach
+    this stream's own encoded SSE text as a STATE_DELTA."""
+    reg = _two_agent_registry(tmp_path, monkeypatch)
+    session_alpha = await reg.attach("alpha")
+    session_beta = reg.get_or_load("beta")
+
+    source = _SessionFrameSource(session_alpha, registry=reg, agent_name="alpha")
+    status_source = _StatusFrameSource(reg, sink=source)
+    source.start()
+    status_source.start()
+    # The REAL status_provider production wiring uses (endpoint.py's own
+    # ``_status_provider`` closure) — reads `source.current_session()`
+    # fresh, never a frozen/constant value, exactly what a real connection
+    # does.
+    from reyn.interfaces.repl.status import _snapshot_for_session
+
+    emitter = AgUiEmitter(
+        source.frames(), lambda: _snapshot_for_session(reg, source.current_session()),
+    )
+
+    stream_iter = emitter.stream()
+    try:
+        # Prime past the connect-time reconnect snapshot chunks
+        # (MESSAGES_SNAPSHOT then STATE_SNAPSHOT — 2 chunks, same as
+        # test_4534_pr2b's own "prime past the initial connect snapshot").
+        await stream_iter.__anext__()
+        await stream_iter.__anext__()
+
+        iv, task = await _dispatch_intervention(session_beta)
+        try:
+            chunk = await asyncio.wait_for(stream_iter.__anext__(), timeout=5)
+        finally:
+            await session_beta.interventions.deliver_answer(iv, "ok")
+            await task
+    finally:
+        status_source.close()
+        source.close()
+
+    events = parse_sse_blocks(chunk.split("\n"))
+    deltas = [ev for ev in events if ev.type == "STATE_DELTA"]
+    assert deltas, (
+        f"session alpha's own connection never saw beta's (unattached) "
+        f"status change reach the wire: {chunk!r}"
+    )
+    beta_rows = [
+        row for row in deltas[0].data["delta"].get("all_sessions_status", [])
+        if row.get("agent") == "beta"
+    ]
+    assert beta_rows and beta_rows[0]["iv_waiting"] is True, (
+        f"the delta did not carry beta's real iv_waiting=True transition: "
+        f"{deltas[0].data!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Client side — RemoteReadModel.add_status_listener's own real wiring
+# (AgUiTransport decoding a real server-produced STATE_DELTA), mirroring
+# test_agui_state_read_model.py's own "real server text → real client"
+# idiom.
+# ---------------------------------------------------------------------------
+
+
+async def _sse_lines(text: str):
+    for line in text.split("\n"):
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_remote_read_model_status_listener_fires_on_a_real_wire_delta() -> None:
+    """Tier 2: the CLIENT half of this PR — was the base class's no-op
+    default (the exact gap #5736 disclosed: values already correct over
+    the wire, nothing woke the ONE consumer). A REAL server-produced
+    STATE_DELTA (via a real ``AgUiEmitter``), decoded by a REAL
+    ``AgUiTransport``, must reach a callback registered through
+    ``RemoteReadModel.add_status_listener`` — the exact seam
+    ``TextualChatApp.on_mount`` calls, unchanged, for either read model."""
+    state = {"all_sessions_status": []}
+
+    def status_provider():
+        return dict(state)
+
+    async def frames():
+        yield DisplayFrame(OutboxMessage(kind="status", text="x"))
+        state["all_sessions_status"] = [
+            {"agent": "beta", "sid": "main", "turn_active": False, "iv_waiting": True},
+        ]
+        yield DisplayFrame(OutboxMessage(kind="status", text="y"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_DELTA" in sse, "test setup sanity: the server must have emitted a delta"
+
+    async def _send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _send)
+    read_model = RemoteReadModel(transport)
+    calls: "list[tuple]" = []
+    read_model.add_status_listener(lambda *args: calls.append(args))
+
+    async for _frame in transport.frames():
+        pass
+
+    assert calls == [("beta", "main", False, True, 1)], (
+        f"expected exactly one callback carrying beta's real transition — "
+        f"got {calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_read_model_status_listener_ignores_unrelated_deltas() -> None:
+    """Tier 2: falsify pair — a STATE_DELTA touching some OTHER key (cost,
+    ctx, …) must not spuriously fire the listener; only a delta that
+    actually carries ``all_sessions_status`` may."""
+    state = {"all_sessions_status": [], "cost_agent": 1.0}
+
+    def status_provider():
+        return dict(state)
+
+    async def frames():
+        yield DisplayFrame(OutboxMessage(kind="status", text="x"))
+        state["cost_agent"] = 5.0  # unrelated key changes
+        yield DisplayFrame(OutboxMessage(kind="status", text="y"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_DELTA" in sse
+
+    async def _send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _send)
+    read_model = RemoteReadModel(transport)
+    calls: "list[tuple]" = []
+    read_model.add_status_listener(lambda *args: calls.append(args))
+
+    async for _frame in transport.frames():
+        pass
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_remote_read_model_remove_status_listener_stops_further_calls() -> None:
+    """Tier 2: the REMOTE side of ★⑥ — ``remove_status_listener`` (called
+    from ``TextualChatApp.on_unmount``, unchanged) must genuinely stop
+    delivery, not merely accept the call."""
+    state = {"all_sessions_status": []}
+
+    def status_provider():
+        return dict(state)
+
+    async def frames():
+        yield DisplayFrame(OutboxMessage(kind="status", text="x"))
+        state["all_sessions_status"] = [
+            {"agent": "beta", "sid": "main", "turn_active": True, "iv_waiting": False},
+        ]
+        yield DisplayFrame(OutboxMessage(kind="status", text="y"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    async def _send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _send)
+    read_model = RemoteReadModel(transport)
+    calls: "list[tuple]" = []
+    callback = lambda *args: calls.append(args)  # noqa: E731
+    read_model.add_status_listener(callback)
+    read_model.remove_status_listener(callback)
+
+    async for _frame in transport.frames():
+        pass
+
+    assert calls == []


### PR DESCRIPTION
**[e2e-coder]** —

owner's own request: "各 agent の状態を reactive で表示してほしい…local/remote 両方対応してね." #5734 landed local (registry-wired `add_status_listener`); this is the remote residual, owner ruling B explicitly kept in scope ("remote client は同 process の未 attach session の状態も見てよい"). Values were ALREADY correct over the wire (`all_sessions_status()` computed fresh, same projection both sides read) — the gap was purely a wake channel: nothing told an open AG-UI SSE stream to re-check status for a session other than the one its own frame source follows.

Design: architect, [issuecomment-5533964539](https://github.com/tya5/reyn/issues/5736#issuecomment-5533964539).

## What changed

**Server side** (`endpoint.py`, `emitter.py`):
- `StatusPingFrame`: a lightweight signal, never encoded as a Display/EventFrame.
- `_StatusFrameSource`: a **separate**, connection-scoped object (`_SessionFrameSource` stays bound to exactly ONE session, unchanged — no widened "1:N" frame source) — subscribes `registry.add_status_listener`/`remove_status_listener`, pushes a `StatusPingFrame` onto `_SessionFrameSource`'s own queue via a new `push_status_ping()` method, coalesced to at most one unconsumed ping at a time (the wire payload is never per-key — the eventual drain always re-reads the CURRENT, whole `all_sessions_status()` list, so nothing is lost).
- `AgUiEmitter.stream()` reacts to `StatusPingFrame` by re-projecting status through the SAME `StatusModel.delta`/`encode_state_delta` path every other status change already uses — never a second diff/encode implementation.
- Wired into `agui_events()` alongside `_SessionFrameSource`, same start/close lifecycle, same try/except/finally window #5119 already established for exception-safety. Subscription lifetime is the **connection**, never the attached session — a `/session switch` never re-subscribes/unsubscribes it.
- Snapshot and delta share the SAME visibility function — no new one added; both already read `AgentRegistry.all_sessions_status()` exclusively.

**Client side** (`client.py`, `read_model.py`):
- `AgUiTransport` gains `add_status_listener`/`remove_status_listener` + dispatch from `_consume_block` whenever a decoded `STATE_DELTA` touches `all_sessions_status` — mirrors `AgentRegistry`'s own callback shape exactly (`TextualChatApp._on_session_status_delta`'s own consumer already ignores every argument but "something changed", so a client-local seq counter is legitimate — there is no per-key server seq to relay in the first place).
- `RemoteReadModel.add_status_listener`/`remove_status_listener`: was the base class's no-op default; now delegates to the transport.

**Doc**: `agui-transport.md`'s `STATE_DELTA` section gains a paragraph documenting the new reactive-delta mechanism — no prior claim there was false, so no `.ja.md` mirror fix needed per house rule.

Strip-falsified (real execution, then restored): removing `RemoteReadModel`'s delegation, and removing `push_status_ping`'s own coalescing guard, each turn a dedicated test red.

## Test plan

- [x] `ruff check`
- [x] `test_tier_audit.py --strict` (12/12 OK, 0 Tier 4 violations)
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] `mkdocs build --strict` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py`
- [x] `pytest` scoped to the diff (`test_5736_remote_status_reactive.py`, plus `test_5729_agent_pane_status_glyphs.py`, `test_5729_status_registry_wiring.py`, `test_agui_state_read_model.py`, `test_4534_pr2b_switch_follow_e2e.py`, `test_3310_n3_remote_switch_parity.py`, `test_5116_connection_agent_owner_cross_attach.py`, `test_stream_drain_yield_3570.py`, `test_5179_backlog_gap_end_to_end.py`, `test_5133_surface_migrates_on_cross_agent_attach.py`, `test_5129_submit_follows_connection_agent.py`, `test_audit_event_kind_vocabulary_3410.py`) — full suite left to CI
- [x] (skipped — no new audit-event kind)

## Scope note

`_StatusFrameSource.close()`'s teardown-on-disconnect is unit-tested directly (real `start()`/`close()` cycles against a real `AgentRegistry`, checking `status_listener_count()`); I did not additionally stand up a real uvicorn server for an HTTP-level version of the same witness (`test_3328_connect_remote_parity_witness.py`'s own `_RealServer` idiom) — the unit-level test drives the exact same production methods `agui_events()` calls, so I judged the marginal value low relative to the added fragility/runtime cost. Flagging in case a stricter HTTP-level witness is wanted.

Closes #5736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51