### PR TITLE
fix(#5747): scope mid-turn HOOK injection to mcp_resource_updated only

### DIFF
--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -708,6 +708,14 @@ class HookDispatcher:
             "name": hook.name or point,
             "text": resolved.message,
             "spillability": (hook.spillability or Spillability.default()).value,
+            # #5747: the bare hook-point string (same form ``bare_point()``
+            # returns, e.g. "mcp_resource_updated") — distinct from
+            # "name" above, which is the OPERATOR's own label when set
+            # and only falls back to the point when it isn't. A mid-turn
+            # injection eligibility check needs to know WHICH POINT
+            # fired, regardless of what the operator named the hook
+            # entry — see ``InboxArbiter.peek_mid_turn_injections``.
+            "point": point,
         }
         # #2072: cross-session push. A ``resolved.session`` naming a DIFFERENT session routes
         # to THAT session's inbox (the canonical wake-triple); ``wake`` rides in the payload

--- a/src/reyn/runtime/inbox_arbiter.py
+++ b/src/reyn/runtime/inbox_arbiter.py
@@ -39,10 +39,21 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Callable
 
-from reyn.runtime.turn_origin import MID_TURN_INJECTABLE
+from reyn.runtime.turn_origin import MID_TURN_INJECTABLE, TurnOrigin
 
 if TYPE_CHECKING:
     from reyn.runtime.services.snapshot_journal import SnapshotJournal
+
+#: #5747: within ``TurnOrigin.HOOK`` (itself in ``MID_TURN_INJECTABLE``, a
+#: coarse per-PRODUCER-TYPE eligibility test), only a push from ONE
+#: specific hook POINT is actually eligible for mid-turn injection today
+#: — see ``peek_mid_turn_injections``'s own docstring for the full
+#: reasoning and what is deliberately left an open question rather than
+#: decided here. Bare form (``dispatcher.py``'s own ``point`` values,
+#: ``hooks/schema_registry.py``'s ``bare_point()``), matching the
+#: ``payload["point"]`` field ``dispatcher.py``'s ``_push_resolved``
+#: threads onto every hook push.
+_HOOK_INJECTABLE_POINTS: "frozenset[str]" = frozenset({"mcp_resource_updated"})
 
 
 # FP-0041 (#489) PR-A: humanic dispatch attribution helper — moved from
@@ -268,6 +279,22 @@ class InboxArbiter:
         see that constant's own docstring for why the two questions are
         separate). What is looked past is every kind NOT in that set.
 
+        **#5747 narrows one member further.** ``TurnOrigin.HOOK`` is in
+        ``MID_TURN_INJECTABLE`` (a lifecycle-hook push may steer an
+        in-flight turn, closing a real reported gap — see that member's
+        own comment in ``turn_origin.py``), but membership there answers
+        only "which PRODUCER TYPES may ever inject", not "every push
+        from that type". A ``HOOK`` item is ALSO required to have fired
+        from :data:`_HOOK_INJECTABLE_POINTS` (today: only
+        ``mcp_resource_updated`` — the owner's own request, a broker/MCP
+        inbox notification). A hook wired to any OTHER point (e.g.
+        ``file_changed``, ``turn_start``) is looked past exactly like any
+        ineligible kind — the design question of which OTHER points
+        should also qualify (and by what rule) is an open discussion,
+        not decided here; widening ``_HOOK_INJECTABLE_POINTS`` is how a
+        settled answer gets applied once one lands, not a config value an
+        operator sets.
+
         A CANCELLED item is the one case this DOES discard outright — mirrors
         ``consume_inbox``'s own skip-at-consume handling, since a cancelled
         item was never going to be eligible for anything. That applies to items
@@ -290,6 +317,15 @@ class InboxArbiter:
                 del self.pending_inbox_items[scan]
                 continue
             if kind not in MID_TURN_INJECTABLE:
+                scan += 1
+                continue
+            # #5747: HOOK's own membership above is necessary, not
+            # sufficient — see this method's own docstring for why only
+            # SOME hook points are actually eligible.
+            if kind == TurnOrigin.HOOK and (
+                not isinstance(payload, dict)
+                or payload.get("point") not in _HOOK_INJECTABLE_POINTS
+            ):
                 scan += 1
                 continue
             collected.append({"payload": payload, "msg_id": msg_id, "kind": kind})

--- a/src/reyn/runtime/turn_origin.py
+++ b/src/reyn/runtime/turn_origin.py
@@ -148,8 +148,13 @@ class TurnOrigin(StrEnum):
 
     #: A wake=true lifecycle-hook push delivered as a turn trigger (#1800 slice
     #: 5b): a system-role ``[hook:name]`` message plus one router turn
-    #: (self-continuation). ``Session.run_one_iteration``'s loop valve counts
-    #: consecutive turns of this member.
+    #: (self-continuation). #5747 correction: no mechanism counts
+    #: consecutive turns of this member — #5561 (owner ruling, 2026-08-30,
+    #: verbatim "hook 起動を回数で制限なんて誰も設定できないでしょ")
+    #: retired the counter that once did, with no successor. (What, if
+    #: anything, bounds a recursive/runaway hook-driven turn instead is
+    #: an open design discussion as of this writing — not settled, and
+    #: deliberately not asserted here.)
     HOOK = "hook"
 
     #: The empty-text pump that starts an ATTACHED pipeline run
@@ -233,40 +238,45 @@ MID_TURN_INJECTABLE: "frozenset[TurnOrigin]" = frozenset({
     # the SAME commit.
     TurnOrigin.EXTERNAL_MESSAGE,
     # #5747 (owner-requested feature, previously unimplemented — this was
-    # never a "wait for a decision" gap): an operator-declared lifecycle
-    # hook (``reyn.yaml``) may steer a turn already in flight, same as
-    # CLIENT_INPUT/AGENT_REQUEST/EXTERNAL_MESSAGE above. Real damage from
-    # the gap: a stop instruction the owner gave mid-turn didn't reach the
-    # session until the NEXT turn boundary — coder-brown had already
-    # pushed a PR implementing an issue the owner had since closed, and
-    # coder-smith sat halted 13 hours because a hook-delivered correction
-    # could not land until its target turn ended.
+    # never a "wait for a decision" gap): a lifecycle-hook push may steer
+    # a turn already in flight, same as CLIENT_INPUT/AGENT_REQUEST/
+    # EXTERNAL_MESSAGE above. Real damage from the gap: a stop instruction
+    # the owner gave mid-turn (via a hook) didn't reach the session until
+    # the NEXT turn boundary — coder-brown had already pushed a PR
+    # implementing an issue the owner had since closed, and coder-smith
+    # sat halted 13 hours because a hook-delivered correction could not
+    # land until its target turn ended.
     #
-    # Architect ruling (3 points, #5747 issue thread):
-    # 1. NOT scoped by a flag or a uri check — either would be form-
-    #    sniffing (deciding the origin's trust by a string the origin
-    #    itself gets to write) and a default-off flag would ship the
-    #    owner's requested feature turned off, which is not shipping it.
-    #    ``HOOK`` here means exactly what ``TurnOrigin.HOOK`` already
-    #    means everywhere else: an operator-declared lifecycle hook push
-    #    — CRON and EXTERNAL_MESSAGE are independent members, never this
-    #    one.
-    # 2. No new gate — ``_render_mid_turn_injection``'s own fail-loud
-    #    raise (this module's own docstring, above) already refuses a
-    #    member with no rendering branch; that branch lands in the SAME
-    #    commit as this line, same as EXTERNAL_MESSAGE's own addition did.
-    # 3. Scope limit, stated here so it cannot be misread later: the
-    #    (#5561-retired) consecutive-hook-turn counter — see
-    #    ``session.py``'s ``run_one_iteration`` and ``hooks/dispatcher.py``
-    #    for where it used to live — counted TURNS. An INJECTION is not a
-    #    turn (it splices into an ALREADY-RUNNING one,
-    #    ``InboxArbiter.peek_mid_turn_injections``), so nothing that ever
-    #    counted consecutive hook turns counts this. No new valve is added
-    #    here either — the bound is producer pace, identical to
-    #    CLIENT_INPUT (a human's own typing rate) above: an operator who
-    #    wires a hook to fire constantly is the same class of
-    #    self-inflicted problem a human mashing Enter would be, not a new
-    #    hazard this feature introduces.
+    # ★ NARROWER than the member alone can say: eligibility here is
+    # necessary but not sufficient. ``InboxArbiter.peek_mid_turn_
+    # injections`` ADDITIONALLY requires the push's own hook point
+    # (``payload["point"]``) to be ``"mcp_resource_updated"`` — see that
+    # method's own docstring for the current reasoning and the parts of
+    # the original design that are still an open discussion, not settled:
+    #
+    # - The owner's own request (a broker/MCP inbox notification steering
+    #   a running turn) IS this one point, so scoping to it closes the
+    #   real, reported harm above completely.
+    # - A broader rule — EVERY hook point unconditionally, or a rule that
+    #   classifies points by "can a turn cause this to fire itself"
+    #   (an anti-recursion design) — was proposed and is, as of this
+    #   writing, an open discussion (owner, 2026-09-04, verbatim: "今の
+    #   は議論だから設計・実装への反映はまだしないでね"). Widening past
+    #   ``mcp_resource_updated`` needs that discussion to resolve first —
+    #   implementing a broader rule now would risk being wrong in a
+    #   direction nobody would notice failing (an unsafe-but-quiet
+    #   default), and would need undoing once it does.
+    # - No mechanism counts consecutive hook-driven turns — #5561 (owner
+    #   ruling, 2026-08-30, verbatim "hook 起動を回数で制限なんて誰も設定
+    #   できないでしょ") retired the counter that once did, with no
+    #   successor. What (if anything) bounds a recursive/runaway
+    #   hook-driven turn is itself part of the open discussion above —
+    #   deliberately not asserted here.
+    #
+    # ``_render_mid_turn_injection``'s own fail-loud raise (this module's
+    # own docstring, above) already refuses a member with no rendering
+    # branch; that branch lands in the SAME commit as this line, same as
+    # EXTERNAL_MESSAGE's own addition did.
     TurnOrigin.HOOK,
 })
 

--- a/tests/core/test_3792_pr2_session_injection.py
+++ b/tests/core/test_3792_pr2_session_injection.py
@@ -105,8 +105,12 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
         TurnOrigin.CLIENT_INPUT: {"text": "hello"},
         TurnOrigin.AGENT_REQUEST: {"from_agent": "a", "request": "r", "depth": 1, "chain_id": "c1"},
         TurnOrigin.EXTERNAL_MESSAGE: {"text": "hi", "sender": "slack:U456"},
-        # #5747: owner-requested feature, previously unimplemented.
-        TurnOrigin.HOOK: {"name": "on_idle", "text": "hi"},
+        # #5747: owner-requested feature, previously unimplemented. Only
+        # the mcp_resource_updated POINT is actually eligible (a NARROWER
+        # gate than this dict's own key-level vacuity check expresses —
+        # see test_hook_injection_is_eligible_only_for_its_one_declared_
+        # point below for that finer-grained accept/deny pair).
+        TurnOrigin.HOOK: {"name": "on_idle", "text": "hi", "point": "mcp_resource_updated"},
     }
     # Vacuity guard: if TurnOrigin grew, shrank, or the enumeration came back
     # empty, this set-equality against the explicit expected membership
@@ -169,16 +173,76 @@ async def test_only_mid_turn_injectable_origins_are_peek_eligible(tmp_path):
     await state_log3.aclose()
 
     # Accept side: HOOK — #5747, owner-requested feature, previously
-    # unimplemented — is ALSO eligible.
+    # unimplemented — is ALSO eligible, when its own point is
+    # mcp_resource_updated (see test_hook_injection_is_eligible_only_
+    # for_its_one_declared_point below for the finer-grained pair this
+    # abbreviates).
     session4, state_log4 = _make_session(
         tmp_path / "hook.wal", tmp_path / "hook.json",
     )
-    await session4._put_inbox(TurnOrigin.HOOK, {"name": "on_idle", "text": "check the queue"})
+    await session4._put_inbox(
+        TurnOrigin.HOOK,
+        {"name": "on_idle", "text": "check the queue", "point": "mcp_resource_updated"},
+    )
     result4 = await session4._inbox_arbiter.peek_mid_turn_injections()
     (only4,) = result4
     assert only4["payload"]["text"] == "check the queue"
     assert only4["kind"] == TurnOrigin.HOOK
     await state_log4.aclose()
+
+
+@pytest.mark.asyncio
+async def test_hook_injection_is_eligible_only_for_its_one_declared_point(tmp_path):
+    """Tier 2: #5747 — ``TurnOrigin.HOOK`` membership in
+    ``MID_TURN_INJECTABLE`` is necessary but not sufficient: a hook push
+    is ALSO required to have fired from ``mcp_resource_updated`` (the
+    owner's own request — a broker/MCP inbox notification steering an
+    in-flight turn). A hook wired to any OTHER point is looked past
+    exactly like an ineligible-kind item — the design question of which
+    other points should also qualify is an open discussion, deliberately
+    not decided by this test (see ``InboxArbiter.peek_mid_turn_
+    injections``'s own docstring).
+
+    Falsification (performed during review): removing the ``payload.get(
+    "point") not in _HOOK_INJECTABLE_POINTS`` guard from
+    ``peek_mid_turn_injections`` (reverting to plain ``TurnOrigin``
+    membership, #5750's own original shipped shape) makes the deny-side
+    assertion below go RED — a hook from ANY point would be injected."""
+    # Accept: mcp_resource_updated.
+    session, state_log = _make_session(tmp_path / "accept.wal", tmp_path / "accept.json")
+    await session._put_inbox(
+        TurnOrigin.HOOK,
+        {"name": "broker-inbox", "text": "peer message arrived", "point": "mcp_resource_updated"},
+    )
+    result = await session._inbox_arbiter.peek_mid_turn_injections()
+    (only,) = result
+    assert only["payload"]["text"] == "peer message arrived"
+    await state_log.aclose()
+
+    # Deny: any other point — file_changed here, the exact one architect's
+    # own self-recursion concern named (a turn's own tool writes a file a
+    # `file_changed` hook watches) — must NOT be injected.
+    session2, state_log2 = _make_session(tmp_path / "deny.wal", tmp_path / "deny.json")
+    await session2._put_inbox(
+        TurnOrigin.HOOK,
+        {"name": "fs-watch", "text": "a file changed", "point": "file_changed"},
+    )
+    result2 = await session2._inbox_arbiter.peek_mid_turn_injections()
+    assert result2 == [], (
+        "a hook from a point OTHER than mcp_resource_updated must not be "
+        "peek-eligible — widening past this one point is an open design "
+        "question, not something this code should do unasked"
+    )
+    await state_log2.aclose()
+
+    # Deny: a HOOK payload missing "point" entirely (a hand-built/legacy
+    # payload shape) must also be treated as ineligible, never as a
+    # free pass — absence is not the same claim as "the right point".
+    session3, state_log3 = _make_session(tmp_path / "deny2.wal", tmp_path / "deny2.json")
+    await session3._put_inbox(TurnOrigin.HOOK, {"name": "no-point", "text": "no point field"})
+    result3 = await session3._inbox_arbiter.peek_mid_turn_injections()
+    assert result3 == [], "a HOOK payload with no 'point' field must not be peek-eligible"
+    await state_log3.aclose()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[tui-coder]** — follow-up narrowing #5750; TESTS-READ needed (touches tests/)

Closes #5747

Follow-up to #5750 (merged, HOOK unconditionally in MID_TURN_INJECTABLE).
Owner (2026-09-04, verbatim): "再帰・無限ループは防ぐ機構は欲しい。ただし
上限という定義しづらい機構ではない何か" ("I want a mechanism that prevents
recursion/infinite loops, but not something ill-defined like a numeric
cap"). Architect's own "hook-point-causality" table (exogenous points
injectable, self-triggerable points wake-only) was initially dispatched
as a ratified decision, then explicitly withdrawn back to "proposal, not
settled" (architect's own correction, same issue thread) once it became
clear the owner's words were a discussion, not a decision.

What both the shipped (#5750) and the withdrawn-proposal designs agree
on, and what closes the owner's actual reported harm (a stop instruction
given mid-turn via a hook not landing until the next turn boundary):
`mcp_resource_updated`-origin hook pushes ARE injectable. Everything else
about HOOK's scope is left for the still-open discussion — this PR does
not decide it, and is worded not to assert an answer either way.

Change: `TurnOrigin.HOOK` stays in `MID_TURN_INJECTABLE` (membership
answers "which PRODUCER TYPES may ever inject" — unchanged, already
correct), but `InboxArbiter.peek_mid_turn_injections` now ALSO requires
a HOOK item's own trigger point (`payload["point"]`, newly threaded
through `dispatcher.py`'s `_push_resolved` — previously only the
operator-facing `name` label reached the inbox payload) to be
`mcp_resource_updated`. A hook wired to any other point (`file_changed`,
`turn_start`, ...) is looked past exactly like any ineligible-kind item.

Also corrects two false claims this same PR's earlier draft (before the
scope was narrowed back down) would have shipped, both already caught
and retracted by lead-coder/architect before landing:
- `TurnOrigin.HOOK`'s own docstring claimed a "loop valve counts
  consecutive turns of this member" — that valve was fully retired by
  #5561 (owner ruling, 2026-08-30, verbatim "hook 起動を回数で制限なんて
  誰も設定できないでしょ"), with no successor of any kind. Corrected to
  state plainly that no counting mechanism exists, without asserting
  what (if anything) bounds a runaway hook-driven turn instead — that
  question is itself part of the still-open discussion above.
- An earlier version of the MID_TURN_INJECTABLE comment claimed CRON and
  EXTERNAL_MESSAGE are wholly independent from HOOK. Under THIS PR's own
  narrower gate (mcp_resource_updated only), that claim is actually now
  true in practice — an operator-declared hook on cron_fired/
  webhook_received would carry a non-matching `point` and stay
  ineligible — so no separate cron/webhook scope-limit note is needed;
  removed the stale broader claim rather than restating a caveat that no
  longer applies.

Test plan:
- [x] `test_hook_injection_is_eligible_only_for_its_one_declared_point` — accept (mcp_resource_updated) + deny (file_changed) + deny (no "point" field at all) in one test
- [x] Manually verified: removing the point-narrowing guard makes the deny assertion go red (a hook from ANY point would be injected — #5750's own original shipped shape), then restored
- [x] `test_only_mid_turn_injectable_origins_are_peek_eligible` (test_3792) — HOOK's accept-side witness updated to include `point: mcp_resource_updated`
- [x] Full mid-turn-injection family (test_5677/test_3792/test_5647/test_3792_pr2_router_loop_injection) — 29/29 green
- [x] Full hooks/ suite (tests/hooks/, tests/runtime/test_5209_cron_action_hook.py, tests/runtime/test_5648_rewind_anchor_prefers_human_prompt.py) — 458/458 green, confirming the new `payload["point"]` field is backward-compatible with every existing hook-push consumer, including the real `mcp_resource_updated` end-to-end test (test_2608_h1_mcp_resource_updated_hook.py)
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / tests-path-literal-reference / bare-tests-import-reference / file-depth-reference / subprocess-reyn-pin — all clean
- [x] closing-intent gate run locally before push (OK)
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)
- [ ] real-machine confirm (deferred — reyn-web currently down, owner's own token-conservation call)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
