### PR TITLE
fix(#5755): a mid-turn non-CLIENT_INPUT injection reaches the live screen

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -7582,6 +7582,34 @@ class Session:
             # producer (#5684) — content meant for the model, MODEL.
             disclosure=Disclosure.MODEL,
         ))
+        # #5755 (owner-reported, real-machine): a NON-CLIENT_INPUT injection
+        # (AGENT_REQUEST / EXTERNAL_MESSAGE / HOOK) was durably appended to
+        # history above, but had NO live-display path at all — the only
+        # mouth that ever reaches the screen is app.py's
+        # ``_handle_turn_started_event`` "promote" (this event, below), and
+        # that promote is keyed to a SENT-QUEUE item's own ``chain_id``; a
+        # producer that never went through the sent-queue (this is never
+        # something the operator typed) has nothing there to match, so the
+        # promote silently finds zero matches and nothing appears — the
+        # LLM read it and acted (confirmed in history/the model's own
+        # reply), the operator's own screen just never showed it.
+        #
+        # Fix: push the SAME rendered text the history entry just got,
+        # ``kind="system"``, through ``_put_outbox`` — the SAME live-display
+        # convention ``lifecycle_forwarder.py``'s own notices (budget
+        # warnings, compaction, #5732's pump-failure visibility) already
+        # use, reused as-is rather than inventing a second mechanism.
+        # Deliberately does NOT touch the sent-queue/``chain_id`` matching
+        # at all — a mid-turn injection is not a queue item and stamping a
+        # fabricated one onto it would misrepresent a fact nobody typed
+        # (lead-coder's own explicit warning, #5755 issue thread). This is
+        # a SEPARATE, parallel display path, not a repair of the promote
+        # one — CLIENT_INPUT is excluded because its own promote path
+        # already works correctly; pushing here too would double-render it.
+        if _rendered["role"] != "user":
+            await self._put_outbox(
+                OutboxMessage(kind="system", text=_rendered["content"], meta=payload.get("meta") or {}),
+            )
         await self._journal.consume_inbox(msg_id=msg_id)
         self._audit_events.emit(
             "turn_started",

--- a/tests/core/test_3792_pr2_session_injection.py
+++ b/tests/core/test_3792_pr2_session_injection.py
@@ -30,6 +30,7 @@ Real ``Session``/``StateLog``/``SnapshotJournal`` throughout (the
 """
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -449,6 +450,92 @@ async def test_commit_appends_history_prunes_snapshot_emits_turn_started(tmp_pat
     (only,) = turn_started_events
     assert only.data["kind"] == TurnOrigin.CLIENT_INPUT
     assert only.data["chain_id"] == peeked[0]["payload"]["chain_id"]
+
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_commit_of_a_hook_injection_reaches_the_live_display(tmp_path):
+    """Tier 2: #5755 — owner-reported (real machine): a HOOK injection was
+    read by the LLM and acted on (confirmed in history), but never showed
+    on the operator's own screen. Root cause: the ONLY live-display path
+    (app.py's ``_handle_turn_started_event`` "promote") is keyed to a
+    sent-queue item's own ``chain_id``; a HOOK push never went through the
+    sent-queue (nobody typed it) and carries ``chain_id=None``, so the
+    promote's own match always finds zero items — nothing ever reaches
+    the screen, even though history/the model both saw it correctly.
+
+    Fix: ``_commit_mid_turn_injection`` ALSO pushes the same rendered text
+    through ``_put_outbox`` (``kind="system"``) — the SAME live-display
+    convention ``lifecycle_forwarder.py``'s own notices already use — a
+    separate path from the sent-queue promote, not a repair of it.
+
+    Falsification (performed during review): removing the new
+    ``_put_outbox`` call from ``_commit_mid_turn_injection`` makes the
+    ``session.outbox.get_nowait()`` call below raise ``QueueEmpty``."""
+    session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
+
+    await session._put_inbox(
+        TurnOrigin.HOOK,
+        {"name": "on_idle", "text": "check the queue", "point": "mcp_resource_updated"},
+    )
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
+    (only,) = peeked
+
+    await session._commit_mid_turn_injection(only["msg_id"])
+    await settle(session)
+
+    pushed = session.outbox.get_nowait()
+    assert pushed.kind == "system"
+    assert pushed.text == "[hook:on_idle] check the queue"
+
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_commit_of_an_agent_request_injection_also_reaches_the_live_display(tmp_path):
+    """Tier 2: #5755 scope check (lead-coder's own explicit ask, unmeasured
+    by them) — AGENT_REQUEST is ALSO not sent-queue-backed (nobody typed
+    it), so it has the SAME display gap HOOK does, and the SAME fix
+    covers it (the fix branches on rendered role, not on kind)."""
+    session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
+
+    await session._put_inbox(
+        TurnOrigin.AGENT_REQUEST,
+        {"from_agent": "peer-agent", "request": "please redo step 1", "depth": 1, "chain_id": "c1"},
+    )
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
+    (only,) = peeked
+
+    await session._commit_mid_turn_injection(only["msg_id"])
+    await settle(session)
+
+    pushed = session.outbox.get_nowait()
+    assert pushed.kind == "system"
+    assert pushed.text == "[agent_request:peer-agent] please redo step 1"
+
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_commit_of_client_input_does_not_double_push_to_the_outbox(tmp_path):
+    """Tier 2: #5755 — CLIENT_INPUT's own promote path (app.py's
+    ``_handle_turn_started_event``, matched by the sent-queue's own
+    ``chain_id``) already works correctly and is untouched by this fix;
+    the NEW outbox push is gated on ``_rendered["role"] != "user"``
+    specifically so CLIENT_INPUT (the ONE role="user" member) is never
+    ALSO pushed here — that would double-render the operator's own line."""
+    session, state_log = _make_session(tmp_path / "s.wal", tmp_path / "s.json")
+
+    msg_id = await session.submit_user_text("inject me", attribution=None)
+    peeked = await session._inbox_arbiter.peek_mid_turn_injections()
+    assert peeked[0]["msg_id"] == msg_id
+
+    await session._commit_mid_turn_injection(msg_id)
+    await settle(session)
+
+    with pytest.raises(asyncio.QueueEmpty):
+        session.outbox.get_nowait()
 
     await state_log.aclose()
 


### PR DESCRIPTION
**[tui-coder]** — the seq-gate 2nd symptom is deliberately NOT in this PR, see the section below asking for the split

Closes #5755

Owner-reported (real machine, verbatim): "inject された？tui には表示されて
ないけど" ("was it injected? it's not showing in the TUI"). Lead-coder's own
measurement, against a real live session (brown): the injection genuinely
succeeded — the LLM read a `[hook:mcp_resource_updated] ...` system message
mid-turn and replied to it correctly, confirmed in history — the operator's
own screen just never showed it.

Root cause: the ONLY live-display path for a mid-turn injection is
app.py's `_handle_turn_started_event` "promote" — it matches the
`turn_started` audit event's own `chain_id` against the CLIENT's sent-queue
model and appends a flow entry only for a match. That match exists BY
CONSTRUCTION for `CLIENT_INPUT` (the operator's own typed line always went
through the sent queue first) but never for AGENT_REQUEST/EXTERNAL_MESSAGE/
HOOK — none of them are ever queued by the operator, so their own
`turn_started` always finds zero sent-queue matches and nothing is ever
promoted, regardless of the injection itself working correctly.

ADR-0046 (merged the same night this PR was dispatched) names exactly this
class of gap as the decision's own outstanding obligation: "a running loop
must be visible, and it must be stoppable. 'User responsibility' is only
coherent when the user can see the thing they are responsible for." The
'visible' half was not yet true for 3 of 4 MID_TURN_INJECTABLE members.

Fix: `_commit_mid_turn_injection` now ALSO pushes the SAME rendered text
(`_render_mid_turn_injection`'s own output — already computed for the
history append right above, re-derived nowhere) through `_put_outbox`,
`kind="system"` — the SAME live-display convention `lifecycle_forwarder.py`'s
own notices (budget warnings, compaction, #5732's pump-failure visibility)
already use, reused as-is rather than a new mechanism. Gated on
`_rendered["role"] != "user"` — CLIENT_INPUT is excluded (its own promote
path already works and is untouched; pushing there too would double-render
the operator's own line). Deliberately does NOT touch the sent-queue/
`chain_id` matching at all: a mid-turn injection is not a queue item, and
stamping a fabricated queue entry onto it (to make it fit the existing
promote path) would misrepresent a fact nobody typed — lead-coder's own
explicit warning on this issue, honored by keeping this a SEPARATE,
parallel display path rather than a repair of the sent-queue one.

Scope measured, not assumed (lead-coder's own explicit ask — they had only
measured HOOK): AGENT_REQUEST has the identical gap (same falsify-verified
below); EXTERNAL_MESSAGE renders through the exact same
`_rendered["role"] != "user"` branch in `_render_mid_turn_injection`, so
the same fix covers it structurally, though this PR's own tests exercise
HOOK and AGENT_REQUEST directly (EXTERNAL_MESSAGE's own rendering is
already covered by `test_5677_mid_turn_injection_wire_rendering.py`, and
this fix does not branch on `kind` — only on the already-tested `role`).

**Not included in this PR** — a second, separately-reported symptom
(owner: a queued "hello" marker's blink never stops after a mid-turn
injection lands) that lead-coder's own message framed as an UNCONFIRMED
hypothesis about `RemoteQueueView.apply_turn_started` advancing its own
seq gate even on zero sent-queue matches, possibly starving an
earlier-seq/still-pending delta. Investigated, not implemented: the
seq-gate's own EXISTING, already-tested invariant
(`test_remote_queue_view_snapshot_mid_stream_stays_consistent_with_
redelivery`, `tests/interfaces/test_3300_p2a_queue_state_publish.py`) is
"a connection's SSE stream preserves per-connection delivery order" — for
seq 3 (the injection) to apply before seq 2 (the operator's own dispatch,
which the injection's own turn is riding INSIDE, so seq 2 necessarily
already happened server-side) would need that already-relied-upon
ordering guarantee to break, which I found no static evidence for and
cannot confirm without a live reproduction/trace. Reported to lead-coder
as a separate, still-open question rather than guess-fixing a
foundational, heavily-tested race-prevention mechanism.

Test plan:
- [x] `test_commit_of_a_hook_injection_reaches_the_live_display` — accept: a HOOK commit pushes `kind="system"` text `[hook:on_idle] check the queue` to `session.outbox`
- [x] `test_commit_of_an_agent_request_injection_also_reaches_the_live_display` — scope check (lead-coder's own explicit ask): AGENT_REQUEST has the identical gap and the same fix closes it
- [x] `test_commit_of_client_input_does_not_double_push_to_the_outbox` — CLIENT_INPUT's own working promote path is untouched; no double-render
- [x] Manually verified: removing the new `_put_outbox` call makes BOTH the HOOK and AGENT_REQUEST tests go red (`QueueEmpty`), confirming both genuinely had the gap pre-fix — then restored
- [x] Full mid-turn-injection family (test_3792/test_5647/test_5677/test_3792_pr2_router_loop_injection) — 32/32 green
- [x] `_put_outbox`'s own existing tests (test_4666_2_completed_response_opt_in.py) — unaffected, 17/17 green
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / tests-path-literal-reference / bare-tests-import-reference / file-depth-reference / subprocess-reyn-pin — all clean
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)
- [ ] real-machine confirm against brown (deferred — reyn-web currently down, owner's own token-conservation call)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
