### PR TITLE
fix(#5745): ctx chip pushes last_call_usage live, per LLM call

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1317,6 +1317,7 @@ class RouterLoop:
         max_schema_reprompt_attempts: int = 2,  # 0062 §2.1 failure-mode-(c): bounded re-prompt budget (extra attempts beyond the first)
         intra_turn_contextual_for_turn_fn: "Any | None" = None,  # #1909 OPT-IN: () -> ContextualPermission|None, re-invoked every run() iteration. None (default) = off — self._contextual_permission stays turn-frozen. RouterLoopDriver only threads this when safety.threat_scan.capability_narrowing is "iteration" (#3501 — the top rung of the 3-value ladder off/turn/iteration; at "turn" the narrowing is resolved at the turn boundary only, so this stays None there too).
         contextual_static_baseline: "object | None" = None,  # #1909: the UN-narrowed static contextual (identity anchor) — a per-iteration resolve equal (by identity) to this means "not tainted"; anything else means the untrusted-composed profile engaged. Only consulted when intra_turn_contextual_for_turn_fn is not None.
+        on_call_usage: "Any | None" = None,  # #5745: Callable[[TokenUsage], None] | None — invoked immediately after EVERY ``self._last_call_usage`` write below (both call sites), never batched to turn-end. This field is ALREADY live per-call on this instance (``self.last_call_usage``); the status-bar ctx chip reads a SEPARATE copy (``BudgetGateway._last_call_usage``, session.py's own ``last_call_usage`` property) that was previously only synced once per whole turn (``add_router_usage``, at run_turn's own end) — a multi-tool-iteration turn could run for minutes with the chip frozen. This callback is the live wire for that copy; it does ONLY that — it must never touch billing/total_usage (that stays add_router_usage's own turn-summed job, called exactly once, unchanged).
     ):
         self.host = host
         self.chain_id = chain_id
@@ -1456,6 +1457,11 @@ class RouterLoop:
         # the same growing context each iteration re-sends, wildly overstating
         # "how much of the window is currently occupied".
         self._last_call_usage: TokenUsage = TokenUsage()
+        # #5745: see the constructor param's own comment — the live wire to
+        # BudgetGateway's separate copy of "most recent call" (what the
+        # status-bar ctx chip actually reads). None for any caller that
+        # doesn't pass one (byte-identical to before this field existed).
+        self._on_call_usage = on_call_usage
         # #1593: the active tool-use scheme. PR-1 = universal-category (the shipped
         # behaviour, behind the protocol) for every layer → byte-identical. Per-layer
         # config selection (tool_use) plugs in here; with all
@@ -2473,6 +2479,14 @@ class RouterLoop:
             if result.usage:
                 self._total_usage += result.usage
                 self._last_call_usage = result.usage
+                # #5745: live per-call wire to the status-bar ctx chip's own
+                # copy — see the constructor param's own comment. Never
+                # touches billing (self._total_usage, just above, already
+                # did that) — this call site's ONLY other job is telling
+                # BudgetGateway which call was most recent, right now,
+                # not at this whole turn's eventual end.
+                if self._on_call_usage is not None:
+                    self._on_call_usage(result.usage)
             # #1593 loop-unify (Issue-1): interpret-driven routing — the active
             # scheme classifies EVERY result, instead of the OS sniffing
             # ``result.tool_calls``. universal-category returns Execute when there
@@ -3291,6 +3305,14 @@ class RouterLoop:
             if result.usage:
                 self._total_usage += result.usage
                 self._last_call_usage = result.usage
+                # #5745: live per-call wire to the status-bar ctx chip's own
+                # copy — see the constructor param's own comment. Never
+                # touches billing (self._total_usage, just above, already
+                # did that) — this call site's ONLY other job is telling
+                # BudgetGateway which call was most recent, right now,
+                # not at this whole turn's eventual end.
+                if self._on_call_usage is not None:
+                    self._on_call_usage(result.usage)
             text = result.content or ""
             try:
                 parsed = json.loads(text)

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -151,14 +151,17 @@ class BudgetGateway:
         (status-bar ctx chip's headline figure). Overwritten (not
         accumulated) on each call.
 
-        #4703/#4709: this field's only two writers today are
-        :meth:`accumulate` (``session.py``'s own router-turn-result path)
-        and :meth:`add_router_usage` (``router_loop_driver.py``) — both
-        ROUTER calls. That is why the ctx chip's figure never needs a
-        ``purpose`` filter: compaction's own LLM call (a real, separate
-        recorder — ``BudgetTracker`` via ``recorder=self._budget_tracker``
-        in ``session.py``, never this gateway) has no path to this field at
-        all. If a THIRD writer is ever wired to this gateway from a
+        #4703/#4709/#5745: this field's writers today are :meth:`accumulate`
+        (``session.py``'s own router-turn-result path), :meth:`add_router_usage`
+        (``router_loop_driver.py``, once per whole turn), and
+        :meth:`update_last_call_usage` (``router_loop.py``'s own
+        ``on_call_usage`` wire, once per LLM call — #5745, the actual LIVE
+        source most of the time a turn is in flight) — all three ROUTER
+        calls. That is why the ctx chip's figure never needs a ``purpose``
+        filter: compaction's own LLM call (a real, separate recorder —
+        ``BudgetTracker`` via ``recorder=self._budget_tracker`` in
+        ``session.py``, never this gateway) has no path to this field at
+        all. If a FOURTH writer is ever wired to this gateway from a
         non-router call site (a purpose OTHER than the conversation turn),
         it will overwrite this property with that call's usage instead —
         silently, no exception, no raise — and the ctx chip will start
@@ -185,6 +188,29 @@ class BudgetGateway:
         if cost_breakdown is not None:
             self._total_cost_breakdown += cost_breakdown
 
+    def update_last_call_usage(self, usage: "TokenUsage | None") -> None:
+        """#5745: the LIVE per-call wire — ``router_loop.py``'s
+        ``on_call_usage`` callback calls this immediately after EVERY LLM
+        call, not just once at the whole turn's end. Touches ONLY
+        ``_last_call_usage`` — never billing (``_total_usage``/
+        ``_total_cost_usd``/``_total_cost_breakdown``, all still exclusively
+        :meth:`add_router_usage`'s and :meth:`accumulate`'s own job, each
+        called exactly as often as before this method existed) — calling
+        this per-call is what a per-call call to ``add_router_usage``
+        itself would have double(triple/...)-counted into billing, which
+        is why this narrower method exists instead of just calling that
+        one more often.
+
+        ``None`` or an all-zero ``usage`` (a call whose provider echoed no
+        usage at all — ``TokenUsage`` has no ``__bool__``, so a bare
+        ``TokenUsage()`` is truthy despite being empty; ``total_tokens``
+        is the real emptiness check, mirroring ``add_router_usage``'s own
+        ``usage.total_tokens == 0`` guard) is a no-op — the previous
+        value, however stale, is a more honest answer than silently
+        zeroing what was actually the most recently OBSERVED figure."""
+        if usage is not None and usage.total_tokens != 0:
+            self._last_call_usage = usage
+
     def add_router_usage(
         self, *, usage: TokenUsage, last_call_usage: "TokenUsage | None" = None,
         resolver, router_model_name: str,
@@ -201,11 +227,23 @@ class BudgetGateway:
         count every call). ``last_call_usage`` — the single most recent call,
         from RouterLoop.last_call_usage — is what last_call_usage reports;
         they are NOT the same figure for a multi-tool-iteration turn.
+
+        #5745 fix: a ``None`` (or omitted) ``last_call_usage`` no longer
+        falls back to writing ``usage`` (the TURN-SUMMED figure) into the
+        single-most-recent-call field — that fallback was itself the bug
+        this issue named, now unreachable from its own ONE call site
+        (``router_loop_driver.py`` always passes ``loop.last_call_usage``)
+        but left in place before as a live footgun for any future caller
+        that omitted it. ``None`` here means "nothing to say about the
+        most recent call" — leave whatever :meth:`update_last_call_usage`
+        (the #5745 per-call live wire) already wrote alone, never overwrite
+        it with a turn aggregate.
         """
         if usage is None or usage.total_tokens == 0:
             return
         self._total_usage += usage
-        self._last_call_usage = last_call_usage if last_call_usage is not None else usage
+        if last_call_usage is not None:
+            self._last_call_usage = last_call_usage
         # F4 Bug 1: strip proxy prefix so estimate_cost lookup succeeds.
         from reyn.llm.llm import proxy_kwargs
         from reyn.llm.pricing import estimate_cost, estimate_cost_breakdown

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -1280,6 +1280,13 @@ class RouterLoopDriver:
             scheme_name=self._chat_scheme_name,
             max_iterations=self._router_max_iterations,
             budget=self._budget_tracker,
+            # #5745: the live per-call wire to the status-bar ctx chip's own
+            # copy of "most recent call" (BudgetGateway._last_call_usage) —
+            # fires on EVERY LLM call this loop makes, not just once at
+            # run_turn's own end below (add_router_usage, unchanged, still
+            # the sole turn-summed BILLING writer). See RouterLoop's own
+            # on_call_usage param docstring and BudgetGateway.update_last_call_usage.
+            on_call_usage=self._budget.update_last_call_usage,
             # #1440 followup: thread the run-once autonomy flag to the LIVE
             # chat-router SP path (router_loop build_system_prompt).
             non_interactive=self._non_interactive,

--- a/tests/llm/test_budget_gateway_invariants.py
+++ b/tests/llm/test_budget_gateway_invariants.py
@@ -364,14 +364,73 @@ def test_add_router_usage_uses_explicit_last_call_usage_not_turn_total():
     assert gw.total_usage.prompt_tokens == 300        # billing still counts every call
 
 
-def test_add_router_usage_falls_back_to_turn_total_when_last_call_usage_omitted():
-    """Tier 2: last_call_usage is optional (default None) — omitting it (as an
-    older/non-UI caller might) falls back to the turn total, so nothing
-    breaks for callers that don't care about the ctx-chip distinction."""
+def test_add_router_usage_leaves_last_call_usage_untouched_when_omitted():
+    """Tier 2: #5745 fix — ``last_call_usage`` is optional (default None) on
+    ``add_router_usage``, but omitting it no longer falls back to writing
+    the TURN-SUMMED total into the single-most-recent-call field (that
+    fallback was itself the bug #5745 named — turn-summed and per-call are
+    two DIFFERENT figures, and silently substituting one for the other
+    the moment a caller omits the newer kwarg is exactly the ambiguity the
+    field exists to avoid). Billing (``total_usage``) is unaffected either
+    way — this only pins that ``last_call_usage`` itself is left alone,
+    not that ``add_router_usage`` stops accumulating."""
     resolver = ModelResolver({"light": "openai/gpt-4o-mini"})
     gw, _ = _make_gateway()
 
+    # A prior per-call value already on the field (the #5745 live wire,
+    # ``update_last_call_usage``, would have put one there) — proves
+    # "omitted" means UNCHANGED, not "zeroed", not "overwritten with the
+    # turn total below".
+    gw.update_last_call_usage(TokenUsage(prompt_tokens=7, completion_tokens=1))
+
     u = TokenUsage(prompt_tokens=40, completion_tokens=5, cached_tokens=5)
     gw.add_router_usage(usage=u, resolver=resolver, router_model_name="light")
-    assert gw.last_call_usage.prompt_tokens == 40
-    assert gw.total_usage.prompt_tokens == 40
+    assert gw.last_call_usage.prompt_tokens == 7, (
+        "omitting last_call_usage must leave the field as it was, not "
+        "overwrite it with the turn-summed total"
+    )
+    assert gw.total_usage.prompt_tokens == 40, "billing still accumulates the turn total"
+
+
+def test_update_last_call_usage_touches_only_the_one_field():
+    """Tier 2: #5745 — ``update_last_call_usage`` (the live per-call wire
+    ``router_loop.py``'s ``on_call_usage`` callback drives) writes
+    ``last_call_usage`` and NOTHING else: not ``total_usage``, not
+    ``total_cost_usd``. Calling this per-call (as intended — every LLM
+    call, not just once per turn) must never double-count billing, which
+    is exactly what would happen if it touched the same totals
+    ``add_router_usage``/``accumulate`` already own."""
+    gw, _ = _make_gateway()
+
+    gw.update_last_call_usage(TokenUsage(prompt_tokens=99, completion_tokens=3))
+
+    assert gw.last_call_usage.prompt_tokens == 99
+    assert gw.total_usage.prompt_tokens == 0, "must never accumulate into billing totals"
+    assert gw.total_cost_usd == 0.0, "must never accumulate into billing totals"
+
+
+def test_update_last_call_usage_overwrites_not_accumulates():
+    """Tier 2: #5745 — each call REPLACES the field (the property's own
+    docstring: "Overwritten (not accumulated) on each call") — two calls
+    in a row must show the SECOND call's figure, never a sum of the two."""
+    gw, _ = _make_gateway()
+
+    gw.update_last_call_usage(TokenUsage(prompt_tokens=10))
+    gw.update_last_call_usage(TokenUsage(prompt_tokens=25))
+
+    assert gw.last_call_usage.prompt_tokens == 25
+
+
+def test_update_last_call_usage_ignores_a_falsy_usage():
+    """Tier 2: #5745 — a call whose provider echoed no usage at all (an
+    empty/falsy ``TokenUsage``, or ``None``) must not clobber whatever the
+    field already honestly reflected — the previous OBSERVED figure stays
+    more accurate than a fabricated zero."""
+    gw, _ = _make_gateway()
+    gw.update_last_call_usage(TokenUsage(prompt_tokens=42))
+
+    gw.update_last_call_usage(None)
+    assert gw.last_call_usage.prompt_tokens == 42
+
+    gw.update_last_call_usage(TokenUsage())  # a real, but all-zero, TokenUsage
+    assert gw.last_call_usage.prompt_tokens == 42

--- a/tests/llm/test_slash_model_router_integration.py
+++ b/tests/llm/test_slash_model_router_integration.py
@@ -20,6 +20,7 @@ import pytest
 from reyn.config.chat import SafetyConfig
 from reyn.core.events.events import EventLog
 from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.services.budget_gateway import BudgetGateway
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
 
 # ---------------------------------------------------------------------------
@@ -40,11 +41,23 @@ class _FakeRouterHost:
         pass
 
 
-class _FakeBudget:
-    def check_and_increment_router_cap(self, text):
+class _FakeBudget(BudgetGateway):
+    """#5748 (lead-coder finding — same shape as #5734's
+    ``_PickerReadModel``/``_TaskSnapshotReadModel``): a hand-written
+    double that only reimplements the methods THIS test drives goes
+    stale the moment the real class gains a new one — ``RouterLoop``
+    construction now unconditionally reads ``self._budget.
+    update_last_call_usage`` (#5745), which a bare ``_FakeBudget``
+    never had. Inherits the real ``BudgetGateway`` (cheap — no I/O in
+    ``__init__``) instead."""
+
+    def __init__(self) -> None:
+        super().__init__(budget_tracker=None, events=EventLog(), agent_name="t-agent")
+
+    def check_and_increment_router_cap(self, user_text):
         pass
 
-    def extend_router_cap(self, n):
+    def extend_router_cap(self, additional):
         pass
 
     def add_router_usage(self, **kwargs):

--- a/tests/runtime/test_5720_spill_carries_real_turn_provenance.py
+++ b/tests/runtime/test_5720_spill_carries_real_turn_provenance.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from reyn.config import CompactionConfig
 from reyn.core.events.events import EventLog
 from reyn.runtime.chat_message import SPILL_TARGET_SEQ_META_KEY, ChatMessage
+from reyn.runtime.services.budget_gateway import BudgetGateway
 from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 from reyn.runtime.services.router_loop_driver import RouterLoopDriver
 from tests._support.events import collect_events
@@ -46,11 +47,25 @@ class _FakeRouterHost:
         pass
 
 
-class _FakeBudget:
-    def check_and_increment_router_cap(self, text):
+class _FakeBudget(BudgetGateway):
+    """#5748 (lead-coder finding, the 3rd instance of this same shape —
+    #5734's ``_PickerReadModel``/``_TaskSnapshotReadModel`` were the
+    first two): a hand-written double that only reimplements the methods
+    THIS test drives goes stale the moment the real class gains a new
+    one — ``RouterLoop`` construction now unconditionally reads
+    ``self._budget.update_last_call_usage`` (#5745), which a bare
+    ``_FakeBudget`` never had. Inheriting the real ``BudgetGateway``
+    (cheap to construct — no I/O in ``__init__``) means every CURRENT
+    and FUTURE method this test doesn't care about is the real,
+    correct one by construction, never a manually-kept-in-sync copy."""
+
+    def __init__(self) -> None:
+        super().__init__(budget_tracker=None, events=EventLog(), agent_name="t-agent")
+
+    def check_and_increment_router_cap(self, user_text):
         pass
 
-    def extend_router_cap(self, n):
+    def extend_router_cap(self, additional):
         pass
 
     def add_router_usage(self, **kwargs):

--- a/tests/runtime/test_session_cost_accumulation.py
+++ b/tests/runtime/test_session_cost_accumulation.py
@@ -292,6 +292,99 @@ def test_router_loop_last_call_usage_is_the_final_iteration_only():
     assert loop.last_call_usage.prompt_tokens != total.prompt_tokens
 
 
+def test_router_loop_on_call_usage_fires_once_per_iteration_not_once_per_turn():
+    """Tier 2: #5745 — ``on_call_usage`` (RouterLoop's live per-call wire)
+    is invoked once per LLM call, with THAT call's own usage — not once at
+    the whole turn's end with the turn-summed total. This is the exact gap
+    #5745 named: the status-bar ctx chip's underlying figure
+    (``BudgetGateway._last_call_usage``, which this callback feeds via
+    ``update_last_call_usage``) previously only synced at ``add_router_
+    usage``'s own turn-end call site, so it stayed frozen through a whole
+    multi-tool-iteration turn even though a live per-call source
+    (``RouterLoop.last_call_usage``, this same field) already existed.
+
+    Real ``RouterLoop`` + real ``LLMToolCallResult``/``TokenUsage`` (no
+    mock) — mirrors the sibling ``test_router_loop_last_call_usage_is_the_
+    final_iteration_only`` above byte-for-byte except for the callback."""
+    import json
+
+    host = _FakeHost()
+    calls: list[TokenUsage] = []
+    loop = RouterLoop(
+        host=host, chain_id="c-test", max_iterations=3,
+        on_call_usage=calls.append,
+    )
+
+    first_usage = TokenUsage(prompt_tokens=50, completion_tokens=10)
+    final_usage = TokenUsage(prompt_tokens=90, completion_tokens=15)
+
+    tool_result = LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": "list_skills", "arguments": json.dumps({})},
+        }],
+        finish_reason="tool_calls",
+        usage=first_usage,
+    )
+    text_result = LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=final_usage,
+    )
+    results_queue = [tool_result, text_result]
+
+    async def fake_call_llm_tools(**kwargs):
+        return results_queue.pop(0)
+
+    async def run_it():
+        import reyn.runtime.router_loop as _rl_mod
+        original = _rl_mod.call_llm_tools
+        _rl_mod.call_llm_tools = fake_call_llm_tools
+        try:
+            return await loop.run(user_text="hi", history=[])
+        finally:
+            _rl_mod.call_llm_tools = original
+
+    asyncio.run(run_it())
+
+    # Non-vacuity + the core claim in one: TWO calls, each with its OWN
+    # iteration's usage, in order — never one call with the turn-summed
+    # total (140), which is what a "fires once, at the end" bug would
+    # produce instead.
+    assert [u.prompt_tokens for u in calls] == [50, 90], (
+        "on_call_usage must fire per iteration with that iteration's own "
+        "usage, not once at turn-end with the summed total"
+    )
+
+
+def test_router_loop_on_call_usage_defaults_to_none_no_behavior_change():
+    """Tier 2: #5745 — a caller that does not pass ``on_call_usage`` (every
+    call site except ``router_loop_driver.py`` today) sees byte-identical
+    behavior: no callback, no exception, run() completes exactly as it did
+    before this parameter existed."""
+    host = _FakeHost()
+    loop = RouterLoop(host=host, chain_id="c-test", max_iterations=3)
+
+    usage = TokenUsage(prompt_tokens=33, completion_tokens=4)
+    result = LLMToolCallResult(content="done", tool_calls=[], finish_reason="stop", usage=usage)
+
+    async def fake_call_llm_tools(**kwargs):
+        return result
+
+    async def run_it():
+        import reyn.runtime.router_loop as _rl_mod
+        original = _rl_mod.call_llm_tools
+        _rl_mod.call_llm_tools = fake_call_llm_tools
+        try:
+            return await loop.run(user_text="hi", history=[])
+        finally:
+            _rl_mod.call_llm_tools = original
+
+    total = asyncio.run(run_it())
+    assert total.prompt_tokens == 33
+    assert loop.last_call_usage.prompt_tokens == 33
+
+
 def test_router_loop_last_call_usage_resets_between_runs():
     """Tier 2: last_call_usage (like total_usage) resets to zero at the start
     of each run() — a stale value from a prior turn must not leak into a new


### PR DESCRIPTION
**[tui-coder]** — implements the (a)-narrowed decision from https://github.com/tya5/reyn/issues/5745#issuecomment-5542393064

Closes #5745

Owner-reported (2026-09-04, verbatim): "brown が働いてるんだけど、connected
tui に ctx が更新されず "-" のまま" ("brown is working, but the connected
TUI's ctx stays at '-', unupdated"). "reactive に更新されることが期待だ
からね".

Root cause, measured against the owner's own live brown session's real
event log: `BudgetGateway.add_router_usage` — the sole writer of the
status-bar ctx chip's underlying figure (`last_call_usage`) — is only
called ONCE, at `router_loop_driver.py`'s `run_turn` completion. `run_turn`
itself drives a WHOLE turn's tool-loop internally (potentially many LLM
calls across many minutes) before returning, so `last_call_usage` stayed
frozen through the entire turn even though `RouterLoop`'s own copy of that
same field (`loop.last_call_usage`) was already being updated live, per
call, the whole time (`router_loop.py`, unchanged by this PR). Confirmed
directly: brown's event log showed 3 `llm_response_received` events
(growing prompt_tokens 621501→622776) between one `turn_started` and the
next `turn_settled`, with `ctx_used` unable to move at all in that window
under the old wiring.

Design decision (architect + lead-coder, issue thread): option (a),
narrowed — push ONLY `last_call_usage` live, per call. Explicitly NOT
option (b) (a transient live-loop reference the status read side would
have to reach for — rejected for a `None`-is-two-facts ambiguity and two
sources of truth for one displayed value at the turn boundary). Explicitly
NOT calling `add_router_usage` per call — that method's `usage` arg is the
TURN-SUMMED figure accumulated into billing; a per-call call would
multiply-count it. Zero new state: the field already existed, and its own
docstring already promised "single MOST RECENT LLM call ... Overwritten on
each call" — what was wrong was only the WRITE FREQUENCY, never the
contract. Per CLAUDE.md's own rule on a *deciding* doc: that promise stays
exactly as written (this PR is the implementation catching up to it), only
the writer-enumeration sentence naming who writes the field is updated.

Changes:
- `router_loop.py`: new optional `on_call_usage` constructor param,
  invoked immediately after each of the 2 existing `self._last_call_usage
  = result.usage` writes (never batched, never touching `_total_usage`).
  `None` for every caller that doesn't pass one — byte-identical to
  before this param existed.
- `router_loop_driver.py`: the ONE production wire — `RouterLoop(...,
  on_call_usage=self._budget.update_last_call_usage)`.
- `budget_gateway.py`: new `update_last_call_usage(usage)` — writes ONLY
  `_last_call_usage`, guarded on `usage.total_tokens != 0` (mirrors
  `add_router_usage`'s own emptiness check; `TokenUsage` has no
  `__bool__`, so a bare `TokenUsage()` is truthy despite being empty).
  Also fixes a newly-reachable pre-existing bug at the SAME field
  (`add_router_usage`'s own `last_call_usage if last_call_usage is not
  None else usage` fallback): a `None` `last_call_usage` no longer
  overwrites the field with the TURN-SUMMED total — it is now a true
  no-op, leaving whatever the live per-call wire already wrote alone.

No new display-side code: `app.py`'s existing "refresh the live chrome …
on EVERY frame — DISPLAY and EVENT alike" already re-reads this field on
every `llm_response_received` EVENT frame — freshening the underlying
value is sufficient, per lead-coder's explicit instruction not to add a
new push channel or polling.

Billing witness: `add_router_usage`'s own turn-summed accumulation path
(`_total_usage`/`_total_cost_usd`/`_total_cost_breakdown`) is untouched —
still called exactly once per turn, exactly as before. Not one cent of
billing logic changed; see the new
`test_update_last_call_usage_touches_only_the_one_field` test.

Real-machine verification: owner has shut down reyn-web for the moment
(token conservation) — deferred to when it's back up, per lead-coder.

Test plan:
- [x] `test_router_loop_on_call_usage_fires_once_per_iteration_not_once_per_turn` — the core #5745 witness: a real 2-iteration RouterLoop.run() (tool-call then text), asserts the callback fires TWICE, with each iteration's OWN usage in order, never once with the turn-summed total
- [x] `test_router_loop_on_call_usage_defaults_to_none_no_behavior_change` — every existing (non-driver) call site is unaffected
- [x] `test_update_last_call_usage_touches_only_the_one_field` — billing witness: total_usage/total_cost_usd stay 0 after a live-wire call
- [x] `test_update_last_call_usage_overwrites_not_accumulates` / `test_update_last_call_usage_ignores_a_falsy_usage`
- [x] `test_add_router_usage_leaves_last_call_usage_untouched_when_omitted` — rewritten from its old (bug-pinning) name/assertion to the corrected behavior
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / check_tests_path_literal_reference / check_bare_tests_import_reference / check_file_depth_reference / check_subprocess_reyn_pin — all clean
- [x] scoped regression: tests/llm/test_budget_gateway_invariants.py, tests/runtime/test_session_cost_accumulation.py, tests/runtime/test_5720_spill_carries_real_turn_provenance.py, tests/runtime/test_embedding_cost_tracking.py, tests/runtime/test_embed_cost_wiring_live_path.py, tests/runtime/test_intervention_subscriber_guard.py, tests/core/test_3783_stage3_invert_default_to_recover.py, tests/interfaces/test_5011_ctx_cache_line_note.py — all green
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)
- [ ] real-machine confirm against brown (deferred — reyn-web currently down, owner's own token-conservation call)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
