### PR TITLE
feat(#4409): pending-queue shows a message the instant it leaves the composer

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from collections import deque
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Callable
@@ -1320,6 +1321,13 @@ class TextualChatApp(App):
         "_streaming_replies",
         "_pending_own_cancels",
         "_call_parents",
+        # #4409: dict-shaped only in spirit (sets — ``.clear()`` is the
+        # same call either way), see ``_dispatched_before_ack``'s own
+        # docstring for what they track and why an OLD session's entries
+        # are meaningless once its queue view is gone too (same reasoning
+        # as ``_queue_item_meta`` just above).
+        "_dispatched_before_ack",
+        "_pending_local_send_ids",
     )
 
     #: #5131 (architect ruling): the FIRST "state down" migration target —
@@ -1647,6 +1655,38 @@ class TextualChatApp(App):
         # client that populated this entry ever restores anything; every
         # other client applies the SAME delta as a plain removal.
         self._pending_own_cancels: "dict[str, str]" = {}
+        # #4409: server ``msg_id``s this client has SEEN dispatched
+        # (``turn_started``, :meth:`_handle_turn_started_event`), used ONLY
+        # to resolve a race :meth:`_reconcile_local_send` cannot otherwise
+        # see: ``submit_user_text``'s ack and the ``user_submitted`` /
+        # ``turn_started`` broadcasts travel on independent channels
+        # (``client_transport.py``'s own ``submit_user_text`` docstring,
+        # F2), so a fast dispatch can promote-then-remove the REAL row
+        # before this client's own ack-driven reconcile ever runs — without
+        # this set, that reconcile would see "no row for msg_id yet" and
+        # wrongly rekey the local placeholder back INTO the queue for an
+        # item that already left it.
+        #
+        # Bound: the sent-queue widget renders EVERY client's queued items
+        # (ADR-0039 attribution — a peer's queue entry shows too), so
+        # ``turn_started`` fires for dispatches that are never this
+        # client's own submission at all; naively adding every one of
+        # those here would accumulate for as long as the attach lasts, not
+        # for as long as this client has anything of its own to reconcile
+        # — the accumulation :attr:`_pending_local_send_ids` exists to
+        # prevent. ``_handle_turn_started_event`` only adds to this set
+        # while that one is non-empty, and the moment it empties (this
+        # client's last outstanding submission resolved,
+        # :meth:`_reconcile_local_send`) this set is wiped too — so its
+        # size is bounded by how many dispatches (of ANY client's items)
+        # interleave during the brief window THIS client has an
+        # unresolved submission of its own, never by session lifetime.
+        self._dispatched_before_ack: "set[str]" = set()
+        # #4409: local placeholder ids (``on_composer_submitted``) still
+        # awaiting :meth:`_reconcile_local_send` — see
+        # ``_dispatched_before_ack``'s own docstring for the bound this
+        # gates.
+        self._pending_local_send_ids: "set[str]" = set()
         # Per-picker parallel SLASH COMMAND lists, keyed by tab id and kept in
         # lock-step with the OptionList options a pane was last refreshed with, so
         # an ``OptionSelected.option_index`` maps back to the command that applies
@@ -3567,7 +3607,14 @@ class TextualChatApp(App):
         # the intended integration, not a targeted jump).
         if event.key == "r" and self.focused is self._flow:
             event.stop()
-            await self._submit("/rewind")
+            # #4409: this call site (and its 2 siblings — the drawer's
+            # own picker-selected commands, and RewindPicker's checkout)
+            # always sends a synthetic, already-``/``-prefixed string, so
+            # ``_submit``'s own slash-dispatch branch always fires and
+            # this id is only ever handed to a harmless no-op remove — no
+            # placeholder was ever shown here to reconcile (unlike
+            # ``on_composer_submitted``'s own real composer text).
+            await self._submit("/rewind", local_id=f"local:{uuid.uuid4().hex}")
 
     def _open_drawer(self, tab_id: "str | None") -> None:
         """Expand/collapse the downward drawer. ``None`` (or the ``"__close__"``
@@ -3756,7 +3803,10 @@ class TextualChatApp(App):
                     return
         cmds = self._pane_commands.get(tab_id or "", [])
         if 0 <= event.option_index < len(cmds) and cmds[event.option_index]:
-            await self._submit(cmds[event.option_index])
+            # #4409: see ``on_key``'s own comment on its ``/rewind``
+            # call site — this is the same shape (a synthetic, already-
+            # ``/``-prefixed command, never composer text).
+            await self._submit(cmds[event.option_index], local_id=f"local:{uuid.uuid4().hex}")
         self._open_drawer(None)
 
     async def _handle_open_inline_artifact_request(self, row: "ArtifactRow") -> None:
@@ -4826,7 +4876,10 @@ class TextualChatApp(App):
         out to seq N`` reply, the branch/fork semantics of ``checkout``) is
         defined in exactly one place, and a rewind triggered from here is
         indistinguishable from a typed one."""
-        await self._submit(f"/rewind {event.seq}")
+        # #4409: see ``on_key``'s own comment on its ``/rewind`` call
+        # site — this is the same shape (a synthetic, already-``/``-
+        # prefixed command, never composer text).
+        await self._submit(f"/rewind {event.seq}", local_id=f"local:{uuid.uuid4().hex}")
         self.query_one(Composer).focus()
 
     def on_rewind_picker_dismissed(self, event: "RewindPicker.Dismissed") -> None:
@@ -6006,7 +6059,15 @@ class TextualChatApp(App):
         )
         if applied and msg_id:
             self._queue_item_meta[msg_id] = dict(data.get("meta") or {})
-            self._sent_queue.show_item(msg_id, text)
+            # #4409: if THIS client's own ``_reconcile_local_send`` already
+            # rekeyed a local placeholder onto ``msg_id`` (its ack, on the
+            # independent send-response channel, arrived before this
+            # broadcast), the row already shows this exact text — a plain
+            # ``show_item`` would remove+re-mount it (its own dedup guard)
+            # for no visible change, only a jump-to-bottom/flash risk. Skip
+            # the remount; the meta write above still lands either way.
+            if not self._sent_queue.has_row(msg_id):
+                self._sent_queue.show_item(msg_id, text)
             self._apply_compact_layout()
         elif not applied:
             # #3688: the rejecting branch used to be pure absence — no row, no
@@ -6072,6 +6133,11 @@ class TextualChatApp(App):
             msg_id = item.get("msg_id")
             if msg_id:
                 self._sent_queue.remove_item(msg_id)
+                # #4409: record BEFORE the pending-ack reconcile can run —
+                # see ``_dispatched_before_ack``'s own docstring for the
+                # race this closes and the bound this gate keeps.
+                if self._pending_local_send_ids:
+                    self._dispatched_before_ack.add(msg_id)
             meta = self._queue_item_meta.pop(msg_id, {}) if msg_id else {}
             # #4691 arc item ④: stamp THIS turn's own chain_id onto the
             # user row itself — the row is created here, at promotion time,
@@ -7212,8 +7278,18 @@ class TextualChatApp(App):
         if not self._transport.has_session():
             self._notify_blocked_on_attach()
             return
+        # #4409: the local placeholder is shown and the composer cleared
+        # back-to-back, with no ``await`` between them — so there is no
+        # frame where the message is visible in NEITHER place (the owner's
+        # own report: "msg enter -> sent 表示の間でメッセージ消えること
+        # 多い"). See ``SentQueue``'s own module docstring for the full
+        # "fourth, LOCAL entry" account and ``_reconcile_local_send`` for
+        # how it resolves once the server acks.
+        local_id = f"local:{uuid.uuid4().hex}"
+        self._sent_queue.show_item(local_id, text, sending=True)
+        self._pending_local_send_ids.add(local_id)
         self.query_one(Composer).clear_and_reset()
-        await self._submit(text)
+        await self._submit(text, local_id=local_id)
 
     def _notify_blocked_on_attach(self) -> None:
         """#3671 P3: tell the operator WHY their Enter did nothing, matching
@@ -7272,8 +7348,33 @@ class TextualChatApp(App):
         except Exception:
             pass
 
-    async def _submit(self, text: str) -> None:
+    def _maybe_sent_queue_remove(self, msg_id: str) -> None:
+        """``self._sent_queue.remove_item(msg_id)``, tolerant of
+        ``_sent_queue`` not existing yet — #4409: ``_sent_queue`` is a
+        widget, constructed in ``compose()`` alongside every OTHER widget
+        this App owns (same convention throughout this module, not
+        something #4409 changes), so it is absent on an App this test
+        suite's own established pattern constructs and calls ``_submit``
+        on DIRECTLY, without mounting (several pre-existing #3595 tests do
+        exactly this). A no-op there is correct, not merely tolerated: no
+        placeholder was ever shown pre-mount either (that only happens in
+        ``on_composer_submitted``, which the framework never calls before
+        mount)."""
+        sent_queue = getattr(self, "_sent_queue", None)
+        if sent_queue is not None:
+            sent_queue.remove_item(msg_id)
+
+    async def _submit(self, text: str, *, local_id: str) -> None:
         """Route one submitted line through the transport send seam.
+
+        ``local_id`` (#4409): the sent-queue row ``on_composer_submitted``
+        already showed, synchronously with clearing the composer, keyed by
+        a LOCAL id (no server ``msg_id`` exists yet). Every exit from this
+        method resolves it exactly once: dispatched as a slash command (was
+        never queued at all — see the ``#3595 S5`` paragraph below) drops
+        it, a submit failure drops it, and an ordinary submission hands the
+        server-acked ``msg_id`` to :meth:`_reconcile_local_send`, which
+        decides drop-vs-promote (see that method's own docstring).
 
         #3299 P1: the Composer is now EXCLUSIVELY for new turns — it no longer
         reads ``pending_intervention_head()`` at all. Answering a pending
@@ -7318,9 +7419,11 @@ class TextualChatApp(App):
         try:
             from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
             if await maybe_dispatch_slash(self._transport, text):
+                self._maybe_sent_queue_remove(local_id)
                 return
-            await self._transport.submit_user_text(text)
+            msg_id = await self._transport.submit_user_text(text)
         except Exception as exc:
+            self._maybe_sent_queue_remove(local_id)
             logger.exception("textual chat: submit failed")
             from reyn.runtime.outbox import OutboxMessage
             detail = f"{type(exc).__name__}: {exc}"
@@ -7332,6 +7435,68 @@ class TextualChatApp(App):
                 )
             except Exception:
                 pass
+        else:
+            self._reconcile_local_send(local_id, msg_id)
+        finally:
+            # #4409: every exit above resolved ``local_id`` one way or
+            # another — see ``_dispatched_before_ack``'s own docstring for
+            # why the moment NONE of this client's own submissions are
+            # still outstanding is exactly the moment that set can hold
+            # nothing worth keeping.
+            self._pending_local_send_ids.discard(local_id)
+            if not self._pending_local_send_ids:
+                self._dispatched_before_ack.clear()
+
+    def _reconcile_local_send(self, local_id: str, msg_id: str) -> None:
+        """#4409: resolve the local SENDING placeholder against the
+        server's ack, once ``submit_user_text`` returns.
+
+        The ack (this call) and the ``user_submitted`` broadcast that
+        materializes the AUTHORITATIVE row (:meth:`_handle_user_submitted_event`)
+        are two independent deliveries of the same fact, over two
+        independent channels (``client_transport.py``'s own
+        ``submit_user_text`` docstring, F2) — either can arrive first:
+
+        - the broadcast already arrived (:meth:`SentQueue.has_row` is
+          ``True`` for ``msg_id``) → the placeholder is now redundant;
+          drop it.
+        - ``msg_id`` was already seen DISPATCHED
+          (:attr:`_dispatched_before_ack` — ``turn_started`` can race
+          ahead of this ack too, see that attribute's own docstring) →
+          the item already left the queue entirely; drop the placeholder
+          rather than rekey it back INTO a queue it no longer belongs to.
+        - neither yet → promote the placeholder in place
+          (:meth:`SentQueue.rekey`), so the still-pending broadcast finds
+          an existing row under ``msg_id`` and updates it rather than
+          adding a second one.
+        - ``msg_id`` is falsy (no id echoed — an implementation detail of
+          ``ClientTransport.submit_user_text``'s own contract, never
+          ``None``) → nothing to reconcile against; the placeholder stays
+          exactly as it is, which is the honest state given no confirmed
+          id exists to promote it onto.
+        """
+        if not msg_id:
+            return
+        sent_queue = getattr(self, "_sent_queue", None)
+        if sent_queue is None:
+            # #4409: only reachable when this method is invoked directly,
+            # pre-mount, the way several existing tests already exercise
+            # ``_submit`` (``_sent_queue`` is a widget, constructed in
+            # ``compose()`` alongside every OTHER widget this App owns —
+            # same convention throughout this module, not something #4409
+            # changes). Nothing to reconcile a placeholder onto: no
+            # placeholder was ever shown pre-mount either (that only
+            # happens in ``on_composer_submitted``, which the framework
+            # never calls before mount).
+            return
+        if msg_id in self._dispatched_before_ack:
+            self._dispatched_before_ack.discard(msg_id)
+            sent_queue.remove_item(local_id)
+            return
+        if sent_queue.has_row(msg_id):
+            sent_queue.remove_item(local_id)
+            return
+        sent_queue.rekey(local_id, msg_id)
 
 
 async def run_textual_chat(

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -31,6 +31,21 @@ seq-gated merge (the P2a order-race protocol, reused as-is — see the app
 module docstring); this widget is a pure renderer of whatever the app tells it
 to show/remove, keyed by ``msg_id``.
 
+**A fourth, LOCAL entry (#4409)**: before any of the three server-driven
+exits above can fire, ``app.py``'s ``on_composer_submitted`` calls
+:meth:`show_item` with ``sending=True`` and a LOCALLY-generated id,
+synchronously with clearing the composer — closing the gap the owner
+reported ("input box から消えると同時に... 消えること多い"): between a
+message leaving the input box and the (async, network-round-trip-bound)
+``user_submitted`` broadcast materializing it here, there was previously a
+window where the message was visible NOWHERE. The row renders with
+:data:`_SENDING_GLYPH` (not :data:`_QUEUED_GLYPH`) while in this state —
+an honest "not yet confirmed sent" distinct from "confirmed queued,
+awaiting dispatch". :meth:`rekey` promotes it in place once
+``submit_user_text`` acks (``app.py``'s ``_reconcile_local_send``); if the
+real broadcast already materialized the row first (:meth:`has_row`), the
+placeholder is simply dropped as redundant.
+
 **Cancel affordance (#3300 Y-client)**: this widget is focusable
 (``can_focus = True``) and keeps a highlighted row index, keyed by the SAME
 ``msg_id`` ordering as :meth:`rendered_texts` (never a guessed/head-of-queue
@@ -117,6 +132,21 @@ _QUEUED_GLYPH = "▷"
 #: hollow-to-filled step as ``▷`` -> the NOW row's running state, so "filled"
 #: consistently means "this is the one being acted on".
 _SELECTED_GLYPH = "▶"
+
+#: The SENDING (not-yet-confirmed) row's glyph — #4409. A row keyed by a
+#: LOCAL id (``app.py``'s ``on_composer_submitted``, no server ``msg_id``
+#: yet) renders with this instead of :data:`_QUEUED_GLYPH`: it is showing
+#: BEFORE any server round trip has confirmed the submission even reached
+#: the inbox, which ``▷`` — "queued, confirmed, waiting on dispatch" — would
+#: overstate. A diamond, not a variant of the triangle family ``▷``/``▶``
+#: already own (#3777's own hollow→filled PROMOTION pairing) — this state
+#: is not a step in that pair, it precedes it, and reusing a shape from
+#: that family would read as a third rung on the SAME ladder rather than
+#: the separate, prior fact it is. ``rekey`` (below) is what promotes a row
+#: OUT of this state once the server acks it, in place, never by
+#: remove+re-add (see that method's own docstring for why position and
+#: on-screen continuity both depend on that).
+_SENDING_GLYPH = "◇"
 
 #: What separates a row's glyph from its label. Two spaces, not one: the NOW
 #: row above the queue carries no glyph at all (#3777), so its text has to
@@ -211,6 +241,11 @@ class SentQueue(Vertical):
         self.display = False
         self._rows: "dict[str, Static]" = {}
         self._labels: "dict[str, str]" = {}
+        #: #4409: keys (of ``_rows``) currently in the SENDING (not-yet-
+        #: confirmed) sub-state — a row's own key set membership, not a
+        #: second row list, so :meth:`rekey`/:meth:`remove_item` only ever
+        #: have ONE place tracking a row's identity to keep in sync.
+        self._sending: "set[str]" = set()
         self._selected_index = 0
         #: #3680: when the terminal is too short to give the queue a row per
         #: item, it renders as one ``Queued: N`` line instead. Every item is
@@ -222,18 +257,30 @@ class SentQueue(Vertical):
         self.mount(self._summary)
         self._summary.display = False
 
-    def show_item(self, msg_id: str, text: str) -> None:
+    def show_item(self, msg_id: str, text: str, *, sending: bool = False) -> None:
         """Materialize a queued item (``user_submitted``): neutralize the
         untrusted text at this display boundary, wrap it in a ``Content``
         literal (never a bare ``str`` — see the module docstring's security
         note), and mount it as a new dim row. A duplicate ``msg_id`` (should
         not happen server-side, but guarded) replaces the existing row rather
-        than stacking a second one."""
+        than stacking a second one.
+
+        ``sending`` (#4409): the row is a LOCAL, not-yet-server-confirmed
+        placeholder — ``app.py``'s ``on_composer_submitted`` calls this,
+        keyed by a local id, synchronously with clearing the composer, so
+        the gap between "left the input box" and "visible somewhere" is
+        zero rather than however long the server round trip takes. Renders
+        with :data:`_SENDING_GLYPH` instead of :data:`_QUEUED_GLYPH` — see
+        that constant's own docstring. :meth:`rekey` is how a caller
+        promotes it out of this state once the server acks."""
         if msg_id in self._rows:
             self.remove_item(msg_id)
         label = _neutralized_label(text)
         self._labels[msg_id] = label
-        row = Static(Content(f"{_QUEUED_GLYPH}{_GLYPH_GAP}{label}"))
+        if sending:
+            self._sending.add(msg_id)
+        glyph = _SENDING_GLYPH if sending else _QUEUED_GLYPH
+        row = Static(Content(f"{glyph}{_GLYPH_GAP}{label}"))
         self._rows[msg_id] = row
         self.mount(row)
         self.display = True
@@ -254,6 +301,7 @@ class SentQueue(Vertical):
         REMOVE exit, #3300 Y-client). No-op for an unknown ``msg_id``.
         Collapses the region back to hidden once the last item is gone."""
         self._labels.pop(msg_id, None)
+        self._sending.discard(msg_id)
         row = self._rows.pop(msg_id, None)
         if row is not None:
             row.remove()
@@ -329,6 +377,33 @@ class SentQueue(Vertical):
             return None
         return order[max(0, min(self._selected_index, len(order) - 1))]
 
+    def has_row(self, msg_id: str) -> bool:
+        """Whether a row keyed by ``msg_id`` is currently shown — #4409's
+        reconciliation read: the app asks this to tell "the server's
+        ``user_submitted`` broadcast already materialized this id" apart
+        from "still waiting", before deciding whether :meth:`rekey`ing a
+        local placeholder onto it would create a duplicate."""
+        return msg_id in self._rows
+
+    def rekey(self, old_id: str, new_id: str) -> None:
+        """Rename a row's key in place — #4409: promotes a local SENDING
+        placeholder (``old_id``) to the server-confirmed ``msg_id``
+        (``new_id``) once ``submit_user_text`` acks it, without moving its
+        queue position or re-mounting it. A plain ``remove_item`` +
+        ``show_item`` pair would do both — the row would jump to the END
+        (dict re-insertion order) and flash off/on for one frame — neither
+        of which is true here: the SAME message is still exactly as queued
+        as it was a moment ago, only its id changed from a local guess to
+        the authoritative one. No-op if ``old_id`` is not currently a row
+        (already reconciled, or removed by a cancel/dispatch that raced
+        this call — the caller's own docstring covers that race)."""
+        if old_id not in self._rows:
+            return
+        self._rows = {new_id if k == old_id else k: v for k, v in self._rows.items()}
+        self._labels = {new_id if k == old_id else k: v for k, v in self._labels.items()}
+        self._sending.discard(old_id)  # now confirmed — drops out of SENDING
+        self._apply_highlight()
+
     def _bring_into_view(self, row: Static) -> None:
         """Scroll ``row`` into the visible window, best-effort.
 
@@ -392,7 +467,16 @@ class SentQueue(Vertical):
             selected = i == self._selected_index
             row = self._rows[msg_id]
             row.set_class(selected, "-selected")
-            glyph = _SELECTED_GLYPH if selected else _QUEUED_GLYPH
+            # #4409: SENDING (not yet server-confirmed) wins over selection —
+            # a selected-but-unconfirmed row still needs to read as
+            # unconfirmed; ``_SELECTED_GLYPH`` only applies once a row has
+            # graduated to :data:`_QUEUED_GLYPH`'s state.
+            if selected and msg_id not in self._sending:
+                glyph = _SELECTED_GLYPH
+            elif msg_id in self._sending:
+                glyph = _SENDING_GLYPH
+            else:
+                glyph = _QUEUED_GLYPH
             # #3777 (owner call, "先頭行だけを区別する話は終わり" — option ①):
             # the NEXT label singling out the head row is gone, with no
             # replacement mark at that position. Every queued row now renders

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -611,6 +611,50 @@ async def test_reset_sent_queue_view_and_widget_and_item_meta(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_reset_clears_a_local_sending_placeholder_not_just_confirmed_rows(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #4409 accept ② — a LOCAL, not-yet-server-confirmed SENDING
+    placeholder (``on_composer_submitted``'s own optimistic row, shown
+    before ``submit_user_text`` has even returned) must not survive an
+    attach switch either — the sibling test above only exercises a
+    CONFIRMED row (materialized via a real ``user_submitted`` broadcast);
+    this one is #4409's own new state, added after that test was written,
+    and needs its own witness. ``SentQueue.clear_all()`` (called
+    unconditionally by the reset, regardless of a row's own sending/
+    confirmed sub-state) is what closes this — the SAME single call, not
+    a second one, so nothing had to special-case the new state."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry(tmp_path)
+    try:
+        await reg.attach("alpha")
+        transport = QueueTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle(pilot)
+
+            sent_queue = app.query_one(SentQueue)
+            sent_queue.show_item("local:abc123", "not yet acked on alpha", sending=True)
+            assert sent_queue.has_items() is True
+            assert any("not yet acked on alpha" in t for t in sent_queue.rendered_texts())
+
+            await reg.attach("beta")
+            transport.push_event(
+                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
+            )
+            await _settle(pilot)
+
+            assert sent_queue.has_items() is False, (
+                "alpha's local SENDING placeholder must not survive the switch to beta"
+            )
+            assert sent_queue.rendered_texts() == []
+    finally:
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_reset_streaming_replies_stale_chain_id_does_not_finalize_into_ghost(
     tmp_path, monkeypatch,
 ) -> None:

--- a/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
+++ b/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
@@ -350,7 +350,7 @@ async def test_the_tui_runs_a_command_without_submitting_it_as_a_turn(
     transport = RecordingTransport(session)
     app = TextualChatApp(transport=transport)
 
-    await app._submit("/help")
+    await app._submit("/help", local_id="local:test-help")
     assert "Slash commands:" in transport.system_text(), (
         "the TUI did not run /help as a command; _submit is not going through "
         f"the shared client-side slash layer. shown={transport.texts()!r}"
@@ -359,7 +359,7 @@ async def test_the_tui_runs_a_command_without_submitting_it_as_a_turn(
         "the TUI submitted /help as a turn as well as running it"
     )
 
-    await app._submit("an ordinary line")
+    await app._submit("an ordinary line", local_id="local:test-ordinary")
     assert [i["text"] for i in session.queued_user_messages()] == [
         "an ordinary line",
     ], (
@@ -580,7 +580,7 @@ async def test_both_clients_run_the_same_layer(tmp_path, monkeypatch) -> None:
     )
 
     tui_transport = RecordingTransport(session)
-    await TextualChatApp(transport=tui_transport)._submit("/halp")
+    await TextualChatApp(transport=tui_transport)._submit("/halp", local_id="local:test")
     tui_text = tui_transport.error_text()
 
     assert "unknown command /halp" in cui_text, (

--- a/tests/interfaces/test_4409_pre_send_indicator.py
+++ b/tests/interfaces/test_4409_pre_send_indicator.py
@@ -1,0 +1,396 @@
+"""#4409 — a visible indicator distinguishing "not yet sent" from "sent,
+awaiting response", closing the disappearing-message window the owner
+reported (verbatim): "実際 msg enter -> sent 表示の間でメッセージ消える
+こと多いので" (a message often seems to vanish between hitting enter and
+appearing as "sent").
+
+**Root cause, measured in this repo** (not guessed): ``on_composer_submitted``
+already cleared the composer BEFORE awaiting
+``ClientTransport.submit_user_text`` — a real network round trip for a
+remote (AG-UI) client — and the sent-queue region only materializes a row
+once the server's ``user_submitted`` broadcast arrives, on an INDEPENDENT
+channel from that awaited call's own return
+(``client_transport.py``'s own ``submit_user_text`` docstring, F2). Between
+the composer clearing and that broadcast landing, the message was visible
+in NEITHER place — exactly the owner's report, and exactly the window a
+diagnostic (owner's ①: distinguish "stuck before being sent" from "sent,
+awaiting response") needs to persist through to be useful at all.
+
+**The fix reuses the existing #3300 sent-queue region** (owner instruction:
+measure existing mechanisms before inventing a new state machine) — a
+FOURTH, LOCAL entry into it (``SentQueue``'s own module docstring), shown
+synchronously with the composer clearing, keyed by a client-generated id
+and rendered with a distinct glyph (:data:`~reyn.interfaces.inline.textual_chat.sent_queue._SENDING_GLYPH`)
+until the server acks the submission (``_reconcile_local_send``).
+
+Owner requirement ① ("入力欄から消えるのと同時に" — the exact same moment):
+verified directly below by observing the composer and the sent-queue in
+the SAME frame, with ``submit_user_text`` held open by a controllable gate
+so the test proves the row is visible while the server has not yet
+responded at all — not merely "eventually".
+
+Owner requirement ② (agent-attach switches the displayed queue) is
+verified separately — ``test_3310_n2_reset_hydrate.py`` already covers the
+``session_attached`` reset barrier the ``/attach`` slash command
+(``registry.attach`` → ``_announce_session_attached``) routes through; this
+file does not duplicate that coverage.
+
+Real ``TextualChatApp`` + a real ``ClientTransportStub`` subclass throughout
+(no ``unittest.mock``) — mirrors ``test_3300_p2b_sentqueue_render.py``'s own
+``QueueTransport``, extended with a controllable ``submit_user_text`` gate
+this file's races need. Public reads only: ``SentQueue.rendered_texts()``
+(the glyph is part of the rendered row, so no private-state peek is needed
+to see which sub-state a row is in), ``item_count()``, ``Composer.text``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+_TEXT = "hello"
+
+
+class _GatedTransport(ClientTransportStub):
+    """A real, minimal :class:`ClientTransport` whose ``submit_user_text``
+    does not return until the test releases :attr:`ack_gate` — the seam
+    every race in this file needs: it lets a test observe app state WHILE
+    the server round trip is still in flight, not just after it settles.
+
+    ``submitted_texts`` records every call, for tests that assert the
+    ordinary submission still reaches the transport unchanged."""
+
+    def __init__(self, *, msg_id: str = "m1", fail: bool = False) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+        self.ack_gate: "asyncio.Event" = asyncio.Event()
+        #: Set the instant ``submit_user_text`` starts waiting on
+        #: ``ack_gate`` — the seam a test awaits (mirrors
+        #: ``test_3310_n2_reset_hydrate.py``'s own ``call_started`` pattern)
+        #: to know the SYNCHRONOUS part of ``on_composer_submitted`` (the
+        #: composer clear + local placeholder show, #4409) has already run,
+        #: without polling or a fixed sleep.
+        self.entered: "asyncio.Event" = asyncio.Event()
+        self._msg_id = msg_id
+        self._fail = fail
+        self.submitted_texts: "list[str]" = []
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> str:
+        self.submitted_texts.append(text)
+        self.entered.set()
+        await self.ack_gate.wait()
+        if self._fail:
+            raise RuntimeError("simulated submit failure")
+        return self._msg_id
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+    return Event(
+        type="user_submitted",
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+    )
+
+
+def _turn_started(*, chain_id: str, seq: int) -> Event:
+    return Event(type="turn_started", data={"kind": "user", "chain_id": chain_id, "seq": seq})
+
+
+def _is_confirmed(row: str) -> bool:
+    """Whether a rendered sent-queue row is in the CONFIRMED (server-acked)
+    sub-state — either its unselected glyph (``▷``) or its selected one
+    (``▶``, ``sent_queue.py``'s own #3777 pairing; a lone row is selected
+    by default, ``_selected_index = 0``) — as opposed to still SENDING
+    (``◇``). Centralized so a test asserts the SUB-STATE, never a specific
+    glyph that selection state could otherwise make it guess wrong about."""
+    return ("▷" in row or "▶" in row) and "◇" not in row
+
+
+def _flow_user_entries(app: TextualChatApp):
+    return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
+
+
+async def _type_and_submit_in_flight(pilot, transport: "_GatedTransport", text: str) -> "asyncio.Task":
+    """Type ``text`` and press Enter, returning BEFORE the submission
+    settles.
+
+    ``on_composer_submitted`` is a single App-level async message handler,
+    and Textual's message pump processes messages for one node
+    sequentially — ``pilot.press("enter")`` awaits until that handler
+    RETURNS, not merely until the key was queued. With
+    :class:`_GatedTransport` holding ``submit_user_text`` open, a plain
+    ``await pilot.press("enter")`` would therefore never return at all.
+    Backgrounding the press as a task and awaiting ``transport.entered``
+    (set the instant ``submit_user_text`` starts blocking — after the
+    composer has already cleared and the local placeholder already shown,
+    both synchronous, #4409) is how a test observes state WHILE the
+    server round trip is still open, without polling or a fixed sleep."""
+    for ch in text:
+        await pilot.press(ch)
+    task = asyncio.create_task(pilot.press("enter"))
+    await transport.entered.wait()
+    return task
+
+
+async def _yield_until(condition) -> None:
+    """Wait on a real condition WITHOUT going through ``pilot.pause()``.
+
+    ``pilot.pause()`` waits for Textual's own message pump to go fully
+    idle — which never happens while :func:`_type_and_submit_in_flight`'s
+    backgrounded ``pilot.press("enter")`` task is still open on
+    ``on_composer_submitted`` (a single App-level handler the pump
+    processes to completion before it can call itself idle again).
+    ``asyncio.sleep(0)`` is a plain scheduler yield, not a pump-quiescence
+    wait, so it lets an INDEPENDENT task (``_pump_frames``, applying a
+    ``push_event``ed frame) make progress without needing the deliberately
+    -stuck one to finish first. CLAUDE.md's Ceiling rule still applies —
+    no fixed iteration count is asserted on; CI's own ``--timeout`` is the
+    real kill switch for a condition that never becomes true."""
+    while not condition():
+        await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# ① — no gap: the queue row appears in the SAME frame the composer clears.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_placeholder_appears_before_the_server_has_responded_at_all() -> None:
+    """Tier 2b: with ``submit_user_text`` held open (never acked), the
+    composer is already empty AND the sent-queue already shows the message
+    — the owner's own report is exactly the window where this was NOT
+    true. Non-vacuity: without the ``on_composer_submitted`` change this
+    asserts against, the sent-queue is empty here (verified by temporarily
+    reverting to the pre-#4409 two-line body — see the PR)."""
+    transport = _GatedTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+
+        composer = app.query_one(Composer)
+        assert composer.text == "", "composer must already be cleared"
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.has_items(), (
+            "the queue must already show the message — the server has not "
+            "even responded yet (ack_gate is still closed)"
+        )
+        (row,) = sent_queue.rendered_texts()
+        assert _TEXT in row
+        assert "◇" in row, "a not-yet-confirmed row must render the SENDING glyph"
+        assert not _is_confirmed(row), "must not claim server-confirmed before any ack"
+
+        transport.ack_gate.set()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_placeholder_reaches_the_transport_with_the_typed_text() -> None:
+    """Tier 2b: non-vacuity for the above — the local placeholder does not
+    replace the real submission, it merely renders before it settles."""
+    transport = _GatedTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+        assert transport.submitted_texts == [_TEXT]
+
+        transport.ack_gate.set()
+        await task
+
+
+# ---------------------------------------------------------------------------
+# ② — reconciliation: ack arrives, then (later) the broadcast too.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ack_promotes_the_placeholder_in_place_no_duplicate() -> None:
+    """Tier 2b: once ``submit_user_text`` acks, the SAME row promotes from
+    SENDING to CONFIRMED (glyph flips ``◇`` → ``▷``) — never a second row,
+    never a remove-then-readd (item_count stays 1 throughout)."""
+    transport = _GatedTransport(msg_id="m1")
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.item_count() == 1
+
+        transport.ack_gate.set()
+        await task
+        await pilot.pause()
+
+        assert sent_queue.item_count() == 1, "the ack must promote in place, not add a row"
+        (row,) = sent_queue.rendered_texts()
+        assert _is_confirmed(row)
+
+
+@pytest.mark.asyncio
+async def test_late_broadcast_after_ack_does_not_duplicate_the_row() -> None:
+    """Tier 2b: the ``user_submitted`` broadcast for the SAME msg_id,
+    arriving AFTER the ack already promoted the row, must be a no-op on
+    the widget (the row already shows the confirmed text) — not a second
+    remove+readd."""
+    transport = _GatedTransport(msg_id="m1")
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+        transport.ack_gate.set()
+        await task
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.item_count() == 1
+
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text=_TEXT, seq=1)
+        )
+        await pilot.pause()
+
+        assert sent_queue.item_count() == 1
+        (row,) = sent_queue.rendered_texts()
+        assert _TEXT in row and _is_confirmed(row)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_before_ack_then_ack_drops_the_now_redundant_placeholder() -> None:
+    """Tier 2b: the opposite ordering — the ``user_submitted`` broadcast
+    materializes the AUTHORITATIVE row before ``submit_user_text`` itself
+    returns. The two rows (real + local placeholder) coexist momentarily;
+    once the ack finally arrives, ``_reconcile_local_send`` recognizes the
+    real row already exists (``SentQueue.has_row``) and drops the
+    placeholder — back to exactly one row, never a lingering duplicate."""
+    transport = _GatedTransport(msg_id="m1")
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.item_count() == 1  # the local placeholder only
+
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text=_TEXT, seq=1)
+        )
+        # #4409 test-only note: NOT ``pilot.pause()`` — see ``_yield_until``'s
+        # own docstring for why that would deadlock here (the backgrounded
+        # ``on_composer_submitted`` task is still open).
+        await _yield_until(lambda: sent_queue.item_count() == 2)
+        assert sent_queue.item_count() == 2, (
+            "the real row and the still-unresolved local placeholder "
+            "legitimately coexist until the ack catches up"
+        )
+
+        transport.ack_gate.set()
+        await task
+        await pilot.pause()
+
+        assert sent_queue.item_count() == 1, "the ack must drop the now-redundant placeholder"
+        (row,) = sent_queue.rendered_texts()
+        assert _TEXT in row and _is_confirmed(row)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_before_ack_drops_the_placeholder_without_requeuing_it() -> None:
+    """Tier 2b: the sharpest race — ``user_submitted`` AND ``turn_started``
+    (the item is dispatched and promoted to a flow entry) both arrive
+    before this client's own ack. Without ``_dispatched_before_ack``, the
+    ack's reconcile would see "no row for msg_id" (turn_started already
+    removed it) and wrongly REKEY the local placeholder back into the
+    queue for an item that already left it — this asserts that does not
+    happen: the placeholder is dropped, the queue ends empty, and the
+    flow entry from the dispatch is untouched."""
+    transport = _GatedTransport(msg_id="m1")
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text=_TEXT, seq=1)
+        )
+        await transport.push_event(_turn_started(chain_id="c1", seq=2))
+        # #4409 test-only note: NOT ``pilot.pause()`` — see ``_yield_until``'s
+        # own docstring for why that would deadlock here.
+        await _yield_until(lambda: bool(_flow_user_entries(app)))
+        (entry,) = _flow_user_entries(app)
+        assert entry.item.text == _TEXT
+
+        transport.ack_gate.set()
+        await task
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert not sent_queue.has_items(), (
+            "the already-dispatched item must not be requeued by a late ack"
+        )
+        assert len(_flow_user_entries(app)) == 1, "the dispatch's own promotion is untouched"
+
+
+# ---------------------------------------------------------------------------
+# ③ — submit failure: the placeholder must not linger claiming "sending".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_failure_removes_the_placeholder() -> None:
+    """Tier 2b: a submission that ultimately fails must not leave a
+    permanent "sending" row behind — the operator would read that as
+    still in flight forever, the opposite of what a diagnostic exists
+    for."""
+    transport = _GatedTransport(fail=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.has_items()
+
+        transport.ack_gate.set()
+        await task
+        await pilot.pause()
+
+        assert not sent_queue.has_items(), "a failed submit must not leave a stale placeholder"

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -477,7 +477,12 @@ async def test_picking_a_checkpoint_rewinds_through_the_real_slash_seam() -> Non
         typed_app = TextualChatApp(transport=typed, read_model=_PickerReadModel())
         async with typed_app.run_test() as typed_pilot:
             await typed_pilot.pause()
-            await typed_app._submit("/rewind 9")
+            # #4409: _submit now requires local_id (the sent-queue's own
+            # local-placeholder reconcile key) — a fixed literal is fine
+            # here, this call is a synthetic "/rewind 9" that never
+            # touches the sent-queue (the slash-dispatch branch always
+            # fires for an already-``/``-prefixed string).
+            await typed_app._submit("/rewind 9", local_id="local:test")
             await typed_pilot.pause()
         assert transport.commands == typed.commands, (
             "the picker's rewind is not the typed /rewind path"


### PR DESCRIPTION
**[tui-coder]** — touches tests/ — TESTS-READ needed

Closes #4409

Owner ruling (verbatim, 2026-09-04): "input box から消えると同時に pending
queue に表示されること期待だね。agent attach で queue 表示切り替え必要である
ことも注意してね" ("expect it to show in the pending queue the SAME instant
it leaves the input box; also note attach-switching needs to switch which
queue displays too"). Real symptom this closes: "実際 msg enter -> sent 表示
の間でメッセージ消えること多いので" — the composer already cleared the
message synchronously, but the sent-queue row only materialized once the
(async, network-round-trip-bound) `user_submitted` broadcast arrived —
leaving a window where the message was visible NOWHERE.

## ① Same-instant display

`on_composer_submitted` now shows a LOCAL, client-generated placeholder row
in the sent-queue — synchronously, back-to-back with clearing the composer,
no `await` between the two — before `submit_user_text` is even called.
Renders with a distinct glyph (`◇`, "sending" — not `▷`, "confirmed
queued") so it never overstates what has actually happened: the message
left the input box, not that the server has acknowledged it.

Reconciliation once the server does ack (`_reconcile_local_send`): the ack
and the real `user_submitted` broadcast are two independent deliveries of
the same fact over two independent channels (either can arrive first,
`client_transport.py`'s own `submit_user_text` docstring, F2) —
- broadcast already materialized the row → drop the now-redundant placeholder.
- the item was already seen DISPATCHED (`turn_started` raced ahead of the
  ack too) → drop the placeholder rather than rekey it back into a queue
  it already left (`_dispatched_before_ack`, bounded — cleared the moment
  this client has nothing outstanding of its own, never by session
  lifetime; see that field's own docstring for why a naive "every dispatch
  witnessed" count would NOT be bounded, since the sent-queue renders every
  client's own queued items, not just this one's).
- neither yet → promote the placeholder IN PLACE (`SentQueue.rekey`, never
  remove+re-add — preserves queue position, no flash).

Falsify-verified (Edit-to-break → red → Edit-to-restore, per instruction —
no `git checkout`/`stash`/`restore` used anywhere in this session):
stripping the reconcile's `_dispatched_before_ack` guard makes a targeted
test go red (a late-dispatched item would wrongly re-enter the queue).

## ② Per-session queue (attach switching)

Already correct on `main`, unowned by this PR: `#3310`'s own reset barrier
(`_handle_session_attached_event`, driven by `/attach`'s real production
path — `request_attach` → `registry.attach` → `_announce_session_attached`
→ `session_attached`) already clears `SentQueue` unconditionally on every
session switch, and this PR's own new per-session state
(`_dispatched_before_ack`, `_pending_local_send_ids`) rides the SAME
data-driven `_PER_SESSION_DICT_STATE` reset tuple every other per-session
dict already does — no new reset logic needed. Added ONE new witness
(`test_reset_clears_a_local_sending_placeholder_not_just_confirmed_rows`)
specifically for the NEW local-placeholder sub-state, since the existing
sibling test only drove a server-CONFIRMED row (this PR's own new state
didn't exist when that test was written).

## Boundary honored (per dispatch's own explicit warning)

#5756 (merged the same day) established: injection is not a queue item.
This PR does not touch `_handle_turn_started_event`'s sent-queue-promote
matching, `MID_TURN_INJECTABLE`, or anything #5747/#5755/#5756 own — the
local placeholder this PR adds is scoped entirely to messages the
OPERATOR typed, never to an injected one.

## A gap this PR's own signature change surfaced (fixed, not test-side-stepped)

`_submit` gained a required `local_id` kwarg. 3 existing PRODUCTION call
sites (RewindPicker/drawer-command/`r`-key `/rewind` shortcuts — all
synthetic, already-`/`-prefixed strings, never composer text) needed one
threaded through; a 4th class of gap was more interesting: several
PRE-EXISTING tests (`test_3595_s5_session_does_not_interpret_text.py`,
`test_textual_chat_copy_rewind_3362.py`) call `TextualChatApp._submit`
DIRECTLY on an UNMOUNTED app (an established pattern in this codebase,
predating #4409) — `self._sent_queue` (a widget, constructed in
`compose()`, same convention every other widget this App owns follows)
does not exist yet on such an instance. `_reconcile_local_send`'s own new
code would have crashed with `AttributeError` the first time one of these
pre-existing tests exercised a non-slash submission. Fixed with a small
`_maybe_sent_queue_remove` helper (`getattr(self, "_sent_queue", None)`)
rather than restructuring `compose()`'s own widget-construction timing —
this is a narrower, correctly-scoped fix: no placeholder is ever shown
pre-mount either (that only happens in `on_composer_submitted`, which the
framework never calls before mount), so a no-op there is the honest
answer, not a papered-over crash.

Test plan:
- [x] `test_placeholder_appears_before_the_server_has_responded_at_all` — the composer is already empty AND the placeholder already shows, with the server round trip still open (a controllable gate holds `submit_user_text` open)
- [x] `test_ack_promotes_the_placeholder_in_place_no_duplicate` / `test_late_broadcast_after_ack_does_not_duplicate_the_row` / `test_broadcast_before_ack_then_ack_drops_the_now_redundant_placeholder` — both delivery orderings of ack vs broadcast
- [x] `test_dispatch_before_ack_drops_the_placeholder_without_requeuing_it` — the sharpest race: dispatch races ahead of this client's own ack; falsify-verified (Edit-to-break, confirmed red, Edit-to-restore)
- [x] `test_submit_failure_removes_the_placeholder` — a failed submit never leaves a stale "sending" row
- [x] `test_reset_clears_a_local_sending_placeholder_not_just_confirmed_rows` — attach switch clears an UNCONFIRMED placeholder, not just a confirmed row
- [x] 125 tests across the full sent-queue/composer/attach-switch/slash-dispatch family — all green (scoped to the diff, per instruction — full pytest left to CI)
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / tests-path-literal-reference / bare-tests-import-reference / file-depth-reference / subprocess-reyn-pin — all clean (path-literal-reference re-run after `git add`, per this session's own established discipline)
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
