### PR TITLE
fix(#5759): reyn doctor reports real byte sizes for state/, memory/, cache/

### DIFF
--- a/src/reyn/interfaces/cli/commands/doctor.py
+++ b/src/reyn/interfaces/cli/commands/doctor.py
@@ -245,6 +245,44 @@ _MEASURABILITY_CRITERION: Final[str] = (
 )
 
 
+def _dir_size_bytes(root: Path) -> "tuple[int, int]":
+    """(file_count, total_bytes) for every FILE under *root*, recursively
+    — #5759 stage 1: a generic bucket-size walk, reused as-is for every
+    bucket that has no OWN pre-existing size-computation function (see
+    ``run()``'s own "Disk usage by bucket" section for which buckets use
+    this vs. one of those). Same shape as ``MediaStore``'s own private
+    ``_dir_stats_recursive`` (``data/workspace/media_store.py``) and this
+    module's own ``_events_dir_stats`` above — a THIRD independent copy
+    of the identical rglob-and-stat walk would be exactly the "same
+    guard, second copy" shape this codebase's own ``unknown_profile_
+    keys`` docstring already names and rejects elsewhere; not imported
+    directly only because both existing copies are module-private to
+    files this module has no other reason to import from, and the walk
+    itself is a few lines — copying THREE LINES of ``Path.rglob`` is not
+    the same class of duplication risk as re-deriving classification
+    rules or default-order logic would be (#5742's own doctor-derivation
+    discipline is about NOT hand-typing a KNOWN VOCABULARY, e.g. field
+    names or default resolution order — a directory-size walk has no
+    vocabulary to drift).
+
+    ``FileNotFoundError`` mid-scan (a concurrent write/rotation) is
+    swallowed — best-effort, matching ``_events_dir_stats``'s own
+    identical policy; any OTHER ``OSError`` is not."""
+    if not root.is_dir():
+        return 0, 0
+    count = 0
+    total_bytes = 0
+    for entry in root.rglob("*"):
+        try:
+            if not entry.is_file():
+                continue
+            total_bytes += entry.stat().st_size
+        except FileNotFoundError:
+            continue
+        count += 1
+    return count, total_bytes
+
+
 def _events_dir_stats(root: Path) -> "tuple[int, int, date | None]":
     """(file_count, total_bytes, oldest_start_date) for every dated
     ``.jsonl`` under ``root`` — read-only, mirrors
@@ -442,6 +480,34 @@ def run(args: argparse.Namespace) -> None:
     print("Project-wide storage cap (storage.max_bytes/pin, #5366/#4478 —")
     print("bounds media/ + tool-results/ TOGETHER, one operator number):")
     _print_storage_cap_status(config, media_stats)
+
+    # ── #5759 stage 1 (architect + lead-coder ruling, issue #5759): the
+    # 2 remaining buckets with NO gate of any kind at all -- unlike
+    # media/tool-results (storage.max_bytes/pin above) and events/ (a
+    # declared, if unenforced, retention policy above), state/ and
+    # cache/ have neither a cap nor a policy to even be out of step
+    # with. Stage 1 is visibility ONLY -- no retention decision, no
+    # deletion mechanism (naive history.jsonl truncation would break
+    # correctness: dropping a wal_seq anchor below the floor resurfaces
+    # a discarded branch's turns into the LLM's context, retention.py's
+    # own verbatim warning). This is the "第三の項" candidate for #4401's
+    # own startup-time investigation (owner's real environment measured
+    # a 500MB history.jsonl) -- the driving reason for measuring at all.
+    print()
+    print("Disk usage by bucket (#5759 stage 1 — visibility only, no")
+    print("retention policy exists for state/ or cache/; agents/*/")
+    print("history.jsonl and events/ are the SAME numbers already")
+    print("reported above, not repeated here):")
+    state_count, state_bytes = _dir_size_bytes(resolved_root / ".reyn" / "state")
+    memory_count, memory_bytes = _dir_size_bytes(resolved_root / ".reyn" / "memory")
+    cache_count, cache_bytes = _dir_size_bytes(resolved_root / ".reyn" / "cache")
+    print(f"  state/:   {state_count} file(s), {state_bytes:,} bytes")
+    print(
+        f"  memory/:  {memory_count} file(s), {memory_bytes:,} bytes "
+        f"(includes history-content/ + tool_result_spills.jsonl already "
+        f"counted as 'tool-results/' above -- NOT additional to it)",
+    )
+    print(f"  cache/:   {cache_count} file(s), {cache_bytes:,} bytes")
 
     # ── C-1: hook argv[0] launch probe (#4364 PR-2, architect ruling) ──────
     print()

--- a/tests/interfaces/test_5759_doctor_disk_bucket_sizes.py
+++ b/tests/interfaces/test_5759_doctor_disk_bucket_sizes.py
@@ -29,6 +29,16 @@ def _write_yaml(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _bucket_line(out: str, label: str) -> str:
+    """The one printed line starting with *label* (e.g. ``"state/:"``) —
+    content-only lookup, never pinning the column-alignment padding
+    between the label and the count (CLAUDE.md: "Never pin algorithm-
+    level behaviour ... exact whitespace" — a future bucket added to
+    this section changes every row's padding width with no defect,
+    lead-coder's own BLOCKING finding on this file's first draft)."""
+    return next(line for line in out.splitlines() if line.strip().startswith(label))
+
+
 @pytest.fixture
 def project(tmp_path: Path) -> Path:
     _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
@@ -47,7 +57,7 @@ def test_state_bucket_reports_real_bytes(project: Path, capsys) -> None:
     run(Namespace(project_root=str(project)))
     out = capsys.readouterr().out
 
-    assert "state/:   1 file(s), 543 bytes" in out
+    assert "1 file(s), 543 bytes" in _bucket_line(out, "state/:")
 
 
 def test_cache_bucket_reports_real_bytes_across_nested_dirs(
@@ -67,7 +77,7 @@ def test_cache_bucket_reports_real_bytes_across_nested_dirs(
     run(Namespace(project_root=str(project)))
     out = capsys.readouterr().out
 
-    assert "cache/:   2 file(s), 421 bytes" in out
+    assert "2 file(s), 421 bytes" in _bucket_line(out, "cache/:")
 
 
 def test_memory_bucket_total_includes_history_content(
@@ -88,7 +98,7 @@ def test_memory_bucket_total_includes_history_content(
     run(Namespace(project_root=str(project)))
     out = capsys.readouterr().out
 
-    assert "memory/:  2 file(s), 333 bytes" in out
+    assert "2 file(s), 333 bytes" in _bucket_line(out, "memory/:")
 
 
 def test_missing_buckets_report_zero_not_a_crash(project: Path, capsys) -> None:
@@ -99,9 +109,9 @@ def test_missing_buckets_report_zero_not_a_crash(project: Path, capsys) -> None:
     run(Namespace(project_root=str(project)))
     out = capsys.readouterr().out
 
-    assert "state/:   0 file(s), 0 bytes" in out
-    assert "memory/:  0 file(s), 0 bytes" in out
-    assert "cache/:   0 file(s), 0 bytes" in out
+    assert "0 file(s), 0 bytes" in _bucket_line(out, "state/:")
+    assert "0 file(s), 0 bytes" in _bucket_line(out, "memory/:")
+    assert "0 file(s), 0 bytes" in _bucket_line(out, "cache/:")
 
 
 def test_dir_size_bytes_helper_directly(tmp_path: Path) -> None:

--- a/tests/interfaces/test_5759_doctor_disk_bucket_sizes.py
+++ b/tests/interfaces/test_5759_doctor_disk_bucket_sizes.py
@@ -1,0 +1,118 @@
+"""Tier 2: #5759 stage 1 (architect + lead-coder assignment, part of
+#5759) — ``reyn doctor`` gains real, measured byte counts for the 2
+buckets with NO gate of any kind (``state/``, ``cache/``) — visibility
+only, no retention decision (that is stage 2).
+
+architect's own census (#5759): ``agents/*/history.jsonl`` and ``events/``
+already have their own dedicated doctor sections (real byte counts,
+pre-#5759) — this file covers the 2 genuinely new lines this stage adds,
+plus the ``memory/`` bucket total (broader than the ``history-content/``
+subset the existing ``tool-results:`` row already reports).
+
+No mocks — drives the real ``run`` against a real on-disk ``.reyn/`` tree
+under ``tmp_path``, matching this command family's own established shape
+(``test_4364_storage_cap_doctor_row.py``, ``test_4364_pr3a_doctor_cli.py``).
+"""
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.cli.commands.doctor import _dir_size_bytes, run
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    _write_yaml(tmp_path / "reyn.yaml", MINIMAL_REYN_YAML)
+    return tmp_path
+
+
+def test_state_bucket_reports_real_bytes(project: Path, capsys) -> None:
+    """Tier 2: strip-falsifier target — a real file written under
+    ``.reyn/state/`` shows up in the printed row with its GENUINE byte
+    count, not a placeholder or a config-declared value (D-1's own
+    "measure, don't assert" rule this whole module follows)."""
+    state_dir = project / ".reyn" / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "wal.jsonl").write_text("x" * 543, encoding="utf-8")
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+
+    assert "state/:   1 file(s), 543 bytes" in out
+
+
+def test_cache_bucket_reports_real_bytes_across_nested_dirs(
+    project: Path, capsys,
+) -> None:
+    """Tier 2: ``cache/`` is measured recursively (``index/<source>/``
+    nesting, matching the real layout ``reyn-dir-layout.md`` documents),
+    not just its own direct children."""
+    cache_dir = project / ".reyn" / "cache" / "index" / "mysource"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "data.sqlite").write_text("y" * 321, encoding="utf-8")
+    (project / ".reyn" / "cache" / "registry-cache" ).mkdir(parents=True)
+    (project / ".reyn" / "cache" / "registry-cache" / "r.json").write_text(
+        "z" * 100, encoding="utf-8",
+    )
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+
+    assert "cache/:   2 file(s), 421 bytes" in out
+
+
+def test_memory_bucket_total_includes_history_content(
+    project: Path, capsys,
+) -> None:
+    """Tier 2: ``memory/``'s own row is the FULL bucket total, including
+    ``history-content/`` — broader than the pre-existing ``tool-results:``
+    row (which reports that one subtree only, under its own legacy
+    field name). Both a memory-only file AND a history-content file must
+    count toward this row."""
+    memory_dir = project / ".reyn" / "memory"
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "notes.md").write_text("a" * 111, encoding="utf-8")
+    hc_dir = memory_dir / "history-content" / "default" / "s1"
+    hc_dir.mkdir(parents=True)
+    (hc_dir / "spill.txt").write_text("b" * 222, encoding="utf-8")
+
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+
+    assert "memory/:  2 file(s), 333 bytes" in out
+
+
+def test_missing_buckets_report_zero_not_a_crash(project: Path, capsys) -> None:
+    """Tier 2: a project with none of state/memory/cache written yet
+    (a fresh install) must not raise — D-1/D-2's own "report, never
+    fabricate, never crash" posture, matching ``_events_dir_stats``'s
+    identical no-directory-yet handling."""
+    run(Namespace(project_root=str(project)))
+    out = capsys.readouterr().out
+
+    assert "state/:   0 file(s), 0 bytes" in out
+    assert "memory/:  0 file(s), 0 bytes" in out
+    assert "cache/:   0 file(s), 0 bytes" in out
+
+
+def test_dir_size_bytes_helper_directly(tmp_path: Path) -> None:
+    """Tier 2: the shared helper itself, driven directly — a nested
+    file counts, a directory entry does not, and a fully-missing root
+    returns (0, 0) rather than raising."""
+    assert _dir_size_bytes(tmp_path / "does-not-exist") == (0, 0)
+
+    root = tmp_path / "bucket"
+    (root / "sub").mkdir(parents=True)
+    (root / "sub" / "a.txt").write_text("12345", encoding="utf-8")
+    (root / "b.txt").write_text("123", encoding="utf-8")
+
+    assert _dir_size_bytes(root) == (2, 8)


### PR DESCRIPTION
**[e2e-coder]** part of #5759 — stage 1 (architect's own design, "1 段目は方針決定不要"). Owner's real environment measured a **500MB** `history.jsonl`; this stage is visibility only, no retention decision.

## What this PR does

`reyn doctor` now reports real, on-disk byte sizes for the 2 buckets that had **no gate of any kind** — `state/` and `cache/` — plus a corrected, FULL total for `memory/` (the pre-existing `tool-results:` row undercounts it, reporting only `history-content/` under a legacy field name).

**Not in scope (explicitly, per lead-coder's dispatch)**: any retention policy, any deletion mechanism, any truncation of `history.jsonl`. A naive truncation would break correctness — dropping a `wal_seq` anchor below the truncation floor resurfaces a discarded branch's turns into the LLM's own context (`retention.py`'s own verbatim warning). Stage 2 needs the numbers this PR adds; it does not attempt stage 2 itself.

- `_dir_size_bytes(root)` — a generic recursive `(file_count, total_bytes)` walk. Same shape as this module's own pre-existing `_events_dir_stats` and `MediaStore`'s private `_dir_stats_recursive` — not imported directly (both existing copies are module-private to files this module has no other reason to import from), but the pattern is reused rather than reinvented. Copying a 3-line `rglob` walk is a different class of duplication risk from hand-typing a KNOWN VOCABULARY (field names, default-resolution order) — the exact thing #5742's own doctor-derivation discipline warns against; a byte-count walk has no vocabulary to drift out of sync with.
- New "Disk usage by bucket" section: `state/`, `memory/` (full total, includes `history-content/`), `cache/` — with an explicit note that `agents/*/history.jsonl` and `events/` are the SAME numbers doctor already prints above (not duplicated).

## Verified via real execution

A real fixture project with real files under `.reyn/state/`, `.reyn/memory/`, `.reyn/cache/` printed the genuine byte counts (500/300/700 bytes respectively, matching what was written).

**Strip-falsify** (`_dir_size_bytes`'s own recursion — `Edit`'d `rglob` → `glob`, non-recursive, not committed): 3 of 5 tests correctly went red (the ones exercising nested content — `cache/index/<source>/`, `memory/history-content/<agent>/<session>/`), reverted via Edit, all 5 green again.

## Local gates (scoped, per PR workflow)

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict tests/interfaces/test_5759_doctor_disk_bucket_sizes.py` — 5/5 OK
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/doctor.py` — OK
- `python scripts/mypy_ratchet.py` — `OK: 200 findings, all baselined (208 declared)`
- `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` — all OK
- Scoped `pytest` (the new file + the 2 closest existing doctor-disk-usage test files) — **21 passed**

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict`
- [x] `verify_module_docstrings.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py`
- [x] Scoped `pytest` (21 passed) + real-execution fixture check + strip-falsify (documented above)
- [x] (skipped — 👁️ Visual: a CLI-only diagnostic change, no TUI/visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
