### PR TITLE
docs(#5759): ADR-0046 — drop the attribution quote of a mutable sibling doc

### DIFF
--- a/docs/deep-dives/decisions/0046-resources-not-control-flow.md
+++ b/docs/deep-dives/decisions/0046-resources-not-control-flow.md
@@ -27,7 +27,7 @@ Three control-flow guards were considered. All three are rejected below, and two
 
 | Alternative | Why not |
 |---|---|
-| **A raw count of hook-driven turns** (`safety.loop.max_hook_driven_turns`, default 25) | Already abolished, #5561, owner ruling 2026-08-30. Owner verbatim: 「hook 起動を回数で制限なんて誰も設定できないでしょ。どんな回数が妥当か誰も判断できない」. The default was, in the concept doc's own words, 「意図的な決定を装った事実上の未検討回答」. |
+| **A raw count of hook-driven turns** (`safety.loop.max_hook_driven_turns`, default 25) | Already abolished, #5561, owner ruling 2026-08-30. Owner verbatim: 「hook 起動を回数で制限なんて誰も設定できないでしょ。どんな回数が妥当か誰も判断できない」. The default was never derived from reyn's own data — no operator could state the correct count, so it stood in for a decision without being one (`docs/concepts/runtime/hooks.ja.md` § ループバルブ records the ruling and its reasoning). |
 | **A predicate detecting a true self-continuation cycle** | Considered and rejected in the same #5561 ruling: no such cycle has ever been observed. |
 | **A static partition of hook points by "can a running turn cause this point to fire"** (architect, #5747) | **Withdrawn by its author.** It is a variant of the already-rejected cycle predicate, and strictly worse: cycle detection costs no expressiveness, while a static partition forbids legitimate watch/build workflows outright. Owner verbatim: 「あなたの考えた機構によってユーザによる決定論的ワークフローのできることを狭めるという弊害が許容できるのかという問題に差し代わるだけ」／「これは、再帰無限を単純に禁止すれば良いという問題ではなさそうに思える」. |
 


### PR DESCRIPTION
**[architect]** — #5759 の残務 **(B)** です。**#5767 が landing したので契機が来ました。** (A) は **#5767 で完了済なので含めていません**（二重に直すと片方が他方を偽にします）。

## 直したもの — 1 箇所

Alternatives 表が、別 doc の**現在の文言**に帰属していました:

> The default was, **in the concept doc's own words**, 「意図的な決定を装った事実上の未検討回答」.

**この形は、誰も強制しない結合を作ります。** 実際この arc で 1 度 壊れています — **ある PR が `retention.py` の docstring を書き換えた一方、この ADR は「その doc の言葉」としてその語句を引いたままでした**（変更後の file に該当語句は 0 件）。

**事実を直接述べ、concept doc は裁定の参照として挙げる**形に置き換えました。**「その語で言っている」とは書きません。**

## ★ 適用した判別子（#5759 に記録済）

> **引くのが *発話* か、*文書の現在の状態* か。**
> - **発話**（owner がそう言った／あの時こう決まった）= **時点に固定** ∴ **引用してよい**
> - **文書の現在の状態**（この docstring は今こう書いてある）= **可変** ∴ **引用しない**

∴ **同じ表に在る owner 逐語 2 件は発話なので無改変**です（実測: `Owner verbatim` は 2 件のまま）。**「更新され得るか」だけの判別子だと owner 逐語まで巻き込むため、この 2 分にしています。**

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — 緑
- [x] `python scripts/check_doc_anchors.py` — `no dangling anchors into published pages`
- [x] `python scripts/check_retired_config_keys_denylist.py` — `0 hits (26 retired top-level key(s) checked)`
- [x] **`**Status**:` 行と `Nothing in this ADR authorises an implementation.` が無変更**（`git diff` の本文行に 0 件）
- [x] **`own words` が 0 件／`Owner verbatim` が 2 件**（発話は残し、文書帰属だけ外したことの witness）
- [x] (skipped — docs のみ、`src/` / `tests/` 無改変) `pytest` / `ruff` / tier audit / mypy ratchet

## 射程外

- **status は動かしません。昇格も提案しません**（owner の保留「今のは議論だから設計・実装への反映はまだしないでね」が生きています）。
- **(A)（Falsification 節の `events/` 訂正）は含めません** — #5767 で完了済です。
- `.ja.md` の対訳は作りません（既存 `.ja.md` の主張を偽にしません）。

part of #5759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow