### PR TITLE
docs(#5759): ADR-0046 — the OS does not discard the user's own data; falsification test now has two candidates

### DIFF
--- a/docs/deep-dives/decisions/0046-resources-not-control-flow.md
+++ b/docs/deep-dives/decisions/0046-resources-not-control-flow.md
@@ -21,6 +21,7 @@ Three control-flow guards were considered. All three are rejected below, and two
 - Each charter band member bounds **its own resource, cause-independently**: `CostConfig` bounds compute, the media store's project-wide cross-session cap bounds storage, the permission gate bounds outward side effects.
 - **Termination of an operator's own workflow is the operator's.** A recursive workflow that converges is legitimate — build systems and file watchers are exactly this shape — and the OS must not forbid the shape in order to prevent the non-converging case.
 - The OS retains two duties, **neither of which is a threshold**: a running loop must be **visible**, and it must be **stoppable**. "User responsibility" is only coherent when the user can see the thing they are responsible for.
+- **The OS bounds resources; it does not discard the user's own data.** A cache is the OS's to reclaim; a conversation is not. The distinction is not size or growth rate but authorship — `cache/` is derived, `events/` is a forensic record the OS writes, and `history.jsonl` **is the conversation itself**. Reclaiming the first two is resource bounding; deleting the third is taking something from the user, which this decision does not authorise. (Raised while drafting the #5759 countermeasures; the practical consequence there was that only turns **no `/rewind` the product will accept can still reach** are eligible, which is not a deletion of anything the user can still see.)
 
 ## Alternatives considered
 
@@ -51,7 +52,16 @@ The common defect in all three: they bound **how the workflow is shaped**, and n
 
 ## Falsification
 
-This decision is falsified by **a runaway that consumes a resource no band member bounds**. None was found while drafting, but the resource list was **not enumerated exhaustively** — the three above were reached by asking "what does a loop cost", not by walking a registry. A fourth resource with no cap would require either a new cap or a revisit of the whole line.
+This decision is falsified by **a runaway that consumes a resource no band member bounds**.
+
+**Two candidates were found after drafting** (2026-09-05, [#5759](https://github.com/tya5/reyn/issues/5759)), by walking `docs/reference/runtime/reyn-dir-layout.md`'s own tree rather than asking "what does a loop cost":
+
+- `agents/*/history.jsonl` — append-only and, in `core/events/retention.py`'s own words, **never floor-truncated**.
+- `events/` — the store supports size- and age-based rotation and is constructed with **both disabled** (`max_bytes=0, max_age_seconds=0`), splitting by date instead; rotation opens a new file and **deletes nothing**, so the daily files accumulate without bound.
+
+The project-wide storage cap (#4478) covers `media/` + `memory/history-content/` together and neither of these. `CostConfig` bounds compute, not a loop that writes without calling an LLM.
+
+**This does not settle the decision either way.** A cap could be added for each (making them band-covered, and the line holds), or their absence could be declared deliberate (and the line needs the qualification). **Deciding that is a precondition for raising this ADR out of PROPOSED**, and it is not decided here.
 
 ## References
 


### PR DESCRIPTION
**[architect]** — **ADR-0046 が PROPOSED のうちに 2 点 修正します。status は動かしません。昇格も提案しません。**

lead-coder の裁定どおり: 「immutability は **once accepted** に掛かる ∴ 批准前の修正は規則の内側。ただし **status を動かさない**、**drive-by でなく 1 本の PR**」。owner の逐語「今のは議論だから設計・実装への反映はまだしないでね」は生きており、**本 PR は実装を 1 行も許可しません**（本文の「Nothing in this ADR authorises an implementation.」も無改変）。

## ① 決定に 1 節 追加 — **OS は資源を縛るが、利用者のデータは捨てない**

判別子は**大きさでも増加率でもなく、誰が書いたか**です:

- `cache/` — 導出 ∴ OS が回収してよい
- `events/` — OS が書く法医学的記録
- **`history.jsonl` — 会話そのもの** ∴ 消すのは資源の bounding ではなく、**利用者から取り上げる行為**

⚪ 出所は #5759 の対策検討です。そこでの実際の帰結は「**製品が受け付ける `/rewind` のどれからも到達できないターンだけが対象**」で、**ユーザに見えているものは 1 行も減りません** — つまりこの節は、実務でも「取り上げない」側に効いています。

## ② Falsification の記述が**偽になったので直します**

本文は「**None was found while drafting**」でしたが、**#5759 の census で 2 件出ました**（`reyn-dir-layout.md` の tree を歩いた結果で、「ループは何を食うか」からの推測ではありません）:

- **`agents/*/history.jsonl`** — `core/events/retention.py` 逐語「**append-only and never floor-truncated**」
- **`events/`** — 回転機能を持つのに `max_bytes=0, max_age_seconds=0` で**両方 無効化**され、日付で分割するだけ。**回転は新しいファイルを開くだけで何も消しません** ∴ 日ごとのファイルが無限に増えます

storage cap（#4478）が覆うのは `media/` ＋ `memory/history-content/` の合算で、**この 2 つは入りません**。`CostConfig` は計算を縛りますが、**LLM を呼ばずに書くだけのループには効きません**。

🔴 **これは決定を否定も肯定もしません。** 2 件に cap を足せば band が覆い、線は保たれます。意図的に覆わないと宣言するなら、線に但し書きが要ります。**どちらを採るかは、この ADR を PROPOSED から上げる前提条件**として本文に書きました。**ここでは決めていません。**

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — 緑
- [x] `python scripts/check_doc_anchors.py` — `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` — `0 hits (26 retired top-level key(s) checked)`
- [x] **Status 行 無改変**（PROPOSED のまま／owner の保留の逐語も残置）
- [x] (skipped — docs のみ、`src/` / `tests/` 無改変) `pytest` / `ruff` / tier audit / mypy ratchet

## 射程外

- **昇格の提案はしません。** owner の保留が生きている間は status に触れません。
- `.ja.md` の対訳は作りません（既存 `.ja.md` の主張を偽にしません）。
- ②が挙げた 2 件を**どうするか**は本 PR では決めません（#5759 の 2 段目、owner が実サイズを見てから）。

part of #5759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow