### PR TITLE
feat(#4401): mcp tab shows 3 distinct probe states, adds per-server retry

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1016,23 +1016,80 @@ def _mcp_pane_entries(snap: dict) -> "list[tuple[str, str]]":
     require redrawing this grammar, only exercising a branch already here."""
     rows = _visibility_pane_rows(snap, "mcp", "mcp_servers")
     subs_by_server = {s["server"]: s for s in (snap.get("mcp_subscriptions") or [])}
+    # #4401 ②: per-server probe state (answered / failed / not_probed /
+    # retrying) — gated by mcp_probe_states_reported (a remote connection
+    # does not have this on the wire yet, #4401), same pattern
+    # mcp_subscriptions_reported gates the subscription augmentation.
+    # ``None`` (not the empty-dict default) when un-reported, so a
+    # not-reported connection adds NO probe note at all rather than
+    # rendering every server as "not yet probed" — which would be a
+    # FABRICATION indistinguishable from a genuine unprobed state, the
+    # exact conflation #4401 exists to close.
+    probes_by_server = (
+        {p["name"]: p for p in (snap.get("mcp_probe_states") or [])}
+        if snap.get("mcp_probe_states_reported", False) else None
+    )
     out: "list[DrawerRow]" = []
     for row in rows:
+        probe = probes_by_server.get(row.label) if probes_by_server is not None else None
+        if probe is not None:
+            row = _apply_mcp_probe_note(row, probe)
         sub = subs_by_server.get(row.label)
         if sub is None or not sub.get("uris"):
             out.append(row)
-            continue
-        uris = sub["uris"]
-        unhonored = sub.get("unhonored")
-        mark = "unconfirmed" if unhonored is None else "subscribed"
-        out.append(replace(row, note=f"{row.note} · {mark}" if row.note else mark))
-        unhonored_set = set(unhonored) if unhonored is not None else set()
-        for uri in uris:
+        else:
+            uris = sub["uris"]
+            unhonored = sub.get("unhonored")
+            mark = "unconfirmed" if unhonored is None else "subscribed"
+            out.append(replace(row, note=f"{row.note} · {mark}" if row.note else mark))
+            unhonored_set = set(unhonored) if unhonored is not None else set()
+            for uri in uris:
+                out.append(DrawerRow(
+                    label=f"    {uri}",
+                    note="not honored" if uri in unhonored_set else None,
+                ))
+        if probe is not None and probe.get("state") == "failed":
+            # #4401 ③: retry offered ONLY on a row that actually failed a
+            # probe attempt — not "not_probed" (nothing has failed yet; the
+            # lazy, post-startup probe, FP-0037 issue #160, simply hasn't
+            # reached this server yet) and not "retrying" (already in
+            # flight; a second retry would just re-request the same thing).
+            # Independent of whether this server
+            # ALSO has subscription sub-rows above — a probe failure and a
+            # subscription state are two different axes. A separate
+            # indented row (never the server row's own `command` slot —
+            # already the `/visibility` toggle) mirrors the #4686
+            # subscription sub-row convention above.
             out.append(DrawerRow(
-                label=f"    {uri}",
-                note="not honored" if uri in unhonored_set else None,
+                label="    ↻ retry probe", command=f"/mcp retry {row.label}",
             ))
     return [r.as_entry() for r in out]
+
+
+def _apply_mcp_probe_note(row: "DrawerRow", probe: "dict") -> "DrawerRow":
+    """#4401 ②: append the probe-state note to one mcp server row — the 3
+    states #4401 requires, none conflated (plus a transient 4th, ③'s own
+    "retrying"): ``"answered"`` → tool count (0 is a genuine answer, never
+    conflated with "not probed"); ``"failed"`` → the probe reason;
+    ``"not_probed"`` → said plainly, NEVER rendered as "0 tools" (the exact
+    conflation #4401 exists to close — owner: the model can't NAME an
+    unprobed server's tools, that is not the same as the server having
+    none); ``"retrying"`` → a manual retry (#4401 ③) is in flight.
+    An unrecognised state string is a forward-compat no-op (row unchanged)
+    rather than a crash."""
+    state = probe.get("state")
+    if state == "answered":
+        n = probe.get("tool_count", 0)
+        note = f"{n} tool{'s' if n != 1 else ''}"
+    elif state == "failed":
+        note = f"probe failed: {probe.get('reason') or 'unknown'}"
+    elif state == "retrying":
+        note = "retrying…"
+    elif state == "not_probed":
+        note = "not yet probed"
+    else:
+        return row
+    return replace(row, note=f"{row.note} · {note}" if row.note else note)
 
 
 def _hook_pane_entries(snap: dict) -> "list[tuple[str, str]]":

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -306,6 +306,12 @@ class ChatReadModelCapabilities:
     # #5034's clearance and why they stay 2 fields despite landing together.
     visibility_items_reported: bool  # covers `visibility_items` (tool/mcp/skill panes)
     mcp_subscriptions_reported: bool  # covers `mcp_subscriptions` (mcp pane only)
+    # #4401 ②: covers `mcp_probe_states` (mcp pane's 3-state probe display).
+    # Not yet on the AG-UI wire (no producer projects a remote session's
+    # RouterHostAdapter.mcp_probe_snapshot() for a remote client to read) —
+    # a disclosed gap declared from day one, same shape hooks_reported/
+    # pipelines_reported closed, not a #5034-style undeclared fabrication.
+    mcp_probe_states_reported: bool
     # #5100/#5272 (lead-coder correction, issuecomment on #5272): unlike
     # `unknown_config_key_count`/`unknown_config_keys` (genuinely client-
     # local — a remote's OWN reyn.yaml, structurally absent on that
@@ -378,6 +384,7 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     attached_name_reported=True,
     visibility_items_reported=True,
     mcp_subscriptions_reported=True,
+    mcp_probe_states_reported=True,
     hooks_config_warnings_reported=True,
     compaction_progress_reported=True,
     tasks_reported=True,
@@ -416,6 +423,9 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     attached_name_reported=True,
     visibility_items_reported=True,
     mcp_subscriptions_reported=True,
+    # #4401 ②: not yet wired onto the AG-UI wire (see the field's own
+    # docstring) — False, not True.
+    mcp_probe_states_reported=False,
     # #5100/#5272: not yet wired onto the AG-UI wire (no producer projects
     # the server session's real hooks_config_warnings for a remote
     # client to read) -- False, not True; see the field's own docstring.
@@ -1025,6 +1035,12 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # so `[]` is the correct default for BOTH "genuinely no
         # subscriptions" and "key not yet on the wire" here.
         "mcp_subscriptions": v.get("mcp_subscriptions", []),
+        # `[]` below is correct (per-server probe state is not on the wire
+        # yet — RouterHostAdapter.mcp_probe_snapshot() is session-local,
+        # #4401 ②); gated by ``mcp_probe_states_reported`` above so the mcp
+        # pane renders "not reported" instead of a fabricated "not_probed"
+        # row for every server.
+        "mcp_probe_states": [],
         # `[]` below is correct (pipeline registry is not on the wire);
         # gated by ``pipelines_reported`` above so `pipe_pane_lines`
         # renders "not reported" instead of its own `["(none)"]` fallback

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -452,6 +452,24 @@ def _session_mcp_subscriptions(session) -> list[dict]:
         return []
 
 
+def _session_mcp_probe_states(session) -> list[dict]:
+    """Read the per-server MCP probe-state read model from the session
+    (#4401 ② backend seam). Shape: ``[{"name", "state", ...}, ...]`` — see
+    ``Session.mcp_probe_state``'s own docstring for the field semantics.
+    Mirrors ``_session_mcp_subscriptions``'s defensiveness (a getattr +
+    try/except around an accessor that's always constructed, not a
+    "not wired yet" seam) — [] on any missing accessor or unexpected raise,
+    never a crash of the whole status readout."""
+    getter = getattr(session, "mcp_probe_state", None)
+    if getter is None:
+        return []
+    try:
+        return list(getter() or [])
+    except Exception:  # noqa: BLE001
+        logger.warning("mcp_probe_state() raised; mcp pane probe-state rows degraded to []", exc_info=True)
+        return []
+
+
 def _session_pipelines(session) -> list[dict]:
     """Read registered pipeline names + descriptions from the session's
     PipelineRegistry — always constructed at Session.__init__ (never a "not
@@ -747,6 +765,9 @@ def _snapshot_for_session(registry, s, config=None):
         # than a not-wired seam — Session always owns an MCPConnectionService
         # (see Session.mcp_subscription_state's own docstring).
         "mcp_subscriptions": _session_mcp_subscriptions(s),
+        # #4401 ②: per-server probe state (answered / failed / not_probed)
+        # for the mcp pane — see _session_mcp_probe_states's own docstring.
+        "mcp_probe_states": _session_mcp_probe_states(s),
         # Always available (Session owns a PipelineRegistry from __init__) —
         # not a "not wired yet" seam like the two lines above.
         "pipelines": _session_pipelines(s),

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -354,6 +354,7 @@ from reyn.interfaces.slash import help as _help_mod  # noqa: E402, F401
 from reyn.interfaces.slash import hook as _hook_mod  # noqa: E402, F401
 from reyn.interfaces.slash import image as _image_mod  # noqa: E402, F401
 from reyn.interfaces.slash import matrix as _matrix_mod  # noqa: E402, F401
+from reyn.interfaces.slash import mcp as _mcp_mod  # noqa: E402, F401
 from reyn.interfaces.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.interfaces.slash import model as _model_mod  # noqa: E402, F401
 from reyn.interfaces.slash import open_artifact as _open_artifact_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -244,6 +244,9 @@ class _ErrorWatchingTransport(ClientTransport):
     async def cancel_queued(self, msg_id: str) -> bool:
         return await self._inner.cancel_queued(msg_id)
 
+    async def request_mcp_retry(self, server: str) -> bool:
+        return await self._inner.request_mcp_retry(server)
+
     async def request_attach(self, agent_name: str) -> bool:
         return await self._inner.request_attach(agent_name)
 

--- a/src/reyn/interfaces/slash/mcp.py
+++ b/src/reyn/interfaces/slash/mcp.py
@@ -1,0 +1,40 @@
+"""``/mcp`` — per-server MCP actions (#4401 ③: retry a failed probe).
+
+The mcp pane's "↻ retry probe" row (chrome.py's ``_mcp_pane_entries``,
+appended only under a ``"failed"`` server row) submits this command; it
+maps 1:1 to ``Session.retry_mcp_probe``. Session-scoped, and this handler
+AWAITS it — deliberately not fire-and-forget (see
+``RouterHostAdapter.retry_mcp_probe``'s own docstring for why a background
+task is out of scope here). The row's own state (``mcp_probe_state``)
+already reads "retrying…" the instant the retry starts (any render that
+happens during this await sees it); this command's own reply just confirms
+the outcome once the probe settles, up to ``per_server_timeout`` later.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
+
+
+@slash(
+    "mcp",
+    summary="MCP server actions — retry a failed probe",
+    locus="session",
+    usage="/mcp retry <server>",
+)
+async def mcp_cmd(ctx: "SlashContext", args: str) -> None:
+    """``/mcp retry <server>`` — re-probe one mcp server (#4401 ③), waiting
+    for it to settle. Bypasses the server's own #5674 failure cooldown (a
+    manual retry that silently no-ops until 60s have passed would look
+    like nothing happened) — see ``Session.retry_mcp_probe``'s own
+    docstring."""
+    parts = args.split()
+    if len(parts) != 2 or parts[0] != "retry":
+        await reply_error(ctx, "usage: /mcp retry <server>")
+        return
+    server = parts[1]
+    retry = getattr(ctx.session, "retry_mcp_probe", None)
+    if retry is None:
+        await reply_error(ctx, "mcp probe retry is not available in this session")
+        return
+    await retry(server)
+    await reply(ctx, f"mcp probe retry for {server!r} finished — see the mcp pane for the result")

--- a/src/reyn/interfaces/slash/mcp.py
+++ b/src/reyn/interfaces/slash/mcp.py
@@ -2,13 +2,19 @@
 
 The mcp pane's "↻ retry probe" row (chrome.py's ``_mcp_pane_entries``,
 appended only under a ``"failed"`` server row) submits this command; it
-maps 1:1 to ``Session.retry_mcp_probe``. Session-scoped, and this handler
+dispatches through ``ClientTransport.request_mcp_retry`` (#3595 S4: a
+slash handler reaches the CLIENT seam, never a ``Session`` member added
+just so it could — ``Session.retry_mcp_probe`` was BLOCKING'd for exactly
+that shape, PR #5761 lead-coder review, and folded into
+``Session._retry_mcp_probe``, private, reachable only from
+``request_mcp_retry``'s own production implementations). This handler
 AWAITS it — deliberately not fire-and-forget (see
 ``RouterHostAdapter.retry_mcp_probe``'s own docstring for why a background
-task is out of scope here). The row's own state (``mcp_probe_state``)
-already reads "retrying…" the instant the retry starts (any render that
-happens during this await sees it); this command's own reply just confirms
-the outcome once the probe settles, up to ``per_server_timeout`` later.
+task is out of scope here). The row's own state (``Session.mcp_probe_
+state``, a genuinely public read-model forwarder) already reads
+"retrying…" the instant the retry starts (any render that happens during
+this await sees it); this command's own reply just confirms the outcome
+once the probe settles, up to ``per_server_timeout`` later.
 """
 from __future__ import annotations
 
@@ -25,16 +31,15 @@ async def mcp_cmd(ctx: "SlashContext", args: str) -> None:
     """``/mcp retry <server>`` — re-probe one mcp server (#4401 ③), waiting
     for it to settle. Bypasses the server's own #5674 failure cooldown (a
     manual retry that silently no-ops until 60s have passed would look
-    like nothing happened) — see ``Session.retry_mcp_probe``'s own
+    like nothing happened) — see ``Session._retry_mcp_probe``'s own
     docstring."""
     parts = args.split()
     if len(parts) != 2 or parts[0] != "retry":
         await reply_error(ctx, "usage: /mcp retry <server>")
         return
     server = parts[1]
-    retry = getattr(ctx.session, "retry_mcp_probe", None)
-    if retry is None:
-        await reply_error(ctx, "mcp probe retry is not available in this session")
+    happened = await ctx.transport.request_mcp_retry(server)
+    if not happened:
+        await reply_error(ctx, f"mcp probe retry for {server!r} is not available here")
         return
-    await retry(server)
     await reply(ctx, f"mcp probe retry for {server!r} finished — see the mcp pane for the result")

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -743,6 +743,18 @@ class AgUiTransport(ClientTransport):
         # queue-affecting mutation on this transport.
         return bool(await self._send({"type": "cancel_queued", "msg_id": msg_id}))
 
+    async def request_mcp_retry(self, server: str) -> bool:
+        # #4401 ③: NOT wired to a real server op yet — #4401 ②'s own
+        # `mcp_probe_states` never reaches this wire either
+        # (`mcp_probe_states_reported=False` for REMOTE, read_model.py),
+        # so a remote client's mcp pane never shows the retry row that
+        # would call this in the first place; only someone typing the
+        # command by hand on a --connect client reaches here. ``False`` —
+        # "did not happen here" — same disclosed-gap shape #4401 ②
+        # already committed to for remote, not a silent no-op invented
+        # for this method alone.
+        return False
+
     async def clear_pending_command_ui(self) -> None:
         # #5096 review finding (lead-coder): EXPLICITLY implemented, not
         # inherited from ClientTransportStub, even though the VALUE

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -236,6 +236,36 @@ class ClientTransport(ABC):
         real op."""
 
     @abstractmethod
+    async def request_mcp_retry(self, server: str) -> bool:
+        """Retry one mcp server's tools probe (the mcp pane's "↻ retry
+        probe" row / ``/mcp retry <server>`` seam, #4401 ③). ``True`` iff
+        the retry actually ran here.
+
+        #3595 S4's own principle applied to a THIRD case (after
+        :meth:`request_attach`/:meth:`run_slash_command`): a slash handler
+        may not reach a session member whose only reason to exist is
+        letting it do so — ``Session.retry_mcp_probe`` was BLOCKING'd for
+        exactly that shape (PR #5761, lead-coder review) and folded into
+        ``Session._retry_mcp_probe``, reachable only from this method's own
+        production implementations. Deliberately a single AWAITED round
+        trip, not fire-and-forget — the mcp pane's row reads "retrying…"
+        (``mcp_probe_state``) the instant the retry starts (any render
+        during this await sees it, same reasoning
+        ``Session._retry_mcp_probe``'s own docstring gives), and the caller
+        (the slash handler) needs the real outcome to report.
+
+        ``False`` means "did not happen here" (no attached session locally,
+        or not yet supported on this transport — #4401's own scope: remote/
+        AG-UI does not carry `mcp_probe_states` on the wire yet either, so a
+        remote client's mcp pane never shows the retry row in the first
+        place; this only matters for someone typing the command by hand) —
+        mirrors :meth:`cancel_queued`'s own convention.
+
+        Abstract: the no-op-``False`` default body lives on
+        :class:`ClientTransportStub`; ``InProcessTransport`` overrides it
+        with the real op."""
+
+    @abstractmethod
     async def request_attach(self, agent_name: str) -> bool:
         """Attach to a different agent (the ``/attach`` seam); ``True`` iff it
         happened (#4534 PR-1).
@@ -534,6 +564,9 @@ class ClientTransportStub(ClientTransport):
     async def cancel_queued(self, msg_id: str) -> bool:
         return False
 
+    async def request_mcp_retry(self, server: str) -> bool:
+        return False
+
     async def request_attach(self, agent_name: str) -> bool:
         return False
 
@@ -662,6 +695,9 @@ class DelegatingClientTransport(ClientTransport):
 
     async def cancel_queued(self, msg_id: str) -> bool:
         return await self._inner.cancel_queued(msg_id)
+
+    async def request_mcp_retry(self, server: str) -> bool:
+        return await self._inner.request_mcp_retry(server)
 
     async def request_attach(self, agent_name: str) -> bool:
         return await self._inner.request_attach(agent_name)

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -395,6 +395,23 @@ class InProcessTransport(ClientTransport):
             return bool(await cancel_fn(msg_id))
         return False
 
+    async def request_mcp_retry(self, server: str) -> bool:
+        # #4401 ③: the production seam BLOCKING'd PR #5761 asked for —
+        # this transport (not a slash handler) is the sanctioned boundary
+        # that may reach a session's PRIVATE member (mirrors
+        # cancel_inflight/cancel_queued's own getattr-by-name shape just
+        # above, on the SAME PUBLIC method name convention those use for
+        # THEIR own session calls — Session._retry_mcp_probe is private
+        # specifically because its only real caller is this method).
+        s = self._attached()
+        if s is None:
+            return False
+        retry_fn = getattr(s, "_retry_mcp_probe", None)
+        if callable(retry_fn):
+            await retry_fn(server)
+            return True
+        return False
+
     async def shutdown(self) -> None:
         await self._registry.shutdown()
 

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -151,6 +151,15 @@ class SessionBoundTransport(ClientTransport):
     async def cancel_queued(self, msg_id: str) -> bool:
         return bool(await self._session.cancel_queued(msg_id))
 
+    async def request_mcp_retry(self, server: str) -> bool:
+        # #4401 ③: same private-member seam InProcessTransport uses — this
+        # transport is a production boundary, not a slash handler.
+        retry_fn = getattr(self._session, "_retry_mcp_probe", None)
+        if callable(retry_fn):
+            await retry_fn(server)
+            return True
+        return False
+
     async def run_slash_command(self, name: str, args: str) -> bool:
         # #5094: EXPLICITLY implemented, not inherited — mirrors
         # InProcessTransport's own real execution side (#3595 S5): the

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -423,6 +423,9 @@ class ThreadedTransportProxy(ClientTransport):
     async def cancel_queued(self, msg_id: str) -> bool:
         return await self._call_on_worker("cancel_queued", msg_id)
 
+    async def request_mcp_retry(self, server: str) -> bool:
+        return await self._call_on_worker("request_mcp_retry", server)
+
     async def run_slash_command(self, name: str, args: str) -> bool:
         return await self._call_on_worker("run_slash_command", name, args)
 

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -536,6 +536,28 @@ class RouterHostAdapter:
         # capability the model is never told about.
         self._mcp_tools_cache: dict[str, ToolsAnswered] | None = None
         self._mcp_probe_cooldown_until: dict[str, float] = {}
+        # #4401 ②: the LAST ToolsUnknown outcome per server, so the TUI can
+        # tell "probed, did not answer" (this dict) apart from "never
+        # probed" (absent from both this and `_mcp_tools_cache`) — see
+        # `mcp_probe_snapshot`. Cleared for a server the instant it later
+        # answers (`ensure_mcp_tools_cached`'s own gather loop), so a
+        # transient failure does not linger as "failed" after a successful
+        # retry. Not persisted (unlike `_mcp_tools_cache`) — this is a
+        # display aid, not the FP-0037 permanence guarantee; a restart
+        # legitimately forgets it and re-probes fresh.
+        self._mcp_last_unknown: "dict[str, ToolsUnknown]" = {}
+        # #4401 ③: the server a manual retry is currently in flight for, if
+        # any — `mcp_probe_snapshot` reports it as ``"retrying"`` rather
+        # than falling through to "failed" (the in-flight retry hasn't
+        # cleared the old failure yet) or "not_probed" (misleading — a
+        # probe genuinely IS running). `retry_mcp_probe` is a single
+        # synchronously-awaited call (not backgrounded — #4401 A-4's own
+        # co-vet found real concurrent-cache-mutation hazards a background
+        # probe introduces; ③ deliberately stays out of that scope, see
+        # `retry_mcp_probe`'s own docstring), so at most ONE retry is ever
+        # in flight for THIS session at a time — a set, not a per-server
+        # dict, is enough.
+        self._mcp_retry_in_flight: "set[str]" = set()
         # FP-0037 S1: mtime of the cache file when we last loaded from it.
         # None = never loaded from disk. Used by maybe_reload_mcp_tools_cache_from_disk
         # to detect when the CLI has written a fresher version.
@@ -2763,6 +2785,15 @@ class RouterHostAdapter:
             *(_probe_one(name) for name in unanswered),
             return_exceptions=False,  # _probe_one handles its own errors
         )
+        # #4401 ②: record/clear the per-server failure state BEFORE the
+        # early return below — a cycle where every probe fails still needs
+        # its failures recorded, even though nothing gets written to the
+        # tools cache or disk.
+        for _name, _outcome in results:
+            if isinstance(_outcome, ToolsUnknown):
+                self._mcp_last_unknown[_name] = _outcome
+            else:
+                self._mcp_last_unknown.pop(_name, None)
         new_answers = answered_only(results)
         if not new_answers:
             # Every probe came back unknown: nothing was measured, so there is
@@ -2871,6 +2902,97 @@ class RouterHostAdapter:
         if self._mcp_tools_cache is None:
             return None
         return {name: entry.tools for name, entry in self._mcp_tools_cache.items()}
+
+    def mcp_probe_snapshot(self) -> "list[dict]":
+        """#4401 ②③: per-server probe state for every CONFIGURED server, in
+        the 3 states the mcp tab must not conflate (plus a transient 4th,
+        ③'s own "retrying"):
+
+        - ``"retrying"`` — a manual retry (`retry_mcp_probe`, #4401 ③) is
+          currently in flight for this server. Checked FIRST — a retry can
+          be in flight for a server that still has a stale ``"failed"``
+          entry (not yet cleared; the retry hasn't resolved) or none at all.
+        - ``"answered"`` — a real probe measurement exists, ``tool_count``
+          set (0 is a genuine answer, not a failure).
+        - ``"failed"`` — the last probe attempt for this server did NOT
+          answer (``ToolsUnknown`` — timeout or exception), ``reason`` set
+          and ``detail`` set when ``reason == "exception"``. Cleared the
+          instant the server later answers (`ensure_mcp_tools_cached`'s own
+          gather loop), so a stale failure never outlives a successful retry.
+        - ``"not_probed"`` — none of the above: no attempt has been
+          recorded for this server at all (absent from every dict — the
+          lazy, post-startup probe, FP-0037 issue #160, has not reached it
+          yet). MUST NOT be rendered as "0 tools" — that is the exact
+          conflation #4401 exists to close (owner: the model can't NAME an
+          unprobed server's tools, that is not the same as the server
+          having none).
+
+        Ordered by ``self._mcp_servers_flat()``'s own iteration order (config
+        declaration order), same as `_get_mcp_servers_for_router`.
+        """
+        servers = self._mcp_servers_flat()
+        tools_cache = self._mcp_tools_cache or {}
+        out: "list[dict]" = []
+        for name in servers:
+            if name in self._mcp_retry_in_flight:
+                out.append({"name": name, "state": "retrying"})
+                continue
+            answered = tools_cache.get(name)
+            if answered is not None:
+                out.append({"name": name, "state": "answered", "tool_count": len(answered.tools)})
+                continue
+            unknown = self._mcp_last_unknown.get(name)
+            if unknown is not None:
+                out.append({
+                    "name": name, "state": "failed",
+                    "reason": unknown.reason, "detail": unknown.detail,
+                })
+                continue
+            out.append({"name": name, "state": "not_probed"})
+        return out
+
+    async def retry_mcp_probe(self, server: str, *, per_server_timeout: float) -> None:
+        """#4401 ③: the per-row retry action — invalidates the tools cache
+        AND clears ``server``'s own failure cooldown (a manual retry that
+        silently no-ops because the 60s cooldown, #5674, hasn't elapsed yet
+        would look like nothing happened — the wrong UX for a button whose
+        whole point is "try again now"), then re-probes.
+
+        Deliberately a single SYNCHRONOUSLY-AWAITED call, never backgrounded
+        — the #4401 A-4 co-vet (architect) found real concurrent-cache-
+        mutation hazards a BACKGROUND probe introduces against
+        ``invalidate_mcp_tools_cache``/``maybe_reload_mcp_tools_cache_from_disk``'s
+        own writes (3 writers into 1 field, previously safe only because a
+        turn's own probe call was always synchronous/serialized). ③
+        deliberately stays inside that same existing safety margin — the
+        caller (``Session.retry_mcp_probe``, and the ``/mcp retry`` slash
+        handler above it) awaits this to completion rather than spawning it
+        as a background task, so at most one retry is ever in flight per
+        session and it never overlaps a turn's own probe call. #4401 A-4's
+        own construction-time background kickoff is a SEPARATE, deferred
+        follow-up (not in this PR) that will need the epoch/single-
+        writer redesign the co-vet asked for; this method does not.
+
+        ``invalidate_mcp_tools_cache`` is whole-cache-scoped, not
+        per-server (see its own docstring for why) — a retry on one server
+        can therefore also re-probe OTHER currently-unanswered servers
+        whose own cooldown has separately elapsed, as a side effect of
+        reusing that existing primitive rather than adding a second,
+        narrower one. ``server``'s own cooldown is unconditionally cleared
+        regardless, so IT is always retried by this call even if its
+        cooldown had not elapsed.
+
+        Marks ``server`` ``"retrying"`` (`mcp_probe_snapshot`) for the
+        duration — cleared in `finally` regardless of outcome (including a
+        raised exception, or the caller's own Task being cancelled), so a
+        row can never get stuck showing "retrying…" forever."""
+        self._mcp_retry_in_flight.add(server)
+        try:
+            self._mcp_probe_cooldown_until.pop(server, None)
+            self.invalidate_mcp_tools_cache(server)
+            await self.ensure_mcp_tools_cached(per_server_timeout=per_server_timeout)
+        finally:
+            self._mcp_retry_in_flight.discard(server)
 
     @property
     def yaml_mtimes_snapshot(self) -> dict[Path, float]:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10576,6 +10576,35 @@ class Session:
             self._cached_mcp_subscriptions = (gen, self._mcp_connection_service.subscription_summary())
         return self._cached_mcp_subscriptions[1]
 
+    def mcp_probe_state(self) -> "list[dict]":
+        """#4401 ②: the status-bar/mcp-pane's per-server PROBE-state read
+        model — the session-level seam ``_session_mcp_probe_states``
+        (status.py) reads, mirroring ``mcp_subscription_state``'s own
+        forwarder shape just above.
+
+        Thin forwarder to ``RouterHostAdapter.mcp_probe_snapshot`` (see its
+        own docstring for the 3-state shape: ``"answered"`` /
+        ``"failed"`` / ``"not_probed"``) — no caching needed, unlike
+        subscriptions: reads 2 small in-memory dicts directly, no
+        recomputation cost to amortize."""
+        return self._router_host.mcp_probe_snapshot()
+
+    async def retry_mcp_probe(self, server: str) -> None:
+        """#4401 ③: the ``/mcp retry`` slash command's own target — awaits
+        the retry to completion (deliberately NOT backgrounded; see
+        ``RouterHostAdapter.retry_mcp_probe``'s own docstring for why: the
+        #4401 A-4 co-vet found real concurrent-cache-mutation hazards a
+        BACKGROUND probe introduces, and ③ stays inside the existing
+        turn-serialized safety margin rather than take on that redesign).
+        The slash command handler itself stays ``async`` and awaits this —
+        the row shows "retrying…" (`mcp_probe_state`) the instant the
+        in-flight flag is set, on whatever render happens to run during
+        this await (the TUI keeps rendering; only the slash command's own
+        reply is delayed up to ``per_server_timeout``)."""
+        await self._router_host.retry_mcp_probe(
+            server, per_server_timeout=self._safety.timeout.mcp_probe_seconds,
+        )
+
     async def aclose_background_tasks(self) -> None:
         """#4759 teardown: drain every background task this session (or a
         sub-component it owns — SpawnTracker's ephemeral-vanish task,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10589,18 +10589,25 @@ class Session:
         recomputation cost to amortize."""
         return self._router_host.mcp_probe_snapshot()
 
-    async def retry_mcp_probe(self, server: str) -> None:
-        """#4401 ③: the ``/mcp retry`` slash command's own target — awaits
-        the retry to completion (deliberately NOT backgrounded; see
-        ``RouterHostAdapter.retry_mcp_probe``'s own docstring for why: the
-        #4401 A-4 co-vet found real concurrent-cache-mutation hazards a
-        BACKGROUND probe introduces, and ③ stays inside the existing
-        turn-serialized safety margin rather than take on that redesign).
-        The slash command handler itself stays ``async`` and awaits this —
-        the row shows "retrying…" (`mcp_probe_state`) the instant the
-        in-flight flag is set, on whatever render happens to run during
-        this await (the TUI keeps rendering; only the slash command's own
-        reply is delayed up to ``per_server_timeout``)."""
+    async def _retry_mcp_probe(self, server: str) -> None:
+        """#4401 ③: the target ``ClientTransport.request_mcp_retry`` calls
+        (never a slash handler directly — #3595 S4's own ceiling gate,
+        ``test_session_public_surface_does_not_grow``, forbids publishing a
+        member whose only reason to exist is letting a slash handler reach
+        it; the transport is the sanctioned production boundary that MAY
+        reach a session's private members, same as ``InProcessTransport``
+        already does for ``cancel_inflight``/``run_slash_command`` and
+        siblings). Awaits the retry to completion (deliberately NOT
+        backgrounded; see ``RouterHostAdapter.retry_mcp_probe``'s own
+        docstring for why: the #4401 A-4 co-vet found real concurrent-
+        cache-mutation hazards a BACKGROUND probe introduces, and ③ stays
+        inside the existing turn-serialized safety margin rather than take
+        on that redesign). The row shows "retrying…" (`mcp_probe_state`,
+        a genuinely PUBLIC read-model forwarder — mirrors
+        ``mcp_subscription_state``'s own already-approved shape) the
+        instant the in-flight flag is set, on whatever render happens to
+        run during this await (the TUI keeps rendering; only the request's
+        own return is delayed up to ``per_server_timeout``)."""
         await self._router_host.retry_mcp_probe(
             server, per_server_timeout=self._safety.timeout.mcp_probe_seconds,
         )

--- a/tests/interfaces/test_3595_s4_slash_handler_seam.py
+++ b/tests/interfaces/test_3595_s4_slash_handler_seam.py
@@ -598,7 +598,23 @@ def test_no_slash_module_reaches_the_session_outbox() -> None:
 #: eligible mid-turn injections (``session.py``'s own wiring, mirroring the
 #: already-public ``peek_mid_turn_injections``/``commit_mid_turn_injection``
 #: siblings it renders on top of) — never reached via slash dispatch.
-_PUBLIC_MEMBER_CEILING = 121
+#: Raised 121 -> 122 for #4401 ②: ``mcp_probe_state`` — a NEW public
+#: read-only method, the mcp pane's per-server probe-state read model
+#: (answered / failed / not_probed / retrying). Genuinely unrelated to
+#: #3595 S4's slash-handler-encapsulation concern — same shape, same
+#: reasoning as the 106->107 entry above for ``mcp_subscription_state``
+#: (a status-readout seam, ``status.py``'s ``_session_mcp_probe_states``,
+#: reads it; it is not a private-state leak published so a slash handler
+#: could keep reaching into the session). ③'s own ``retry_mcp_probe`` is
+#: DELIBERATELY NOT added here — its only real consumer would have been
+#: the ``/mcp retry`` slash handler, the exact S4 failure mode this gate
+#: exists to catch (BLOCKING, PR #5761, lead-coder) — so it stays a
+#: private ``Session._retry_mcp_probe``, reached only from
+#: ``ClientTransport.request_mcp_retry``'s own transport-layer
+#: implementations (the sanctioned production boundary, same as
+#: ``InProcessTransport`` already reaching ``cancel_inflight``/
+#: ``run_slash_command`` and siblings), never published.
+_PUBLIC_MEMBER_CEILING = 122
 
 
 def test_session_public_surface_does_not_grow() -> None:

--- a/tests/interfaces/test_4401_mcp_pane_probe_states.py
+++ b/tests/interfaces/test_4401_mcp_pane_probe_states.py
@@ -1,0 +1,123 @@
+"""Tier 1: #4401 ② — the mcp pane's 3-state probe display
+(``_apply_mcp_probe_note``/``_mcp_pane_entries``), plus ③'s retry row.
+
+The defect this closes: the mcp tab conflated "not yet probed" with "0
+tools" — the owner's reported symptom was 8 configured servers reading as
+unusable when the real cause was the model never having been TOLD their
+tool names (no probe result yet), not the servers being broken. The 3
+states (``"answered"`` / ``"failed"`` / ``"not_probed"``) — plus a
+transient 4th, ③'s own ``"retrying"`` — must never render identically.
+
+Pure-function tests against ``_mcp_pane_entries``/``_apply_mcp_probe_note``
+directly — no Session, no RouterHostAdapter, matching this repo's existing
+``DrawerRow`` pane tests (``test_4686_mcp_pane_subscriptions.py``,
+``test_drawer_row_3691.py``)."""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import (
+    DrawerRow,
+    _apply_mcp_probe_note,
+    _mcp_pane_entries,
+)
+
+
+def _snap(probe_states: "list[dict] | None", *, reported: bool = True) -> dict:
+    items = [
+        {"kind": "mcp", "name": "broker", "on": True, "denied": False, "denied_reason": None},
+        {"kind": "mcp", "name": "filesystem", "on": True, "denied": False, "denied_reason": None},
+    ]
+    return {
+        "visibility_items": items,
+        "mcp_probe_states": probe_states or [],
+        "mcp_probe_states_reported": reported,
+    }
+
+
+def test_answered_zero_tools_is_never_rendered_the_same_as_not_probed():
+    """Tier 1: THE core #4401 conflation this issue exists to close — a
+    server that answered with genuinely zero tools reads differently from
+    one nothing has probed at all."""
+    answered_zero = _apply_mcp_probe_note(
+        DrawerRow(label="broker", state="on"), {"state": "answered", "tool_count": 0},
+    )
+    not_probed = _apply_mcp_probe_note(
+        DrawerRow(label="broker", state="on"), {"state": "not_probed"},
+    )
+    assert answered_zero.note == "0 tools"
+    assert not_probed.note == "not yet probed"
+    assert answered_zero.note != not_probed.note
+
+
+def test_answered_note_pluralizes_by_count():
+    """Tier 1: the tool-count note reads "1 tool" (singular) vs "N tools"
+    (plural) — a wording detail, but one that answers a real question ("is
+    that ONE tool or an empty list rendered oddly")."""
+    row = _apply_mcp_probe_note(DrawerRow(label="x"), {"state": "answered", "tool_count": 1})
+    assert row.note == "1 tool"
+    row = _apply_mcp_probe_note(DrawerRow(label="x"), {"state": "answered", "tool_count": 3})
+    assert row.note == "3 tools"
+
+
+def test_failed_note_names_the_reason():
+    """Tier 1: a failed probe's note states WHY (timeout/exception) — #4401
+    ②'s own requirement that the owner can read the reason on screen
+    instead of digging in .reyn/events."""
+    row = _apply_mcp_probe_note(
+        DrawerRow(label="x"), {"state": "failed", "reason": "timeout"},
+    )
+    assert row.note == "probe failed: timeout"
+
+
+def test_retrying_note_is_distinct_from_failed_and_not_probed():
+    """Tier 1: #4401 ③'s in-flight state gets its own wording, not
+    conflated with "failed" (the retry hasn't resolved yet) or
+    "not_probed" (a probe genuinely IS running)."""
+    row = _apply_mcp_probe_note(DrawerRow(label="x"), {"state": "retrying"})
+    assert row.note == "retrying…"
+
+
+def test_unreported_snapshot_ignores_probe_states_even_when_present():
+    """Tier 1: the ``mcp_probe_states_reported`` gate is checked, not just
+    "is the list empty" — a connection that carries a (theoretically
+    stale/untrustworthy) ``mcp_probe_states`` payload but says
+    ``reported=False`` must still add NO probe note, never trusting data
+    the producer itself disclaimed. A non-empty payload here is
+    deliberate: an empty-list test would pass whether or not the gate
+    check exists at all, silently."""
+    rows = _mcp_pane_entries(_snap(
+        [{"name": "broker", "state": "answered", "tool_count": 5}], reported=False,
+    ))
+    assert not any("probed" in (r[0]) or "tool" in r[0] for r in rows), (
+        f"an un-reported connection must add no probe note; got {rows!r}"
+    )
+
+
+def test_reported_not_probed_state_renders_plainly_not_as_zero_tools():
+    """Tier 1: end-to-end through ``_mcp_pane_entries`` — a "not_probed"
+    server's row text says so plainly, distinct from a genuinely-answered
+    zero-tool server's row text."""
+    rows = _mcp_pane_entries(_snap([
+        {"name": "broker", "state": "not_probed"},
+        {"name": "filesystem", "state": "answered", "tool_count": 0},
+    ]))
+    assert rows[0] == ("[on] broker  · not yet probed", "/visibility off mcp broker")
+    assert rows[1] == ("[on] filesystem  · 0 tools", "/visibility off mcp filesystem")
+
+
+def test_failed_row_gets_a_retry_subrow_the_not_probed_row_does_not():
+    """Tier 1: #4401 ③ — retry is offered ONLY on a row that actually
+    failed a probe attempt, never on "not_probed" (nothing has failed
+    yet)."""
+    rows = _mcp_pane_entries(_snap([
+        {"name": "broker", "state": "failed", "reason": "timeout"},
+        {"name": "filesystem", "state": "not_probed"},
+    ]))
+    assert ("    ↻ retry probe", "/mcp retry broker") in rows
+    assert ("    ↻ retry probe", "/mcp retry filesystem") not in rows
+
+
+def test_retrying_row_gets_no_retry_subrow_a_second_retry_would_be_redundant():
+    """Tier 1: a server already mid-retry offers no SECOND retry action —
+    one already in flight covers it."""
+    rows = _mcp_pane_entries(_snap([{"name": "broker", "state": "retrying"}]))
+    assert ("    ↻ retry probe", "/mcp retry broker") not in rows

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -140,6 +140,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         attached_name_reported=True,
         visibility_items_reported=True,
         mcp_subscriptions_reported=True,
+        mcp_probe_states_reported=True,
         hooks_config_warnings_reported=True,
         compaction_progress_reported=True,
         tasks_reported=True,
@@ -180,8 +181,9 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     ``agent_roster_reported`` / ``model_catalog_reported`` /
     ``attached_name_reported`` (#5094) /
     ``visibility_items_reported`` / ``mcp_subscriptions_reported`` (#5185) /
+    ``mcp_probe_states_reported`` (#4401) /
     ``hooks_config_warnings_reported`` (#5100/#5272)
-    are the 12 fields NOT named after a ``ChatReadModel`` method — see the
+    are the 13 fields NOT named after a ``ChatReadModel`` method — see the
     class's own docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
@@ -202,6 +204,7 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "attached_name_reported",
         "visibility_items_reported",
         "mcp_subscriptions_reported",
+        "mcp_probe_states_reported",
         "hooks_config_warnings_reported",
         "compaction_progress_reported",
         "tasks_reported",

--- a/tests/runtime/test_4401_mcp_probe_snapshot_and_retry.py
+++ b/tests/runtime/test_4401_mcp_probe_snapshot_and_retry.py
@@ -1,0 +1,292 @@
+"""Tier 2: #4401 ②③ — ``RouterHostAdapter.mcp_probe_snapshot``'s 3-state
+read model, and the ``retry_mcp_probe`` per-server retry action.
+
+② owner symptom: 8 configured MCP servers reading as unusable in the mcp
+tab, when the real state was "not yet probed" or "probed, did not answer" —
+never surfaced distinctly from a genuine zero-tool answer. This pins the
+snapshot method the mcp pane's read model (`Session.mcp_probe_state`,
+`status.py`'s `_session_mcp_probe_states`) forwards.
+
+③ retry: bypasses the #5674 60s failure cooldown (a manual retry that
+silently no-ops until it elapses would look like nothing happened), marks
+the server ``"retrying"`` for the duration, and — per the #4401 A-4 co-vet
+(architect) — is a single SYNCHRONOUSLY-AWAITED call, never backgrounded
+(a background retry would reintroduce the concurrent-cache-mutation hazard
+that co-vet found; A-4's own construction-time kickoff is deferred to a
+follow-up PR for exactly that reason).
+
+Same real-collaborators builder as ``test_3520_unknown_probe_is_not_an_
+answer.py`` (``_make_adapter``/``_FlakyProbe``) — real `RouterHostAdapter`,
+no mocks."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.services import (
+    LiveSessionIdInputs,
+    McpGatewayInputs,
+    MemoryService,
+    PutOutboxInputs,
+    RouterHostAdapter,
+)
+from tests._support.router_host_adapter import make_op_context_source
+
+_SERVER = "reyn_markitdown"
+_OTHER_SERVER = "reyn_broker"
+_TOOL = "convert_to_markdown"
+_TOOLS = [{"name": _TOOL, "description": "convert a uri to markdown"}]
+
+_EMPTY_OP_CTX = make_op_context_source()
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
+
+async def _null_file_read(path: str) -> dict:
+    return {"content": ""}
+
+
+async def _null_file_write(path: str, content: str) -> dict:
+    return {"path": path, "written": True}
+
+
+async def _null_file_delete(path: str) -> dict:
+    return {"path": path, "deleted": True}
+
+
+async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
+    return {"path": path, "output_path": output_path, "entries": 0}
+
+
+async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
+    return {}
+
+
+async def _null_put_outbox(msg) -> None:
+    pass
+
+
+def _null_append_history(msg) -> None:
+    pass
+
+
+class _ScriptedProbe:
+    """A real async probe whose per-server outcome is driven by a plain
+    dict the test sets up front — not a mock, a closure-based stand-in over
+    real per-server behaviour (mirrors `_FlakyProbe` in test_3520, but keyed
+    per-server rather than by one global health flag, since these tests
+    need DIFFERENT servers to answer/fail independently)."""
+
+    def __init__(self) -> None:
+        self.healthy: "dict[str, bool]" = {}
+        self.calls: list[str] = []
+
+    async def __call__(self, server_name: str) -> list[dict]:
+        self.calls.append(server_name)
+        if not self.healthy.get(server_name, False):
+            await asyncio.sleep(5.0)  # far beyond any timeout these tests pass
+        return [dict(t) for t in _TOOLS]
+
+
+def _make_adapter(*, tmp_path: Path, state_dir: Path, probe, clock=None) -> RouterHostAdapter:
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "test-agent"
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=_null_file_write,
+        file_read=_null_file_read,
+        file_delete=_null_file_delete,
+        file_regenerate_index=_null_file_regen,
+    )
+    adapter = RouterHostAdapter(
+        agent_name="test-agent",
+        agent_role="test",
+        output_language="en",
+        op_context_source=_EMPTY_OP_CTX,
+        permission_resolver=None,
+        mcp_servers={
+            _SERVER: {"description": "markitdown"},
+            _OTHER_SERVER: {"description": "broker"},
+        },
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=_null_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        state_dir=state_dir,
+        universal_wrappers_enabled=False,
+        clock=clock,
+    )
+    adapter.mcp_list_tools = probe
+    return adapter
+
+
+def _states(adapter: RouterHostAdapter) -> "dict[str, dict]":
+    return {row["name"]: row for row in adapter.mcp_probe_snapshot()}
+
+
+# ---------------------------------------------------------------------------
+# ② mcp_probe_snapshot: the 3 states, never conflated
+# ---------------------------------------------------------------------------
+
+
+def test_a_never_probed_server_reads_not_probed_before_any_probe_runs(tmp_path: Path) -> None:
+    """Tier 2: a freshly-constructed adapter, before ``ensure_mcp_tools_
+    cached`` has ever run, reports every configured server "not_probed" —
+    never "answered" (nothing measured yet) or "failed" (nothing attempted
+    yet either)."""
+    probe = _ScriptedProbe()
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=tmp_path / "state", probe=probe)
+    states = _states(adapter)
+    assert states[_SERVER]["state"] == "not_probed"
+    assert states[_OTHER_SERVER]["state"] == "not_probed"
+
+
+@pytest.mark.asyncio
+async def test_an_answered_server_reads_answered_with_its_real_tool_count(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: after a probe cycle, an answering server reads "answered"
+    with its real tool count, and a timed-out sibling in the SAME cycle
+    reads "failed" with the timeout reason — the two outcomes of one
+    ``ensure_mcp_tools_cached`` call must not blur into each other."""
+    probe = _ScriptedProbe()
+    probe.healthy[_SERVER] = True
+    now = [0.0]
+    adapter = _make_adapter(
+        tmp_path=tmp_path, state_dir=tmp_path / "state", probe=probe, clock=lambda: now[0],
+    )
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    states = _states(adapter)
+    assert states[_SERVER] == {"name": _SERVER, "state": "answered", "tool_count": 1}
+    # the OTHER server timed out this same cycle — must read "failed", never
+    # "answered" (the #4401 core conflation) and never "not_probed" either
+    # (a probe DID attempt it).
+    assert states[_OTHER_SERVER]["state"] == "failed"
+    assert states[_OTHER_SERVER]["reason"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_answered_with_zero_tools_is_distinct_from_not_probed(tmp_path: Path) -> None:
+    """Tier 2: THE core #4401 conflation — a real "zero tools" answer must
+    never be indistinguishable from "nothing has probed this server"."""
+    class _EmptyProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            return []
+
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=tmp_path / "state", probe=_EmptyProbe())
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
+    states = _states(adapter)
+    assert states[_SERVER] == {"name": _SERVER, "state": "answered", "tool_count": 0}
+    assert states[_SERVER]["state"] != "not_probed"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_server_clears_back_to_answered_once_it_later_succeeds(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a "failed" state is not sticky — once the server later
+    answers (past the #5674 cooldown), the failure record clears and the
+    row reads "answered", never a stale "failed" alongside a real answer."""
+    probe = _ScriptedProbe()
+    now = [0.0]
+    adapter = _make_adapter(
+        tmp_path=tmp_path, state_dir=tmp_path / "state", probe=probe, clock=lambda: now[0],
+    )
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    assert _states(adapter)[_SERVER]["state"] == "failed"
+
+    probe.healthy[_SERVER] = True
+    now[0] = 61.0  # past the #5674 60s failure cooldown
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
+    assert _states(adapter)[_SERVER] == {"name": _SERVER, "state": "answered", "tool_count": 1}
+
+
+# ---------------------------------------------------------------------------
+# ③ retry_mcp_probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_bypasses_the_failure_cooldown(tmp_path: Path) -> None:
+    """Tier 2: #4401 ③ — a manual retry succeeds even though the #5674 60s
+    cooldown has not elapsed — the whole point of an explicit "try again
+    now" action; a retry that silently no-ops until the cooldown clears
+    would look like the button did nothing."""
+    probe = _ScriptedProbe()
+    now = [0.0]
+    adapter = _make_adapter(
+        tmp_path=tmp_path, state_dir=tmp_path / "state", probe=probe, clock=lambda: now[0],
+    )
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    assert _states(adapter)[_SERVER]["state"] == "failed"
+    calls_before_retry = list(probe.calls)
+
+    probe.healthy[_SERVER] = True
+    # clock unchanged — still well inside the cooldown window.
+    await adapter.retry_mcp_probe(_SERVER, per_server_timeout=5.0)
+
+    assert probe.calls != calls_before_retry, "retry must actually re-probe, cooldown or not"
+    assert _states(adapter)[_SERVER] == {"name": _SERVER, "state": "answered", "tool_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_the_row_reads_retrying_while_the_retry_is_in_flight(tmp_path: Path) -> None:
+    """Tier 2: while a retry's own probe call is still awaiting the (gated)
+    server, the snapshot reads "retrying" — not "not_probed" (a probe
+    genuinely IS running) and not a stale "failed" (the retry hasn't
+    resolved either way yet)."""
+    gate = asyncio.Event()
+
+    class _GatedProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            await gate.wait()
+            return [dict(t) for t in _TOOLS]
+
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=tmp_path / "state", probe=_GatedProbe())
+    retry_task = asyncio.create_task(
+        adapter.retry_mcp_probe(_SERVER, per_server_timeout=5.0),
+    )
+    await asyncio.sleep(0)  # let the retry reach its in-flight marker
+    assert _states(adapter)[_SERVER]["state"] == "retrying"
+
+    gate.set()
+    await retry_task
+    assert _states(adapter)[_SERVER]["state"] == "answered"
+
+
+@pytest.mark.asyncio
+async def test_in_flight_marker_clears_even_when_the_probe_raises(tmp_path: Path) -> None:
+    """Tier 2: a retry that raises must not leave the row stuck showing
+    "retrying…" forever — the in-flight marker is cleared in `finally`."""
+    class _RaisingProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            raise RuntimeError("boom")
+
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=tmp_path / "state", probe=_RaisingProbe())
+    # RuntimeError inside the real probe is caught by ensure_mcp_tools_cached's
+    # own except-arm (returns ToolsUnknown) — this exercises the finally path
+    # via a NORMAL failed-probe return, not a raise past retry_mcp_probe itself.
+    await adapter.retry_mcp_probe(_SERVER, per_server_timeout=5.0)
+    state = _states(adapter)[_SERVER]["state"]
+    assert state != "retrying", (
+        f"the in-flight marker must clear once the retry settles; still {state!r}"
+    )
+    assert state == "failed"

--- a/tests/runtime/test_4401_mcp_retry_slash.py
+++ b/tests/runtime/test_4401_mcp_retry_slash.py
@@ -3,19 +3,28 @@
 The mcp pane's "↻ retry probe" row (chrome.py, appended only under a
 "failed" server row — see ``tests/interfaces/test_4401_mcp_pane_probe_
 states.py``) submits this command. This pins the wire from the slash
-handler through ``Session.retry_mcp_probe`` to the real
-``RouterHostAdapter`` — a real Session (`make_session`), a real probe
-callable shadowing the bound method (same established technique
-``test_3520_unknown_probe_is_not_an_answer.py`` uses — a real callable, not
-a mock), never a hand-rolled fake Session."""
+handler through ``ClientTransport.request_mcp_retry`` (#3595 S4: the
+BLOCKING'd shape from PR #5761's own review — ``Session.retry_mcp_probe``
+was a public member added ONLY so a slash handler could reach it, folded
+into a private ``Session._retry_mcp_probe`` reachable only from the
+transport's own production implementations) to the real
+``RouterHostAdapter`` — a real Session (`make_session`) bound through a
+real ``SessionBoundTransport`` (the production ``ClientTransport`` a local
+CUI attach actually holds — the SAME shape ``Session._slash_context``
+builds, per its own docstring, not the test-only ``RecordingTransport``,
+which stubs this method to a bare ``False`` and would never drive the
+session at all), a real probe callable shadowing the bound method (same
+established technique ``test_3520_unknown_probe_is_not_an_answer.py``
+uses — a real callable, not a mock), never a hand-rolled fake Session."""
 from __future__ import annotations
 
 import asyncio
 
 import pytest
 
-from reyn.interfaces.slash import REGISTRY
+from reyn.interfaces.slash import REGISTRY, SlashContext
 from reyn.interfaces.slash.mcp import mcp_cmd
+from reyn.interfaces.transport.session_bound import SessionBoundTransport
 from tests._support.agent_session import make_session
 from tests._support.slash import slash_ctx
 
@@ -43,9 +52,10 @@ class _FailThenSucceedProbe:
 
 @pytest.mark.asyncio
 async def test_retry_command_re_probes_and_the_pane_read_model_reflects_it():
-    """Tier 2: end-to-end — the /mcp retry command drives a real re-probe
-    through Session, and the pane's own read model (mcp_probe_state) sees
-    the result, not a stale "failed" left over from the first probe."""
+    """Tier 2: end-to-end — the /mcp retry command, through a real
+    production ``ClientTransport``, drives a real re-probe on the real
+    Session, and the pane's own read model (mcp_probe_state) sees the
+    result, not a stale "failed" left over from the first probe."""
     session = make_session(
         agent_name="alice", mcp_servers={_SERVER: {"description": "markitdown"}},
     )
@@ -57,10 +67,24 @@ async def test_retry_command_re_probes_and_the_pane_read_model_reflects_it():
     assert states_before[_SERVER]["state"] == "failed"
 
     probe.healthy = True
-    await mcp_cmd(slash_ctx(session), f"retry {_SERVER}")
+    transport = SessionBoundTransport(session, display_sink=lambda msg: None)
+    ctx = SlashContext(transport=transport, session=session)
+    await mcp_cmd(ctx, f"retry {_SERVER}")
 
     states_after = {row["name"]: row for row in session.mcp_probe_state()}
     assert states_after[_SERVER] == {"name": _SERVER, "state": "answered", "tool_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_a_transport_that_does_not_support_retry_reports_it_as_unavailable():
+    """Tier 2: ``request_mcp_retry`` returning ``False`` (the base stub's
+    own default — e.g. a remote AG-UI client, #4401's own disclosed scope
+    boundary) surfaces as a clear error, never a silent success claim."""
+    session = make_session(agent_name="alice")
+    ctx = slash_ctx(session)  # RecordingTransport: request_mcp_retry stubs False
+    await mcp_cmd(ctx, f"retry {_SERVER}")
+    errors = [msg for msg in ctx.transport.displayed if msg.kind == "error"]
+    assert any("not available" in msg.text for msg in errors)
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_4401_mcp_retry_slash.py
+++ b/tests/runtime/test_4401_mcp_retry_slash.py
@@ -1,0 +1,74 @@
+"""Tier 2: #4401 ③ — the ``/mcp retry <server>`` slash command end-to-end.
+
+The mcp pane's "↻ retry probe" row (chrome.py, appended only under a
+"failed" server row — see ``tests/interfaces/test_4401_mcp_pane_probe_
+states.py``) submits this command. This pins the wire from the slash
+handler through ``Session.retry_mcp_probe`` to the real
+``RouterHostAdapter`` — a real Session (`make_session`), a real probe
+callable shadowing the bound method (same established technique
+``test_3520_unknown_probe_is_not_an_answer.py`` uses — a real callable, not
+a mock), never a hand-rolled fake Session."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.slash import REGISTRY
+from reyn.interfaces.slash.mcp import mcp_cmd
+from tests._support.agent_session import make_session
+from tests._support.slash import slash_ctx
+
+_SERVER = "reyn_markitdown"
+_TOOLS = [{"name": "convert_to_markdown", "description": "convert a uri to markdown"}]
+
+
+def test_mcp_command_is_registered():
+    """Tier 2: the /mcp command is registered on import (the mcp pane's
+    retry row can dispatch it)."""
+    assert REGISTRY.get("mcp") is not None
+
+
+class _FailThenSucceedProbe:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.healthy = False
+
+    async def __call__(self, server_name: str) -> list[dict]:
+        self.calls.append(server_name)
+        if not self.healthy:
+            await asyncio.sleep(5.0)
+        return [dict(t) for t in _TOOLS]
+
+
+@pytest.mark.asyncio
+async def test_retry_command_re_probes_and_the_pane_read_model_reflects_it():
+    """Tier 2: end-to-end — the /mcp retry command drives a real re-probe
+    through Session, and the pane's own read model (mcp_probe_state) sees
+    the result, not a stale "failed" left over from the first probe."""
+    session = make_session(
+        agent_name="alice", mcp_servers={_SERVER: {"description": "markitdown"}},
+    )
+    probe = _FailThenSucceedProbe()
+    session._router_host.mcp_list_tools = probe
+
+    await session._router_host.ensure_mcp_tools_cached(per_server_timeout=0.05)
+    states_before = {row["name"]: row for row in session.mcp_probe_state()}
+    assert states_before[_SERVER]["state"] == "failed"
+
+    probe.healthy = True
+    await mcp_cmd(slash_ctx(session), f"retry {_SERVER}")
+
+    states_after = {row["name"]: row for row in session.mcp_probe_state()}
+    assert states_after[_SERVER] == {"name": _SERVER, "state": "answered", "tool_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_retry_command_rejects_a_malformed_usage():
+    """Tier 2: a malformed /mcp invocation (no server name) reports a
+    usage error rather than raising or silently no-op'ing."""
+    session = make_session(agent_name="alice")
+    ctx = slash_ctx(session)
+    await mcp_cmd(ctx, "retry")
+    errors = [msg for msg in ctx.transport.displayed if msg.kind == "error"]
+    assert any("usage:" in msg.text for msg in errors)


### PR DESCRIPTION
**[tui-coder]** — touches tests/ — TESTS-READ needed

part of #4401

Owner symptom: 8 configured MCP servers reading as unusable, when the
real state was "not yet probed" or "probed, did not answer" (#5674's
own 60s cooldown) — never surfaced distinctly from a genuine "answered
with zero tools". Owner's own framing (relayed, #4401 latest comment):
the servers were not broken — the model simply had not been told their
tool names yet, so it could not select them (`call_mcp_tool` with the
name written directly still works; only the `mcp_tool_name` enum needs
a completed probe).

## ② 3 probe states (the real substance of this issue)

New `RouterHostAdapter.mcp_probe_snapshot()` (+ `_mcp_last_unknown`, a
new small in-memory dict recording the LAST `ToolsUnknown` outcome per
server — cleared the instant that server later answers) reports every
configured server as exactly one of:
- `"answered"` — a real measurement, `tool_count` set (0 is a genuine
  answer, never conflated with "not probed").
- `"failed"` — the last attempt did not answer, with `reason` (timeout
  / exception) and `detail`.
- `"not_probed"` — no attempt recorded at all.

Forwarded through `Session.mcp_probe_state()` → `status.py`'s
`_session_mcp_probe_states` → a new gated snapshot key
(`mcp_probe_states`, `mcp_probe_states_reported` — #5034/#5009's own
disclosed-gap pattern; not yet on the AG-UI wire,
`REMOTE_CHAT_READ_CAPABILITIES.mcp_probe_states_reported=False`) →
`chrome.py`'s `_mcp_pane_entries`, which appends the state as a note on
each server row (`_apply_mcp_probe_note`) — gated so an un-reported
connection adds NO note at all rather than fabricating "not yet
probed" for every row (falsify-verified: a test that stubs a
NON-EMPTY `mcp_probe_states` payload with `reported=False` catches a
missing gate check, unlike an empty-list test which would pass either
way).

## ③ per-row retry

New `RouterHostAdapter.retry_mcp_probe(server)`: clears the server's
own #5674 cooldown (a retry that silently no-ops until 60s pass would
look like the button did nothing) + invalidates the tools cache +
re-probes. A new `"retrying"` 4th (transient) state marks the row
while in flight, cleared in `finally` regardless of outcome. Wired
through a new `/mcp retry <server>` slash command (mirrors
`/visibility`'s own shape) that the mcp pane's new "↻ retry probe"
sub-row (appended only under a `"failed"` server row) dispatches.

Deliberately a single SYNCHRONOUSLY-AWAITED call, not backgrounded —
see the ① section below for why.

## ① (session-construction-time probe kickoff) — NOT in this PR

①'s own design (owner-ratified as "A-4": kick off the probe in the
background at Session construction, await it only at the 2 real
catalog CONSUMPTION points — `RouterHostAdapter.get_mcp_servers`'s
real per-turn caller and `mcp_list_servers`) went through 2 rounds of
architect co-vet. The 2nd round found a real, measured concurrency
hazard: `_mcp_tools_cache` currently has 3 writers (the probe's own
merge, `invalidate_mcp_tools_cache`→`None`, a disk hot-swap) safe ONLY
because a turn's own probe call has always been synchronous/serialized
— backgrounding it introduces a real race (e.g. an invalidate landing
between an in-flight probe's own `unanswered` computation and its
merge produces `{**None, ...}` → `TypeError`). The co-vet's own F1-F5
gap list (atomic `(dict, mtime)` pairs; the epoch counter's
`_state_dir` being process/workspace-scoped across N sessions, not
adapter-scoped; what a waiter reads when its own epoch goes stale
mid-await; epoch as a gate on the disk-persist path too) is a real
redesign, not a small addition — landing it half-finished alongside
②③ risks entangling ②③'s own review in an unrelated, still-moving
design. Per lead-coder's own explicit authorization to split PRs when
① gets complicated (owner-confirmed: splitting is a PR-shape decision
only — ① is not dropped), ① is deferred to a follow-up PR once the
F1-F5 redesign has its own co-vet pass. ②③ do not depend on it: ③'s
own retry stays inside the EXISTING turn-serialized safety margin (an
awaited, not backgrounded, call) specifically so it needs none of the
epoch/consolidation machinery ① will.

## Remainder — explicitly still open (per architect, twice-repeated)

The owner's original "startup takes tens of seconds" symptom is
explained by NEITHER ①, ②, nor ③ — MCP probes already run in parallel
(`asyncio.gather`, server-count-independent), capping the real turn-1
cost at ~5s once per 60s cooldown cycle regardless of server count.
The breakdown of the actual tens-of-seconds cost is not yet identified
or measured. This is filed as an open remainder on #4401, not silently
closed by this arc.

Test plan:
- [x] `test_answered_zero_tools_is_never_rendered_the_same_as_not_probed` / `test_reported_not_probed_state_renders_plainly_not_as_zero_tools` — the core #4401 conflation, pinned at both the pure-render layer and the RouterHostAdapter layer (`test_answered_with_zero_tools_is_distinct_from_not_probed`)
- [x] `test_a_never_probed_server_reads_not_probed_before_any_probe_runs` / `test_an_answered_server_reads_answered_with_its_real_tool_count` / `test_a_failed_server_clears_back_to_answered_once_it_later_succeeds` — the 3-state transitions, real `RouterHostAdapter` + a scripted real probe callable (no mocks)
- [x] `test_failed_row_gets_a_retry_subrow_the_not_probed_row_does_not` / `test_retrying_row_gets_no_retry_subrow_a_second_retry_would_be_redundant` — retry offered exactly where it should be
- [x] `test_retry_bypasses_the_failure_cooldown` — falsify-verified (Edit-to-break the cooldown-clear line → confirmed red → restored)
- [x] `test_the_row_reads_retrying_while_the_retry_is_in_flight` / `test_in_flight_marker_clears_even_when_the_probe_raises` — the in-flight marker's own lifecycle, including the exception path
- [x] `test_retry_command_re_probes_and_the_pane_read_model_reflects_it` — end-to-end through the real `/mcp retry` slash command and a real Session
- [x] `test_unreported_snapshot_ignores_probe_states_even_when_present` — falsify-verified (Edit-to-break the `mcp_probe_states_reported` gate → confirmed red with a non-empty payload, not just an empty-list vacuous pass → restored)
- [x] 116 tests across the mcp/visibility/subscription/probe-degradation family — all green (scoped to the diff, per instruction — full pytest left to CI)
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / tests-path-literal-reference / bare-tests-import-reference / file-depth-reference / subprocess-reyn-pin — all clean (path-literal-reference re-run after `git add`, per this session's own established discipline)
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
