### PR TITLE
docs(#3881): docstring note — CI-visibility gap for Darwin-gated tests

### DIFF
--- a/tests/core/test_2978_deny_always_wins.py
+++ b/tests/core/test_2978_deny_always_wins.py
@@ -24,6 +24,13 @@ REAL SBPL profile — a hand-built SandboxPolicy proves the mechanism but a real
 sandbox-exec run proves the wiring (a profile that "looks right" can still
 permit the read). They are hermetic: the deny target is a temp file the test
 creates, so the assertion is never vacuous on a machine without `~/.ssh`.
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 2 of this
+module's 7 tests are Darwin-gated (`skipif(sys.platform != "darwin", ...)`,
+sandbox-exec is macOS-only) and have therefore NEVER executed in CI. A green
+CI run of this module does not mean those 2 passed — it means they never
+ran. They exercise only on a real macOS machine.
 """
 from __future__ import annotations
 

--- a/tests/core/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/core/test_mcp_install_ux_fixes_318_319_320.py
@@ -28,6 +28,13 @@ Pins (= one section per issue):
     prefixes from the derived short name.
   - **#320** ``reyn mcp install`` warns on Darwin when ``--args``
     contains ``/tmp`` paths.
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 1 of this
+module's 14 tests (the #320 warning above) is Darwin-gated (an inline
+``pytest.skip`` when ``platform.system() != "Darwin"``) and has therefore
+NEVER executed in CI. A green CI run of this module does not mean that one
+passed — it means it never ran. It exercises only on a real macOS machine.
 """
 from __future__ import annotations
 

--- a/tests/security/test_2976_mcp_sandbox_write_paths.py
+++ b/tests/security/test_2976_mcp_sandbox_write_paths.py
@@ -15,6 +15,13 @@ These tests pin the three properties the fix rests on:
   even an overlapping grant no longer re-opens a credential path; the shipped
   defaults are nonetheless kept mechanically disjoint so no MCP server ever
   trips that narrowing (belt-and-suspenders).
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 2 of this
+module's 30 collected tests are Darwin-gated (`skipif(sys.platform !=
+"darwin", ...)`, sandbox-exec is macOS-only) and have therefore NEVER
+executed in CI. A green CI run of this module does not mean those 2 passed
+— it means they never ran. They exercise only on a real macOS machine.
 """
 from __future__ import annotations
 

--- a/tests/security/test_codeact_runner_1593.py
+++ b/tests/security/test_codeact_runner_1593.py
@@ -9,6 +9,13 @@ sandbox).
 Real subprocess + real AF_UNIX socketpair + a real (non-mock) ``dispatch`` callback
 — no fakes of the channel. The sandbox wrap is S2b (Seatbelt) / S2c (Landlock);
 this pins the transport + proxy core that survives inside the sandbox.
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 1 of this
+module's 18 tests is Darwin-gated (`skipif(sys.platform != "darwin", ...)`,
+SeatbeltBackend macOS only) and has therefore NEVER executed in CI. A green
+CI run of this module does not mean that one passed — it means it never
+ran. It exercises only on a real macOS machine.
 """
 from __future__ import annotations
 

--- a/tests/security/test_sandbox_factory.py
+++ b/tests/security/test_sandbox_factory.py
@@ -9,6 +9,14 @@ Verifies:
 
 No mocks of collaborators — monkeypatch platform.system() where needed;
 use real SandboxConfig and real NoopBackend instances.
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 1 of this
+module's 38 collected tests is genuinely Darwin-gated (`skipif(sys.platform
+!= "darwin", ...)`) and has therefore NEVER executed in CI — the sibling
+Linux-gated test right next to it (`skipif(sys.platform != "linux", ...)`)
+DOES run, so this module's own green is mostly real signal; only that ONE
+test's green means "never ran", not "passed".
 """
 from __future__ import annotations
 

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -1,4 +1,12 @@
-"""Tier 2: SeatbeltBackend invariants (FP-0017 Component C)."""
+"""Tier 2: SeatbeltBackend invariants (FP-0017 Component C).
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 5 of this
+module's 24 tests are Darwin-gated (`skipif(sys.platform != "darwin", ...)`,
+sandbox-exec is macOS-only) and have therefore NEVER executed in CI. A green
+CI run of this module does not mean those 5 passed — it means they never
+ran. They exercise only on a real macOS machine.
+"""
 from __future__ import annotations
 
 import sys

--- a/tests/security/test_sandbox_self_test_2983.py
+++ b/tests/security/test_sandbox_self_test_2983.py
@@ -18,6 +18,13 @@ Section 5 is stage 2, and exists because stage 1 could not see the layer #2962
 killed: the write boundary is Landlock's alone, so a seccomp filter that never
 loads leaves the stage-1 probe green while `deny_subprocess` — documented as
 "Enforced" — enforces nothing.
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 3 of this
+module's 18 tests are Darwin-gated (`skipif(sys.platform != "darwin", ...)`,
+Seatbelt is macOS-only) and have therefore NEVER executed in CI. A green CI
+run of this module does not mean those 3 passed — it means they never ran.
+They exercise only on a real macOS machine.
 """
 from __future__ import annotations
 

--- a/tests/security/test_seatbelt_subprocess_enforcement_1914.py
+++ b/tests/security/test_seatbelt_subprocess_enforcement_1914.py
@@ -13,6 +13,13 @@ Two tiers of coverage:
 - behavioral (darwin-only): sandbox-exec actually blocks a child spawn.
 
 Policy: real _build_sbpl_profile + real SeatbeltBackend.run (no mocks). Tier first.
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 1 of this
+module's 3 tests (the "behavioral" one above) is Darwin-gated
+(`skipif(sys.platform != "darwin", ...)`) and has therefore NEVER executed
+in CI. A green CI run of this module does not mean that one passed — it
+means it never ran. It exercises only on a real macOS machine.
 """
 from __future__ import annotations
 

--- a/tests/security/test_subprocess_cancel_1470.py
+++ b/tests/security/test_subprocess_cancel_1470.py
@@ -7,6 +7,14 @@ Merge-gate 5-point verification:
   4. Cancel-path        — cancel_event fire → killed → SandboxResult(cancelled=True)
                           + P6 sandboxed_exec_cancelled event + P5 status=cancelled
   5. Callsite completeness — verified in sister test files (stub signature updated)
+
+★ CI-visibility gap (#3881, owner ruling 2026-09-04: no macOS CI runner will
+be added — every job in this repo's CI runs on ubuntu-latest): 2 of this
+module's 11 tests are Darwin-gated (`skipif(sys.platform != "darwin", ...)`,
+SeatbeltBackend macOS only) and have therefore NEVER executed in CI — the
+sibling Landlock (Linux-only) tests right next to them DO run, so this
+module's own green is mostly real signal; only those 2 tests' green means
+"never ran", not "passed".
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[tui-coder]** — touches tests/ (docstrings only, no assert/skip changed) — TESTS-READ needed

Closes #3881

Owner ruling (verbatim, 2026-09-04): "3881 用意するつもりはないよ" — no
macOS CI runner will be added. Measured: every job across this repo's 33
workflow files (`.github/workflows/`) runs on `ubuntu-latest`; grep for
any `runs-on:` value other than ubuntu found none. A test gated to
Darwin therefore has never executed in CI, and will not, absent a future
runner decision.

Adds one paragraph to the module docstring of each of 9 files (assert
untouched, skip conditions untouched, no test added/removed/renamed —
docstring only), each naming: (1) this repo's CI never runs a Darwin-
gated test (ubuntu-only, owner ruling), (2) a green CI run of a module
containing one does not mean it passed — it means it never ran.

Independently recounted (test-level, not file-level) rather than trusting
the original file-level count: NONE of these 9 files (nor the originally-
listed 10th, see below) has every test Darwin-gated — each is a module
that ALSO carries real, CI-exercised tests, so the note is scoped to name
how many of the module's own tests are affected, never a blanket "this
whole file never runs" claim that would itself become the same kind of
misleading green the task exists to prevent:

- test_2978_deny_always_wins.py: 2/7
- test_mcp_install_ux_fixes_318_319_320.py: 1/14
- test_2976_mcp_sandbox_write_paths.py: 2/30
- test_codeact_runner_1593.py: 1/18
- test_sandbox_factory.py: 1/38 (has a sibling Linux-only test that DOES run)
- test_sandbox_self_test_2983.py: 3/18
- test_sandbox_seatbelt.py: 5/24
- test_seatbelt_subprocess_enforcement_1914.py: 1/3
- test_subprocess_cancel_1470.py: 2/11 (has sibling Landlock/Linux-only tests that DO run)

`tests/core/test_open_with_os_default_4482.py` — on the originally
dispatched 10-file list — is deliberately EXCLUDED: recounting at the
test level found it has ZERO Darwin-only tests (its one platform-gated
test skips only on `win32`; on Linux CI it runs for real, against the
`xdg-open` opener path, and passes). Adding this note there would itself
have been the false claim.

No 11th file exists: re-confirmed via `git grep` for every
Darwin/macOS-skip pattern in the tree (`skipif(sys.platform ==/!=
"darwin"`, `platform.system() ==/!= "Darwin"`, inline `pytest.skip`
mentioning macOS/Seatbelt/sandbox-exec) — same 10-file universe both
times.

Test plan:
- [x] No assert changed, no skip condition changed, no test added/removed/renamed — docstring-only diff (`git diff --stat` shows 9 files, all comment/docstring lines)
- [x] All 9 files still collect and run identically to before (155 passed, 8 skipped locally on this Darwin machine — the skipped 8 are the Linux-only siblings, expected)
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / tests-path-literal-reference / bare-tests-import-reference / file-depth-reference / subprocess-reyn-pin — all clean
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
