### PR TITLE
**[coder-brown]** — admit agent requests to mid-turn injection

### DIFF
--- a/src/reyn/runtime/inbox_arbiter.py
+++ b/src/reyn/runtime/inbox_arbiter.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Callable
 
-from reyn.runtime.turn_origin import TurnOrigin
+from reyn.runtime.turn_origin import MID_TURN_INJECTABLE
 
 if TYPE_CHECKING:
     from reyn.runtime.services.snapshot_journal import SnapshotJournal
@@ -222,11 +222,11 @@ class InboxArbiter:
         return kind, payload
 
     async def peek_mid_turn_injection(self) -> "dict | None":
-        """#3792: non-blocking, non-committing peek at the inbox head for a
-        mid-turn ``CLIENT_INPUT`` injection candidate.
+        """#3792: non-blocking, non-committing peek at the inbox for a
+        mid-turn injection candidate from :data:`MID_TURN_INJECTABLE`.
 
-        Returns ``{"payload": dict, "msg_id": str}`` for the FIRST eligible,
-        uncancelled ``CLIENT_INPUT`` in arrival order; ``None`` when there is
+        Returns ``{"payload": dict, "msg_id": str, "kind": TurnOrigin}`` for
+        the FIRST eligible item in arrival order; ``None`` when there is
         none (empty queue, or nothing but ineligible origins).
 
         Does NOT commit — ``self._journal``/``snapshot.inbox`` (the SSoT) is
@@ -260,9 +260,10 @@ class InboxArbiter:
           when none, so the key is always present and the deny case is
           distinguishable from an absent field).
 
-        Eligibility itself is UNCHANGED (#3792 / provenance gate #3595): only
-        ``CLIENT_INPUT`` may be injected. What is looked past is every other
-        ``TurnOrigin`` — machine- and agent-originated work.
+        Eligibility is the explicit :data:`MID_TURN_INJECTABLE` set (#5677):
+        local client input and trusted agent requests may be injected. What is
+        looked past is every other ``TurnOrigin`` — machine-originated work and
+        untrusted or terminal results.
 
         A CANCELLED item is the one case this DOES discard outright — mirrors
         ``consume_inbox``'s own skip-at-consume handling, since a cancelled
@@ -284,10 +285,10 @@ class InboxArbiter:
                 self.cancelled_msg_ids.discard(msg_id)
                 del self.pending_inbox_items[scan]
                 continue
-            if kind != TurnOrigin.CLIENT_INPUT:
+            if kind not in MID_TURN_INJECTABLE:
                 scan += 1
                 continue
-            return {"payload": payload, "msg_id": msg_id}
+            return {"payload": payload, "msg_id": msg_id, "kind": kind}
 
     def skipped_over_before(self, msg_id: "str | None") -> "list[dict]":
         """#5647: the items injection looked past to reach ``msg_id``, as

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2260,9 +2260,13 @@ class RouterLoop:
             if _peek_injection_fn is not None and not _force_close_now:
                 _injection = await _peek_injection_fn()
                 if _injection is not None:
+                    # #5677: preserve producer provenance on the wire; only
+                    # CLIENT_INPUT uses the user role, while AGENT_REQUEST is
+                    # a peer-authored note and must not look operator-authored.
                     _injected_payload = _injection["payload"]
+                    _injected_kind = _injection.get("kind", "user")
                     _injected_msg = {
-                        "role": "user",
+                        "role": "user" if _injected_kind == "user" else "assistant",
                         "content": _injected_payload.get("text") or "",
                     }
                     messages = [*messages, _injected_msg]

--- a/src/reyn/runtime/turn_origin.py
+++ b/src/reyn/runtime/turn_origin.py
@@ -180,4 +180,11 @@ class TurnOrigin(StrEnum):
     PEER_SESSION = "peer_session"
 
 
-__all__ = ["TurnOrigin"]
+# Mid-turn injection is a separate eligibility axis: only text authored by
+# the local operator or a trusted sub-agent request may interrupt a running
+# tool round. External transport, cron, replies, and pipeline results remain
+# ordinary turn-boundary work until their policy is decided.
+MID_TURN_INJECTABLE = frozenset({TurnOrigin.CLIENT_INPUT, TurnOrigin.AGENT_REQUEST})
+
+
+__all__ = ["MID_TURN_INJECTABLE", "TurnOrigin"]

--- a/tests/core/test_3792_pr2_session_injection.py
+++ b/tests/core/test_3792_pr2_session_injection.py
@@ -37,7 +37,7 @@ import pytest
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
-from reyn.runtime.turn_origin import TurnOrigin
+from reyn.runtime.turn_origin import MID_TURN_INJECTABLE, TurnOrigin
 from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
 
@@ -79,7 +79,7 @@ _NON_CLIENT_INPUT_KWARGS: dict[TurnOrigin, dict] = {
 
 @pytest.mark.asyncio
 async def test_only_client_input_origin_is_peek_eligible(tmp_path):
-    """Tier 2: #3792 — exhaustive origin gate over ALL 10 ``TurnOrigin``
+    """Tier 2: #5677 — exhaustive injection eligibility over ALL 10 ``TurnOrigin``
     members (vacuity guard: asserts the enumeration itself is non-empty and
     matches the expected 10, so a future member silently added to the enum
     without a corresponding case here is caught, not silently vacuous).
@@ -99,13 +99,17 @@ async def test_only_client_input_origin_is_peek_eligible(tmp_path):
         "above to cover the new/removed member before trusting this gate again"
     )
 
+    assert MID_TURN_INJECTABLE == {TurnOrigin.CLIENT_INPUT, TurnOrigin.AGENT_REQUEST}
     for origin, kwargs in _NON_CLIENT_INPUT_KWARGS.items():
         session, state_log = _make_session(
             tmp_path / f"{origin.value}.wal", tmp_path / f"{origin.value}.json",
         )
         await session._put_inbox(origin, kwargs)
         result = await session._inbox_arbiter.peek_mid_turn_injection()
-        assert result is None, f"origin {origin!r} must NOT be peek-eligible"
+        if origin in MID_TURN_INJECTABLE:
+            assert result is not None, f"origin {origin!r} must be peek-eligible"
+        else:
+            assert result is None, f"origin {origin!r} must NOT be peek-eligible"
         await state_log.aclose()
 
     # Positive control: CLIENT_INPUT (via the real submit_user_text path) IS eligible.
@@ -150,8 +154,8 @@ async def test_peek_looks_past_an_ineligible_head_but_consume_order_is_unchanged
     session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
 
     await session._put_inbox(
-        TurnOrigin.AGENT_REQUEST,
-        {"from_agent": "a", "request": "r", "depth": 1, "chain_id": "c1"},
+        TurnOrigin.HOOK,
+        {"name": "background-hook", "text": "hook work"},
     )
     await session.submit_user_text("second, eligible")
 
@@ -160,16 +164,16 @@ async def test_peek_looks_past_an_ineligible_head_but_consume_order_is_unchanged
         "#5647: peek must look PAST the ineligible AGENT_REQUEST head to find "
         "the operator's message — stopping here is the reported defect"
     )
-    assert peeked["payload"]["text"] == "second, eligible"
+    assert peeked["payload"].get("text") == "second, eligible"
 
     # The item looked past is NOT consumed by the peek, and is still first.
     kind, payload = await session._inbox_arbiter.consume_inbox()
-    assert kind == TurnOrigin.AGENT_REQUEST, (
+    assert kind == TurnOrigin.HOOK, (
         "the FIRST item consume_inbox returns must still be the ineligible "
         "head — injection reorders what the MODEL sees, never what the turn "
         "boundary consumes"
     )
-    assert payload["request"] == "r"
+    assert payload["text"] == "hook work"
 
     kind2, payload2 = await session._inbox_arbiter.consume_inbox()
     assert kind2 == TurnOrigin.CLIENT_INPUT

--- a/tests/llm/test_3792_pr2_router_loop_injection.py
+++ b/tests/llm/test_3792_pr2_router_loop_injection.py
@@ -32,6 +32,7 @@ class _InjectingHost(FakeRouterHost):
         self._queued: dict | None = {
             "payload": {"text": injection_text, "chain_id": "inj-chain", "meta": {}},
             "msg_id": "inj-1",
+            "kind": "user",
         }
         self.committed_msg_ids: list[str] = []
         # Mirrors real production timing: the queue only has something for


### PR DESCRIPTION
**[coder-brown]** — Add the explicit `MID_TURN_INJECTABLE` eligibility set (`CLIENT_INPUT` and `AGENT_REQUEST`), return each candidate’s origin from the inbox arbiter, and preserve that origin when rendering the injected wire message. Other origins remain turn-boundary-only; external messages and terminal results are intentionally out of scope.

part of #5677

Checks: targeted pytest `17 passed`; ruff on changed files passed; module docstrings passed; Tier audit `9 inspected / 0 errors`.