### PR TITLE
fix(#4872): CLAUDE.md word count -- ratchet, not report

### DIFF
--- a/.github/workflows/claude-md-word-count.yml
+++ b/.github/workflows/claude-md-word-count.yml
@@ -1,8 +1,13 @@
 # CLAUDE.md loads into every session, so its word count is the cost of every
 # rule in it — which is why the file itself asks for `wc -w` in any PR that
-# touches it. Three PRs in a row reported that number wrong (a value read at
-# some intermediate head, not the one being merged), so the number is printed
-# here instead of transcribed by hand. Report-only: it never fails.
+# touches it. #4872: this used to be report-only ("it never fails") — under
+# that posture, root CLAUDE.md grew 2,240 -> 2,588 words in 3 weeks with no
+# gate stopping it. Now a ratchet (scripts/claude_md_word_count_ratchet.py,
+# same skeleton as mypy_ratchet.py / flat_tests_ratchet.py): crossing the
+# committed baseline (scripts/claude_md_word_count_baseline.json) fails CI.
+# Raising the baseline is not forbidden — see that script's own module
+# docstring — but it must be a real PR action (--write-baseline, committed),
+# never silent.
 name: CLAUDE.md word count
 on:
   pull_request:
@@ -15,7 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: {fetch-depth: 0}
-      - name: word count, this head vs the base
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: word count, this head vs the base (report only, for context)
         run: |
           set -euo pipefail
           base="origin/${{ github.base_ref }}"
@@ -26,3 +37,9 @@ jobs:
             printf '%s: %s -> %s (%+d words)\n' "${f}" "${was}" "${now}" "$((now - was))" \
               | tee -a "${GITHUB_STEP_SUMMARY}"
           done
+
+      # scripts/claude_md_word_count_ratchet.py is stdlib-only (argparse /
+      # json / pathlib). No pip install needed. This is the BLOCKING step —
+      # the diff report above is context, this is the gate.
+      - name: Check the CLAUDE.md word-count ratchet (no file over its baseline)
+        run: python scripts/claude_md_word_count_ratchet.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ Path-conditional gates:
 
 - `docs/` → `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`, in that order (anchors needs the built `site/`).
 - `tests/` → `python scripts/check_bare_tests_import_reference.py`, `python scripts/check_file_depth_reference.py`, and `python scripts/check_subprocess_reyn_pin.py`.
+- `CLAUDE.md` / `**/CLAUDE.md` → `python scripts/claude_md_word_count_ratchet.py` (#4872: word count is a ratchet, not a report — raising it needs `--write-baseline` committed in the same PR).
 
 1. **Finish your own Test plan before merge.** Tick every Manual/Visual item or replace with `- [x] (skipped — <reason>)`. **Never tick a check that did not happen.** **Standing waiver, Visual items only** (owner 2026-08-08): merge with the Visual box unchecked — do not fabricate it.
 2. **Role-prefix every issue / PR body / PR comment** — `**[lead-coder]** — `, etc. The PR body counts. This is the ONLY cross-session signal.

--- a/scripts/claude_md_word_count_baseline.json
+++ b/scripts/claude_md_word_count_baseline.json
@@ -1,0 +1,9 @@
+{
+  "CLAUDE.md": 2614,
+  "src/reyn/core/events/CLAUDE.md": 74,
+  "src/reyn/interfaces/CLAUDE.md": 396,
+  "src/reyn/mcp/CLAUDE.md": 22,
+  "src/reyn/schemas/CLAUDE.md": 34,
+  "src/reyn/security/sandbox/CLAUDE.md": 31,
+  "tests/interfaces/CLAUDE.md": 46
+}

--- a/scripts/claude_md_word_count_ratchet.py
+++ b/scripts/claude_md_word_count_ratchet.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""CLAUDE.md's word count is a ratchet, not a report — #4872.
+
+Every `CLAUDE.md` (root and any nested one, `**/CLAUDE.md`) loads into every
+session that reads it — its word count is the cost every rule in it charges
+per turn, not a one-time authoring cost. `.github/workflows/claude-md-word-
+count.yml` already measured this-head-vs-base per PR, but was, verbatim,
+"Report-only: it never fails." Under that gate, root `CLAUDE.md` grew
+2,240 -> 2,588 words in 3 weeks (#4869 had just cut 203 words of PROSE with
+zero rules removed; #4872 itself moved 255 words of module-scoped rules OUT
+to nested files) -- the reduction was overwritten by the next round of
+additions before the ink dried. CLAUDE.md's own first cross-cutting
+question -- "Who stops this if it repeats?" -- had no answer for this file's
+own size: a report has no subject, only a gate does.
+
+Owner ruling (#4872, verbatim): rule COUNT is not the problem ("67 本は上限
+に近くはありません") -- word count is. This ratchet does not gate how many
+rules exist, only how many words the file(s) carrying them cost.
+
+Same skeleton as `mypy_ratchet.py` (#3726) / `flat_tests_ratchet.py`
+(#3879): a committed BASELINE (word count per file, this time, not a set of
+names) that only a real PR touching the baseline file can raise. Cross the
+baseline -> CI fails, immediately, the same day the growth lands, not
+noticed three weeks and 348 words later. A file that shrinks needs no
+edit to "count" -- `--write-baseline` exists to lock in a real reduction
+the same way `mypy_ratchet.py`'s does for a real fix, but the CHECK itself
+never requires it: `measured <= baseline` passes silently regardless of by
+how much.
+
+Deliberately does NOT auto-lower the baseline on every green run: a
+scripted or CI-side rewrite of a committed file is itself the "silently pay
+the cost, or in this case silently BANK the improvement without a PR
+reviewing why" shape #4869/#4872's own review vocabulary already treats as
+a smell (`--write-baseline` is a human's explicit act, in a real PR, the
+same way RAISING the ceiling is).
+
+Raising the ceiling is not forbidden -- CLAUDE.md's own owner ruling here is
+explicit that adding rules is fine. What is forbidden is doing so for free:
+`--write-baseline` must be run and committed in the SAME PR that grows the
+file, which is the concrete form of "write down that you are raising every
+session's per-turn cost" (lead-coder's own framing, #4872 dispatch) -- an
+action, not merely a comment nobody has to make.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_BASELINE_PATH = _ROOT / "scripts" / "claude_md_word_count_baseline.json"
+
+#: Directories a `CLAUDE.md` under them would never be a real, load-bearing
+#: rules file this ratchet should track -- mirrors the exclusions the
+#: existing `claude-md-word-count.yml` workflow's own `git diff` scope
+#: already gets for free (only files git tracks) and `flat_tests_ratchet.py`'s
+#: own `.venv`/`.git` walk-exclusion precedent.
+_EXCLUDED_DIR_NAMES = {".git", ".venv", "node_modules", "__pycache__"}
+
+
+def _claude_md_files(root: Path = _ROOT) -> "list[Path]":
+    """Every `CLAUDE.md` under *root*, sorted for a stable report order --
+    the SAME set `.github/workflows/claude-md-word-count.yml`'s own `git
+    diff --name-only ... | grep -E '(^|/)CLAUDE\\.md$'` targets, just
+    measured directly against the working tree rather than a diff (this
+    ratchet checks ABSOLUTE word count, not the per-PR delta that
+    report-only workflow already prints)."""
+    return sorted(
+        p for p in root.rglob("CLAUDE.md")
+        if not any(part in _EXCLUDED_DIR_NAMES for part in p.relative_to(root).parts)
+    )
+
+
+def measured_word_counts(root: Path = _ROOT) -> "dict[str, int]":
+    """`{relative posix path: word count}` for every `CLAUDE.md` under
+    *root* right now. Word count is `str.split()`'s own whitespace-run
+    split (verified byte-for-byte against `wc -w` on this repo's own
+    CLAUDE.md files, including the CJK/mixed-script prose several of them
+    carry) -- native, no `wc` subprocess, no locale dependency."""
+    return {
+        p.relative_to(root).as_posix(): len(p.read_text(encoding="utf-8").split())
+        for p in _claude_md_files(root)
+    }
+
+
+def load_baseline(path: Path = _BASELINE_PATH) -> "dict[str, int]":
+    return dict(json.loads(path.read_text(encoding="utf-8")))
+
+
+def write_baseline(counts: "dict[str, int]", path: Path = _BASELINE_PATH) -> None:
+    path.write_text(
+        json.dumps(dict(sorted(counts.items())), indent=2) + "\n", encoding="utf-8",
+    )
+
+
+def over_baseline(
+    measured: "dict[str, int]", baseline: "dict[str, int]",
+) -> "dict[str, tuple[int, int]]":
+    """The ratchet check itself: `{path: (baseline, measured)}` for every
+    file whose CURRENT word count exceeds its baseline entry, OR that has
+    no baseline entry at all (a brand-new `CLAUDE.md` this ratchet has
+    never measured is a silent-cost-add of exactly the shape this gate
+    exists to catch, the same "new = must be declared" posture
+    `flat_tests_ratchet.py` already applies to a new flat test file) --
+    baseline 0 for that comparison, so ANY word count on a new file reports
+    as growth needing `--write-baseline`, never a free pass.
+
+    A path that DROPS OUT of `measured` (a `CLAUDE.md` deleted or moved) is
+    not reported here at all -- nothing to grow FROM once the file is
+    gone, mirroring `flat_tests_ratchet.py`'s identical silent-shrink
+    treatment for a name leaving its own `measured` set."""
+    out: "dict[str, tuple[int, int]]" = {}
+    for path, count in measured.items():
+        was = baseline.get(path, 0)
+        if count > was:
+            out[path] = (was, count)
+    return out
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help=(
+            "regenerate the baseline from the CURRENT word counts instead of "
+            "checking against it. Use for initial adoption, a real reduction "
+            "you want to lock in, or a deliberate, reviewed increase -- "
+            "commit the result in the SAME PR that changed the file(s), "
+            "never to silently absorb an unreviewed growth."
+        ),
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    measured = measured_word_counts(_ROOT)
+
+    if args.write_baseline:
+        write_baseline(measured, _BASELINE_PATH)
+        print(f"Wrote {len(measured)} CLAUDE.md word count(s) to {_BASELINE_PATH}")
+        return 0
+
+    baseline = load_baseline(_BASELINE_PATH)
+    over = over_baseline(measured, baseline)
+
+    if over:
+        print("CLAUDE.md word-count ratchet FAILED:\n", file=sys.stderr)
+        for path in sorted(over):
+            was, now = over[path]
+            label = "new file, no baseline entry" if path not in baseline else f"{was} -> {now}"
+            print(f"  {path}: {label} ({now - was:+d} words)", file=sys.stderr)
+        print(
+            "\nEvery CLAUDE.md loads into every session that reads it -- its "
+            "word count is a per-turn cost, not a one-time authoring cost. "
+            "Either trim the file(s) above back under baseline, or if the "
+            "growth is deliberate and reviewed, run `python scripts/"
+            "claude_md_word_count_ratchet.py --write-baseline` and commit "
+            "the updated baseline in THIS PR -- that is the concrete act of "
+            "writing down 'this raises every session's per-turn cost,' not "
+            "a comment anyone can skip.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"CLAUDE.md word-count ratchet OK: {len(measured)} file(s) measured, "
+        f"all at or under baseline ({_BASELINE_PATH.relative_to(_ROOT)})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_4872_claude_md_word_count_ratchet.py
+++ b/tests/scripts/test_4872_claude_md_word_count_ratchet.py
@@ -1,0 +1,171 @@
+"""Tier 2: #4872 — the CLAUDE.md word-count ratchet
+(scripts/claude_md_word_count_ratchet.py).
+
+Placed in tests/scripts/ (not flat) deliberately: this file is itself NEW,
+so it must obey the flat-tests gate on its own introducing PR — the same
+reason test_flat_tests_ratchet_3879.py names for its own placement.
+
+Real filesystem throughout (a real tmp_path tree with real CLAUDE.md files)
+— no mocks; the functions under test are themselves thin wrappers over the
+filesystem, so faking it would test nothing real.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import scripts.claude_md_word_count_ratchet as ratchet
+from scripts.claude_md_word_count_ratchet import (
+    load_baseline,
+    main,
+    measured_word_counts,
+    over_baseline,
+    write_baseline,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_measured_word_counts_matches_wc_dash_w(tmp_path: Path) -> None:
+    """Tier 2: word count is `str.split()`'s whitespace-run split — the
+    module docstring's own claim that this matches `wc -w` byte-for-byte,
+    verified here for a real file (not just asserted in prose)."""
+    _write(tmp_path / "CLAUDE.md", "one two  three\nfour\tfive\n")
+    assert measured_word_counts(tmp_path) == {"CLAUDE.md": 5}
+
+
+def test_measured_word_counts_finds_nested_files(tmp_path: Path) -> None:
+    """Tier 2: a CLAUDE.md under a subdirectory is measured too — the
+    ratchet's whole point (#4872's own background: 6 nested CLAUDE.md files
+    already exist, each its own load-bearing per-directory cost)."""
+    _write(tmp_path / "CLAUDE.md", "root file")
+    _write(tmp_path / "src" / "pkg" / "CLAUDE.md", "a b c")
+    assert measured_word_counts(tmp_path) == {
+        "CLAUDE.md": 2,
+        "src/pkg/CLAUDE.md": 3,
+    }
+
+
+def test_measured_word_counts_excludes_git_and_venv_dirs(tmp_path: Path) -> None:
+    """Tier 2: a CLAUDE.md-named file inside .git or .venv (never a real
+    rules file a session would load) must not be counted — false growth
+    from tooling internals would make this gate untrustworthy."""
+    _write(tmp_path / "CLAUDE.md", "root")
+    _write(tmp_path / ".git" / "CLAUDE.md", "not a real rules file")
+    _write(tmp_path / ".venv" / "lib" / "CLAUDE.md", "also not real")
+    assert measured_word_counts(tmp_path) == {"CLAUDE.md": 1}
+
+
+def test_over_baseline_flags_growth_only() -> None:
+    """Tier 2: the ratchet's core arithmetic — only a file whose CURRENT
+    count exceeds its baseline is flagged; a match or a shrink is not."""
+    measured = {"CLAUDE.md": 10, "sub/CLAUDE.md": 5}
+    baseline = {"CLAUDE.md": 8, "sub/CLAUDE.md": 5}
+    assert over_baseline(measured, baseline) == {"CLAUDE.md": (8, 10)}
+
+
+def test_over_baseline_flags_a_shrink_as_not_over() -> None:
+    """Tier 2: the other side — a file that got SHORTER than its baseline
+    (a real, welcome cut) must not be reported. Without this, a fix that
+    flagged any DIFFERENCE (not just growth) would still pass the test
+    above."""
+    measured = {"CLAUDE.md": 5}
+    baseline = {"CLAUDE.md": 10}
+    assert over_baseline(measured, baseline) == {}
+
+
+def test_over_baseline_flags_a_brand_new_file_with_no_entry() -> None:
+    """Tier 2: a CLAUDE.md with no baseline entry at all (a brand-new nested
+    file) is treated as baseline 0 — ANY word count on it is growth, never
+    a free pass. Mirrors flat_tests_ratchet.py's identical "new = must be
+    declared" posture for a new flat test file."""
+    measured = {"CLAUDE.md": 100, "new/CLAUDE.md": 12}
+    baseline = {"CLAUDE.md": 100}
+    assert over_baseline(measured, baseline) == {"new/CLAUDE.md": (0, 12)}
+
+
+def test_over_baseline_a_removed_file_is_silently_absent() -> None:
+    """Tier 2: a baseline entry whose file no longer exists at all (deleted
+    or moved) is not reported — nothing to grow FROM once it's gone,
+    mirroring flat_tests_ratchet.py's identical silent-shrink treatment."""
+    measured = {"CLAUDE.md": 10}
+    baseline = {"CLAUDE.md": 10, "gone/CLAUDE.md": 999}
+    assert over_baseline(measured, baseline) == {}
+
+
+def test_write_baseline_then_load_baseline_round_trips(tmp_path: Path) -> None:
+    """Tier 2: the baseline file format round-trips through write/load —
+    catches a JSON-shape mismatch between the writer and the reader."""
+    path = tmp_path / "baseline.json"
+    write_baseline({"b/CLAUDE.md": 3, "CLAUDE.md": 10}, path)
+    assert load_baseline(path) == {"CLAUDE.md": 10, "b/CLAUDE.md": 3}
+    # Sorted on disk — a stable diff is why write_baseline sorts by key
+    # rather than dumping dict insertion order.
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert list(on_disk.keys()) == sorted(on_disk.keys())
+
+
+# ── main() end-to-end — the gate's own CLI entry point ──────────────────
+# lead-coder's own #3879 review finding (test_flat_tests_ratchet_3879.py's
+# comment): helper-level tests alone can leave main()'s actual wiring
+# unverified. These drive `main()` directly against a real tmp_path tree.
+
+
+def test_main_fails_when_a_file_exceeds_its_baseline(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: the gate's own reason to exist — `main([])` must exit
+    nonzero when a real file's word count exceeds its committed baseline.
+
+    Strip-falsifier (verified locally, not committed): reverting
+    `over_baseline`'s `count > was` check to `count != was` still catches
+    this case (a shrink would also fail then) — the SEPARATE shrink test
+    below is what actually isolates the `>` behavior; together they pin
+    the exact comparison."""
+    _write(tmp_path / "CLAUDE.md", "one two three four five")
+    baseline_path = tmp_path / "baseline.json"
+    write_baseline({"CLAUDE.md": 3}, baseline_path)
+    monkeypatch.setattr(ratchet, "_ROOT", tmp_path)
+    monkeypatch.setattr(ratchet, "_BASELINE_PATH", baseline_path)
+
+    assert main([]) != 0
+
+
+def test_main_passes_when_every_file_is_at_or_under_baseline(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: the non-vacuity twin of the test above — a real tree that
+    genuinely satisfies its baseline (including a real reduction) must
+    exit 0. Without this, a `main()` that always returns nonzero would
+    still pass the failing-case test."""
+    _write(tmp_path / "CLAUDE.md", "one two three")
+    baseline_path = tmp_path / "baseline.json"
+    write_baseline({"CLAUDE.md": 10}, baseline_path)  # shrank since baseline
+    monkeypatch.setattr(ratchet, "_ROOT", tmp_path)
+    monkeypatch.setattr(ratchet, "_BASELINE_PATH", baseline_path)
+
+    assert main([]) == 0
+
+
+def test_main_write_baseline_locks_in_the_current_counts(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Tier 2: `main(["--write-baseline"])` regenerates the baseline file
+    from the CURRENT tree — the real adoption/deliberate-raise path #4872's
+    own dispatch requires ("commit the updated baseline in the SAME PR")."""
+    _write(tmp_path / "CLAUDE.md", "one two three four")
+    baseline_path = tmp_path / "baseline.json"
+    write_baseline({"CLAUDE.md": 1}, baseline_path)
+    monkeypatch.setattr(ratchet, "_ROOT", tmp_path)
+    monkeypatch.setattr(ratchet, "_BASELINE_PATH", baseline_path)
+
+    assert main([]) != 0, "sanity: the pre-write-baseline tree must be red first"
+
+    exit_code = main(["--write-baseline"])
+
+    assert exit_code == 0
+    assert load_baseline(baseline_path) == {"CLAUDE.md": 4}
+    assert main([]) == 0, "after --write-baseline, the same tree must be green"


### PR DESCRIPTION
**[e2e-coder]** Closes #4872. Owner ruling in the issue's own latest comments.

## What this PR does

`.github/workflows/claude-md-word-count.yml` already measured this-head-vs-base word count per PR touching a `CLAUDE.md`, but was, verbatim, **"Report-only: it never fails."** Under that posture root `CLAUDE.md` grew **2,240 → 2,588 words in 3 weeks** — #4869 cut 203 words of prose with zero rules removed, and this issue's own analysis moved 255 more words of module-scoped rules out to nested `CLAUDE.md` files, and root **still** grew. CLAUDE.md loads into every session — its word count is a per-turn cost, not a one-time authoring cost.

**Owner ruling (verbatim, #4872): rule COUNT is not the problem** ("67 本は上限に近くはありません") — **word count is**. This PR does not gate rule count, only word count.

- `scripts/claude_md_word_count_ratchet.py` — same skeleton as `mypy_ratchet.py`/`flat_tests_ratchet.py`: a committed baseline (word count per `CLAUDE.md` file, root and every nested one) that only a real PR touching the baseline can raise. `--write-baseline` exists for real adoption/reduction/deliberate-raise, never to silently absorb growth. A brand-new `CLAUDE.md` with no baseline entry is treated as baseline `0` — any word count on it is growth, never a free pass (mirrors `flat_tests_ratchet.py`'s own "new = must be declared" posture for a new flat test file).
- `.github/workflows/claude-md-word-count.yml` — kept the existing this-head-vs-base diff report (useful context), added the ratchet script as the actual **blocking** step.
- `CLAUDE.md` — one line in the PR-workflow path-conditional-gates list.
- `tests/scripts/test_4872_claude_md_word_count_ratchet.py` — helper-level coverage (measurement including nested files and `.git`/`.venv` exclusion, the growth/shrink/new-file/removed-file comparison, baseline round-trip) plus `main()`-level end-to-end tests (fails on real growth, passes on real shrink, `--write-baseline` locks in the current tree). lead-coder's own `test_flat_tests_ratchet_3879.py` review comment names helper-only coverage as an incomplete gate for exactly this ratchet family — driven directly here.

## This PR touches CLAUDE.md itself — gated by its own new check

**Initial baseline = this PR's own final word counts** (root `2,588 → 2,614`, the +26 words for the one line this PR adds to the PR-workflow section; the 6 nested `CLAUDE.md` files unchanged). This is **adoption**, not a raise against a prior ratchet — there was none before this PR.

## Verified via real execution, not reasoned

- The CLI run end to end: clean tree → green. A real appended sentence in `CLAUDE.md` → red, with the exact word delta printed (`CLAUDE.md: 2614 -> 2620 (+6 words)`). Reverted **via Edit** (not `git checkout`/`stash`), re-confirmed green.
- `over_baseline`'s own `count > was` comparison strip-falsified (Edit to a no-op condition, not committed): 4 of 11 tests correctly go red (the ones that actually exercise growth detection), reverted, all 11 green again.

## Local gates (scoped, per PR workflow)

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict tests/scripts/test_4872_claude_md_word_count_ratchet.py` — 11/11 OK
- `python scripts/verify_module_docstrings.py scripts/claude_md_word_count_ratchet.py` — OK
- `python scripts/mypy_ratchet.py` — `OK: 200 findings, all baselined (208 declared)`
- `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- Scoped `pytest` (`test_4872_claude_md_word_count_ratchet.py` + `test_flat_tests_ratchet_3879.py` + `test_3726_mypy_ratchet.py`, the 3 ratchet-family test files together) — **47 passed**

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] Scoped `pytest` (47 passed) + real end-to-end CLI strip-falsify (documented above)
- [x] (skipped — 👁️ Visual: a CI/tooling change, no TUI/visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
