### PR TITLE
feat(#4401): background MCP tools probe at session construction

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1704,6 +1704,28 @@ class RouterLoop:
         self._total_usage = TokenUsage()
         self._last_call_usage = TokenUsage()
         host = self.host
+        # #4401 A-4: await the background MCP probe (kicked off at Session
+        # construction) BEFORE this turn reads `host.get_mcp_servers()` —
+        # either inline below (system-prompt build) or later via the
+        # SchemeOps `present`/`base_tools` calls this same turn makes.
+        # `test_4401_render_for_router_state_census.py` pins that every
+        # `render_for_router(state=...)` call site (the only ones that can
+        # inject the mcp enum into an LLM-facing schema) sits downstream of
+        # THIS point — issue #4401's own empirical trace found 2 OTHER
+        # `get_mcp_servers()` call sites that do NOT (a compaction budget
+        # size estimate, and 4 op-execution-only contexts that never build
+        # an LLM schema at all), so this single await is sufficient without
+        # enumerating every entry point. One of the 2 real catalog
+        # CONSUMPTION points (`mcp_list_servers` is the other) —
+        # getattr-guarded so a narrow test host (FakeRouterHost) without
+        # this method degrades to a no-op, same convention as the other
+        # host-capability probes just below.
+        _await_mcp_ready = getattr(host, "await_mcp_probe_ready", None)
+        if _await_mcp_ready is not None:
+            from reyn.runtime.services.router_host_adapter import (
+                _DEFAULT_MCP_PROBE_SECONDS,
+            )
+            await _await_mcp_ready(per_server_timeout=_DEFAULT_MCP_PROBE_SECONDS)
         # FP-0034 PR-3b-iii: read universal wrapper visibility from host.
         # getattr fallback so narrow hosts (= test FakeRouterHost) that don't
         # implement the method default to off (= the prior flat tools= shape).

--- a/src/reyn/runtime/services/mcp_cache_file.py
+++ b/src/reyn/runtime/services/mcp_cache_file.py
@@ -19,6 +19,26 @@ simply absent from the mapping, so it is naturally re-probed the next
 time it is needed. An empty ``ToolsAnswered.tools`` means, and only
 means, "measured: this server exposes zero tools".
 
+#4401 A-4 co-vet (F2, load-bearing — read this before "optimizing" what
+gets persisted here) — **this file is shared by every session in the same
+workspace** (``RouterHostAdapter._state_dir`` defaults to
+``cwd/.reyn/state``, one file, N sessions, N independent in-memory
+epochs). "Every writer re-reads the file's current mtime before writing"
+(true of both writers today) does NOT by itself prevent a LOST UPDATE
+across that shared file — two sessions can both read, then whichever
+writes second silently clobbers the answers the other just wrote. What
+actually keeps a clobbered answer from being silently wrong FOREVER is
+the property this module's own #3520 paragraph above states: **an absent
+server is simply re-probed the next time it's needed.** A clobbered
+answer is temporarily MISSING, not permanently wrong — self-healing, not
+correctness, and that distinction is exactly why the type-level "only
+``ToolsAnswered`` is storable" rule matters beyond #3520's own original
+motivation. If a future change ever persists ``ToolsUnknown`` too (e.g.
+as a "let's skip re-probing known-failed servers" optimization), it
+silently removes the ONE property this cross-session tolerance depends
+on — a lost update would then stay lost, not self-heal. Do not make that
+change without re-deriving this paragraph's own conclusion first.
+
 Format (version 2):
     {
         "version": 2,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -534,7 +534,72 @@ class RouterHostAdapter:
         # apart from "not measured", and absence is what makes the unmeasured
         # server re-probed on the next turn instead of being frozen as a
         # capability the model is never told about.
-        self._mcp_tools_cache: dict[str, ToolsAnswered] | None = None
+        # #4401 A-4 (co-vet, architect+lead-coder, approved): the cache
+        # container is NEVER ``None`` — "not yet probed" lives INSIDE the
+        # value, as key absence, never as the whole container being a
+        # second, structurally different type. This matters once a probe
+        # can run concurrently with an invalidate/reload (A-4's
+        # construction-time background kickoff, below): a bare
+        # ``self._mcp_tools_cache = None`` mid-probe used to make the
+        # in-flight probe's own merge (``{**None, **answers}``) raise
+        # ``TypeError`` the instant it resolved — a real, measured tear,
+        # not a hypothetical one. ``_mcp_disk_warm_start_attempted``
+        # replaces the old "``is None`` = never touched" test in
+        # ``ensure_mcp_tools_cached`` (gates the disk-read attempt, once);
+        # ``_mcp_cache_populated`` is the SEPARATE flag
+        # ``mcp_tools_cache_snapshot`` reads for its own "None = never
+        # populated" contract — separate because a warm-start-attempted
+        # flag says nothing about whether `maybe_reload_mcp_tools_cache_
+        # from_disk` populated the cache WITHOUT `ensure_mcp_tools_cached`
+        # ever running at all (a real, achievable order: an explicit
+        # `reyn mcp refresh` write landing before this session's first
+        # turn). Both are set/cleared alongside the cache itself, by
+        # `_apply_mcp_cache`/`invalidate_mcp_tools_cache` — never
+        # independently.
+        self._mcp_tools_cache: "dict[str, ToolsAnswered]" = {}
+        self._mcp_disk_warm_start_attempted: bool = False
+        self._mcp_cache_populated: bool = False
+        # #4401 A-4 co-vet (F1): the (cache, mtime) PAIR is the unit of
+        # atomicity, not the cache alone — a write that advances the dict
+        # but not the mtime (or vice versa) is exactly what let one
+        # concurrent writer's result get silently discarded by another's
+        # staleness check. Both fields — and, when the write REPLACES
+        # rather than adds, the epoch below — are assigned together by
+        # `_apply_mcp_cache`, the ONE method every writer (the probe's own
+        # merge, `invalidate_mcp_tools_cache`, the disk hot-swap in
+        # `maybe_reload_mcp_tools_cache_from_disk`) routes through — see
+        # that method's own docstring.
+        self._mcp_tools_cache_mtime: float | None = None
+        # #4401 A-4 co-vet (F2/F5): bumped by EVERY REPLACE (invalidate,
+        # disk hot-swap) — never by the probe-merge itself, which only
+        # ADDS. A probe captures the epoch at its OWN start
+        # (`ensure_mcp_tools_cached`'s `epoch_at_start`) and discards
+        # (never merges into memory, never persists to disk) its results
+        # if the epoch has moved by the time they are ready — the one
+        # uniform "is this measurement still about the state I started
+        # against" check every writer needs, rather than a bespoke guard
+        # per writer.
+        #
+        # F2 — this epoch is per-ADAPTER (per Session), but the on-disk
+        # cache file is per-WORKSPACE, shared by every session in the same
+        # process (`_state_dir` defaults to `cwd/.reyn/state`) — N sessions,
+        # N independent epochs, 1 file. "every writer reads the disk's
+        # current mtime before writing" (true today: `maybe_reload_mcp_
+        # tools_cache_from_disk` always re-reads `file_mtime`; the persist
+        # step below does too) does NOT by itself prevent a lost update
+        # across that shared file — two sessions can both read, then the
+        # later write clobbers the earlier one's answers. What actually
+        # bounds the damage is `mcp_cache_file.py`'s own FP-0037 design:
+        # an absent server is simply re-probed the next time it's needed,
+        # so a clobbered answer is not silently wrong forever, only
+        # temporarily missing — self-healing, not correctness. See that
+        # module's own docstring for the load-bearing statement (cross-
+        # referenced from here, not restated, so it cannot drift out of
+        # sync) and its own warning against ever persisting `ToolsUnknown`
+        # as a future "optimization" — doing so would silently remove the
+        # exact property this epoch's own tolerance for cross-session lost
+        # updates depends on.
+        self._mcp_cache_epoch: int = 0
         self._mcp_probe_cooldown_until: dict[str, float] = {}
         # #4401 ②: the LAST ToolsUnknown outcome per server, so the TUI can
         # tell "probed, did not answer" (this dict) apart from "never
@@ -544,24 +609,32 @@ class RouterHostAdapter:
         # transient failure does not linger as "failed" after a successful
         # retry. Not persisted (unlike `_mcp_tools_cache`) — this is a
         # display aid, not the FP-0037 permanence guarantee; a restart
-        # legitimately forgets it and re-probes fresh.
+        # legitimately forgets it and re-probes fresh. Same epoch
+        # discipline as the cache itself — a stale probe cycle's failures
+        # are dropped, not recorded, alongside its (also dropped) answers.
         self._mcp_last_unknown: "dict[str, ToolsUnknown]" = {}
         # #4401 ③: the server a manual retry is currently in flight for, if
         # any — `mcp_probe_snapshot` reports it as ``"retrying"`` rather
         # than falling through to "failed" (the in-flight retry hasn't
         # cleared the old failure yet) or "not_probed" (misleading — a
-        # probe genuinely IS running). `retry_mcp_probe` is a single
-        # synchronously-awaited call (not backgrounded — #4401 A-4's own
-        # co-vet found real concurrent-cache-mutation hazards a background
-        # probe introduces; ③ deliberately stays out of that scope, see
-        # `retry_mcp_probe`'s own docstring), so at most ONE retry is ever
-        # in flight for THIS session at a time — a set, not a per-server
-        # dict, is enough.
+        # probe genuinely IS running). `retry_mcp_probe` stays a single
+        # synchronously-awaited call (unchanged by A-4 landing — it never
+        # needed the epoch machinery itself, only benefits from
+        # `ensure_mcp_tools_cached`'s own protection now covering it too),
+        # so at most ONE retry is ever in flight for THIS session at a
+        # time — a set, not a per-server dict, is enough.
         self._mcp_retry_in_flight: "set[str]" = set()
-        # FP-0037 S1: mtime of the cache file when we last loaded from it.
-        # None = never loaded from disk. Used by maybe_reload_mcp_tools_cache_from_disk
-        # to detect when the CLI has written a fresher version.
-        self._mcp_tools_cache_mtime: float | None = None
+        # #4401 A-4: the background probe task kicked off at Session
+        # construction (`start_mcp_probe`, called by `Session.__init__`
+        # right after this adapter is built) — None until `start_mcp_probe`
+        # runs, and again once `await_mcp_probe_ready` has consumed it (see
+        # that method's own docstring for why it is consumed exactly
+        # once). A construction-time kickoff that could not start (no
+        # running loop yet — a sync/test construction path) leaves this
+        # None permanently; `await_mcp_probe_ready` degrades to running the
+        # probe inline in that case, same as every call site behaved
+        # before A-4.
+        self._mcp_probe_task: "asyncio.Task[None] | None" = None
         # FP-0037 S1: state dir for the persistent cache file.
         # #3705: was a MODULE-LEVEL constant frozen at import time (whatever
         # cwd happened to be at first `import router_host_adapter`, not even
@@ -2443,7 +2516,15 @@ class RouterHostAdapter:
         return result
 
     async def mcp_list_servers(self) -> list[dict]:
-        """Returns the configured MCP server list with descriptions."""
+        """Returns the configured MCP server list with descriptions.
+
+        #4401 A-4: one of the 2 real catalog CONSUMPTION points (the LLM
+        naming an mcp tool via `describe_mcp_tool`/`list_mcp_tools` reads
+        this list first, op D1) — awaits the background probe before
+        reading the cache so the returned `tools=` shape is decided, not
+        mid-flight.
+        """
+        await self.await_mcp_probe_ready(per_server_timeout=_DEFAULT_MCP_PROBE_SECONDS)
         return self._get_mcp_servers_for_router()
 
     async def mcp_list_subscriptions(self) -> list[dict]:
@@ -2703,14 +2784,31 @@ class RouterHostAdapter:
         # FP-0037 S1: warm-start from persistent cache file when available.
         # Only on the very first call — once the in-memory cache exists, the
         # disk file is the business of maybe_reload_mcp_tools_cache_from_disk.
-        if self._mcp_tools_cache is None:
+        # #4401 A-4: gated on `_mcp_disk_warm_start_attempted`, not
+        # `self._mcp_tools_cache is None` — the cache container is never
+        # None (see that flag's own __init__ comment). Routes through
+        # `_apply_mcp_cache` (a REPLACE, bumps epoch) like every other
+        # writer — a warm-start IS a fresh view of the world, exactly like
+        # a disk hot-swap, not an addition to what was already there
+        # (there is nothing there yet on this branch).
+        if not self._mcp_disk_warm_start_attempted:
+            self._mcp_disk_warm_start_attempted = True
             disk_cache = read_cache(cache_path)
             if disk_cache is not None:
-                self._mcp_tools_cache = disk_cache
-                self._mcp_tools_cache_mtime = file_mtime(cache_path)
-            else:
-                self._mcp_tools_cache = {}
+                self._apply_mcp_cache(disk_cache, mtime=file_mtime(cache_path), bump_epoch=True)
 
+        # #4401 A-4 (F2/F3/F5): captured BEFORE `unanswered` is computed
+        # (which itself reads `self._mcp_tools_cache`) — this probe cycle's
+        # results are applied (both the in-memory merge AND the disk
+        # persist, F5) ONLY if the epoch is UNCHANGED when they're ready.
+        # An invalidate/reload that lands after this line makes this whole
+        # cycle's eventual results stale, discarded rather than merged
+        # over state this cycle never saw. A stale cycle is not an error:
+        # the next turn (or a waiter still awaiting THIS cycle, F3) reads
+        # whatever the CURRENT cache holds and proceeds — see
+        # `await_mcp_probe_ready`'s own docstring for why a waiter does
+        # not itself re-wait for a fresher epoch.
+        epoch_at_start = self._mcp_cache_epoch
         servers = self._mcp_servers_flat()
         unanswered = [
             name for name in servers
@@ -2785,6 +2883,16 @@ class RouterHostAdapter:
             *(_probe_one(name) for name in unanswered),
             return_exceptions=False,  # _probe_one handles its own errors
         )
+        # #4401 A-4 (F3/F5): this cycle's results are STALE the moment
+        # something else replaced the cache while the probes above were in
+        # flight — discard EVERYTHING this cycle would otherwise do (the
+        # failure bookkeeping, the in-memory merge, AND the disk persist)
+        # rather than act on state this cycle never saw. Checked once,
+        # synchronously, before any of the three — no `await` between here
+        # and the merge below, so nothing can invalidate mid-application
+        # (asyncio's single-threaded, interleaves-only-at-await guarantee).
+        if epoch_at_start != self._mcp_cache_epoch:
+            return
         # #4401 ②: record/clear the per-server failure state BEFORE the
         # early return below — a cycle where every probe fails still needs
         # its failures recorded, even though nothing gets written to the
@@ -2800,19 +2908,55 @@ class RouterHostAdapter:
             # nothing to record. Rewriting the file here would only advance its
             # mtime and make every following turn reload an unchanged cache.
             return
-        self._mcp_tools_cache = {**self._mcp_tools_cache, **new_answers}
+        # #4401 A-4 (F1/②): the ONE place this cycle assigns the cache — a
+        # plain merge (ADD, never replace), so it does NOT bump the epoch
+        # (only a REPLACE does — see `_mcp_cache_epoch`'s own comment).
+        merged = {**self._mcp_tools_cache, **new_answers}
 
         # FP-0037 S1: persist the live-probe result so subsequent sessions
         # and turns can warm-start from disk. Failures are opportunistic
-        # and must NOT abort the session.
+        # and must NOT abort the session. #4401 A-4 (F1): `write_cache` is
+        # the I/O step, deliberately BEFORE `_apply_mcp_cache` — if it
+        # raises, the in-memory cache still advances (session correctness
+        # over disk durability, unchanged from before A-4) but the mtime
+        # passed to `_apply_mcp_cache` stays the LAST KNOWN GOOD value
+        # (never the value a failed write did not actually produce), so a
+        # later `maybe_reload_mcp_tools_cache_from_disk` still correctly
+        # reads "still stale" instead of skipping a reload it should do.
+        mtime = self._mcp_tools_cache_mtime
         try:
-            write_cache(cache_path, self._mcp_tools_cache)
-            self._mcp_tools_cache_mtime = file_mtime(cache_path)
+            write_cache(cache_path, merged)
+            mtime = file_mtime(cache_path)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "ensure_mcp_tools_cached: could not write cache to %s: %r",
                 cache_path, exc,
             )
+        self._apply_mcp_cache(merged, mtime=mtime, bump_epoch=False)
+
+    def _apply_mcp_cache(
+        self, value: "dict[str, ToolsAnswered]", *, mtime: "float | None", bump_epoch: bool,
+    ) -> None:
+        """#4401 A-4 (F1/F2/②): the ONLY place ``self._mcp_tools_cache`` /
+        ``self._mcp_tools_cache_mtime`` / ``self._mcp_cache_epoch`` are
+        assigned — every external driver of the cache (the probe's own
+        merge in ``ensure_mcp_tools_cached``, ``invalidate_mcp_tools_cache``,
+        the disk hot-swap in ``maybe_reload_mcp_tools_cache_from_disk``)
+        routes through here.
+
+        The three assignments are ONE synchronous statement group — no
+        ``await`` between them, so nothing else on this event loop can
+        observe a torn state (dict advanced but mtime/epoch not yet, or
+        vice versa). ``bump_epoch=True`` for a REPLACE (invalidate, disk
+        hot-swap, the FIRST disk warm-start); ``False`` for the probe's own
+        ADD-only merge, which does not invalidate anything an in-flight
+        reader might already be looking at.
+        """
+        self._mcp_tools_cache = value
+        self._mcp_tools_cache_mtime = mtime
+        self._mcp_cache_populated = True
+        if bump_epoch:
+            self._mcp_cache_epoch += 1
 
     def invalidate_mcp_tools_cache(self, server: str) -> None:
         """Invalidate the lazy MCP tools cache (#2597 S2b) so the next
@@ -2842,10 +2986,21 @@ class RouterHostAdapter:
         wasn't itself refreshed, invalidation still warm-starts from it (stale)
         instead of forcing a live probe. This mirrors the disk-cache's own existing
         staleness window (``reyn mcp refresh`` is the operator-driven cache-buster)
-        and is out of scope for #2597 S2b to close.
+        and is out of scope for #2597 S2b to close. #4401 A-4: preserved verbatim —
+        resetting ``_mcp_disk_warm_start_attempted`` here (alongside the cache
+        itself) is what makes the NEXT ``ensure_mcp_tools_cached`` call re-consult
+        disk, same as the pre-A-4 ``is None`` check did.
+
+        #4401 A-4: routes through ``_apply_mcp_cache`` (a REPLACE, bumps epoch)
+        like every other writer — see that method's own docstring. Unlike
+        every other driver, THIS one resets ``_mcp_cache_populated`` back to
+        False right after (invalidate is the one operation whose whole
+        point is "forget everything", the one case `_apply_mcp_cache`'s own
+        unconditional "populated" mark is wrong for).
         """
-        self._mcp_tools_cache = None
-        self._mcp_tools_cache_mtime = None
+        self._mcp_disk_warm_start_attempted = False
+        self._apply_mcp_cache({}, mtime=None, bump_epoch=True)
+        self._mcp_cache_populated = False
 
     def maybe_reload_mcp_tools_cache_from_disk(self) -> None:
         """Reload the in-memory MCP tools cache if the on-disk file is newer.
@@ -2861,6 +3016,9 @@ class RouterHostAdapter:
         - File mtime unchanged since last load → no-op.
         - File mtime advanced → replace in-memory cache + update mtime record.
         Never raises.
+
+        #4401 A-4: routes through ``_apply_mcp_cache`` (a REPLACE, bumps
+        epoch) like every other writer — see that method's own docstring.
         """
         from reyn.runtime.services.mcp_cache_file import (
             cache_file_path,
@@ -2880,8 +3038,7 @@ class RouterHostAdapter:
         fresh = read_cache(cache_path)
         if fresh is None:
             return
-        self._mcp_tools_cache = fresh
-        self._mcp_tools_cache_mtime = current_mtime
+        self._apply_mcp_cache(fresh, mtime=current_mtime, bump_epoch=True)
 
     @property
     def mcp_tools_cache_snapshot(self) -> dict[str, list[dict]] | None:
@@ -2898,8 +3055,22 @@ class RouterHostAdapter:
         that was measured, so ``[]`` in this snapshot means "measured, zero
         tools". A server that could not be measured is ABSENT — read a missing
         key as "unknown", never as "no tools".
+
+        #4401 A-4: the cache container is never ``None`` (see that field's
+        own __init__ comment) — gated on ``_mcp_cache_populated`` instead,
+        which is False in EXACTLY the same situations the old ``is None``
+        check was: before the cache has EVER been written by any driver
+        (the probe's own merge, a disk warm-start OR hot-swap), and again
+        right after ``invalidate_mcp_tools_cache`` (which resets it, same
+        as it used to reset the cache to ``None``) — this method's own
+        external contract is unchanged. (NOT
+        ``_mcp_disk_warm_start_attempted`` — that flag only tracks whether
+        ``ensure_mcp_tools_cached``'s own once-per-session disk-read
+        attempt has run, which stays False if `maybe_reload_mcp_tools_
+        cache_from_disk` populates the cache on its own, before any turn
+        ever calls `ensure_mcp_tools_cached` at all.)
         """
-        if self._mcp_tools_cache is None:
+        if not self._mcp_cache_populated:
             return None
         return {name: entry.tools for name, entry in self._mcp_tools_cache.items()}
 
@@ -2993,6 +3164,82 @@ class RouterHostAdapter:
             await self.ensure_mcp_tools_cached(per_server_timeout=per_server_timeout)
         finally:
             self._mcp_retry_in_flight.discard(server)
+
+    def start_mcp_probe(self, *, per_server_timeout: float, spawn: "Callable[..., Any]") -> None:
+        """#4401 A-4 step 1: kick off the MCP tools probe in the BACKGROUND
+        at Session construction (never awaited here) — ``spawn`` is
+        ``Session._background_tasks.spawn`` (``TrackedTaskSet``, #4759),
+        threaded in rather than imported so this module stays independent
+        of Session's own construction plumbing.
+
+        Requires a running event loop (``asyncio.get_running_loop()``) —
+        true for every PRODUCTION construction path (`AgentRegistry.attach`/
+        `restore_all`, both `async def`, are the only callers of the sole
+        production `Session(` construction site,
+        `scoped_session_factory.py`), verified before implementing this.
+        A sync/test-only construction path (no running loop yet) leaves
+        `_mcp_probe_task` `None` — `await_mcp_probe_ready` below degrades
+        to running the probe inline in that case, i.e. exactly the
+        pre-A-4 behaviour, never a crash.
+
+        #4401 A-4 co-vet (F3, condition): ``disposition="await"`` —
+        deliberately NOT ``"cancel_join"``. A tracked task with
+        `cancel_join` gets externally CANCELLED on session shutdown
+        (`TrackedTaskSet.aclose`); if a turn were still awaiting this exact
+        task via `await_mcp_probe_ready` when that happened, the
+        cancellation would propagate into the turn as an unhandled
+        `CancelledError` instead of the turn completing normally. `"await"`
+        makes shutdown wait for the probe to finish instead (bounded by
+        `per_server_timeout` — a few seconds at most, never unbounded), so
+        the task always resolves normally and a waiter never sees an
+        exception or a hang from this source.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._mcp_probe_task = spawn(
+            self.ensure_mcp_tools_cached(per_server_timeout=per_server_timeout),
+            disposition="await", appends_wal=False, name="mcp-tools-probe-construction",
+        )
+
+    async def await_mcp_probe_ready(self, *, per_server_timeout: float) -> None:
+        """#4401 A-4 step 3: the ONE seam both catalog-consuming call sites
+        (`RouterLoop.run`'s turn start, and `mcp_list_servers` — the LLM-
+        naming-a-tool consumers) route through, in place of the old
+        turn-boundary ``await ensure_mcp_tools_cached(...)``.
+
+        Awaits the background task `start_mcp_probe` kicked off at
+        construction, if it is still around; runs the probe inline
+        otherwise (task never started — no loop at construction time; or
+        this is a later turn and the construction-time task already
+        finished and was consumed). Consumed exactly ONCE — the reference
+        is cleared the moment it is awaited, so a later call in the SAME
+        session always re-checks `ensure_mcp_tools_cached`'s own per-server
+        cache/cooldown gate (already a cheap no-op once every server has
+        answered) rather than re-awaiting an already-done Task forever.
+
+        #4401 A-4 co-vet (F3): does NOT re-wait if the epoch moves while
+        this call is itself awaiting — a single `await`, never a loop. If
+        the in-flight probe's own results get discarded as stale
+        (`ensure_mcp_tools_cached`'s own epoch check), this call still
+        returns normally once that probe settles; the CURRENT cache (as
+        of whenever this returns) is what the caller reads next, not a
+        guarantee that it reflects this exact call's own epoch. The next
+        turn/consumption point sees the newer epoch and probes again then.
+
+        Deliberately NOT called from the status-bar preview
+        (`capability_visibility.py`'s `_VisibilityProbeOps.present`/
+        `base_tools`, every render frame, sync) — that caller reads
+        whatever `get_mcp_servers()` currently has cached, unblocked, by
+        design (lead-coder ruling, #4401: a preview is not "the LLM naming
+        a tool", so it never waits on the catalog)."""
+        task = self._mcp_probe_task
+        if task is not None:
+            self._mcp_probe_task = None
+            await task
+            return
+        await self.ensure_mcp_tools_cached(per_server_timeout=per_server_timeout)
 
     @property
     def yaml_mtimes_snapshot(self) -> dict[Path, float]:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -613,6 +613,25 @@ class RouterHostAdapter:
         # discipline as the cache itself — a stale probe cycle's failures
         # are dropped, not recorded, alongside its (also dropped) answers.
         self._mcp_last_unknown: "dict[str, ToolsUnknown]" = {}
+        # #4401 A-4 (single source of truth for ①/②/③ — architect+lead-coder
+        # ruling, PR #5763): whether THIS session has ever DISPATCHED a
+        # probe for a server — never conflated with `_mcp_tools_cache`
+        # (answered), `_mcp_last_unknown` (answered=no, with a reason), or
+        # `_mcp_probe_cooldown_until` ("don't retry yet", a TIMING fact —
+        # architect: reusing it as an "attempted" proxy would make one
+        # value carry two facts). Set in `ensure_mcp_tools_cached`, for
+        # every name about to be probed, BEFORE `asyncio.gather` runs and
+        # BEFORE the epoch-staleness check (F3/F5) that can later discard
+        # that cycle's own results — "attempted" means a probe was
+        # genuinely dispatched, regardless of whether its outcome got
+        # applied. `await_mcp_probe_ready`'s own fallback (①) and
+        # `mcp_probe_snapshot`'s own "not_probed" state (③) both read this
+        # set as their ONLY source for "has this server ever been tried" —
+        # never a second, independently-derived answer to the same
+        # question. Never cleared (a server invalidated/retried stays
+        # "attempted" — `_mcp_tools_cache`/`_mcp_last_unknown` are what
+        # track its CURRENT outcome).
+        self._mcp_attempted: "set[str]" = set()
         # #4401 ③: the server a manual retry is currently in flight for, if
         # any — `mcp_probe_snapshot` reports it as ``"retrying"`` rather
         # than falling through to "failed" (the in-flight retry hasn't
@@ -2817,6 +2836,14 @@ class RouterHostAdapter:
         ]
         if not unanswered:
             return
+        # #4401 A-4 (single source of truth, ①/②/③): mark every name about
+        # to be probed BEFORE gather runs and BEFORE the epoch-staleness
+        # check below can discard this cycle's results — "attempted" means
+        # a probe was genuinely DISPATCHED, independent of whether its
+        # outcome ever gets applied. `await_mcp_probe_ready`'s own fallback
+        # (①) and `mcp_probe_snapshot` (③) both read this set — see
+        # `_mcp_attempted`'s own __init__ comment.
+        self._mcp_attempted.update(unanswered)
 
         async def _probe_one(server_name: str) -> tuple[str, ProbeOutcome]:
             # ``asyncio.timeout()`` (Python 3.11+) instead of
@@ -2904,9 +2931,24 @@ class RouterHostAdapter:
                 self._mcp_last_unknown.pop(_name, None)
         new_answers = answered_only(results)
         if not new_answers:
-            # Every probe came back unknown: nothing was measured, so there is
-            # nothing to record. Rewriting the file here would only advance its
-            # mtime and make every following turn reload an unchanged cache.
+            # Every probe came back unknown: nothing was MEASURED, so there is
+            # nothing new to persist — rewriting the file here would only
+            # advance its mtime for no reason. But the probe DID run, and
+            # that fact matters: #4401 architect review (PR #5763) — `{}`
+            # ("probed, nobody answered") and `None` ("never probed at all")
+            # are two different facts `mcp_tools_cache_snapshot`'s own
+            # contract is built to distinguish (see that property's own
+            # docstring), and #4401 A-4 silently collapsed them by only
+            # marking the cache "populated" from THIS branch's own merge
+            # below — a probe cycle where every server timed out never
+            # reached it, so `_mcp_cache_populated` stayed False forever.
+            # Establishing it here (self-merge — the value is unchanged,
+            # same object, so this is a no-op except the flag) is the fix:
+            # the SAME single apply point every other writer uses, not a
+            # second, parallel way to set the flag.
+            self._apply_mcp_cache(
+                self._mcp_tools_cache, mtime=self._mcp_tools_cache_mtime, bump_epoch=False,
+            )
             return
         # #4401 A-4 (F1/②): the ONE place this cycle assigns the cache — a
         # plain merge (ADD, never replace), so it does NOT bump the epoch
@@ -3085,18 +3127,30 @@ class RouterHostAdapter:
           entry (not yet cleared; the retry hasn't resolved) or none at all.
         - ``"answered"`` — a real probe measurement exists, ``tool_count``
           set (0 is a genuine answer, not a failure).
-        - ``"failed"`` — the last probe attempt for this server did NOT
-          answer (``ToolsUnknown`` — timeout or exception), ``reason`` set
-          and ``detail`` set when ``reason == "exception"``. Cleared the
-          instant the server later answers (`ensure_mcp_tools_cached`'s own
-          gather loop), so a stale failure never outlives a successful retry.
-        - ``"not_probed"`` — none of the above: no attempt has been
-          recorded for this server at all (absent from every dict — the
-          lazy, post-startup probe, FP-0037 issue #160, has not reached it
-          yet). MUST NOT be rendered as "0 tools" — that is the exact
-          conflation #4401 exists to close (owner: the model can't NAME an
-          unprobed server's tools, that is not the same as the server
-          having none).
+        - ``"failed"`` — this session has DISPATCHED a probe for this
+          server (`_mcp_attempted`, #4401 A-4's single source of truth for
+          "has this server ever been tried" — see that field's own
+          __init__ comment) and it has not answered. ``reason``/``detail``
+          come from `_mcp_last_unknown` when present.
+          ⚠️ Disclosed gap (lead-coder/architect review, PR #5763, accepted
+          as a transient display artifact rather than fixed): `_mcp_
+          attempted` is marked BEFORE the epoch-staleness check (F3/F5)
+          that can discard a probe cycle's own results — a server whose
+          cycle got discarded as stale (not a real answer failure, just a
+          superseded measurement, with a fresh probe already in flight)
+          reads as ``"failed"`` with ``reason="unknown"`` for the brief
+          window until the next cycle settles, rather than as a distinct
+          "a fresher probe is already running" state. Accepted because it
+          is momentary and self-correcting, never a lingering false
+          "0 tools" (the #4401 conflation this method exists to close) —
+          reopen if this is ever observed to persist rather than resolve
+          on the next probe cycle.
+        - ``"not_probed"`` — none of the above: `_mcp_attempted` has no
+          record of this server at all — no probe was ever dispatched for
+          it, by this session, yet. MUST NOT be rendered as "0 tools" —
+          that is the exact conflation #4401 exists to close (owner: the
+          model can't NAME an unprobed server's tools, that is not the
+          same as the server having none).
 
         Ordered by ``self._mcp_servers_flat()``'s own iteration order (config
         declaration order), same as `_get_mcp_servers_for_router`.
@@ -3112,14 +3166,15 @@ class RouterHostAdapter:
             if answered is not None:
                 out.append({"name": name, "state": "answered", "tool_count": len(answered.tools)})
                 continue
-            unknown = self._mcp_last_unknown.get(name)
-            if unknown is not None:
-                out.append({
-                    "name": name, "state": "failed",
-                    "reason": unknown.reason, "detail": unknown.detail,
-                })
+            if name not in self._mcp_attempted:
+                out.append({"name": name, "state": "not_probed"})
                 continue
-            out.append({"name": name, "state": "not_probed"})
+            unknown = self._mcp_last_unknown.get(name)
+            out.append({
+                "name": name, "state": "failed",
+                "reason": unknown.reason if unknown is not None else "unknown",
+                "detail": unknown.detail if unknown is not None else None,
+            })
         return out
 
     async def retry_mcp_probe(self, server: str, *, per_server_timeout: float) -> None:
@@ -3210,14 +3265,28 @@ class RouterHostAdapter:
         turn-boundary ``await ensure_mcp_tools_cached(...)``.
 
         Awaits the background task `start_mcp_probe` kicked off at
-        construction, if it is still around; runs the probe inline
-        otherwise (task never started — no loop at construction time; or
-        this is a later turn and the construction-time task already
-        finished and was consumed). Consumed exactly ONCE — the reference
-        is cleared the moment it is awaited, so a later call in the SAME
-        session always re-checks `ensure_mcp_tools_cached`'s own per-server
-        cache/cooldown gate (already a cheap no-op once every server has
-        answered) rather than re-awaiting an already-done Task forever.
+        construction, if it is still around (consumed exactly ONCE — the
+        reference is cleared the moment it is awaited).
+
+        #4401 A-4 (real regression found driving this method — PR #5763
+        CI, `test_2761_pr3_mcp_immediate_probe.py`): after awaiting that
+        task, this method does NOT simply return. A server added to the
+        roster AFTER the construction-time task already finished (e.g.
+        ``mcp_install``'s immediate probe-commit reassigning the roster)
+        would otherwise never get probed at all — the finished task's own
+        scan never saw it, and nothing else would ever call `ensure_mcp_
+        tools_cached` for it. The fallback condition is deliberately NOT
+        "any server still unanswered" (lead-coder/architect review): that
+        would ALSO catch a server that already answered "no" and is
+        sitting in its #5674 60s cooldown, reintroducing exactly the
+        turn-path 5-second cost A-4 exists to remove — the owner's own
+        reported environment (every server unreachable) is precisely that
+        case. The condition is "a server this session has never even
+        DISPATCHED a probe for" (`_mcp_attempted`, #4401 A-4's single
+        source of truth — see that field's own __init__ comment): a
+        genuinely new server is never in it; an already-tried, still-
+        cooling-down server always is, from the moment its own probe
+        cycle dispatched, so it is never re-probed synchronously here.
 
         #4401 A-4 co-vet (F3): does NOT re-wait if the epoch moves while
         this call is itself awaiting — a single `await`, never a loop. If
@@ -3238,8 +3307,12 @@ class RouterHostAdapter:
         if task is not None:
             self._mcp_probe_task = None
             await task
-            return
-        await self.ensure_mcp_tools_cached(per_server_timeout=per_server_timeout)
+        never_attempted = [
+            name for name in self._mcp_servers_flat()
+            if name not in self._mcp_attempted
+        ]
+        if never_attempted:
+            await self.ensure_mcp_tools_cached(per_server_timeout=per_server_timeout)
 
     @property
     def yaml_mtimes_snapshot(self) -> dict[Path, float]:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1795,6 +1795,26 @@ class Session:
         # router_host, which THIS call builds -- so this one eager pre-waist consumer is threaded
         # the local var explicitly rather than reading a not-yet-constructed self._capability_visibility).
         self._router_host = self._build_router_waist(contextual_permission=contextual_permission)
+        # #4401 A-4 (owner-ratified, approved by architect+lead-coder after
+        # 2 rounds of co-vet, issue #4401): kick off the MCP tools probe
+        # now, in the background — never awaited here. A probe is a
+        # precondition for the LLM NAMING an mcp tool (the schema's
+        # `mcp_tool_name` enum), never for executing one (roster +
+        # connection pool only) — so starting it this early costs nothing
+        # a turn would otherwise pay later, and a hook-woken turn 1 (which
+        # never reaches this Session.__init__ → first-turn gap the old
+        # lazy design left unable to name any mcp tool) gets the same head
+        # start as a normal turn. See `RouterHostAdapter.start_mcp_probe`/
+        # `await_mcp_probe_ready` for the consumption-point half of this
+        # design, and the empirical trace in issue #4401's own comments
+        # for why `RouterLoop.run()`'s own top is the sufficient single
+        # await point (every `render_for_router(state=...)` call site that
+        # can inject the mcp enum sits downstream of it today — pinned by
+        # `test_4401_render_for_router_state_census.py`).
+        self._router_host.start_mcp_probe(
+            per_server_timeout=self._safety.timeout.mcp_probe_seconds,
+            spawn=self._background_tasks.spawn,
+        )
 
         # Owns the per-session capability/skill visibility override + the envelope-composed
         # contextual_permission/excluded_categories it derives (#2285, see #3121 step3 Extract Class);
@@ -5204,7 +5224,13 @@ class Session:
         try:
             await self._router_host.maybe_refresh_mcp_tools_from_yaml()
             self._router_host.maybe_reload_mcp_tools_cache_from_disk()
-            await self._router_host.ensure_mcp_tools_cached(
+            # #4401 A-4: same seam the 2 real consumption points now route
+            # through (RouterLoop.run / mcp_list_servers) — an explicit
+            # `reyn mcp refresh` still genuinely waits (operator-triggered,
+            # synchronous-by-design, unlike the turn-boundary wait A-4
+            # removes), it just no longer duplicates `ensure_mcp_tools_cached`
+            # as a second, independent call shape.
+            await self._router_host.await_mcp_probe_ready(
                 per_server_timeout=self._safety.timeout.mcp_probe_seconds,
             )
         except Exception as exc:  # noqa: BLE001
@@ -11162,11 +11188,17 @@ class Session:
             # NEW turn — never cleared mid-turn (see the flag's own
             # docstring in __init__).
             self._in_flight_untrusted_this_turn = False
+            # #4401 A-4: the probe itself is no longer awaited HERE — every
+            # turn used to pay for it unconditionally, including a turn
+            # that never touches the mcp catalog at all (a named op call,
+            # a hook dispatch with no schema-building step). The 2 real
+            # catalog CONSUMPTION points (`RouterLoop.run`'s own
+            # turn-start, `RouterHostAdapter.mcp_list_servers`) each await
+            # `await_mcp_probe_ready` themselves now — a turn that never
+            # reaches either one pays nothing. The yaml/disk steps below
+            # stay unconditional (FP-0037 S1/S2, cheap, orthogonal to A-4).
             await self._router_host.maybe_refresh_mcp_tools_from_yaml()
             self._router_host.maybe_reload_mcp_tools_cache_from_disk()
-            await self._router_host.ensure_mcp_tools_cached(
-                per_server_timeout=self._safety.timeout.mcp_probe_seconds,
-            )
             with active_turn(chain_id):
                 await self._loop_driver.run_turn(user_text, chain_id)
             _turn_completed = True

--- a/tests/runtime/test_4401_a4_cache_concurrency.py
+++ b/tests/runtime/test_4401_a4_cache_concurrency.py
@@ -1,0 +1,282 @@
+"""Tier 2: #4401 A-4 — the concurrency-safety redesign the architect co-vet
+required before landing the construction-time background probe (issue
+#4401, F1/F2/F3/F5, plus R3's "witness state transitions, not private call
+counts" correction).
+
+Background: A-4 makes `RouterHostAdapter.ensure_mcp_tools_cached` run
+concurrently with `invalidate_mcp_tools_cache`/`maybe_reload_mcp_tools_
+cache_from_disk` for the first time (previously safe only because a turn's
+own probe call was always synchronous/serialized). These tests pin the
+observable behaviour the redesign promises:
+
+- F1: the (cache, mtime) pair advances together (never one without the other).
+- F3/F5: a probe cycle whose epoch went stale while it was in flight is
+  discarded — no in-memory merge, no disk write.
+- ②/R3: the 3 external drivers (probe merge / invalidate / disk reload) each
+  produce their own observable state transition through the PUBLIC surface
+  (`mcp_tools_cache_snapshot`, `mcp_probe_snapshot`) — never a private
+  `_apply_mcp_cache` call count (CLAUDE.md: "a test must not depend on
+  private state").
+
+Same real-collaborators builder as ``test_4401_mcp_probe_snapshot_and_
+retry.py`` — real `RouterHostAdapter`, a scripted real probe callable, no
+mocks."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.services import (
+    LiveSessionIdInputs,
+    McpGatewayInputs,
+    MemoryService,
+    PutOutboxInputs,
+    RouterHostAdapter,
+)
+from tests._support.router_host_adapter import make_op_context_source
+
+_SERVER = "reyn_markitdown"
+_TOOLS = [{"name": "convert_to_markdown", "description": "convert a uri to markdown"}]
+
+_EMPTY_OP_CTX = make_op_context_source()
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
+
+async def _null_file_read(path: str) -> dict:
+    return {"content": ""}
+
+
+async def _null_file_write(path: str, content: str) -> dict:
+    return {"path": path, "written": True}
+
+
+async def _null_file_delete(path: str) -> dict:
+    return {"path": path, "deleted": True}
+
+
+async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
+    return {"path": path, "output_path": output_path, "entries": 0}
+
+
+async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
+    return {}
+
+
+async def _null_put_outbox(msg) -> None:
+    pass
+
+
+def _null_append_history(msg) -> None:
+    pass
+
+
+def _make_adapter(*, tmp_path: Path, state_dir: Path, probe) -> RouterHostAdapter:
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "test-agent"
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=_null_file_write,
+        file_read=_null_file_read,
+        file_delete=_null_file_delete,
+        file_regenerate_index=_null_file_regen,
+    )
+    adapter = RouterHostAdapter(
+        agent_name="test-agent",
+        agent_role="test",
+        output_language="en",
+        op_context_source=_EMPTY_OP_CTX,
+        permission_resolver=None,
+        mcp_servers={_SERVER: {"description": "markitdown"}},
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=_null_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        state_dir=state_dir,
+        universal_wrappers_enabled=False,
+    )
+    adapter.mcp_list_tools = probe
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# F1: (cache, mtime) advance together
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_successful_probe_leaves_disk_reload_a_no_op(tmp_path: Path) -> None:
+    """Tier 2: F1 — after a successful probe+persist, the in-memory mtime
+    already reflects the write, so an immediate `maybe_reload_mcp_tools_
+    cache_from_disk` finds nothing newer (proves the dict and its mtime
+    advanced TOGETHER — a torn update, dict-ahead-of-mtime, would make this
+    reload wrongly think the disk is newer and re-swap the cache)."""
+    class _AnsweringProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            return [dict(t) for t in _TOOLS]
+
+    state_dir = tmp_path / "state"
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=_AnsweringProbe())
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
+    before = adapter.mcp_tools_cache_snapshot
+
+    adapter.maybe_reload_mcp_tools_cache_from_disk()
+    after = adapter.mcp_tools_cache_snapshot
+    assert after == before, "a no-op reload must not change the observable snapshot"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_disk_write_still_advances_the_in_memory_answer(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: F1 — when `write_cache` raises (session correctness over
+    disk durability, unchanged from before A-4), the in-memory cache still
+    reflects the new answer — a failed persist must not silently drop the
+    probe's own measurement."""
+    class _AnsweringProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            return [dict(t) for t in _TOOLS]
+
+    # A state_dir that cannot be written to (a file where a directory is
+    # expected) makes cache_file_path's own write step fail.
+    state_dir = tmp_path / "not_a_real_dir"
+    state_dir.parent.mkdir(parents=True, exist_ok=True)
+    state_dir.write_text("blocking file, not a directory")
+
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=_AnsweringProbe())
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
+    snapshot = adapter.mcp_tools_cache_snapshot
+    assert snapshot is not None and _SERVER in snapshot, (
+        "a probe answer must survive in-memory even if persisting it to "
+        f"disk failed; got {snapshot!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F3/F5: a stale probe cycle is discarded — no merge, no persist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_is_invalidated_mid_flight_is_discarded_not_merged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: F3/F5 — an invalidate landing WHILE a probe is in flight
+    bumps the epoch; when that probe's own results become ready, they are
+    discarded (never merged into memory, never written to disk) rather
+    than applied over state the probe cycle never saw."""
+    gate = asyncio.Event()
+
+    class _GatedProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            await gate.wait()
+            return [dict(t) for t in _TOOLS]
+
+    state_dir = tmp_path / "state"
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=_GatedProbe())
+
+    probe_task = asyncio.create_task(adapter.ensure_mcp_tools_cached(per_server_timeout=5.0))
+    await asyncio.sleep(0)  # let the probe cycle capture its epoch and start gathering
+
+    adapter.invalidate_mcp_tools_cache(_SERVER)  # bumps the epoch mid-flight
+    gate.set()
+    await probe_task
+
+    assert adapter.mcp_tools_cache_snapshot is None, (
+        "a stale probe cycle's answer must not be merged after an "
+        "invalidate landed mid-flight"
+    )
+    from reyn.runtime.services.mcp_cache_file import cache_file_path
+    assert not cache_file_path(state_dir).exists(), (
+        "a stale probe cycle must not persist its discarded answer to disk either"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_waiter_does_not_re_wait_when_the_epoch_moves_mid_await(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: F3 — `await_mcp_probe_ready` is a SINGLE await, never a
+    loop: even though the in-flight task it awaits gets its own results
+    discarded as stale (the test above), the waiter itself still returns
+    normally (no exception, no hang) the moment that task settles."""
+    gate = asyncio.Event()
+
+    class _GatedProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            await gate.wait()
+            return [dict(t) for t in _TOOLS]
+
+    state_dir = tmp_path / "state"
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=_GatedProbe())
+
+    tracked: "list" = []
+    adapter.start_mcp_probe(  # the real, public kickoff — not a private poke
+        per_server_timeout=5.0,
+        spawn=lambda coro, **kw: tracked.append(asyncio.create_task(coro)) or tracked[-1],
+    )
+    waiter = asyncio.create_task(adapter.await_mcp_probe_ready(per_server_timeout=5.0))
+    await asyncio.sleep(0)
+
+    adapter.invalidate_mcp_tools_cache(_SERVER)
+    gate.set()
+
+    await asyncio.wait_for(waiter, timeout=5.0)  # must not hang
+
+
+# ---------------------------------------------------------------------------
+# ②/R3: 3 external drivers, each its own observable state transition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_each_of_the_three_external_drivers_produces_its_own_observable_transition(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ②/R3 — the probe's own merge, `invalidate_mcp_tools_cache`,
+    and `maybe_reload_mcp_tools_cache_from_disk` each drive the cache
+    through ONE shared apply point, witnessed here via PUBLIC state
+    transitions (`mcp_tools_cache_snapshot`) — never by counting calls to
+    the private `_apply_mcp_cache` (CLAUDE.md: a test must not depend on
+    private state)."""
+    class _AnsweringProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            return [dict(t) for t in _TOOLS]
+
+    state_dir = tmp_path / "state"
+    adapter = _make_adapter(tmp_path=tmp_path, state_dir=state_dir, probe=_AnsweringProbe())
+
+    # Driver 1: the probe's own merge — None -> populated.
+    assert adapter.mcp_tools_cache_snapshot is None
+    await adapter.ensure_mcp_tools_cached(per_server_timeout=5.0)
+    assert adapter.mcp_tools_cache_snapshot is not None and _SERVER in adapter.mcp_tools_cache_snapshot
+
+    # Driver 2: invalidate — populated -> None.
+    adapter.invalidate_mcp_tools_cache(_SERVER)
+    assert adapter.mcp_tools_cache_snapshot is None
+
+    # Driver 3: disk reload — None -> whatever the (still-present, unwritten-
+    # over) file holds, without a live probe running at all.
+    adapter.maybe_reload_mcp_tools_cache_from_disk()
+    assert adapter.mcp_tools_cache_snapshot is not None and _SERVER in adapter.mcp_tools_cache_snapshot, (
+        "the disk-reload driver must independently reach the same "
+        "observable populated state, without any probe call in this step"
+    )

--- a/tests/runtime/test_4401_a4_stale_construction_probe_regression.py
+++ b/tests/runtime/test_4401_a4_stale_construction_probe_regression.py
@@ -1,0 +1,217 @@
+"""Tier 2: #4401 ① regression witness — driven reproduction of the exact
+mechanism behind the 2 CI failures on PR #5763 (`test_2761_pr3_mcp_
+immediate_probe.py::test_local_install_new_reachable_is_live_same_turn`,
+`test_3475_mcp_probe_priming_all_turn_kinds.py`), written BEFORE choosing a
+fix per lead-coder's explicit instruction.
+
+★ This test DISCONFIRMS architect's own initial inferred mechanism (a
+`grep`-only reading of the diff, explicitly caveated as unverified): NOT a
+disk-warm-start REPLACE racing an install's own probe and discarding it via
+the epoch check. Driving the actual production call chain (`RouterHost
+Adapter.start_mcp_probe` → `await_mcp_probe_ready`) shows a DIFFERENT, more
+precise mechanism:
+
+1. `Session.__init__` kicks off `start_mcp_probe` against the roster AT
+   CONSTRUCTION TIME. If that roster is empty (no mcp servers configured
+   yet), the background task's own `ensure_mcp_tools_cached` finds
+   `unanswered == []` and returns immediately — the Task object is DONE,
+   but still sits in `self._mcp_probe_task` (not yet consumed).
+2. A server is added to the roster AFTER that (e.g. `mcp_install`'s
+   `refresh_mcp_servers` reassigning `self._mcp_servers`).
+3. `await_mcp_probe_ready` is called: it finds `self._mcp_probe_task` is
+   NOT None (still holding the ALREADY-FINISHED task from step 1), awaits
+   it (resolves instantly, having done nothing for the new server), and
+   RETURNS — without ever calling `ensure_mcp_tools_cached` again to catch
+   the newly-unanswered server the finished task's own scan never covered.
+
+No epoch discard is involved at all — the bug is that a stale, already-
+resolved construction-time task is trusted as "the catalog is ready"
+without re-checking whether new work appeared after it finished."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.runtime.services import (
+    LiveSessionIdInputs,
+    McpGatewayInputs,
+    MemoryService,
+    PutOutboxInputs,
+    RouterHostAdapter,
+)
+from tests._support.router_host_adapter import make_op_context_source
+
+_SERVER = "pidsrv"
+_TOOLS = [{"name": "convert_to_markdown", "description": "convert a uri to markdown"}]
+
+_EMPTY_OP_CTX = make_op_context_source()
+_EMPTY_MCP_GATEWAY = McpGatewayInputs(
+    mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+)
+
+
+async def _null_file_read(path: str) -> dict:
+    return {"content": ""}
+
+
+async def _null_file_write(path: str, content: str) -> dict:
+    return {"path": path, "written": True}
+
+
+async def _null_file_delete(path: str) -> dict:
+    return {"path": path, "deleted": True}
+
+
+async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
+    return {"path": path, "output_path": output_path, "entries": 0}
+
+
+async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
+    return {}
+
+
+async def _null_put_outbox(msg) -> None:
+    pass
+
+
+def _null_append_history(msg) -> None:
+    pass
+
+
+def _make_adapter(*, tmp_path: Path, mcp_servers: dict, probe) -> RouterHostAdapter:
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "test-agent"
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=_null_file_write,
+        file_read=_null_file_read,
+        file_delete=_null_file_delete,
+        file_regenerate_index=_null_file_regen,
+    )
+    adapter = RouterHostAdapter(
+        agent_name="test-agent",
+        agent_role="test",
+        output_language="en",
+        op_context_source=_EMPTY_OP_CTX,
+        permission_resolver=None,
+        mcp_servers=mcp_servers,
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        mcp_call_tool=_null_mcp_call_tool,
+        mcp_gateway_inputs=_EMPTY_MCP_GATEWAY,
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_null_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=_null_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        state_dir=tmp_path / "state",
+        universal_wrappers_enabled=False,
+    )
+    adapter.mcp_list_tools = probe
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_a_server_added_after_the_construction_probe_finished_is_still_probed(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: reproduces the exact #4401 A-4 regression (PR #5763 CI) via
+    the real production seam (`start_mcp_probe` → `await_mcp_probe_ready`),
+    mirroring `mcp_install`'s own real sequence: construct with an EMPTY
+    roster (the construction-time probe finds nothing and finishes
+    instantly), THEN add a server to the roster (mimics `refresh_mcp_
+    servers`'s roster reassignment), THEN call `await_mcp_probe_ready`
+    (mimics `refresh_mcp_servers`'s own consumption point) — the newly
+    added server must still get probed, not silently skipped because the
+    stale, already-finished construction task is trusted as sufficient."""
+    class _AnsweringProbe:
+        async def __call__(self, server_name: str) -> list[dict]:
+            return [dict(t) for t in _TOOLS]
+
+    adapter = _make_adapter(tmp_path=tmp_path, mcp_servers={}, probe=_AnsweringProbe())
+
+    tracked: "list" = []
+    adapter.start_mcp_probe(
+        per_server_timeout=5.0,
+        spawn=lambda coro, **kw: tracked.append(asyncio.create_task(coro)) or tracked[-1],
+    )
+    # Let the construction-time task actually run — with an empty roster it
+    # finds nothing to probe and finishes immediately, exactly like the
+    # real `mcp_install` sequence's own timing (the task gets its first
+    # scheduling chance during some OTHER await in the real call chain,
+    # e.g. `probe_mcp_server`'s own network round trip).
+    await asyncio.sleep(0)
+    assert tracked[0].done(), "the construction task must have already finished by this point"
+
+    # Now a server is added — mirrors refresh_mcp_servers's own roster
+    # reassignment (self._router_host._mcp_servers = fresh_roster).
+    adapter._mcp_servers = {_SERVER: {"description": "pid server"}}
+
+    await adapter.await_mcp_probe_ready(per_server_timeout=5.0)
+
+    snapshot = adapter.mcp_tools_cache_snapshot
+    assert snapshot is not None and _SERVER in snapshot, (
+        "a server added to the roster AFTER the construction-time probe "
+        f"already finished must still be probed by await_mcp_probe_ready; "
+        f"got snapshot={snapshot!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_already_tried_unresponsive_server_is_not_reprobed_on_the_turn_path(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the OTHER half of the fix (lead-coder/architect review,
+    PR #5763) — the owner's own reported environment (every configured mcp
+    server unresponsive). Once a server has been ATTEMPTED (even if it
+    never answered and is sitting in its #5674 60s cooldown),
+    `await_mcp_probe_ready` must NOT fall back to `ensure_mcp_tools_cached`
+    for it on a later turn — that would pay the real network-timeout cost
+    synchronously on the turn path, exactly what #4401 ① exists to remove.
+    Only a server this session has NEVER attempted (`_mcp_attempted`)
+    triggers the fallback — never "still unanswered" alone, which would
+    also catch this case."""
+    class _NeverAnsweringProbe:
+        def __init__(self) -> None:
+            self.calls: "list[str]" = []
+
+        async def __call__(self, server_name: str) -> "list[dict] | None":
+            self.calls.append(server_name)
+            await asyncio.sleep(5.0)  # far beyond the per_server_timeout below
+            return None  # unreachable — the timeout always fires first
+
+    probe = _NeverAnsweringProbe()
+    adapter = _make_adapter(
+        tmp_path=tmp_path, mcp_servers={_SERVER: {"description": "pid server"}}, probe=probe,
+    )
+
+    tracked: "list" = []
+    adapter.start_mcp_probe(
+        per_server_timeout=0.05,
+        spawn=lambda coro, **kw: tracked.append(asyncio.create_task(coro)) or tracked[-1],
+    )
+    await asyncio.wait_for(tracked[0], timeout=5.0)  # the construction probe times out and settles
+    assert probe.calls == [_SERVER]
+
+    # A later turn's own consumption point — the server is STILL unanswered
+    # (it's in its cooldown window) but has been ATTEMPTED, so this must be
+    # a fast no-op, never a second real probe dispatch.
+    await adapter.await_mcp_probe_ready(per_server_timeout=0.05)
+
+    assert probe.calls == [_SERVER], (
+        "a server already attempted (and cooling down after failing) must "
+        f"not be re-dispatched by a later await_mcp_probe_ready call; "
+        f"probe.calls={probe.calls!r}"
+    )

--- a/tests/runtime/test_4401_render_for_router_state_census.py
+++ b/tests/runtime/test_4401_render_for_router_state_census.py
@@ -32,6 +32,19 @@ does not say "add it here" — it says "prove it's downstream of run()'s
 await FIRST", because that proof is the actual content of what this test
 protects, not the set membership itself.
 
+★ lead-coder BLOCKING (PR #5763): the first cut of this test keyed each
+site on ``(file, lineno)``. A line number is NOT a closed target — any
+unrelated edit landing ABOVE line 802 in `router_tools.py` shifts every
+declared entry at once, so all 9 sites go "undeclared" together though not
+one new call site was added. A reviewer who sees that shape once learns
+"just fix the numbers, no proof needed" — the exact operation the R3
+failure message above forbids — and the SAME reflex then silences a real
+new site the next time one appears. The key is now
+``(file, enclosing_function_name, receiver_variable_name)`` — e.g.
+``("...router_tools.py", "build_tools", "_call_mcp_tool_def")`` — stable
+under any line-number churn, and still fully AST-derived (no hand-typed
+string beyond what the source itself names the receiver).
+
 AST-based (not a grep), same closed-target reasoning
 ``test_3595_s4_slash_handler_seam.py``'s own ``_ResidueCollector`` gives —
 ``state=`` is a keyword argument, syntactically closed, so the walk finds
@@ -44,47 +57,81 @@ from tests._support.paths import REPO_ROOT
 
 _SRC_ROOT = REPO_ROOT / "src"
 
+class _RenderForRouterStateCallCollector(ast.NodeVisitor):
+    """Walks one module, tracking the innermost enclosing function/method
+    name, and records every ``<name>.render_for_router(..., state=..., ...)``
+    call as ``(enclosing_function, receiver_name)``. Only a plain-Name
+    receiver is recorded (every known call site today has this shape,
+    ``<tool>_def.render_for_router(...)``) — a call through some other
+    expression shape (e.g. a subscript or a call result) would need this
+    walk extended, not silently ignored, so such a shape raises rather
+    than being dropped."""
 
-def _find_state_passing_render_for_router_calls() -> "set[tuple[str, int]]":
-    """Every ``<expr>.render_for_router(..., state=..., ...)`` call in
-    ``src/`` — ``(module-relative-path, lineno)`` pairs. The population
-    this test reasons about is derived STRUCTURALLY (an AST walk over
-    every call site), never a hand-maintained enumeration — only the
-    DECLARED (expected) side below is a maintained list; the FOUND side
-    always reflects the actual code."""
-    found: "set[tuple[str, int]]" = set()
+    def __init__(self) -> None:
+        self._func_stack: "list[str]" = []
+        self.found: "set[tuple[str, str]]" = set()
+
+    def _enclosing(self) -> str:
+        return self._func_stack[-1] if self._func_stack else "<module>"
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "render_for_router":
+            if any(kw.arg == "state" for kw in node.keywords):
+                if not isinstance(func.value, ast.Name):
+                    raise AssertionError(
+                        f"render_for_router(state=...) called through a non-Name "
+                        f"receiver ({ast.dump(func.value)!r}) at line {node.lineno} — "
+                        "this walk's (function, receiver-name) key assumes every "
+                        "call site is `<name>.render_for_router(...)`; extend the "
+                        "key shape here rather than silently dropping this call."
+                    )
+                self.found.add((self._enclosing(), func.value.id))
+        self.generic_visit(node)
+
+
+def _find_state_passing_render_for_router_calls() -> "set[tuple[str, str, str]]":
+    """Every ``<name>.render_for_router(..., state=..., ...)`` call in
+    ``src/`` — ``(module-relative-path, enclosing_function, receiver_name)``
+    triples. The population this test reasons about is derived
+    STRUCTURALLY (an AST walk over every call site), never a hand-
+    maintained enumeration — only the DECLARED (expected) side below is a
+    maintained list; the FOUND side always reflects the actual code."""
+    found: "set[tuple[str, str, str]]" = set()
     for path in sorted(_SRC_ROOT.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if not (isinstance(func, ast.Attribute) and func.attr == "render_for_router"):
-                continue
-            if any(kw.arg == "state" for kw in node.keywords):
-                found.add((str(path.relative_to(REPO_ROOT)), node.lineno))
+        collector = _RenderForRouterStateCallCollector()
+        collector.visit(tree)
+        rel = str(path.relative_to(REPO_ROOT))
+        for func_name, receiver in collector.found:
+            found.add((rel, func_name, receiver))
     return found
 
 
 #: Every call site KNOWN to pass ``state=`` today — all 9 are the MCP tool
 #: definitions (D3/D4 call_mcp_tool/describe_mcp_tool + the 7 resource/
-#: prompt verbs) inside ``router_tools.py``'s ``build_tools()`` (lines
-#: 264-988; the file's only OTHER top-level function,
-#: ``_build_tools_via_registry``, starts at line 990 and does not appear
-#: here). `build_tools()` is called only from `RouterLoop.present`/
-#: `base_tools()` (#4401's own trace, issue #4401 R2 comment), which are
-#: reachable only from inside `RouterLoop.run()` — the boundary #4401 ①'s
-#: await sits at the top of.
-_DECLARED_SITES: "set[tuple[str, int]]" = {
-    ("src/reyn/runtime/router_tools.py", 802),   # D3 call_mcp_tool
-    ("src/reyn/runtime/router_tools.py", 815),   # D4 describe_mcp_tool
-    ("src/reyn/runtime/router_tools.py", 844),   # list_mcp_resources
-    ("src/reyn/runtime/router_tools.py", 857),   # list_mcp_resource_templates
-    ("src/reyn/runtime/router_tools.py", 870),   # read_mcp_resource
-    ("src/reyn/runtime/router_tools.py", 883),   # subscribe_mcp_resource
-    ("src/reyn/runtime/router_tools.py", 896),   # unsubscribe_mcp_resource
-    ("src/reyn/runtime/router_tools.py", 909),   # list_mcp_prompts
-    ("src/reyn/runtime/router_tools.py", 922),   # get_mcp_prompt
+#: prompt verbs) inside ``router_tools.py``'s ``build_tools()``. That
+#: function is called only from `RouterLoop.present`/`base_tools()`
+#: (#4401's own trace, issue #4401 R2 comment), which are reachable only
+#: from inside `RouterLoop.run()` — the boundary #4401 ①'s await sits at
+#: the top of.
+_DECLARED_SITES: "set[tuple[str, str, str]]" = {
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_call_mcp_tool_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_describe_mcp_tool_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_list_mcp_resources_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_list_mcp_resource_templates_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_read_mcp_resource_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_subscribe_mcp_resource_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_unsubscribe_mcp_resource_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_list_mcp_prompts_def"),
+    ("src/reyn/runtime/router_tools.py", "build_tools", "_get_mcp_prompt_def"),
 }
 
 
@@ -104,7 +151,11 @@ def test_every_state_passing_call_site_is_declared_and_known() -> None:
     """Tier 2: the ratchet — a NEW ``render_for_router(state=...)`` call
     site outside the declared set is exactly the shape #4401 ①'s await
     stops covering (a partial mcp catalog could then reach an LLM-facing
-    enum without ever passing through `RouterLoop.run()`'s own await)."""
+    enum without ever passing through `RouterLoop.run()`'s own await).
+    Keyed on (file, enclosing function, receiver variable name) — NOT
+    line number (see this module's own docstring, lead-coder's BLOCKING on
+    PR #5763, for why a line-number key makes every unrelated edit above
+    line 802 a false "undeclared" alarm for all 9 sites at once)."""
     found = _find_state_passing_render_for_router_calls()
     undeclared = found - _DECLARED_SITES
     assert not undeclared, (
@@ -124,16 +175,17 @@ def test_every_state_passing_call_site_is_declared_and_known() -> None:
 
 def test_no_declared_site_is_stale() -> None:
     """Tier 2: the standing positive control — every declared site is still
-    FOUND. A site that's genuinely gone (code moved/removed) needs its
-    entry deleted here, not left stale; more importantly, a REGRESSED walk
-    (a lost AST shape) would make declared sites vanish from the found set,
-    which would otherwise read as "the census got smaller" — the most
-    flattering possible way for this gate to break silently."""
+    FOUND. A site that's genuinely gone (code moved/removed/renamed) needs
+    its entry deleted (or updated) here, not left stale; more importantly,
+    a REGRESSED walk (a lost AST shape) would make declared sites vanish
+    from the found set, which would otherwise read as "the census got
+    smaller" — the most flattering possible way for this gate to break
+    silently."""
     found = _find_state_passing_render_for_router_calls()
     stale = _DECLARED_SITES - found
     assert not stale, (
         f"_DECLARED_SITES declares site(s) the walk no longer finds: {sorted(stale)!r}. "
-        "If genuinely gone, delete the entry and say so in the PR. If not, "
-        "the walk regressed and the 'no undeclared site' result above is "
-        "understated."
+        "If genuinely gone (or renamed), update the entry and say so in "
+        "the PR. If not, the walk regressed and the 'no undeclared site' "
+        "result above is understated."
     )

--- a/tests/runtime/test_4401_render_for_router_state_census.py
+++ b/tests/runtime/test_4401_render_for_router_state_census.py
@@ -1,0 +1,139 @@
+"""Tier 2: #4401 ① condition (lead-coder, architect R1's own "tomorrow's
+optimization quietly falsifies today's invariant" shape, applied a second
+time) — a completeness census over every ``ToolDefinition.render_for_router``
+call site that passes ``state=``.
+
+Why this exists: #4401's own empirical trace (issue #4401, the R2 comment)
+found `RouterHostAdapter.get_mcp_servers()` has 8 call sites, 5 of which
+reach the model — but only a call site that ALSO threads a ``RouterCallerState``
+into ``render_for_router(state=...)`` can actually trigger `tools/mcp.py`'s
+``_enrich_router_schema`` (the schema-enricher that injects the
+`server`/`mcp_tool_name` enums an LLM sees). Today, EVERY such call site sits
+inside ``router_tools.py``'s ``build_tools()`` — which #4401's own trace
+confirmed is reachable ONLY via ``RouterLoop.present``/``base_tools()``,
+themselves reachable ONLY from inside ``RouterLoop.run()``. That is what
+makes "await once at the top of `run()`" (#4401 ①) sufficient: every
+enum-injecting call site is downstream of it.
+
+That sufficiency is a fact about TODAY'S code, not a structural guarantee —
+a future PR could add a NEW ``render_for_router(state=...)`` call site
+OUTSIDE `build_tools()` (e.g. one of #4401's own ④/⑤ non-`run()`-gated
+paths growing a schema-enricher call it doesn't have today) and the #4401 ①
+await would silently stop covering it, exactly the failure architect named
+for R1 (the OTHER #4401 invariant, in `mcp_cache_file.py`, that a "later
+optimization" could silently break). This test is the mechanical ratchet
+that turns that silent break into a red test instead.
+
+★ Architect's own R3 addition: the ratchet is a DETECTOR, not a repair
+obligation — "add the new site to the declared set" is exactly the move
+that makes a red test green WITHOUT fixing anything (a correctly-looking
+operation that leaves the hole open). The failure message below therefore
+does not say "add it here" — it says "prove it's downstream of run()'s
+await FIRST", because that proof is the actual content of what this test
+protects, not the set membership itself.
+
+AST-based (not a grep), same closed-target reasoning
+``test_3595_s4_slash_handler_seam.py``'s own ``_ResidueCollector`` gives —
+``state=`` is a keyword argument, syntactically closed, so the walk finds
+every spelling a plain string search over source text could miss."""
+from __future__ import annotations
+
+import ast
+
+from tests._support.paths import REPO_ROOT
+
+_SRC_ROOT = REPO_ROOT / "src"
+
+
+def _find_state_passing_render_for_router_calls() -> "set[tuple[str, int]]":
+    """Every ``<expr>.render_for_router(..., state=..., ...)`` call in
+    ``src/`` — ``(module-relative-path, lineno)`` pairs. The population
+    this test reasons about is derived STRUCTURALLY (an AST walk over
+    every call site), never a hand-maintained enumeration — only the
+    DECLARED (expected) side below is a maintained list; the FOUND side
+    always reflects the actual code."""
+    found: "set[tuple[str, int]]" = set()
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "render_for_router"):
+                continue
+            if any(kw.arg == "state" for kw in node.keywords):
+                found.add((str(path.relative_to(REPO_ROOT)), node.lineno))
+    return found
+
+
+#: Every call site KNOWN to pass ``state=`` today — all 9 are the MCP tool
+#: definitions (D3/D4 call_mcp_tool/describe_mcp_tool + the 7 resource/
+#: prompt verbs) inside ``router_tools.py``'s ``build_tools()`` (lines
+#: 264-988; the file's only OTHER top-level function,
+#: ``_build_tools_via_registry``, starts at line 990 and does not appear
+#: here). `build_tools()` is called only from `RouterLoop.present`/
+#: `base_tools()` (#4401's own trace, issue #4401 R2 comment), which are
+#: reachable only from inside `RouterLoop.run()` — the boundary #4401 ①'s
+#: await sits at the top of.
+_DECLARED_SITES: "set[tuple[str, int]]" = {
+    ("src/reyn/runtime/router_tools.py", 802),   # D3 call_mcp_tool
+    ("src/reyn/runtime/router_tools.py", 815),   # D4 describe_mcp_tool
+    ("src/reyn/runtime/router_tools.py", 844),   # list_mcp_resources
+    ("src/reyn/runtime/router_tools.py", 857),   # list_mcp_resource_templates
+    ("src/reyn/runtime/router_tools.py", 870),   # read_mcp_resource
+    ("src/reyn/runtime/router_tools.py", 883),   # subscribe_mcp_resource
+    ("src/reyn/runtime/router_tools.py", 896),   # unsubscribe_mcp_resource
+    ("src/reyn/runtime/router_tools.py", 909),   # list_mcp_prompts
+    ("src/reyn/runtime/router_tools.py", 922),   # get_mcp_prompt
+}
+
+
+def test_extraction_is_not_vacuous() -> None:
+    """Tier 2: the walk actually finds calls — an extractor that silently
+    returns nothing would make every assertion below pass vacuously."""
+    found = _find_state_passing_render_for_router_calls()
+    assert found, (
+        "the walk found NO render_for_router(state=...) call anywhere in "
+        "src/ — either the extractor is broken, or every #4401-relevant "
+        "call site is genuinely gone (verify before believing it; a broken "
+        "walk looks identical to that)."
+    )
+
+
+def test_every_state_passing_call_site_is_declared_and_known() -> None:
+    """Tier 2: the ratchet — a NEW ``render_for_router(state=...)`` call
+    site outside the declared set is exactly the shape #4401 ①'s await
+    stops covering (a partial mcp catalog could then reach an LLM-facing
+    enum without ever passing through `RouterLoop.run()`'s own await)."""
+    found = _find_state_passing_render_for_router_calls()
+    undeclared = found - _DECLARED_SITES
+    assert not undeclared, (
+        f"undeclared render_for_router(state=...) call site(s): {sorted(undeclared)!r}. "
+        "★ Before touching _DECLARED_SITES: this new call site can bypass "
+        "#4401 ①'s single await-at-run()-top guard — PROVE it is reached "
+        "only from inside RouterLoop.run() (trace every caller, the way "
+        "issue #4401's own R2 comment did for the existing 9), the same "
+        "way #4401 ① protects the declared sites today. Adding the line "
+        "here WITHOUT that proof only silences this test — it does not "
+        "close the hole. If the new site is NOT downstream of run()'s "
+        "await, #4401 ①'s design itself needs revisiting (a new "
+        "consumption point, or a different seam) before this test may "
+        "go green again."
+    )
+
+
+def test_no_declared_site_is_stale() -> None:
+    """Tier 2: the standing positive control — every declared site is still
+    FOUND. A site that's genuinely gone (code moved/removed) needs its
+    entry deleted here, not left stale; more importantly, a REGRESSED walk
+    (a lost AST shape) would make declared sites vanish from the found set,
+    which would otherwise read as "the census got smaller" — the most
+    flattering possible way for this gate to break silently."""
+    found = _find_state_passing_render_for_router_calls()
+    stale = _DECLARED_SITES - found
+    assert not stale, (
+        f"_DECLARED_SITES declares site(s) the walk no longer finds: {sorted(stale)!r}. "
+        "If genuinely gone, delete the entry and say so in the PR. If not, "
+        "the walk regressed and the 'no undeclared site' result above is "
+        "understated."
+    )


### PR DESCRIPTION
**[tui-coder]** — touches tests/ — TESTS-READ needed

part of #4401

Owner-ratified design (A-4, issue #4401), approved by architect+lead-coder
after 2 rounds of co-vet: kick off the MCP tools probe in the background
at Session construction (never awaited there), and await it ONLY at the
2 real catalog CONSUMPTION points instead of unconditionally at every
turn boundary. A probe is a precondition for the LLM NAMING an mcp tool
(the schema's mcp_tool_name enum), never for executing one (roster +
connection pool only, architect's own principle) — so a turn that never
touches the mcp catalog now pays nothing, and a hook-woken turn 1 (which
never reaches Session.__init__ → first-turn gap the old lazy design left
unable to name any mcp tool) gets the same head start as a normal turn.

## The design

- `Session.__init__` calls `RouterHostAdapter.start_mcp_probe` right
  after the router-host waist is built — a fire-and-forget background
  task via `TrackedTaskSet.spawn` (disposition="await", so session
  shutdown waits for it to finish rather than cancelling it out from
  under an in-flight waiter — the F3 condition below).
- `RouterLoop.run()`'s own top now awaits `await_mcp_probe_ready` before
  anything in that turn reads `host.get_mcp_servers()`.
  `RouterHostAdapter.mcp_list_servers()` (op D1) awaits it internally too.
  These are the 2 real consumption points; `get_mcp_servers()` itself
  stays sync and unchanged — a 3rd, per-render-frame status-bar preview
  caller (`capability_visibility.py`) deliberately never waits (a preview
  is not "the LLM naming a tool").
- The turn-boundary `await ensure_mcp_tools_cached(...)` this replaces is
  removed from both `Session._run_router_loop` and `refresh_mcp_servers`
  (the latter now routes through the same `await_mcp_probe_ready` seam).

## Why this required 2 rounds of co-vet, and what changed

`RouterHostAdapter._mcp_tools_cache` has 3 writers (the probe's own
merge, `invalidate_mcp_tools_cache`, a disk hot-swap) that were safe only
because a turn's own probe call was always synchronous/serialized —
backgrounding it introduces real concurrency for the first time. The
architect co-vet's F1/F2/F3/F5 findings are now addressed structurally:

- **F1** (atomic pair): a single `_apply_mcp_cache(value, mtime, bump_epoch)`
  is the ONLY place the cache dict + its mtime + the new epoch counter are
  assigned — one synchronous statement group, no `await` between them.
- **F2** (the epoch is per-session, the cache FILE is per-workspace,
  shared by N sessions): documented as a scope limit whose actual
  tolerance is FP-0037's own "absent ⇒ re-probed" property
  (`mcp_cache_file.py`, cross-referenced from both sides, load-bearing —
  a future "persist unknowns too" optimization would silently break it).
- **F3** (a waiter never re-waits): `await_mcp_probe_ready` is a single
  `await`, never a loop — if the epoch moves mid-await, the waiter still
  returns normally once the in-flight probe settles (even if THAT probe's
  own results get discarded as stale); the next turn/consumption point
  sees the newer epoch and re-probes then.
- **F5** (epoch gates the disk persist too, not just the in-memory
  merge): a stale probe cycle writes nothing to the shared cache file
  either — closing the F2 window through which a stale view could
  otherwise reach another session.
- **R1** (moved the weight-bearing invariant to the side that actually
  carries it): `mcp_cache_file.py`'s own module docstring now states the
  "self-healing, not correctness" property explicitly, since architect's
  R1 point was that "read before write" alone does not prevent a lost
  update — what bounds the damage is FP-0037's re-probe-on-absence design.
- **R2** (the empirical trace, issue #4401's own comments): confirmed
  `get_mcp_servers()`'s 5 model-facing call sites are NOT all downstream
  of `RouterLoop.run()`'s top — 2 aren't (a compaction budget size
  estimate, and 4 op-execution-only contexts). Further tracing showed
  those 4 never pass `state=` to `render_for_router`, so they never
  trigger `_enrich_router_schema`'s enum injection — no actual LLM-facing
  leak. `test_4401_render_for_router_state_census.py` is the mechanical
  ratchet the architect's own condition required: it pins EVERY
  `render_for_router(state=...)` call site (an AST walk, not a grep) and
  goes red the day a new one appears outside the declared, `run()`-gated
  set — with a failure message that demands proof of `run()`-reachability
  BEFORE the declared set is touched (R3's own "the gate is a detector,
  not a repair obligation" correction — updating the list alone would
  silence the test without closing the hole).
- **R3** (the ②/single-apply-point witness must use state transitions,
  never private call counts): `test_4401_a4_cache_concurrency.py`'s own
  witness test drives all 3 external cache drivers and asserts on the
  PUBLIC `mcp_tools_cache_snapshot` transitions each produces, never on
  how many times the private `_apply_mcp_cache` was called.

A real bug surfaced while writing the witness test itself: gating
`mcp_tools_cache_snapshot`'s own "None = never populated" contract on
`_mcp_disk_warm_start_attempted` (a flag `ensure_mcp_tools_cached`-only)
left it silently wrong for a cache populated ONLY via `maybe_reload_mcp_
tools_cache_from_disk` (a real, reachable order — an explicit `reyn mcp
refresh` landing before this session's first turn) — fixed with a
separate `_mcp_cache_populated` flag every driver sets.

## BLOCKING fixes (2 rounds, PR review)

1. `_DECLARED_SITES` keyed on `(file, lineno)` — fixed to `(file, enclosing_function, receiver_variable_name)`, line-number-independent (falsify-verified both directions).
2. 2 real CI regressions (`test_2761_pr3_mcp_immediate_probe.py`, `test_3475_mcp_probe_priming_all_turn_kinds.py`) traced by driving the real `start_mcp_probe`/`await_mcp_probe_ready` seam (disconfirmed architect's own inferred warm-start/epoch-race mechanism — the real one is simpler: a construction-time probe against an empty roster finishes instantly, and its FINISHED task then gets trusted as sufficient for a server added afterward). Fixed with a new **single source of truth for ①②③**: `RouterHostAdapter._mcp_attempted: set[str]` — the one fact "has this session ever dispatched a probe for this server", read by ①'s `await_mcp_probe_ready` fallback, ②'s `{}`-vs-`None` establishment, and ③'s `mcp_probe_snapshot` "not_probed" state alike, never three independently-derived answers to the same question.

Test plan:
- [x] `test_a_probe_that_is_invalidated_mid_flight_is_discarded_not_merged` / `test_a_waiter_does_not_re_wait_when_the_epoch_moves_mid_await` — F3/F5, falsify-verified (Edit-to-break the epoch-discard check → confirmed red → restored, no `git checkout`/`stash`/`restore` used anywhere in this worktree)
- [x] `test_a_successful_probe_leaves_disk_reload_a_no_op` / `test_a_failed_disk_write_still_advances_the_in_memory_answer` — F1, the (cache, mtime) pair
- [x] `test_each_of_the_three_external_drivers_produces_its_own_observable_transition` — R3, state-transition witness (never a private call count)
- [x] `test_a_server_added_after_the_construction_probe_finished_is_still_probed` / `test_an_already_tried_unresponsive_server_is_not_reprobed_on_the_turn_path` — the 2 BLOCKING CI regressions, driven-reproduced then fixed via `_mcp_attempted`; falsify-verified
- [x] `test_every_state_passing_call_site_is_declared_and_known` / `test_no_declared_site_is_stale` — R2/R3's own completeness census over `render_for_router(state=...)`, AST-based
- [x] 2366 `tests/runtime/`, 763 `tests/llm/` (full RouterLoop/LLM-replay family, since `RouterLoop.run()` itself changed), plus every mcp/visibility/transport/S4-family test already exercised by the merged #5761 — all green (scoped to the diff, per instruction — full pytest left to CI)
- [x] ruff / mypy_ratchet / test_tier_audit --strict / verify_module_docstrings / flat_tests_ratchet / tests-path-literal-reference — all clean (path-literal-reference re-run after `git add`, per this session's own established discipline)
- [ ] 👁️ Visual (standing waiver — owner 2026-08-08, unchecked, not fabricated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7

