### PR TITLE
feat(#5771): stage 1+2 - close the wire-vocabulary drift, wire the 8 real cost keys to remote

### DIFF
--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -49,8 +49,11 @@ the gate is RED:
    the wire protocol automatically re-enters this gate's scope, no second
    edit needed) is the set of ``.get()`` KEY ARGUMENTS with no possible
    "not yet on the wire" state. Matched against the ``.get()`` call's own
-   key argument (not necessarily the dict's own output key — e.g.
-   ``cost_usd``'s call reads the ``"cost_agent"`` wire key).
+   key argument (not necessarily the dict's own output key — #5771 fixed
+   the one case that used to differ, ``cost_usd``'s call reading the
+   ``"cost_agent"`` wire key under a different name; see this module's
+   own "second axis" section below for why THAT shape needed a separate
+   check, not a fix to this remedy).
 2. **A declared axis exists.** ``ChatReadModelCapabilities`` has a field
    named ``f"{key}_reported"``, OR the key is one of the hand-maintained
    grouped pairings below (a boolean covering more than one dict key —
@@ -97,12 +100,15 @@ cannot see the SHAPE of — turned out to be one symptom of a bigger,
 independent question :func:`find_unwired_key_violations` asks instead of
 trying to widen the AST walk into container literals: never mind what
 SHAPE a value is — is the dict KEY it is assigned to even a real
-``project_status`` key? ``"cost_usd": v.get("cost_agent", 0.0)`` passes
-EVERY remedy above (``"cost_agent"``, the ``.get()`` call's own key
-ARGUMENT, is genuinely on the wire per ``_WIRE_KEYS``) while the OUTPUT
-key ``"cost_usd"`` is not a real ``project_status`` key at all — an
-alias, not a placeholder, and invisible to remedies ①②③ because none of
-them ever look at the output key's own name against ``project_status``.
+``project_status`` key? Before #5771 stage②, ``"cost_usd": v.get(
+"cost_agent", 0.0)`` passed EVERY remedy above (``"cost_agent"``, the
+``.get()`` call's own key ARGUMENT, was genuinely on the wire per
+``_WIRE_KEYS``) while the OUTPUT key ``"cost_usd"`` was not a real
+``project_status`` key at all — an alias, not a placeholder, invisible
+to remedies ①②③ because none of them ever look at the output key's own
+name against ``project_status`` (stage② later wired ``cost_usd`` for
+real, closing this SPECIFIC instance — the general question this axis
+asks stays live for every other key).
 #5098's own invariant ("one declaration, not two that can drift apart")
 is about exactly this — a SEPARATE, narrower promise than "is this
 value's placeholder-ness declared" — so :func:`find_unwired_key_
@@ -141,12 +147,16 @@ _GROUPED_AXIS_KEYS = {
     # #5094/#5097: one flag covers both halves of the model-class catalog.
     "model_classes": "model_catalog_reported",
     "model_active_class": "model_catalog_reported",
-    # #5009: cache-hit accounting shares 1 axis with "session_cached_tokens"
-    # below (the axis docstring's own "covers two snapshot() dict KEYS
-    # instead" note); "ctx_recent_usage" itself is a tuple-shaped value this
-    # gate's shape detector does not parse (see module docstring's own
-    # disclosed gap) so it never reaches this mapping today.
-    "session_cached_tokens": "cache_usage_reported",
+    # #5771 stage②: "session_cached_tokens" used to share this entry with
+    # "cache_usage_reported" (#5009) -- REMOVED, not updated to the new
+    # split field name, because the key is now genuinely, unconditionally
+    # on the wire (_WIRE_KEYS) and this remedy is unreachable for it: a
+    # dict entry here is only ever consulted by find_violations's remedy②,
+    # which remedy① (the _WIRE_KEYS membership check) already short-
+    # circuits before reaching. "ctx_recent_usage" itself is a tuple-
+    # shaped value this gate's shape detector does not parse (see module
+    # docstring's own disclosed gap) so it never reached this mapping
+    # either, before or after.
     # #5034: the hook-pane's 2nd dict key rides the same axis as "hooks".
     "hook_items": "hooks_reported",
     # #5009: the compaction-status callable slot is explicitly "gated by
@@ -438,18 +448,19 @@ def find_unwired_key_violations(
     #5098's own invariant is a DIFFERENT, narrower promise: ``project_
     status`` is "the SOLE declaration of which keys ride the wire" (that
     function's own docstring, verbatim). Those two questions can give
-    opposite answers on the SAME key: ``"cost_usd": v.get("cost_agent",
-    0.0)`` passes remedy① today (``"cost_agent"`` — the ``.get()``
-    ARGUMENT — is genuinely, unconditionally on the wire, per
-    ``_WIRE_KEYS``) even though the OUTPUT key ``"cost_usd"`` itself is
-    not a real ``project_status`` key at all — the value is quietly
-    aliased from a DIFFERENT wire fact under a name that claims to be
-    its own. #5098's invariant is violated the moment ANY output key
-    lacks a same-named ``project_status`` entry, independent of whether
-    remedies ①②③ would separately excuse its placeholder-ness — so this
-    check does not consult them, deliberately: a key can be an honestly-
-    declared placeholder (passing #5093's own gate) and STILL be exactly
-    the drift #5098 exists to prevent.
+    opposite answers on the SAME key — before #5771 stage②,
+    ``"cost_usd": v.get("cost_agent", 0.0)`` passed remedy① (``"cost_
+    agent"`` — the ``.get()`` ARGUMENT — was genuinely, unconditionally
+    on the wire, per ``_WIRE_KEYS``) even though the OUTPUT key
+    ``"cost_usd"`` itself was not a real ``project_status`` key at all —
+    the value was quietly aliased from a DIFFERENT wire fact under a
+    name that claimed to be its own (stage② later wired it for real,
+    closing this specific instance). #5098's invariant is violated the
+    moment ANY output key lacks a same-named ``project_status`` entry,
+    independent of whether remedies ①②③ would separately excuse its
+    placeholder-ness — so this check does not consult them, deliberately:
+    a key can be an honestly-declared placeholder (passing #5093's own
+    gate) and STILL be exactly the drift #5098 exists to prevent.
 
     Deliberately WIDE, deliberately un-filtered (#5771 stage ① scope,
     lead-coder dispatch): this returns EVERY output key without a
@@ -643,9 +654,15 @@ _PENDING = "PENDING"
 #: flagged — encouraged, not required, so a fix elsewhere never needs to
 #: touch this file.
 #:
-#: 40 entries. PENDING (3): the cost-tab keys this PR's own stage① exists
-#: to eventually fix — #5771's own issue body commits to wiring these in
-#: stage②, reusing ``CostBreakdown.to_dict()``. LOCAL (37): 16 literal
+#: 38 entries (was 40 — #5771 stage② wired ``cost_usd``/``usage``/
+#: ``session_cached_tokens`` for real and removed them here, then added 1
+#: new spread field, ``session_cache_usage_reported``, split off ``cache_
+#: usage_reported`` on the SAME PR; a wired key is no longer unwired-key
+#: drift at all, so a baseline entry for it would be a standing lie about
+#: the gate's own findings). PENDING (2): ``hooks_config_warnings``/
+#: ``mcp_probe_states`` — real session data, not yet wired, filed on
+#: #5774 for triage (see their own entries below for the citation).
+#: LOCAL (36): 14 literal
 #: output keys whose OWN inline comment in ``project_remote_snapshot``
 #: already says the underlying data is session-local/client-local by
 #: construction (``skills``/``mcp_servers``/``turn_usage_fn`` already sit
@@ -653,7 +670,7 @@ _PENDING = "PENDING"
 #: ``unknown_config_key_count``/``unknown_config_keys`` name the CLIENT's
 #: own reyn.yaml, structurally absent on a remote connection; ``ctx_
 #: source`` is a label, not fabricatable figure; ``tasks`` is explicitly
-#: "never on the wire" per its own comment) — plus all 21
+#: "never on the wire" per its own comment) — plus all 22
 #: ``ChatReadModelCapabilities`` field names reached through the
 #: ``**reported_snapshot_keys(...)`` spread, LOCAL by DESIGN rather than
 #: by accident: a ``*_reported`` flag is a CLIENT-side declaration about
@@ -669,13 +686,17 @@ _PENDING = "PENDING"
 #: session-local literal keys above — their own inline comments in
 #: ``project_remote_snapshot`` explicitly say "not wired onto the wire
 #: YET" (not "structurally cannot exist"), the opposite framing the LOCAL
-#: entries' own comments use — genuinely different from the other 35,
+#: entries' own comments use — genuinely different from the other 36,
 #: filed on #5774 for real triage rather than guessed here.
 _UNWIRED_KEY_VIOLATIONS_BASELINE: "dict[str, str]" = {
-    # PENDING — #5771 stage② commits to wiring these for real.
-    "cost_usd": _PENDING,
-    "usage": _PENDING,
-    "session_cached_tokens": _PENDING,
+    # #5771 stage②: "cost_usd"/"usage"/"session_cached_tokens" REMOVED —
+    # all 3 are now genuinely, unconditionally on the wire (project_status
+    # emits them for real); find_unwired_key_violations no longer flags
+    # them at all, so a baseline entry for them would be a standing lie
+    # (lead-coder's own instruction on the stage② dispatch: "残すと gate
+    # は緑のまま宣言が嘘になります" — leaving it would keep the gate green
+    # while the declaration itself became false).
+    #
     # PENDING — real session data, explicitly "not wired onto the wire
     # YET" per project_remote_snapshot's own inline comment (unlike the
     # LOCAL entries below, whose own comments say the opposite) -- #5774
@@ -723,6 +744,10 @@ _UNWIRED_KEY_VIOLATIONS_BASELINE: "dict[str, str]" = {
     "hooks_config_warnings_reported": _LOCAL,
     "compaction_progress_reported": _LOCAL,
     "tasks_reported": _LOCAL,
+    # #5771 stage②: new field (split from cache_usage_reported) — LOCAL
+    # by the same DESIGN reasoning as every other spread field above, a
+    # client-side declaration, never wire data.
+    "session_cache_usage_reported": _LOCAL,
 }
 
 

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -88,7 +88,28 @@ this gate's own enforcement — a FUTURE change to either that drops the
 axis check would not be caught here. Widening the AST walk to recurse
 into container literals is future work, not attempted in this PR (#5093's
 own scope: the placeholder shapes actually observed at #5009/#5034/#5094's
-own findings, all of which were shape (a)/(b), not a nested tuple)."""
+own findings, all of which were shape (a)/(b), not a nested tuple).
+
+## A second axis (#5771): does the OUTPUT KEY itself ride the wire at all
+
+The gap above — the ``usage``/``ctx_recent_usage`` tuples this gate
+cannot see the SHAPE of — turned out to be one symptom of a bigger,
+independent question :func:`find_unwired_key_violations` asks instead of
+trying to widen the AST walk into container literals: never mind what
+SHAPE a value is — is the dict KEY it is assigned to even a real
+``project_status`` key? ``"cost_usd": v.get("cost_agent", 0.0)`` passes
+EVERY remedy above (``"cost_agent"``, the ``.get()`` call's own key
+ARGUMENT, is genuinely on the wire per ``_WIRE_KEYS``) while the OUTPUT
+key ``"cost_usd"`` is not a real ``project_status`` key at all — an
+alias, not a placeholder, and invisible to remedies ①②③ because none of
+them ever look at the output key's own name against ``project_status``.
+#5098's own invariant ("one declaration, not two that can drift apart")
+is about exactly this — a SEPARATE, narrower promise than "is this
+value's placeholder-ness declared" — so :func:`find_unwired_key_
+violations` does not consult ①②③ at all; see its own docstring for the
+full reasoning and #5771's own issue thread for why this axis is
+deliberately reported wide (every unbacked key), not filtered down to
+an allowlisted few."""
 from __future__ import annotations
 
 import ast
@@ -334,10 +355,93 @@ def find_wire_keys_violations(agui_state_path: "Path | None" = None) -> "list[st
     ]
 
 
+def find_unwired_key_violations(
+    package_dir: "Path | None" = None, agui_state_path: "Path | None" = None,
+) -> "list[str]":
+    """#5771 stage ① — the axis #5093's own 2 existing checks do NOT cover:
+    a ``project_remote_snapshot`` OUTPUT key that is not itself a key
+    ``project_status`` (agui/state.py) emits, regardless of whether its
+    VALUE'S OWN placeholder-ness is properly declared.
+
+    #5093's existing :func:`find_violations` asks "is this value's
+    graceful-degrade nature honestly declared" (remedies ①②③, all keyed
+    off the VALUE's shape or the ``.get()`` call's own key ARGUMENT).
+    #5098's own invariant is a DIFFERENT, narrower promise: ``project_
+    status`` is "the SOLE declaration of which keys ride the wire" (that
+    function's own docstring, verbatim). Those two questions can give
+    opposite answers on the SAME key: ``"cost_usd": v.get("cost_agent",
+    0.0)`` passes remedy① today (``"cost_agent"`` — the ``.get()``
+    ARGUMENT — is genuinely, unconditionally on the wire, per
+    ``_WIRE_KEYS``) even though the OUTPUT key ``"cost_usd"`` itself is
+    not a real ``project_status`` key at all — the value is quietly
+    aliased from a DIFFERENT wire fact under a name that claims to be
+    its own. #5098's invariant is violated the moment ANY output key
+    lacks a same-named ``project_status`` entry, independent of whether
+    remedies ①②③ would separately excuse its placeholder-ness — so this
+    check does not consult them, deliberately: a key can be an honestly-
+    declared placeholder (passing #5093's own gate) and STILL be exactly
+    the drift #5098 exists to prevent.
+
+    Deliberately WIDE, deliberately un-filtered (#5771 stage ① scope,
+    lead-coder dispatch): this returns EVERY output key without a
+    same-named ``project_status`` entry, including ones that are
+    genuinely, permanently session-local (``cron_jobs``, ``tasks``,
+    etc. — these will likely never gain a ``project_status`` twin, and
+    that is fine; #5098's invariant was never "every key must be on the
+    wire", only "a key that name-claims to be one thing must not
+    silently be a different, unwired one"). Stage ① does not attempt to
+    tell the two apart with a per-key exemption list — see
+    ``test_5771_unwired_key_violations_expose_the_cost_tab_drift.py``
+    for the current disclosed list and #5771's own issue thread for the
+    triage split (cost tab keys fixed here; every other exposed key
+    filed as its own issue, not silenced by an allowlist invented for
+    this PR alone)."""
+    if package_dir is None:
+        package_dir = _PACKAGE_DIR
+    if agui_state_path is None:
+        agui_state_path = _AGUI_STATE_PATH
+
+    remote_dict, error = _find_function_return_dict(package_dir, "project_remote_snapshot")
+    if remote_dict is None:
+        return [error or "unknown error locating project_remote_snapshot"]
+    status_dict, error = _find_function_return_dict(agui_state_path, "project_status")
+    if status_dict is None:
+        return [error or "unknown error locating project_status"]
+
+    wire_keys = {
+        key_node.value
+        for key_node in status_dict.keys
+        if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)
+    }
+
+    violations: "list[str]" = []
+    for key_node in remote_dict.keys:
+        if key_node is None:  # a ``**spread`` entry -- not a literal output key
+            continue
+        if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
+            continue
+        dict_key = key_node.value
+        if dict_key in wire_keys:
+            continue
+        violations.append(
+            f'"{dict_key}": project_remote_snapshot maps this key, but '
+            f'project_status (agui/state.py) has no key of this name -- '
+            f'#5098\'s "one declaration, not two that can drift apart" is '
+            f'broken for this key regardless of whether its placeholder-ness '
+            f'is otherwise declared. Either add "{dict_key}" to '
+            f'project_status\'s own return dict (if it is genuinely '
+            f'real, per-connection wire data), or confirm it is intentionally '
+            f'session-local and file/track it separately -- this check does '
+            f'not accept a same-file exemption.'
+        )
+    return violations
+
+
 def main() -> int:
     violations = find_violations(_PACKAGE_DIR)
     wire_key_violations = find_wire_keys_violations(_AGUI_STATE_PATH)
-    if violations or wire_key_violations:
+    unwired_key_violations = find_unwired_key_violations(_PACKAGE_DIR, _AGUI_STATE_PATH)
+    if violations or wire_key_violations or unwired_key_violations:
         if violations:
             print(
                 "check_remote_snapshot_placeholder_declared: "
@@ -354,10 +458,20 @@ def main() -> int:
             )
             for v in wire_key_violations:
                 print(f"  - {v}")
+        if unwired_key_violations:
+            print(
+                "check_remote_snapshot_placeholder_declared: "
+                f"{len(unwired_key_violations)} project_remote_snapshot key(s) "
+                "not backed by a same-named project_status key (#5771):\n"
+            )
+            for v in unwired_key_violations:
+                print(f"  - {v}")
         return 1
     print("check_remote_snapshot_placeholder_declared: OK, every placeholder-shaped "
-          "key is covered by _WIRE_KEYS, a declared axis, or a cited exemption, and "
-          "_WIRE_KEYS is a verified subset of project_status's unconditional keys.")
+          "key is covered by _WIRE_KEYS, a declared axis, or a cited exemption, "
+          "_WIRE_KEYS is a verified subset of project_status's unconditional keys, "
+          "and every project_remote_snapshot output key is backed by a same-named "
+          "project_status key.")
     return 0
 
 

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -117,7 +117,12 @@ import sys
 from pathlib import Path
 
 from reyn.interfaces.repl import read_model as read_model_module
-from reyn.interfaces.repl.read_model import _WIRE_KEYS, ChatReadModelCapabilities
+from reyn.interfaces.repl.read_model import (
+    _WIRE_KEYS,
+    REMOTE_CHAT_READ_CAPABILITIES,
+    ChatReadModelCapabilities,
+    reported_snapshot_keys,
+)
 from reyn.interfaces.transport.agui import state as agui_state_module
 
 #: #5093 — keys whose placeholder-shaped value is covered by ONE declared
@@ -206,6 +211,27 @@ def _get_call_placeholder_key(node: "ast.expr") -> "str | None":
     return key_arg.value
 
 
+def _own_return_statements(func_node: "ast.FunctionDef") -> "list[ast.Return]":
+    """#5773: every ``ast.Return`` that belongs to *func_node* ITSELF —
+    inside its own ``if``/``for``/``with`` bodies, but NOT inside a nested
+    ``def``/``async def``/``lambda`` (a return there belongs to that
+    NESTED function, never to *func_node*; a bare ``ast.walk`` conflates
+    the two, over-collecting). Order is source order (line number)."""
+    found: "list[ast.Return]" = []
+
+    def _walk(node: "ast.AST") -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.Return):
+                found.append(child)
+                continue
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue  # a nested scope's own return is not func_node's
+            _walk(child)
+
+    _walk(func_node)
+    return sorted(found, key=lambda n: n.lineno)
+
+
 def _find_function_return_dict(
     package_dir: Path, func_name: str,
 ) -> "tuple[ast.Dict | None, str | None]":
@@ -218,7 +244,25 @@ def _find_function_return_dict(
     shape) — the LAST top-level assignment to the returned name before the
     ``return`` statement, matching how a reader would resolve it by eye.
     Returns ``(None, error_message)`` if the function, its return, or the
-    dict literal it resolves to could not be found."""
+    dict literal it resolves to could not be found.
+
+    #5773 (architect BLOCKING finding, agreed by lead-coder): this used to
+    take the FIRST ``ast.Return`` found via a bare ``ast.walk`` -- a real,
+    silent hazard shared by EVERY check that calls this helper, not just
+    #5773's own new one. An early guard clause (e.g. ``if values is None:
+    return {}``) added to either producer in the future would make this
+    silently resolve to the WRONG (possibly empty) dict, and every caller's
+    own population would just as silently shrink to whatever that early
+    return happened to be -- the exact "empty population, still green"
+    shape CLAUDE.md's own test-review question 4 names, now closed at the
+    SOURCE rather than trusted per-caller. Two independent guards: (1)
+    collect every top-level ``Return`` belonging to THIS function (not
+    walking into a nested ``def``/``lambda``, where a return would belong
+    to a DIFFERENT function entirely) and refuse to guess if there is more
+    than one; (2) refuse a return that resolves to a dict literal with ZERO
+    keys -- neither producer this gate parses has ever had a legitimately
+    empty return, so an empty result here is always a mis-resolution, never
+    a real shape to accept quietly."""
     source = package_dir.read_text(encoding="utf-8")
     tree = ast.parse(source, filename=str(package_dir))
 
@@ -234,18 +278,35 @@ def _find_function_return_dict(
             f"Update this gate's function-name lookup."
         )
 
-    return_node = None
-    for node in ast.walk(func_node):
-        if isinstance(node, ast.Return):
-            return_node = node
-            break
-    if return_node is None:
+    return_nodes = _own_return_statements(func_node)
+    if not return_nodes:
         return None, (
             f"check_remote_snapshot_placeholder_declared: {func_name} has no "
             f"return statement -- update this gate."
         )
+    if len(return_nodes) > 1:
+        return None, (
+            f"check_remote_snapshot_placeholder_declared: {func_name} has "
+            f"{len(return_nodes)} return statements (lines "
+            f"{[n.lineno for n in return_nodes]}) -- this gate assumes exactly "
+            f"one and cannot safely guess which is the real one (an early "
+            f"guard-clause return would silently shrink this gate's own "
+            f"population). Update this gate to resolve the correct one "
+            f"explicitly."
+        )
+    return_node = return_nodes[0]
 
     if isinstance(return_node.value, ast.Dict):
+        if len(return_node.value.keys) == 0:
+            return None, (
+                f"check_remote_snapshot_placeholder_declared: {func_name}'s "
+                f"return resolves to an EMPTY dict literal at line "
+                f"{return_node.lineno} -- neither producer this gate parses "
+                f"legitimately returns an empty dict; this is almost "
+                f"certainly the wrong return statement or a stubbed/mis-"
+                f"parsed source. Refusing to silently treat an empty "
+                f"population as a clean one."
+            )
         return return_node.value, None
 
     if isinstance(return_node.value, ast.Name):
@@ -262,6 +323,14 @@ def _find_function_return_dict(
             ):
                 return_dict = node.value  # last assignment wins (top-to-bottom walk)
         if return_dict is not None:
+            if len(return_dict.keys) == 0:
+                return None, (
+                    f"check_remote_snapshot_placeholder_declared: {func_name}'s "
+                    f"``{returned_name}`` resolves to an EMPTY dict literal -- "
+                    f"neither producer this gate parses legitimately returns "
+                    f"an empty dict; refusing to silently treat an empty "
+                    f"population as a clean one."
+                )
             return return_dict, None
 
     return None, (
@@ -415,10 +484,42 @@ def find_unwired_key_violations(
     }
 
     violations: "list[str]" = []
-    for key_node in remote_dict.keys:
-        if key_node is None:  # a ``**spread`` entry -- not a literal output key
+    for key_node, value_node in zip(remote_dict.keys, remote_dict.values):
+        if key_node is None:  # a ``**spread`` entry
+            spread_keys = _resolve_reported_snapshot_keys_spread(value_node)
+            if spread_keys is None:
+                violations.append(
+                    "an unrecognized `**spread` entry in project_remote_"
+                    "snapshot's return dict cannot be statically analyzed by "
+                    "this check -- #5773 (architect BLOCKING finding): a "
+                    "silently-skipped spread is a silent gap in this gate's "
+                    "own census, not an exemption. Either make this gate "
+                    "recognize the new spread shape (see "
+                    "_resolve_reported_snapshot_keys_spread), or confirm by "
+                    "hand that every key it expands to is backed by a "
+                    "same-named project_status key."
+                )
+                continue
+            for spread_key in spread_keys:
+                if spread_key in wire_keys:
+                    continue
+                violations.append(
+                    f'"{spread_key}" (via **reported_snapshot_keys(...)): '
+                    f'project_remote_snapshot maps this key through the '
+                    f'ChatReadModelCapabilities spread, but project_status '
+                    f'(agui/state.py) has no key of this name -- same #5098 '
+                    f'drift as a literal key, just reached through the '
+                    f'spread instead of a direct dict entry.'
+                )
             continue
         if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
+            violations.append(
+                f"project_remote_snapshot's return dict has a key at line "
+                f"{key_node.lineno} that is not a string literal -- this "
+                f"check cannot verify a computed key against project_status "
+                f"and refuses to silently skip it (#5773: a skip here is a "
+                f"census gap, not a pass)."
+            )
             continue
         dict_key = key_node.value
         if dict_key in wire_keys:
@@ -435,6 +536,34 @@ def find_unwired_key_violations(
             f'not accept a same-file exemption.'
         )
     return violations
+
+
+def _resolve_reported_snapshot_keys_spread(node: "ast.expr") -> "list[str] | None":
+    """#5773 (architect BLOCKING finding): recognize the ONE ``**spread``
+    shape ``project_remote_snapshot`` actually uses —
+    ``**reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)`` — and
+    resolve it to its REAL field names via a genuine import + call (not a
+    second, hand-typed guess at what it expands to), so
+    :func:`find_unwired_key_violations` can check each one same as any
+    other output key. Every ``ChatReadModelCapabilities`` field name is
+    itself absent from ``project_status`` today (that dataclass's fields
+    are declared-axis booleans, never wire keys) — this is precisely the
+    "stage③'s own family is invisible to this census" gap the architect
+    finding named; surfacing it here, once, at the ONE call site that
+    produces it, is cheaper and more honest than trying to keep a second
+    hand-typed list of field names in sync with the dataclass. Returns
+    ``None`` for any OTHER spread shape (unrecognized -- the caller must
+    not silently accept it either)."""
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "reported_snapshot_keys"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "REMOTE_CHAT_READ_CAPABILITIES"
+    ):
+        return None
+    return sorted(reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES))
 
 
 def main() -> int:

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -470,25 +470,79 @@ def find_unwired_key_violations(
     if agui_state_path is None:
         agui_state_path = _AGUI_STATE_PATH
 
-    remote_dict, error = _find_function_return_dict(package_dir, "project_remote_snapshot")
-    if remote_dict is None:
-        return [error or "unknown error locating project_remote_snapshot"]
+    examined, unanalyzable = _examine_remote_output_keys(package_dir)
+    if examined is None:
+        return unanalyzable
+
     status_dict, error = _find_function_return_dict(agui_state_path, "project_status")
     if status_dict is None:
         return [error or "unknown error locating project_status"]
-
     wire_keys = {
         key_node.value
         for key_node in status_dict.keys
         if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)
     }
 
-    violations: "list[str]" = []
+    violations: "list[str]" = list(unanalyzable)
+    for dict_key, via_spread in examined:
+        if dict_key in wire_keys:
+            continue
+        if via_spread:
+            violations.append(
+                f'"{dict_key}" (via **reported_snapshot_keys(...)): '
+                f'project_remote_snapshot maps this key through the '
+                f'ChatReadModelCapabilities spread, but project_status '
+                f'(agui/state.py) has no key of this name -- same #5098 '
+                f'drift as a literal key, just reached through the '
+                f'spread instead of a direct dict entry.'
+            )
+        else:
+            violations.append(
+                f'"{dict_key}": project_remote_snapshot maps this key, but '
+                f'project_status (agui/state.py) has no key of this name -- '
+                f'#5098\'s "one declaration, not two that can drift apart" is '
+                f'broken for this key regardless of whether its placeholder-ness '
+                f'is otherwise declared. Either add "{dict_key}" to '
+                f'project_status\'s own return dict (if it is genuinely '
+                f'real, per-connection wire data), or confirm it is intentionally '
+                f'session-local and file/track it separately -- this check does '
+                f'not accept a same-file exemption.'
+            )
+    return violations
+
+
+def _examine_remote_output_keys(
+    package_dir: "Path | None" = None,
+) -> "tuple[list[tuple[str, bool]] | None, list[str]]":
+    """#5771/#5773: every output key ``project_remote_snapshot``'s return
+    dict actually has, as ``(key_name, via_spread)`` pairs — independent
+    of whether each is a violation. Split out of :func:`find_unwired_key_
+    violations` so a caller can ask "how many keys did this walk even
+    examine" (lead-coder BLOCKING, PR #5773: a NON-EXPIRING non-vacuity
+    witness — the walk finding SOME keys is true today and stays true
+    after stage② fixes the 3 cost-tab keys, unlike asserting those 3
+    SPECIFIC keys are still violations, which stops being true the moment
+    they're fixed — see :func:`count_examined_output_keys`).
+
+    Returns ``(None, [error])`` if ``project_remote_snapshot`` itself
+    could not be parsed. The 2nd element is always the list of entries
+    this walk could NOT resolve to a key name at all (an unrecognized
+    ``**spread``, a non-literal key) — never silently dropped; these are
+    always violations in :func:`find_unwired_key_violations`, but they
+    are not key NAMES so they cannot appear in the 1st element."""
+    if package_dir is None:
+        package_dir = _PACKAGE_DIR
+    remote_dict, error = _find_function_return_dict(package_dir, "project_remote_snapshot")
+    if remote_dict is None:
+        return None, [error or "unknown error locating project_remote_snapshot"]
+
+    examined: "list[tuple[str, bool]]" = []
+    unanalyzable: "list[str]" = []
     for key_node, value_node in zip(remote_dict.keys, remote_dict.values):
         if key_node is None:  # a ``**spread`` entry
             spread_keys = _resolve_reported_snapshot_keys_spread(value_node)
             if spread_keys is None:
-                violations.append(
+                unanalyzable.append(
                     "an unrecognized `**spread` entry in project_remote_"
                     "snapshot's return dict cannot be statically analyzed by "
                     "this check -- #5773 (architect BLOCKING finding): a "
@@ -500,20 +554,10 @@ def find_unwired_key_violations(
                     "same-named project_status key."
                 )
                 continue
-            for spread_key in spread_keys:
-                if spread_key in wire_keys:
-                    continue
-                violations.append(
-                    f'"{spread_key}" (via **reported_snapshot_keys(...)): '
-                    f'project_remote_snapshot maps this key through the '
-                    f'ChatReadModelCapabilities spread, but project_status '
-                    f'(agui/state.py) has no key of this name -- same #5098 '
-                    f'drift as a literal key, just reached through the '
-                    f'spread instead of a direct dict entry.'
-                )
+            examined.extend((k, True) for k in spread_keys)
             continue
         if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
-            violations.append(
+            unanalyzable.append(
                 f"project_remote_snapshot's return dict has a key at line "
                 f"{key_node.lineno} that is not a string literal -- this "
                 f"check cannot verify a computed key against project_status "
@@ -521,21 +565,25 @@ def find_unwired_key_violations(
                 f"census gap, not a pass)."
             )
             continue
-        dict_key = key_node.value
-        if dict_key in wire_keys:
-            continue
-        violations.append(
-            f'"{dict_key}": project_remote_snapshot maps this key, but '
-            f'project_status (agui/state.py) has no key of this name -- '
-            f'#5098\'s "one declaration, not two that can drift apart" is '
-            f'broken for this key regardless of whether its placeholder-ness '
-            f'is otherwise declared. Either add "{dict_key}" to '
-            f'project_status\'s own return dict (if it is genuinely '
-            f'real, per-connection wire data), or confirm it is intentionally '
-            f'session-local and file/track it separately -- this check does '
-            f'not accept a same-file exemption.'
-        )
-    return violations
+        examined.append((key_node.value, False))
+    return examined, unanalyzable
+
+
+def count_examined_output_keys(package_dir: "Path | None" = None) -> int:
+    """#5771 (lead-coder BLOCKING, PR #5773): the non-expiring non-vacuity
+    witness for the ratchet below. Counting VIOLATIONS (as the original
+    version of this PR's own test did, asserting the 3 known cost-tab
+    keys are present) has an expiry date built in: stage② fixing those 3
+    keys makes them vanish from the violation list, and a test pinned to
+    "these 3 specific keys are still violations" would then have to be
+    deleted or weakened — losing the non-vacuity guard at exactly the
+    moment a silently-broken walk would look identical to "everything got
+    fixed". Counting EXAMINED keys instead never expires: this is > 0
+    today, stays > 0 after every currently-known violation is fixed
+    (project_remote_snapshot will always have SOME output keys), and only
+    goes to 0 if the walk itself regresses."""
+    examined, _unanalyzable = _examine_remote_output_keys(package_dir)
+    return len(examined) if examined is not None else 0
 
 
 def _resolve_reported_snapshot_keys_spread(node: "ast.expr") -> "list[str] | None":
@@ -566,11 +614,175 @@ def _resolve_reported_snapshot_keys_spread(node: "ast.expr") -> "list[str] | Non
     return sorted(reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES))
 
 
+#: A key's declared DISPOSITION in :data:`_UNWIRED_KEY_VIOLATIONS_BASELINE`
+#: — ``LOCAL`` (permanently session-local; no ``project_status`` twin is
+#: ever planned) or ``PENDING`` (real, per-connection data that genuinely
+#: could/should ride the wire — tracked for triage on #5774, or, for the 3
+#: cost-tab keys, committed to #5771's own stage②). #5771 (lead-coder
+#: BLOCKING, PR #5773): a bare set of key NAMES let ``cron_jobs`` (never
+#: wired, ever) and ``cost_usd`` (a real fact this PR's own issue commits
+#: to wiring) sit as the identical shape — architect's own #5772 finding,
+#: "one spelling, two facts", recurring here. The disposition is what
+#: makes the repair-obligation message in :func:`find_new_unwired_key_
+#: violations` mechanically askable per key, not just a generic reminder.
+_LOCAL = "LOCAL"
+_PENDING = "PENDING"
+
+#: #5771 (lead-coder BLOCKING, PR #5773 head 2c59bbfc0): "①に無い key を②が
+#: map *できない* 形にする" means DETECTING drift is not enough — something
+#: must actually STOP a NEW one from landing unnoticed. Without this,
+#: :func:`find_unwired_key_violations` only ever produces a number someone
+#: has to remember to re-check by hand; stage②'s own 8 new wire keys could
+#: introduce a 41st drifted key and nothing here would say so — the exact
+#: "adding ② before ① is closed becomes a 4th drift" architect warned about
+#: (agreed by lead-coder). This is the KNOWN, currently-reported violation
+#: set as of THIS baseline's own last update (:func:`find_new_unwired_key_
+#: violations` below is the actual ratchet: real-source violations must be
+#: a SUBSET of this set's keys, new is red). SHRINKING this dict (dropping
+#: a key once it is genuinely fixed) is always safe and never itself
+#: flagged — encouraged, not required, so a fix elsewhere never needs to
+#: touch this file.
+#:
+#: 40 entries. PENDING (3): the cost-tab keys this PR's own stage① exists
+#: to eventually fix — #5771's own issue body commits to wiring these in
+#: stage②, reusing ``CostBreakdown.to_dict()``. LOCAL (37): 16 literal
+#: output keys whose OWN inline comment in ``project_remote_snapshot``
+#: already says the underlying data is session-local/client-local by
+#: construction (``skills``/``mcp_servers``/``turn_usage_fn`` already sit
+#: in ``_CLEARED_NON_FABRICATING_KEYS`` above for the same reason;
+#: ``unknown_config_key_count``/``unknown_config_keys`` name the CLIENT's
+#: own reyn.yaml, structurally absent on a remote connection; ``ctx_
+#: source`` is a label, not fabricatable figure; ``tasks`` is explicitly
+#: "never on the wire" per its own comment) — plus all 21
+#: ``ChatReadModelCapabilities`` field names reached through the
+#: ``**reported_snapshot_keys(...)`` spread, LOCAL by DESIGN rather than
+#: by accident: a ``*_reported`` flag is a CLIENT-side declaration about
+#: what the wire carries, never wire data itself, so it was never
+#: expected to have its own ``project_status`` twin (true even for the 5
+#: fields already ``True`` for remote — ``intervention_head``/``agent_
+#: roster_reported``/``model_catalog_reported``/``attached_name_
+#: reported``/``visibility_items_reported``/``mcp_subscriptions_
+#: reported`` — since what they report reflects reaches the wire under
+#: OTHER, real key names, e.g. ``agent_names``/``session_tree``, never
+#: under the flag's own name). ``hooks_config_warnings`` and ``mcp_probe_
+#: states`` are marked PENDING, not LOCAL, DESPITE looking like the other
+#: session-local literal keys above — their own inline comments in
+#: ``project_remote_snapshot`` explicitly say "not wired onto the wire
+#: YET" (not "structurally cannot exist"), the opposite framing the LOCAL
+#: entries' own comments use — genuinely different from the other 35,
+#: filed on #5774 for real triage rather than guessed here.
+_UNWIRED_KEY_VIOLATIONS_BASELINE: "dict[str, str]" = {
+    # PENDING — #5771 stage② commits to wiring these for real.
+    "cost_usd": _PENDING,
+    "usage": _PENDING,
+    "session_cached_tokens": _PENDING,
+    # PENDING — real session data, explicitly "not wired onto the wire
+    # YET" per project_remote_snapshot's own inline comment (unlike the
+    # LOCAL entries below, whose own comments say the opposite) -- #5774
+    # triage, not guessed here.
+    "hooks_config_warnings": _PENDING,
+    "mcp_probe_states": _PENDING,
+    # LOCAL — genuinely, permanently session-local per each key's own
+    # inline comment in project_remote_snapshot.
+    "ctx_recent_usage": _LOCAL,
+    "ctx_source": _LOCAL,
+    "ctx_compaction_status_fn": _LOCAL,
+    "compaction_progress_raw": _LOCAL,
+    "turn_usage_fn": _LOCAL,
+    "cron_jobs": _LOCAL,
+    "mcp_servers": _LOCAL,
+    "hooks": _LOCAL,
+    "skills": _LOCAL,
+    "hook_items": _LOCAL,
+    "pipelines": _LOCAL,
+    "unknown_config_key_count": _LOCAL,
+    "unknown_config_keys": _LOCAL,
+    "tasks": _LOCAL,
+    # LOCAL by DESIGN — every ChatReadModelCapabilities field name (via
+    # the **reported_snapshot_keys(...) spread): a client-side capability
+    # DECLARATION, never wire data, so none of these was ever expected to
+    # have its own project_status twin (see the block comment above).
+    "completion_source": _LOCAL,
+    "intervention_head": _LOCAL,
+    "pending_command_ui": _LOCAL,
+    "has_command_ui_region": _LOCAL,
+    "conversation_history": _LOCAL,
+    "load_older_conversation_history": _LOCAL,
+    "cache_usage_reported": _LOCAL,
+    "cron_jobs_reported": _LOCAL,
+    "usage_breakdown_reported": _LOCAL,
+    "ctx_compaction_reported": _LOCAL,
+    "hooks_reported": _LOCAL,
+    "pipelines_reported": _LOCAL,
+    "agent_roster_reported": _LOCAL,
+    "model_catalog_reported": _LOCAL,
+    "attached_name_reported": _LOCAL,
+    "visibility_items_reported": _LOCAL,
+    "mcp_subscriptions_reported": _LOCAL,
+    "mcp_probe_states_reported": _LOCAL,
+    "hooks_config_warnings_reported": _LOCAL,
+    "compaction_progress_reported": _LOCAL,
+    "tasks_reported": _LOCAL,
+}
+
+
+def _unwired_key_names(
+    package_dir: "Path | None" = None, agui_state_path: "Path | None" = None,
+) -> "set[str]":
+    """The bare key-name set behind :func:`find_unwired_key_violations`'s
+    own messages — the ONE place that parses them back out, so the
+    ratchet below and any future consumer never re-derive the "first
+    `"..."`-quoted token" convention independently."""
+    violations = find_unwired_key_violations(package_dir, agui_state_path)
+    names: "set[str]" = set()
+    for v in violations:
+        if v.startswith('"'):
+            names.add(v.split('"')[1])
+    return names
+
+
+def find_new_unwired_key_violations(
+    package_dir: "Path | None" = None, agui_state_path: "Path | None" = None,
+) -> "list[str]":
+    """#5771's own ratchet (lead-coder BLOCKING): a key ``find_unwired_key_
+    violations`` reports that is NOT already a key of :data:`_UNWIRED_KEY_
+    VIOLATIONS_BASELINE`. Real-source violations that ARE in the baseline
+    are known, disclosed debt (tracked on PR #5773's own comment thread,
+    not re-flagged here every run); a NEW one is exactly the "stage② adds
+    a key, nothing notices" hole the BLOCKING named — this is what
+    actually stops it, not just reports it.
+
+    Same "repair obligation, not a silencing knob" shape as ``_DECLARED_
+    SITES``'s own ratchet test in ``test_4401_render_for_router_state_
+    census.py``: adding a key to the baseline WITHOUT first either wiring
+    it onto ``project_status`` for real (PENDING) or confirming it is
+    genuinely, permanently session-local (LOCAL) does not close the gap
+    #5098/#5771 exist to close — it only silences this one check."""
+    found = _unwired_key_names(package_dir, agui_state_path)
+    new = found - set(_UNWIRED_KEY_VIOLATIONS_BASELINE)
+    return [
+        f'"{key}": a NEW project_remote_snapshot key with no same-named '
+        f'project_status entry, not already a key of _UNWIRED_KEY_'
+        f'VIOLATIONS_BASELINE. Before adding "{key}" there: if it is '
+        f'genuinely, permanently session-local, add it with disposition '
+        f'LOCAL and cite the reason (mirroring an existing LOCAL entry\'s '
+        f'own comment); if it is real, per-connection data that should '
+        f'ride the wire, either add the real key to project_status instead '
+        f'of baselining this one, or add it with disposition PENDING and '
+        f'cite the issue/PR that will wire it. Adding it to the baseline '
+        f'without one of those does not close #5098\'s own "one '
+        f'declaration, not two that can drift apart" hole -- it only '
+        f'silences this check.'
+        for key in sorted(new)
+    ]
+
+
 def main() -> int:
     violations = find_violations(_PACKAGE_DIR)
     wire_key_violations = find_wire_keys_violations(_AGUI_STATE_PATH)
     unwired_key_violations = find_unwired_key_violations(_PACKAGE_DIR, _AGUI_STATE_PATH)
-    if violations or wire_key_violations or unwired_key_violations:
+    new_unwired_key_violations = find_new_unwired_key_violations(_PACKAGE_DIR, _AGUI_STATE_PATH)
+    if violations or wire_key_violations or new_unwired_key_violations:
         if violations:
             print(
                 "check_remote_snapshot_placeholder_declared: "
@@ -591,16 +803,26 @@ def main() -> int:
             print(
                 "check_remote_snapshot_placeholder_declared: "
                 f"{len(unwired_key_violations)} project_remote_snapshot key(s) "
-                "not backed by a same-named project_status key (#5771):\n"
+                "not backed by a same-named project_status key (#5771, "
+                f"{len(new_unwired_key_violations)} of them NEW, not yet "
+                "baselined):\n"
             )
             for v in unwired_key_violations:
+                print(f"  - {v}")
+        if new_unwired_key_violations:
+            print(
+                "check_remote_snapshot_placeholder_declared: "
+                f"{len(new_unwired_key_violations)} NEW unwired-key "
+                "violation(s), not in _UNWIRED_KEY_VIOLATIONS_BASELINE:\n"
+            )
+            for v in new_unwired_key_violations:
                 print(f"  - {v}")
         return 1
     print("check_remote_snapshot_placeholder_declared: OK, every placeholder-shaped "
           "key is covered by _WIRE_KEYS, a declared axis, or a cited exemption, "
           "_WIRE_KEYS is a verified subset of project_status's unconditional keys, "
           "and every project_remote_snapshot output key is backed by a same-named "
-          "project_status key.")
+          "project_status key or already-baselined disclosed debt.")
     return 0
 
 

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1449,12 +1449,17 @@ def _cache_hit_line(
     9-char column every other cost/ctx line uses (it was misaligned when the label
     itself carried the qualifier, e.g. ``"cache (cumulative)"``).
 
-    ``reported`` (#5009, ``snap["cache_usage_reported"]``): a REMOTE client's
-    ``cached``/``prompt`` are always ``0`` (cache-hit accounting is
-    session-local, never on the AG-UI wire) — indistinguishable on their own
-    from a genuine 0% hit rate. ``False`` here renders an explicit "not
-    reported" line instead of computing a percentage off zeros, so this
-    reads as "unavailable", never as a fabricated real 0%."""
+    ``reported`` (#5009; #5771 stage② split this into 2 separate snapshot
+    keys, one per call site — the Cost pane's cumulative line passes
+    ``snap["session_cache_usage_reported"]``, the Ctx pane's recent-call
+    line passes ``snap["cache_usage_reported"]``, see each call site's own
+    comment): a REMOTE client's ``cached``/``prompt`` are ``0`` when NOT
+    reported (cache-hit accounting used to be session-local for both;
+    the Cost pane's own figures are genuinely wired now) —
+    indistinguishable on their own from a genuine 0% hit rate. ``False``
+    here renders an explicit "not reported" line instead of computing a
+    percentage off zeros, so this reads as "unavailable", never as a
+    fabricated real 0%."""
     if not reported:
         return f"{label:<9}not reported on this connection"
     pct = round(100 * cached / prompt) if prompt > 0 else 0
@@ -1693,7 +1698,12 @@ def cost_pane_lines(snap: "dict | None") -> list[str]:
         f"tokens   {prompt_completion} · total {agent_tokens:,}",
         _cache_hit_line(
             "cache", cached, p, note="cumulative",
-            reported=snap.get("cache_usage_reported", False),
+            # #5771 stage②: SPLIT from cache_usage_reported (this pane's
+            # own key, session_cached_tokens, is genuinely wired now —
+            # the Ctx pane's ctx_recent_usage below is not; see
+            # ChatReadModelCapabilities.session_cache_usage_reported's
+            # own docstring for the full split reasoning).
+            reported=snap.get("session_cache_usage_reported", False),
         ),
     ]
     # #3695: the status row can only afford a mark; this pane has room to say

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -52,6 +52,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 from reyn.interfaces.repl.status import _snapshot
+from reyn.llm.pricing import CostBreakdown
 
 if TYPE_CHECKING:
     from reyn.data.skills.registry import SkillEntry
@@ -329,6 +330,22 @@ class ChatReadModelCapabilities:
     # currently-RUNNING task rows) — REMOTE/AG-UI does not put this on the
     # wire, same shape every other *_reported field here closes.
     tasks_reported: bool
+    # #5771 stage②: SPLIT from ``cache_usage_reported`` above, not a new
+    # concept — that field's own docstring already named it as covering
+    # "two snapshot() dict KEYS instead" (`session_cached_tokens` /
+    # `ctx_recent_usage`), a coupling this stage's own cost-tab fix broke
+    # apart: `session_cached_tokens` is genuinely wired now,
+    # `ctx_recent_usage` is not (#5771's own issue body scopes the wire
+    # additions to exactly 8 keys, and this is not one of them). Flipping
+    # the SHARED flag to True would have wrongly told the Ctx pane's
+    # `_cache_hit_line` (`ctx_recent_usage`'s own consumer, chrome.py)
+    # that ITS data is real too — the same "one spelling, two facts"
+    # shape architect flagged on #5773's baseline during this same PR's
+    # own review. `cache_usage_reported` keeps its EXISTING name and
+    # scope (the Ctx pane's recent-call line only, still False for
+    # remote); this new field covers ONLY the Cost pane's cumulative
+    # cache line (`chrome.py`'s OTHER `_cache_hit_line` call site).
+    session_cache_usage_reported: bool
 
 
 def reported_snapshot_keys(
@@ -388,6 +405,7 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     hooks_config_warnings_reported=True,
     compaction_progress_reported=True,
     tasks_reported=True,
+    session_cache_usage_reported=True,
 )
 
 #: :class:`RemoteReadModel` — the frame-sufficiency boundary each of these
@@ -412,9 +430,15 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     has_command_ui_region=False,
     conversation_history=False,
     load_older_conversation_history=False,
+    # #5771 stage②: ctx_recent_usage (this field's own sole remaining
+    # consumer, the Ctx pane's recent-call cache line — see the field's
+    # own docstring for the split) is NOT one of stage②'s 8 wired keys —
+    # stays False.
     cache_usage_reported=False,
     cron_jobs_reported=False,
-    usage_breakdown_reported=False,
+    # #5771 stage②: usage (prompt/completion/total) is now genuinely
+    # wired — was a fixed (0, 0, agent_tokens) placeholder before this PR.
+    usage_breakdown_reported=True,
     ctx_compaction_reported=False,
     hooks_reported=False,
     pipelines_reported=False,
@@ -432,6 +456,10 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     hooks_config_warnings_reported=False,
     compaction_progress_reported=False,
     tasks_reported=False,
+    # #5771 stage②: session_cached_tokens is now genuinely wired — see
+    # the field's own docstring for why this is a SPLIT from
+    # cache_usage_reported (which stays False above), not the same flag.
+    session_cache_usage_reported=True,
 )
 
 
@@ -882,19 +910,39 @@ class RegistryReadModel(ChatReadModel):
 #: removed from here automatically re-enters the gate's scope, no second
 #: edit required.
 #:
-#: ``cost_usd`` is NOT listed separately: its own ``.get(...)`` call reads
-#: the ``"cost_agent"`` wire key (an intentional alias, see the dict below),
-#: so the gate matches on the ``.get()`` call's own key ARGUMENT, not the
-#: dict's output key name — one membership check covers both.
-#:
 #: ``queue``/``turn_active``/``queue_seq`` (#3300 P2b/#5098) are the
 #: server-authoritative sent-queue state, folded onto the wire the same way
 #: the cost/ctx figures are — see ``project_remote_snapshot``'s own inline
 #: comment at those 3 keys for the citation.
+#:
+#: #5771 stage②: ``cost_usd`` used to be excluded from this set on purpose
+#: — its own ``.get(...)`` call read the ``"cost_agent"`` wire key (an
+#: ALIAS, not its own real key; #5773's own finding named this the exact
+#: drift #5098 exists to prevent). Now genuinely its own real,
+#: unconditional wire key, same as every other entry here — no alias, no
+#: special case. ``cost_breakdown_session``/``cost_breakdown_agent``/
+#: ``cost_breakdown_project``/``usage``/``session_cached_tokens``/
+#: ``turn_cost_usd``/``turn_tokens`` joined the same way (real data,
+#: project_status now unconditionally emits every one of them, even when
+#: the underlying VALUE is ``None`` — see that function's own inline
+#: comments at each key for what ``None`` means there).
 _WIRE_KEYS = frozenset({
-    "cost_agent", "cost_total", "agent_tokens", "ctx_used", "ctx_window",
-    "queue", "turn_active", "queue_seq",
+    "cost_agent", "cost_total", "cost_usd", "agent_tokens", "ctx_used",
+    "ctx_window", "queue", "turn_active", "queue_seq",
+    "cost_breakdown_session", "cost_breakdown_agent", "cost_breakdown_project",
+    "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens",
 })
+
+
+def _cost_breakdown_from_wire(data: "dict | None") -> "CostBreakdown | None":
+    """#5771 stage②: the wire-side decode half of the SAME encode/decode
+    pair agui/state.py's own ``_cost_breakdown_wire`` uses to encode —
+    ``CostBreakdown.from_dict()`` (llm/pricing.py), never a second,
+    hand-rolled deserialization. ``None`` passes through unchanged — a
+    server that never populated this key (an older, pre-#5771 server, or
+    a test double) degrades to "nothing to show", not a fabricated
+    all-zero breakdown."""
+    return CostBreakdown.from_dict(data) if data is not None else None
 
 
 def project_remote_snapshot(values: "dict | None") -> dict:
@@ -931,7 +979,26 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "all_sessions_status": v.get("all_sessions_status", []),
         "cost_agent": v.get("cost_agent", 0.0),
         "cost_total": v.get("cost_total", 0.0),
-        "cost_usd": v.get("cost_agent", 0.0),
+        # #5771 stage②: was ``v.get("cost_agent", 0.0)`` — a quiet ALIAS
+        # of a DIFFERENT wire fact under this key's own name (the #5773
+        # drift this stage exists to close). Now genuinely its own key —
+        # real per-connection wire data (agui/state.py's own
+        # ``project_status``), not a placeholder or an alias.
+        "cost_usd": v.get("cost_usd", 0.0),
+        # #5771 stage②: the 3-scope CostBreakdown table — decoded via
+        # CostBreakdown.from_dict() (llm/pricing.py), the wire-side half
+        # of the SAME encode/decode pair agui/state.py's own
+        # ``project_status`` uses to encode it (``_cost_breakdown_wire``,
+        # that module's own helper) — never a second serialization.
+        "cost_breakdown_session": _cost_breakdown_from_wire(v.get("cost_breakdown_session")),
+        "cost_breakdown_agent": _cost_breakdown_from_wire(v.get("cost_breakdown_agent")),
+        "cost_breakdown_project": _cost_breakdown_from_wire(v.get("cost_breakdown_project")),
+        # #5771 stage②: was a fixed ``(0, 0, v.get("agent_tokens", 0))``
+        # placeholder (invisible to #5093's own AST walk — a tuple, #5773's
+        # own finding) — now the real ``(prompt, completion, total)`` wire
+        # triple, gated by ``usage_breakdown_reported`` below exactly as
+        # before (that axis is now ``True`` for remote, see
+        # ``REMOTE_CHAT_READ_CAPABILITIES``).
         "agent_tokens": v.get("agent_tokens", 0),
         "ctx_used": v.get("ctx_used", 0),
         "ctx_window": v.get("ctx_window", 0),
@@ -951,27 +1018,42 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # that dataclass reaches every producer for free, no call-site
         # edit required.
         **reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES),
-        # The prompt/completion SPLIT below is `0`/`0` while the total is
-        # real wire data — an inconsistent breakdown (`0 + 0 != total`)
-        # the Cost pane never flags on its own; gated by
-        # ``usage_breakdown_reported`` above.
-        "usage": (0, 0, v.get("agent_tokens", 0)),
-        # `0`/`(0, 0)` below are the correct graceful-degrade VALUES for
-        # both cache figures (neither is projected onto the AG-UI wire —
-        # cache-hit accounting is session-local); gated by
-        # ``cache_usage_reported`` above, consulted by `chrome.py`'s
-        # `_cache_hit_line` so BOTH panes reading these 2 keys (Cost
-        # pane's cumulative line, Ctx pane's recent-call line) render a
-        # "not reported" line instead of a fabricated "0% hit (0 / 0)".
+        # #5771 stage②: was a fixed `(0, 0, agent_tokens)` placeholder
+        # (invisible to #5093's own AST walk, #5773's own finding) — now
+        # the real (prompt, completion, total) wire triple; gated by
+        # ``usage_breakdown_reported`` above, now ``True`` for remote
+        # (see ``REMOTE_CHAT_READ_CAPABILITIES``).
+        "usage": v.get("usage", (0, 0, v.get("agent_tokens", 0))),
+        # #5771 stage②: session_cached_tokens is now real wire data,
+        # gated by its OWN axis (``session_cache_usage_reported``,
+        # SPLIT from ``cache_usage_reported`` below on this same PR — the
+        # 2 keys that axis used to cover together no longer share ONE
+        # fact: this one is wired for real now, ``ctx_recent_usage``
+        # below is not). Consulted by `chrome.py`'s cost-pane cache line
+        # only; the ctx-pane one keeps reading ``cache_usage_reported``.
+        "session_cached_tokens": v.get("session_cached_tokens", 0),
+        # `(0, 0)` below is the correct graceful-degrade VALUE (neither
+        # is projected onto the AG-UI wire — cache-hit accounting is
+        # session-local); gated by ``cache_usage_reported`` above,
+        # consulted by `chrome.py`'s `_cache_hit_line` for the Ctx pane's
+        # recent-call line, so it renders a "not reported" line instead
+        # of a fabricated "0% hit (0 / 0)".
         #
         # Scope, explicit (architect, #5009): this is NOT the owner's actual
         # "cache stuck at 0%" observation — that was measured on a LOCAL
         # session (owner-confirmed) and is a separate, still-unresolved
         # symptom this key does not touch. This key only makes the REMOTE
         # "0 could mean unsupported" case honestly say so.
-        "session_cached_tokens": 0,
         "ctx_recent_usage": (0, 0),
         "ctx_source": "remote",
+        # #5771 stage②: the current/most-recent turn's own total — real
+        # wire data (agui/state.py's own ``project_status``), ``None``
+        # when there is no figure yet, same "never a fabricated 0"
+        # convention its own producer (status.py) already documents.
+        # ``turn_usage_fn`` (the KEYED per-row accessor the gutter uses
+        # locally) is a callable and stays OFF the wire — not read here.
+        "turn_cost_usd": v.get("turn_cost_usd"),
+        "turn_tokens": v.get("turn_tokens"),
         # `None` below is correct (no compaction-status source on the
         # wire); gated by ``ctx_compaction_reported`` above so the Ctx
         # pane renders "not reported" instead of the fabricated-looking

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -32,6 +32,20 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from reyn.core.present.guard import get_neutralizer
+from reyn.llm.pricing import CostBreakdown
+
+
+def _cost_breakdown_wire(breakdown: "CostBreakdown | None") -> "dict | None":
+    """#5771 stage②: the ONE place ``project_status`` puts a ``CostBreakdown``
+    onto the wire — ``.to_dict()`` (llm/pricing.py), never a second,
+    hand-rolled serialization (architect's own explicit instruction on
+    #5771: a raw dataclass instance would otherwise reach ``json.dumps``
+    with no ``default=`` at the SSE emit boundary and raise ``TypeError``,
+    the exact failure the instruction names). ``None`` passes through
+    unchanged — a snapshot that never populated this key (a test double,
+    or a pre-#5771 producer) degrades to "nothing to show", never a
+    fabricated all-zero breakdown."""
+    return breakdown.to_dict() if breakdown is not None else None
 
 
 def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) -> dict:
@@ -92,9 +106,41 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         "mcp_subscriptions": snap.get("mcp_subscriptions", []),
         "cost_agent": snap.get("cost_agent", 0.0),
         "cost_total": snap.get("cost_total", 0.0),
+        # #5771 stage②: the session-cumulative TOTAL (a different fact
+        # from cost_agent above — see this project's own #5773 finding,
+        # "cost_usd was aliased to cost_agent" — now genuinely wired
+        # under its own name, not read off a neighbour).
+        "cost_usd": snap.get("cost_usd", 0.0),
+        # #5771 stage②: the 3-scope CostBreakdown table (Input/Output/
+        # Saved/Saved% rows) the Cost pane already renders locally —
+        # encoded via CostBreakdown.to_dict() (llm/pricing.py), the ONE
+        # existing serialization, never a second one invented for the
+        # wire. None only if the local snapshot itself never populated
+        # the key (a test double, or a pre-#5771 producer) — never a
+        # graceful-degrade placeholder for a real absence, since the
+        # session-scope object is never None once #cost-panel-breakdown
+        # actually ran.
+        "cost_breakdown_session": _cost_breakdown_wire(snap.get("cost_breakdown_session")),
+        "cost_breakdown_agent": _cost_breakdown_wire(snap.get("cost_breakdown_agent")),
+        "cost_breakdown_project": _cost_breakdown_wire(snap.get("cost_breakdown_project")),
+        # #5771 stage②: (prompt, completion, total) — a plain int triple,
+        # already JSON-safe as-is (no CostBreakdown-style encode needed).
+        "usage": snap.get("usage", (0, 0, 0)),
         "agent_tokens": snap.get("agent_tokens", 0),
         "ctx_used": snap.get("ctx_used", 0),
         "ctx_window": snap.get("ctx_window", 0),
+        # #5771 stage②: cache-hit accounting is genuinely measured
+        # LOCALLY (status.py's own inline comment at this key) — now
+        # forwarded for real, the same pattern #5094/#5185 already used
+        # for the agent roster / visibility keys above.
+        "session_cached_tokens": snap.get("session_cached_tokens", 0),
+        # #5771 stage②: the current/most-recent turn's own total — None
+        # when there is no figure yet (status.py's own convention: never
+        # a fabricated 0). turn_usage_fn (the KEYED per-row accessor the
+        # gutter uses) is a callable and stays OFF the wire entirely —
+        # not read here, not forwarded by project_remote_snapshot either.
+        "turn_cost_usd": snap.get("turn_cost_usd"),
+        "turn_tokens": snap.get("turn_tokens"),
         "waiting_on": waiting_on,
         # #5050: the pending closed-set intervention (id/prompt/detail/
         # choices), or None — the source ``RemoteReadModel.

--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -429,6 +429,49 @@ class CostBreakdown:
             "cached_tokens": self.cached_tokens,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict) -> "CostBreakdown":
+        """Reconstruct from a dict produced by :meth:`to_dict` — #5771
+        stage②: the AG-UI wire's own decode side for ``cost_breakdown_
+        session``/``cost_breakdown_agent``/``cost_breakdown_project``
+        (``project_remote_snapshot``, read_model.py), reusing this ONE
+        encode/decode pair rather than inventing a second serialization
+        (architect's own explicit instruction on #5771).
+
+        ``total_cost``/``cache_hit_rate`` are DERIVED properties, not
+        constructor fields — :meth:`to_dict` includes them for a reader
+        that only wants the finished figures (the cost panel's own
+        table), but reconstructing from them here would either silently
+        drop them (they're not settable) or, worse, invite a future
+        edit to add them as fields and diverge from the property that
+        already computes them. Only the 7 real fields are read back;
+        the properties re-derive correctly from those alone.
+
+        Resilient to missing/malformed fields the same way ``TokenUsage.
+        from_dict`` is (older/hand-edited/corrupted data defaults each
+        field to its own dataclass default, never raises)."""
+        def _coerce_float(v: object, default: float) -> float:
+            try:
+                return float(v)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return default
+
+        def _coerce_int(v: object, default: int) -> int:
+            try:
+                return int(v)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return default
+
+        return cls(
+            prompt_cost=_coerce_float(data.get("prompt_cost"), 0.0),
+            cache_read_cost=_coerce_float(data.get("cache_read_cost"), 0.0),
+            cache_creation_cost=_coerce_float(data.get("cache_creation_cost"), 0.0),
+            completion_cost=_coerce_float(data.get("completion_cost"), 0.0),
+            cache_savings=_coerce_float(data.get("cache_savings"), 0.0),
+            prompt_tokens=_coerce_int(data.get("prompt_tokens"), 0),
+            cached_tokens=_coerce_int(data.get("cached_tokens"), 0),
+        )
+
 
 def estimate_cost_breakdown(
     model: str,

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -144,6 +144,7 @@ def test_capabilities_dataclass_rejects_a_missing_field():
         hooks_config_warnings_reported=True,
         compaction_progress_reported=True,
         tasks_reported=True,
+        session_cache_usage_reported=True,
     )
     with pytest.raises(TypeError):
         ChatReadModelCapabilities(  # type: ignore[call-arg]
@@ -182,8 +183,10 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
     ``attached_name_reported`` (#5094) /
     ``visibility_items_reported`` / ``mcp_subscriptions_reported`` (#5185) /
     ``mcp_probe_states_reported`` (#4401) /
-    ``hooks_config_warnings_reported`` (#5100/#5272)
-    are the 13 fields NOT named after a ``ChatReadModel`` method — see the
+    ``hooks_config_warnings_reported`` (#5100/#5272) /
+    ``session_cache_usage_reported`` (#5771, split off ``cache_usage_
+    reported`` when only ONE of its 2 covered keys got wired for real)
+    are the 14 fields NOT named after a ``ChatReadModel`` method — see the
     class's own docstring for why they live here anyway."""
     names = {f.name for f in fields(ChatReadModelCapabilities)}
     assert names == {
@@ -208,6 +211,7 @@ def test_capabilities_dataclass_has_exactly_the_declared_fields():
         "hooks_config_warnings_reported",
         "compaction_progress_reported",
         "tasks_reported",
+        "session_cache_usage_reported",
     }
 
 

--- a/tests/interfaces/test_5009_cache_reported_declaration.py
+++ b/tests/interfaces/test_5009_cache_reported_declaration.py
@@ -117,7 +117,13 @@ def test_cost_pane_shows_not_reported_instead_of_a_fabricated_zero_percent():
         "usage": (0, 0, 0),
         "agent_tokens": 0,
         "session_cached_tokens": 0,
-        "cache_usage_reported": False,
+        # #5771 stage②: the Cost pane's OWN split-off axis (see this
+        # file's own test_cost_pane_still_shows_a_real_percentage_when_
+        # reported for the split) — named explicitly here rather than
+        # relying on the key's own absence to default False, so this
+        # negative control bites on the SAME key the accept-side test
+        # flips to True.
+        "session_cache_usage_reported": False,
     }
     blob = "\n".join(cost_pane_lines(snap))
     assert "not reported on this connection" in blob, blob
@@ -136,7 +142,10 @@ def test_cost_pane_still_shows_a_real_percentage_when_reported():
         "usage": (12345, 6789, 19134),
         "agent_tokens": 19134,
         "session_cached_tokens": 5180,
-        "cache_usage_reported": True,
+        # #5771 stage②: the Cost pane's OWN split-off axis — see
+        # chrome.py's own comment at this pane's _cache_hit_line call
+        # site for why this is no longer cache_usage_reported.
+        "session_cache_usage_reported": True,
     }
     blob = "\n".join(cost_pane_lines(snap))
     assert "42% hit" in blob, blob

--- a/tests/interfaces/test_5009_closing_pass_declarations.py
+++ b/tests/interfaces/test_5009_closing_pass_declarations.py
@@ -65,12 +65,19 @@ from reyn.interfaces.repl.read_model import (
 
 
 def test_capabilities_declare_the_3_closing_pass_keys():
-    """Tier 1: the declarations themselves."""
+    """Tier 1: the declarations themselves.
+
+    #5771 stage②: ``usage_breakdown_reported`` flips to ``True`` for
+    REMOTE here — ``usage`` (prompt/completion/total) is now genuinely
+    wired (see ``project_remote_snapshot``'s own inline comment at that
+    key); this is a deliberate, real capability change, not a regression
+    of this test's own #5009 finding. The other 2 are untouched by
+    stage② and stay exactly as #5009 declared them."""
     assert LOCAL_CHAT_READ_CAPABILITIES.cron_jobs_reported is True
     assert LOCAL_CHAT_READ_CAPABILITIES.usage_breakdown_reported is True
     assert LOCAL_CHAT_READ_CAPABILITIES.ctx_compaction_reported is True
     assert REMOTE_CHAT_READ_CAPABILITIES.cron_jobs_reported is False
-    assert REMOTE_CHAT_READ_CAPABILITIES.usage_breakdown_reported is False
+    assert REMOTE_CHAT_READ_CAPABILITIES.usage_breakdown_reported is True
     assert REMOTE_CHAT_READ_CAPABILITIES.ctx_compaction_reported is False
 
 
@@ -79,7 +86,11 @@ def test_the_shared_helper_derives_all_3_from_the_capabilities_given():
     these 3 fields specifically — see that function's own docstring, in
     read_model.py, for why ONE generic helper (not 4 near-identical
     single-field ones, the shape this PR replaced) is what both
-    producers derive every `*_reported` key from."""
+    producers derive every `*_reported` key from.
+
+    #5771 stage②: ``usage_breakdown_reported`` is ``True`` for remote now
+    — see ``test_capabilities_declare_the_3_closing_pass_keys`` above for
+    why."""
     local_keys = reported_snapshot_keys(LOCAL_CHAT_READ_CAPABILITIES)
     assert local_keys["cron_jobs_reported"] is True
     assert local_keys["usage_breakdown_reported"] is True
@@ -87,18 +98,23 @@ def test_the_shared_helper_derives_all_3_from_the_capabilities_given():
 
     remote_keys = reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)
     assert remote_keys["cron_jobs_reported"] is False
-    assert remote_keys["usage_breakdown_reported"] is False
+    assert remote_keys["usage_breakdown_reported"] is True
     assert remote_keys["ctx_compaction_reported"] is False
 
 
-def test_remote_snapshot_declares_all_3_unreported():
+def test_remote_snapshot_declares_2_of_the_3_unreported():
     """Tier 1: the real producer — `project_remote_snapshot` — carries
-    all 3 declarations through, paired with the existing graceful
-    degrade values those keys already carried."""
+    the declarations through, paired with the existing graceful degrade
+    values those keys already carried.
+
+    #5771 stage②: renamed from `..._declares_all_3_unreported` —
+    `usage`/`usage_breakdown_reported` is genuinely wired now (see
+    `test_capabilities_declare_the_3_closing_pass_keys` above), so only
+    2 of the original 3 stay unreported through this producer."""
     snap = project_remote_snapshot({})
     assert snap["cron_jobs_reported"] is False
     assert snap["cron_jobs"] == []
-    assert snap["usage_breakdown_reported"] is False
+    assert snap["usage_breakdown_reported"] is True
     assert snap["ctx_compaction_reported"] is False
     assert snap["ctx_compaction_status_fn"] is None
 

--- a/tests/interfaces/test_5011_ctx_cache_line_note.py
+++ b/tests/interfaces/test_5011_ctx_cache_line_note.py
@@ -69,7 +69,10 @@ def test_cost_pane_cache_line_still_names_itself_cumulative():
         "usage": (12345, 6789, 19134),
         "agent_tokens": 19134,
         "session_cached_tokens": 5180,
-        "cache_usage_reported": True,
+        # #5771 stage②: the Cost pane's OWN split-off axis, not the Ctx
+        # pane's cache_usage_reported (see chrome.py's own comment at
+        # this pane's _cache_hit_line call site for the split).
+        "session_cache_usage_reported": True,
     }
     blob = "\n".join(cost_pane_lines(snap))
     assert "42% hit" in blob, blob

--- a/tests/interfaces/test_5771_cost_tab_wired_to_remote.py
+++ b/tests/interfaces/test_5771_cost_tab_wired_to_remote.py
@@ -1,0 +1,153 @@
+"""Tier 2: #5771 stage② — the 8 real cost keys reach a remote client's wire.
+
+Owner report (relayed via architect): the web/connect cost tab stayed '-'.
+Stage① (#5773) found and closed the structural drift (a project_remote_
+snapshot output key not backed by a same-named project_status key); this
+stage adds the missing project_status keys for real, so project_remote_
+snapshot's own reads of them stop degrading.
+
+Real project_status/project_remote_snapshot throughout — no mocks; a
+snapshot dict is the only fixture, matching every other read-model test in
+this package.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.repl.read_model import project_remote_snapshot
+from reyn.interfaces.transport.agui.state import project_status
+from reyn.llm.pricing import CostBreakdown
+
+
+def _local_snapshot() -> dict:
+    """A LOCAL _snapshot()-shaped dict carrying the 8 cost-tab fields the
+    real producer (status.py) already builds — see that module's own
+    dict literal for the field names this mirrors."""
+    return {
+        "cost_usd": 1.2345,
+        "cost_breakdown_session": CostBreakdown(
+            prompt_cost=0.5, completion_cost=0.6, prompt_tokens=100, cached_tokens=20,
+        ),
+        "cost_breakdown_agent": CostBreakdown(
+            prompt_cost=0.3, completion_cost=0.2, prompt_tokens=50, cached_tokens=5,
+        ),
+        "cost_breakdown_project": CostBreakdown(
+            prompt_cost=0.9, completion_cost=0.8, prompt_tokens=200, cached_tokens=40,
+        ),
+        "usage": (1000, 400, 1400),
+        "cost_agent": 0.5,
+        "cost_total": 1.5,
+        "agent_tokens": 1400,
+        "session_cached_tokens": 65,
+        "turn_cost_usd": 0.02,
+        "turn_tokens": 150,
+        "turn_usage_fn": lambda chain_id: {"tokens": 1, "cost_usd": 0.0},
+    }
+
+
+def test_project_status_carries_the_8_cost_keys_for_real() -> None:
+    """Tier 2: the wire-side producer — agui/state.py's project_status —
+    emits real values for all 8 keys, not a placeholder."""
+    out = project_status(_local_snapshot())
+    assert out["cost_usd"] == 1.2345
+    assert out["cost_breakdown_session"] == {
+        "prompt_cost": 0.5, "cache_read_cost": 0.0, "cache_creation_cost": 0.0,
+        "completion_cost": 0.6, "total_cost": 1.1, "cache_savings": 0.0,
+        "cache_hit_rate": 0.2, "prompt_tokens": 100, "cached_tokens": 20,
+    }
+    assert out["usage"] == (1000, 400, 1400)
+    assert out["session_cached_tokens"] == 65
+    assert out["turn_cost_usd"] == 0.02
+    assert out["turn_tokens"] == 150
+
+
+def test_turn_usage_fn_never_reaches_project_status_output() -> None:
+    """Tier 2: turn_usage_fn is a callable (Session.turn_usage, keyed
+    per-chain_id) — architect's explicit instruction: it must never ride
+    the wire. project_status's own dict literal simply never reads this
+    key off snap; this proves that structurally, not by trusting the
+    absence."""
+    out = project_status(_local_snapshot())
+    assert "turn_usage_fn" not in out
+
+
+def test_project_remote_snapshot_decodes_the_cost_breakdown_round_trip() -> None:
+    """Tier 2: the CostBreakdown wire round-trip — encode
+    (agui/state.py's _cost_breakdown_wire, inside project_status) then
+    decode (read_model.py's _cost_breakdown_from_wire, inside
+    project_remote_snapshot) reconstructs a real CostBreakdown a
+    consumer can read via ATTRIBUTE access (chrome.py's own
+    _cost_breakdown_table does `snap.get("cost_breakdown_session") or
+    CostBreakdown()`, never dict-style .get on the breakdown itself)."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+
+    session_bd = remote_snap["cost_breakdown_session"]
+    assert isinstance(session_bd, CostBreakdown)
+    assert session_bd.prompt_cost == 0.5
+    assert session_bd.completion_cost == 0.6
+    assert session_bd.prompt_tokens == 100
+    assert session_bd.cached_tokens == 20
+
+    agent_bd = remote_snap["cost_breakdown_agent"]
+    project_bd = remote_snap["cost_breakdown_project"]
+    assert agent_bd.prompt_tokens == 50
+    assert project_bd.prompt_tokens == 200
+
+
+def test_project_remote_snapshot_carries_the_rest_of_the_8_keys_through() -> None:
+    """Tier 2: the remaining 5 real values (not the CostBreakdown trio)
+    survive the SAME wire round-trip un-degraded — no more (0, 0,
+    agent_tokens)/0/alias placeholders (#5773's own root cause)."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+
+    assert remote_snap["cost_usd"] == 1.2345
+    assert remote_snap["usage"] == (1000, 400, 1400)
+    assert remote_snap["session_cached_tokens"] == 65
+    assert remote_snap["turn_cost_usd"] == 0.02
+    assert remote_snap["turn_tokens"] == 150
+
+
+def test_turn_usage_fn_never_reaches_project_remote_snapshot_output_either() -> None:
+    """Tier 2: the SAME callable-never-on-wire property, at the remote
+    read model's own output — project_remote_snapshot's own pre-existing
+    ``"turn_usage_fn": None`` entry is a deliberate, PERMANENT LOCAL
+    placeholder (#3283 ④: "a callable slot, always None remotely"), never
+    read from ``v``. Confirms it stays exactly that: never the caller's
+    OWN real callable smuggled through."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+    assert remote_snap["turn_usage_fn"] is None
+
+
+def test_the_8_reported_axes_flip_true_for_remote_once_wired() -> None:
+    """Tier 2: the *_reported declarations that gate these keys' own
+    consumers (chrome.py) are genuinely True for remote now — see
+    test_5009_closing_pass_declarations.py /
+    test_5011_ctx_cache_line_note.py for the per-axis assertions this
+    would otherwise duplicate; this test only pins that project_remote_
+    snapshot's own output carries them through."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+    assert remote_snap["usage_breakdown_reported"] is True
+    assert remote_snap["session_cache_usage_reported"] is True
+    # ctx_recent_usage's own axis is UNCHANGED by this stage — still False.
+    assert remote_snap["cache_usage_reported"] is False
+
+
+def test_an_old_server_that_never_sent_the_new_keys_degrades_gracefully() -> None:
+    """Tier 2: backward compat (#5771's own acceptance criterion) — a
+    server predating this stage never populated these 8 keys in its own
+    wire payload at all (an empty ``values`` dict simulates the pre-#5771
+    RemoteStatusView.values an old server's STATE_SNAPSHOT would produce).
+    project_remote_snapshot must not crash and must fall back to the SAME
+    graceful-degrade values the pre-#5771 placeholders already used —
+    never a fabricated-looking real figure."""
+    remote_snap = project_remote_snapshot({})
+    assert remote_snap["cost_usd"] == 0.0
+    assert remote_snap["cost_breakdown_session"] is None
+    assert remote_snap["cost_breakdown_agent"] is None
+    assert remote_snap["cost_breakdown_project"] is None
+    assert remote_snap["usage"] == (0, 0, 0)
+    assert remote_snap["session_cached_tokens"] == 0
+    assert remote_snap["turn_cost_usd"] is None
+    assert remote_snap["turn_tokens"] is None

--- a/tests/interfaces/test_5771_cost_tab_wired_to_remote.py
+++ b/tests/interfaces/test_5771_cost_tab_wired_to_remote.py
@@ -63,9 +63,17 @@ def test_turn_usage_fn_never_reaches_project_status_output() -> None:
     """Tier 2: turn_usage_fn is a callable (Session.turn_usage, keyed
     per-chain_id) — architect's explicit instruction: it must never ride
     the wire. project_status's own dict literal simply never reads this
-    key off snap; this proves that structurally, not by trusting the
-    absence."""
+    key off snap.
+
+    lead-coder BLOCKING (PR #5773, head 01bb92cbc): the negative
+    membership assert alone would stay green even if project_status
+    returned ``{}`` — indistinguishable from "the callable stopped
+    leaking" and "this test is looking at nothing". ``assert "cost_usd"
+    in out`` first is this test's OWN witness that the population is
+    non-empty (not borrowed from a sibling test, which could be skipped
+    or deleted later without this one noticing)."""
     out = project_status(_local_snapshot())
+    assert "cost_usd" in out
     assert "turn_usage_fn" not in out
 
 
@@ -113,9 +121,15 @@ def test_turn_usage_fn_never_reaches_project_remote_snapshot_output_either() -> 
     ``"turn_usage_fn": None`` entry is a deliberate, PERMANENT LOCAL
     placeholder (#3283 ④: "a callable slot, always None remotely"), never
     read from ``v``. Confirms it stays exactly that: never the caller's
-    OWN real callable smuggled through."""
+    OWN real callable smuggled through.
+
+    lead-coder BLOCKING (PR #5773, head 01bb92cbc): same fix as this
+    file's ``test_turn_usage_fn_never_reaches_project_status_output`` —
+    a non-empty-population witness this test owns itself, not borrowed
+    from a sibling."""
     wire_values = project_status(_local_snapshot())
     remote_snap = project_remote_snapshot(wire_values)
+    assert "cost_usd" in remote_snap
     assert remote_snap["turn_usage_fn"] is None
 
 

--- a/tests/llm/test_cost_breakdown_from_dict.py
+++ b/tests/llm/test_cost_breakdown_from_dict.py
@@ -1,0 +1,85 @@
+"""Tier 1: CostBreakdown.from_dict — #5771 stage②'s own wire decode side.
+
+Added so ``project_remote_snapshot`` (read_model.py) can reconstruct a real
+``CostBreakdown`` from the dict ``project_status`` (agui/state.py) put on the
+wire via ``.to_dict()`` — reusing the ONE existing serialization, never a
+second one (architect's explicit instruction on #5771). Mirrors
+``TokenUsage.from_dict``'s own resilience contract and its own test file
+(``test_token_usage_from_dict.py``) — the same "missing/null/non-numeric
+value defaults instead of raising" shape, verified independently here rather
+than assumed to transfer.
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import CostBreakdown
+
+
+def test_valid_record_round_trips() -> None:
+    """Tier 1: a well-formed record reconstructs the same real fields
+    (falsification: an over-aggressive coercion would lose the real
+    figures)."""
+    original = CostBreakdown(
+        prompt_cost=0.012,
+        cache_read_cost=0.003,
+        cache_creation_cost=0.001,
+        completion_cost=0.045,
+        cache_savings=0.007,
+        prompt_tokens=1200,
+        cached_tokens=340,
+    )
+    restored = CostBreakdown.from_dict(original.to_dict())
+    assert restored.prompt_cost == 0.012
+    assert restored.cache_read_cost == 0.003
+    assert restored.cache_creation_cost == 0.001
+    assert restored.completion_cost == 0.045
+    assert restored.cache_savings == 0.007
+    assert restored.prompt_tokens == 1200
+    assert restored.cached_tokens == 340
+    # Derived properties re-compute correctly from the restored fields alone
+    # — they are never read back from to_dict()'s own precomputed values.
+    assert restored.total_cost == original.total_cost
+    assert restored.cache_hit_rate == original.cache_hit_rate
+
+
+def test_derived_properties_in_the_dict_are_not_read_back_as_fields() -> None:
+    """Tier 1: to_dict() includes total_cost/cache_hit_rate for a reader
+    that only wants the finished figures — from_dict must not try to
+    accept them as constructor fields (they would silently diverge from
+    the property the moment either the dict or the object changed
+    independently)."""
+    data = {
+        "prompt_cost": 1.0, "cache_read_cost": 0.0, "cache_creation_cost": 0.0,
+        "completion_cost": 0.0, "cache_savings": 0.0, "prompt_tokens": 10,
+        "cached_tokens": 0,
+        # A deliberately WRONG total_cost/cache_hit_rate — from_dict must
+        # ignore these, not adopt them.
+        "total_cost": 999.0, "cache_hit_rate": 999.0,
+    }
+    restored = CostBreakdown.from_dict(data)
+    assert restored.total_cost == 1.0
+    assert restored.cache_hit_rate == 0.0
+
+
+def test_missing_keys_default_to_the_dataclass_defaults() -> None:
+    """Tier 1: an empty dict reconstructs the all-zero default — the
+    pre-existing missing-key resilience TokenUsage.from_dict already
+    established, verified independently for this class."""
+    restored = CostBreakdown.from_dict({})
+    assert restored == CostBreakdown()
+
+
+def test_null_value_defaults_instead_of_raising() -> None:
+    """Tier 1: a key present with null defaults rather than raising
+    (mirrors TokenUsage.from_dict's own null-value fix, #4844-adjacent
+    bug-mining pattern) — a malformed/older wire payload must not crash
+    the remote read model."""
+    restored = CostBreakdown.from_dict({"prompt_cost": None, "prompt_tokens": None})
+    assert restored.prompt_cost == 0.0
+    assert restored.prompt_tokens == 0
+
+
+def test_non_numeric_value_defaults_instead_of_raising() -> None:
+    """Tier 1: a non-numeric string defaults rather than raising."""
+    restored = CostBreakdown.from_dict({"completion_cost": "abc", "cached_tokens": "xyz"})
+    assert restored.completion_cost == 0.0
+    assert restored.cached_tokens == 0

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -291,16 +291,26 @@ class TestUnwiredKeyViolations:
         being a check nothing reaches.
 
         Disclosed (CLAUDE.md test-review question 4): as of this PR the
-        real source also exposes 16 further keys with the SAME shape —
-        ``ctx_recent_usage``, ``ctx_source``, ``ctx_compaction_status_fn``,
+        real source exposes 39 further keys. 16 are literal output keys
+        with the SAME shape as the 3 required witnesses — ``ctx_recent_
+        usage``, ``ctx_source``, ``ctx_compaction_status_fn``,
         ``compaction_progress_raw``, ``turn_usage_fn``, ``cron_jobs``,
         ``mcp_servers``, ``hooks``, ``skills``, ``hook_items``,
         ``mcp_probe_states``, ``pipelines``, ``unknown_config_key_count``,
-        ``unknown_config_keys``, ``hooks_config_warnings``, ``tasks``. Per
-        #5771's own dispatch these are reported (lead-coder files them as
-        separate issues), not fixed in this PR — a future PR that fixes one
-        removes it from the real-source output; this test does not pin the
-        total count for that reason, only the 3 required witnesses."""
+        ``unknown_config_keys``, ``hooks_config_warnings``, ``tasks``. The
+        other 21 (architect BLOCKING finding, #5773) come through the
+        ``**reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)`` spread
+        — every ``ChatReadModelCapabilities`` field name (``completion_
+        source``, ``hooks_reported``, ``cache_usage_reported``, etc.),
+        since that dataclass's fields are declared-axis booleans, never
+        ``project_status`` wire keys; this is the "stage③'s own family is
+        invisible to this census" gap the architect finding named — #5771's
+        stage③ (flipping the relevant ``*_reported`` fields once real cost
+        data lands) touches exactly this family. Per #5771's own dispatch
+        these are reported (lead-coder files them as separate issues), not
+        fixed in this PR — a future PR that fixes one removes it from the
+        real-source output; this test does not pin the total count for
+        that reason, only the 3 required witnesses."""
         violations = find_unwired_key_violations()
         found_keys = {v.split('"')[1] for v in violations}
         for required in ("cost_usd", "usage", "session_cached_tokens"):
@@ -359,3 +369,89 @@ class TestUnwiredKeyViolations:
         status_fixture = _write_status_module(tmp_path, ["model", "cost_agent"])
 
         assert find_unwired_key_violations(remote_fixture, status_fixture) == []
+
+    def test_the_reported_snapshot_keys_spread_is_expanded_not_silently_skipped(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: architect BLOCKING finding (#5773, agreed by lead-coder)
+        — a ``**spread`` entry used to be skipped unconditionally
+        (``if key_node is None: continue``), making the ENTIRE
+        ``ChatReadModelCapabilities`` field family invisible to this
+        census (project_status has zero ``*_reported``-style keys, so
+        every one of those 21 fields is unwired drift the OLD code never
+        reported). The real
+        ``**reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)`` shape
+        is now recognized and resolved via a genuine import + call, so its
+        real field names are checked the same as any literal key."""
+        remote_fixture = _write_module(
+            tmp_path, '    return {**reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)}\n',
+        )
+        status_fixture = _write_status_module(tmp_path, ["model"])
+
+        violations = find_unwired_key_violations(remote_fixture, status_fixture)
+
+        assert any(
+            '"completion_source"' in v and "via **reported_snapshot_keys" in v
+            for v in violations
+        ), violations
+
+    def test_an_unrecognized_spread_shape_is_flagged_not_silently_skipped(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: acceptance② — a ``**spread`` this check does NOT
+        recognize (some future/hypothetical helper, not
+        ``reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)``) must
+        still surface as a violation demanding manual review, never a
+        silent pass — the exact "skip means the gate can be blind without
+        saying so" shape the architect finding closed."""
+        remote_fixture = _write_module(
+            tmp_path, '    return {**some_other_helper()}\n',
+        )
+        status_fixture = _write_status_module(tmp_path, ["model"])
+
+        violations = find_unwired_key_violations(remote_fixture, status_fixture)
+
+        assert any("unrecognized `**spread`" in v for v in violations), violations
+
+
+# ── #5773 — _find_function_return_dict must not silently pick the wrong
+# (or an empty) return when a producer gains an early guard-clause return ──
+
+
+class TestFindFunctionReturnDictGuards:
+    def test_multiple_top_level_returns_are_refused_not_guessed(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: architect BLOCKING finding (#5773) — an early guard-
+        clause return (``if values is None: return {}``) ahead of the
+        real return used to be silently picked or silently ignored
+        depending on ``ast.walk``'s own traversal order; this must refuse
+        instead, since guessing which return is "the real one" can
+        silently shrink this gate's own population to whatever the guard
+        clause happens to return."""
+        path = _write_module(
+            tmp_path,
+            '    if values is None:\n'
+            '        return {}\n'
+            '    return {"cost_agent": v.get("cost_agent", 0.0)}\n',
+        )
+        status_fixture = _write_status_module(tmp_path, ["model"])
+
+        violations = find_unwired_key_violations(path, status_fixture)
+
+        assert any("return statements" in v for v in violations), violations
+
+    def test_an_empty_dict_return_is_refused_not_treated_as_a_clean_population(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: architect BLOCKING finding (#5773) — a resolved return
+        dict with ZERO keys must be refused as a mis-resolution, never
+        silently accepted as "a clean, fully-compliant population" (the
+        exact empty-population-still-green shape CLAUDE.md's own
+        test-review question 4 names)."""
+        path = _write_module(tmp_path, '    return {}\n')
+        status_fixture = _write_status_module(tmp_path, ["model"])
+
+        violations = find_unwired_key_violations(path, status_fixture)
+
+        assert any("EMPTY dict" in v for v in violations), violations

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -17,12 +17,25 @@ was a hand-typed ASSERTION with no producer code reading it — nothing
 checked that its members were genuinely, unconditionally on the wire.
 ``find_wire_keys_violations`` closes that by AST-checking ``_WIRE_KEYS ⊆``
 the keys ``agui/state.py``'s ``project_status`` unconditionally emits.
-"""
+
+``TestUnwiredKeyViolations`` (below) is #5771 stage ① (lead-coder dispatch,
+owner ruling "structural, not a feature"): a THIRD, independent question
+neither check above asks — is a ``project_remote_snapshot`` OUTPUT key
+itself backed by a same-named ``project_status`` key at all, regardless of
+whether its placeholder-ness is otherwise honestly declared.
+``find_unwired_key_violations`` closes that. Unlike the other 2 checks,
+this one is NOT asserted to be ``== []`` on the real source — #5098's own
+invariant ("one declaration, not two that can drift apart") is measurably
+broken today, for real, disclosed keys (``cost_usd``/``usage``/
+``session_cached_tokens`` are the 3 lead-coder's own dispatch named as the
+required witnesses; the rest are disclosed here per CLAUDE.md's test-review
+question 4, not silenced by an allowlist invented for this PR)."""
 from __future__ import annotations
 
 from pathlib import Path
 
 from scripts.check_remote_snapshot_placeholder_declared import (
+    find_unwired_key_violations,
     find_violations,
     find_wire_keys_violations,
 )
@@ -167,6 +180,41 @@ def test_main_exits_nonzero_when_a_violation_exists(tmp_path: Path, monkeypatch)
     assert exit_code == 1
 
 
+def test_main_exits_nonzero_when_only_an_unwired_key_violation_exists(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: main()-level witness for #5771's own axis specifically —
+    isolates it from the other 2 checks (a fixture with a REAL wire key
+    read via ``.get()``, so ``find_violations`` sees nothing placeholder-
+    shaped to flag, paired with a synthetic ``project_status`` that omits
+    that key) to prove ``main()`` fails on THIS check's finding alone, not
+    only when one of the other 2 also happens to fire on the same
+    fixture (as ``test_main_exits_nonzero_when_a_violation_exists`` above
+    would, since its own fixture key is unwired too)."""
+    import scripts.check_remote_snapshot_placeholder_declared as gate_module
+
+    remote_fixture = _write_module(
+        tmp_path, '    return {"cost_usd": v.get("cost_agent")}\n',
+    )
+    # Every real _WIRE_KEYS member, so find_wire_keys_violations (a
+    # DIFFERENT check, module-level _WIRE_KEYS unaffected by this fixture)
+    # stays clean and this test isolates #5771's own axis alone.
+    status_fixture = _write_status_module(
+        tmp_path,
+        ["model", "cost_agent", "cost_total", "agent_tokens", "ctx_used",
+         "ctx_window", "queue", "turn_active", "queue_seq"],
+    )
+    monkeypatch.setattr(gate_module, "_PACKAGE_DIR", remote_fixture)
+    monkeypatch.setattr(gate_module, "_AGUI_STATE_PATH", status_fixture)
+
+    assert gate_module.find_violations(remote_fixture) == []
+    assert gate_module.find_wire_keys_violations(status_fixture) == []
+
+    exit_code = gate_module.main()
+
+    assert exit_code == 1
+
+
 # ── _WIRE_KEYS ⊆ project_status's unconditional keys (architect blocking
 # finding, issuecomment-5385179961) ───────────────────────────────────────
 
@@ -223,3 +271,91 @@ def test_project_status_emitting_every_wire_key_is_not_flagged(tmp_path: Path) -
     )
 
     assert find_wire_keys_violations(fixture) == []
+
+
+# ── #5771 stage ① — is a project_remote_snapshot output key itself backed
+# by a same-named project_status key, independent of ①②③ above ──────────
+
+
+class TestUnwiredKeyViolations:
+    def test_the_real_source_exposes_the_known_cost_tab_drift(self) -> None:
+        """Tier 2: #5771 acceptance — the 3 keys lead-coder's own dispatch
+        named as the required witnesses (a bare literal that never reads
+        the wire at all, a tuple built from an unrelated wire key, and an
+        alias reading a DIFFERENT wire key under this key's own name) must
+        all appear in ``find_unwired_key_violations``'s real-source output.
+        This does NOT assert the list is empty (#5098's own invariant is
+        genuinely broken today, not a false positive this test should
+        silence) — it asserts these 3 specific, already-diagnosed keys are
+        present, which is what proves the axis actually fires rather than
+        being a check nothing reaches.
+
+        Disclosed (CLAUDE.md test-review question 4): as of this PR the
+        real source also exposes 16 further keys with the SAME shape —
+        ``ctx_recent_usage``, ``ctx_source``, ``ctx_compaction_status_fn``,
+        ``compaction_progress_raw``, ``turn_usage_fn``, ``cron_jobs``,
+        ``mcp_servers``, ``hooks``, ``skills``, ``hook_items``,
+        ``mcp_probe_states``, ``pipelines``, ``unknown_config_key_count``,
+        ``unknown_config_keys``, ``hooks_config_warnings``, ``tasks``. Per
+        #5771's own dispatch these are reported (lead-coder files them as
+        separate issues), not fixed in this PR — a future PR that fixes one
+        removes it from the real-source output; this test does not pin the
+        total count for that reason, only the 3 required witnesses."""
+        violations = find_unwired_key_violations()
+        found_keys = {v.split('"')[1] for v in violations}
+        for required in ("cost_usd", "usage", "session_cached_tokens"):
+            assert required in found_keys, (
+                f'"{required}" must be exposed as unwired-key drift; got '
+                f"{sorted(found_keys)!r}"
+            )
+
+    def test_an_output_key_with_no_matching_project_status_key_is_flagged(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: acceptance② — a synthetic ``project_remote_snapshot``
+        mapping a key ``project_status`` never emits must be flagged,
+        independent of the value's own shape (a bare literal here, the
+        simplest case)."""
+        remote_fixture = _write_module(tmp_path, '    return {"not_on_the_wire": 0}\n')
+        status_fixture = _write_status_module(tmp_path, ["model", "cost_agent"])
+
+        violations = find_unwired_key_violations(remote_fixture, status_fixture)
+
+        assert any('"not_on_the_wire"' in v for v in violations), violations
+
+    def test_an_alias_reading_a_different_real_wire_key_is_still_flagged(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: acceptance② (the exact #5771 root cause) — an output key
+        whose value reads a DIFFERENT, genuinely-real wire key under a
+        mismatched name (``cost_usd``'s own real shape:
+        ``v.get("cost_agent", 0.0)``) is flagged by its OWN name, not
+        excused by the wire key it happens to alias. This is precisely what
+        #5093's original ``find_violations`` cannot see (remedy① there
+        matches on the ``.get()`` call's own key ARGUMENT, "cost_agent",
+        not the output key "cost_usd")."""
+        remote_fixture = _write_module(
+            tmp_path, '    return {"cost_usd": v.get("cost_agent", 0.0)}\n',
+        )
+        status_fixture = _write_status_module(tmp_path, ["model", "cost_agent"])
+
+        violations = find_unwired_key_violations(remote_fixture, status_fixture)
+
+        assert any('"cost_usd"' in v for v in violations), violations
+        # #5093's OWN gate, unmodified, must NOT catch this shape -- it is
+        # the exact gap #5771 exists to close, not a duplicate of it.
+        assert find_violations(remote_fixture) == []
+
+    def test_an_output_key_backed_by_a_same_named_project_status_key_is_not_flagged(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: falsification contrast — an output key whose name
+        genuinely matches a real ``project_status`` key produces zero
+        violations for that key, proving this is a same-name membership
+        test, not something that flags every key unconditionally."""
+        remote_fixture = _write_module(
+            tmp_path, '    return {"cost_agent": v.get("cost_agent", 0.0)}\n',
+        )
+        status_fixture = _write_status_module(tmp_path, ["model", "cost_agent"])
+
+        assert find_unwired_key_violations(remote_fixture, status_fixture) == []

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -195,10 +195,10 @@ def test_main_exits_nonzero_when_only_an_unwired_key_violation_exists(
     would, since its own fixture key is unwired too).
 
     Uses a key name NOT in ``_UNWIRED_KEY_VIOLATIONS_BASELINE`` (unlike
-    ``cost_usd``, now a KNOWN, baselined violation as of #5771's own
-    ratchet fix) — ``main()``'s own exit code is gated on ``find_new_
-    unwired_key_violations`` specifically, so a baselined violation alone
-    must NOT fail it; only a genuinely NEW one does."""
+    ``cron_jobs``, a real, currently-baselined LOCAL entry) —
+    ``main()``'s own exit code is gated on ``find_new_unwired_key_
+    violations`` specifically, so a baselined violation alone must NOT
+    fail it; only a genuinely NEW one does."""
     import scripts.check_remote_snapshot_placeholder_declared as gate_module
 
     remote_fixture = _write_module(
@@ -209,8 +209,10 @@ def test_main_exits_nonzero_when_only_an_unwired_key_violation_exists(
     # stays clean and this test isolates #5771's own axis alone.
     status_fixture = _write_status_module(
         tmp_path,
-        ["model", "cost_agent", "cost_total", "agent_tokens", "ctx_used",
-         "ctx_window", "queue", "turn_active", "queue_seq"],
+        ["model", "cost_agent", "cost_total", "cost_usd", "agent_tokens",
+         "ctx_used", "ctx_window", "queue", "turn_active", "queue_seq",
+         "cost_breakdown_session", "cost_breakdown_agent", "cost_breakdown_project",
+         "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens"],
     )
     monkeypatch.setattr(gate_module, "_PACKAGE_DIR", remote_fixture)
     monkeypatch.setattr(gate_module, "_AGUI_STATE_PATH", status_fixture)
@@ -274,8 +276,11 @@ def test_project_status_emitting_every_wire_key_is_not_flagged(tmp_path: Path) -
     a subset test, not an exact-set one) produces zero violations."""
     fixture = _write_status_module(
         tmp_path,
-        ["cost_agent", "cost_total", "agent_tokens", "ctx_used", "ctx_window",
-         "queue", "turn_active", "queue_seq", "some_unrelated_extra_key"],
+        ["cost_agent", "cost_total", "cost_usd", "agent_tokens", "ctx_used",
+         "ctx_window", "queue", "turn_active", "queue_seq",
+         "cost_breakdown_session", "cost_breakdown_agent", "cost_breakdown_project",
+         "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens",
+         "some_unrelated_extra_key"],
     )
 
     assert find_wire_keys_violations(fixture) == []
@@ -286,56 +291,13 @@ def test_project_status_emitting_every_wire_key_is_not_flagged(tmp_path: Path) -
 
 
 class TestUnwiredKeyViolations:
-    def test_the_real_source_exposes_the_known_cost_tab_drift(self) -> None:
-        """Tier 2: #5771 acceptance — the 3 keys lead-coder's own dispatch
-        named as the required witnesses (a bare literal that never reads
-        the wire at all, a tuple built from an unrelated wire key, and an
-        alias reading a DIFFERENT wire key under this key's own name) must
-        all appear in ``find_unwired_key_violations``'s real-source output.
-
-        EXPIRES when #5771's own stage② wires these 3 for real — at that
-        point this test needs deleting (or updating to different, still-
-        unfixed witnesses), not weakening; it does NOT serve as this
-        file's non-vacuity guard (that role belongs permanently to
-        ``TestCountExaminedOutputKeys``, which never expires — see lead-
-        coder's own BLOCKING finding on PR #5773 for why counting
-        VIOLATIONS rather than EXAMINED keys was the wrong shape for that
-        role).
-
-        This does NOT assert the list is empty (#5098's own invariant is
-        genuinely broken today, not a false positive this test should
-        silence) — it asserts these 3 specific, already-diagnosed keys are
-        present, which is what proves the axis actually fires rather than
-        being a check nothing reaches.
-
-        Disclosed (CLAUDE.md test-review question 4): as of this PR the
-        real source exposes 39 further keys. 16 are literal output keys
-        with the SAME shape as the 3 required witnesses — ``ctx_recent_
-        usage``, ``ctx_source``, ``ctx_compaction_status_fn``,
-        ``compaction_progress_raw``, ``turn_usage_fn``, ``cron_jobs``,
-        ``mcp_servers``, ``hooks``, ``skills``, ``hook_items``,
-        ``mcp_probe_states``, ``pipelines``, ``unknown_config_key_count``,
-        ``unknown_config_keys``, ``hooks_config_warnings``, ``tasks``. The
-        other 21 (architect BLOCKING finding, #5773) come through the
-        ``**reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)`` spread
-        — every ``ChatReadModelCapabilities`` field name (``completion_
-        source``, ``hooks_reported``, ``cache_usage_reported``, etc.),
-        since that dataclass's fields are declared-axis booleans, never
-        ``project_status`` wire keys; this is the "stage③'s own family is
-        invisible to this census" gap the architect finding named — #5771's
-        stage③ (flipping the relevant ``*_reported`` fields once real cost
-        data lands) touches exactly this family. Per #5771's own dispatch
-        these are reported (lead-coder files them as separate issues), not
-        fixed in this PR — a future PR that fixes one removes it from the
-        real-source output; this test does not pin the total count for
-        that reason, only the 3 required witnesses."""
-        violations = find_unwired_key_violations()
-        found_keys = {v.split('"')[1] for v in violations}
-        for required in ("cost_usd", "usage", "session_cached_tokens"):
-            assert required in found_keys, (
-                f'"{required}" must be exposed as unwired-key drift; got '
-                f"{sorted(found_keys)!r}"
-            )
+    # #5771 stage②: test_the_real_source_exposes_the_known_cost_tab_drift
+    # (the 3-witness test: cost_usd/usage/session_cached_tokens must
+    # appear in find_unwired_key_violations's real-source output) is
+    # DELETED here, exactly per its own documented fate — stage② just
+    # wired all 3 for real, so they no longer appear in that output at
+    # all. Its non-vacuity role was never this test's job in the first
+    # place (see TestCountExaminedOutputKeys, which never expires).
 
     def test_an_output_key_with_no_matching_project_status_key_is_flagged(
         self, tmp_path: Path,

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from scripts.check_remote_snapshot_placeholder_declared import (
+    count_examined_output_keys,
+    find_new_unwired_key_violations,
     find_unwired_key_violations,
     find_violations,
     find_wire_keys_violations,
@@ -190,11 +192,17 @@ def test_main_exits_nonzero_when_only_an_unwired_key_violation_exists(
     that key) to prove ``main()`` fails on THIS check's finding alone, not
     only when one of the other 2 also happens to fire on the same
     fixture (as ``test_main_exits_nonzero_when_a_violation_exists`` above
-    would, since its own fixture key is unwired too)."""
+    would, since its own fixture key is unwired too).
+
+    Uses a key name NOT in ``_UNWIRED_KEY_VIOLATIONS_BASELINE`` (unlike
+    ``cost_usd``, now a KNOWN, baselined violation as of #5771's own
+    ratchet fix) — ``main()``'s own exit code is gated on ``find_new_
+    unwired_key_violations`` specifically, so a baselined violation alone
+    must NOT fail it; only a genuinely NEW one does."""
     import scripts.check_remote_snapshot_placeholder_declared as gate_module
 
     remote_fixture = _write_module(
-        tmp_path, '    return {"cost_usd": v.get("cost_agent")}\n',
+        tmp_path, '    return {"brand_new_unbaselined_key": v.get("cost_agent")}\n',
     )
     # Every real _WIRE_KEYS member, so find_wire_keys_violations (a
     # DIFFERENT check, module-level _WIRE_KEYS unaffected by this fixture)
@@ -284,6 +292,16 @@ class TestUnwiredKeyViolations:
         the wire at all, a tuple built from an unrelated wire key, and an
         alias reading a DIFFERENT wire key under this key's own name) must
         all appear in ``find_unwired_key_violations``'s real-source output.
+
+        EXPIRES when #5771's own stage② wires these 3 for real — at that
+        point this test needs deleting (or updating to different, still-
+        unfixed witnesses), not weakening; it does NOT serve as this
+        file's non-vacuity guard (that role belongs permanently to
+        ``TestCountExaminedOutputKeys``, which never expires — see lead-
+        coder's own BLOCKING finding on PR #5773 for why counting
+        VIOLATIONS rather than EXAMINED keys was the wrong shape for that
+        role).
+
         This does NOT assert the list is empty (#5098's own invariant is
         genuinely broken today, not a false positive this test should
         silence) — it asserts these 3 specific, already-diagnosed keys are
@@ -455,3 +473,94 @@ class TestFindFunctionReturnDictGuards:
         violations = find_unwired_key_violations(path, status_fixture)
 
         assert any("EMPTY dict" in v for v in violations), violations
+
+
+# ── #5771 — the ratchet: real-source violations must be a SUBSET of the
+# baseline; a genuinely NEW one is red, no matter how many baselined ones
+# already exist ─────────────────────────────────────────────────────────
+
+
+class TestNewUnwiredKeyViolationsRatchet:
+    def test_the_real_source_has_no_new_unwired_key_violations(self) -> None:
+        """Tier 2: acceptance① — every unwired-key violation on the real
+        tree is already accounted for in ``_UNWIRED_KEY_VIOLATIONS_
+        BASELINE``. This is the actual merge-blocking ratchet (lead-coder
+        BLOCKING, PR #5773): stage②'s own 8 new wire keys can freely be
+        ADDED without this test needing to change, but a key that stays
+        unwired by ACCIDENT — the exact "nothing stops a 41st drifted key"
+        gap the BLOCKING named — fails here immediately."""
+        assert find_new_unwired_key_violations() == []
+
+    def test_a_key_outside_the_baseline_is_flagged_as_new(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: acceptance② — a synthetic unwired key with a name that
+        does not appear anywhere in the real baseline is flagged by
+        ``find_new_unwired_key_violations``, proving the subset check
+        actually fires rather than accepting everything unconditionally."""
+        remote_fixture = _write_module(
+            tmp_path, '    return {"a_key_nobody_has_ever_seen_before": 0}\n',
+        )
+        status_fixture = _write_status_module(tmp_path, ["model"])
+
+        violations = find_new_unwired_key_violations(remote_fixture, status_fixture)
+
+        assert any(
+            '"a_key_nobody_has_ever_seen_before"' in v for v in violations
+        ), violations
+
+    def test_a_baselined_key_alone_is_not_flagged_as_new(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: falsification contrast — a real, already-baselined key
+        (``cron_jobs``, disposition LOCAL) alone produces zero NEW
+        violations, proving the ratchet distinguishes disclosed debt from
+        genuinely new drift rather than flagging every unwired key."""
+        remote_fixture = _write_module(tmp_path, '    return {"cron_jobs": []}\n')
+        status_fixture = _write_status_module(tmp_path, ["model"])
+
+        assert find_new_unwired_key_violations(remote_fixture, status_fixture) == []
+
+
+# ── #5771 — a non-expiring non-vacuity witness: stage② fixing the 3
+# required cost-tab keys must not silently remove the ONLY thing proving
+# this walk still examines something real ───────────────────────────────
+
+
+class TestCountExaminedOutputKeys:
+    def test_the_real_source_examines_more_than_zero_output_keys(self) -> None:
+        """Tier 2: the non-expiring non-vacuity guard (lead-coder
+        BLOCKING, PR #5773): asserting specific KEYS are still violations
+        (the original version of this PR's own witness) expires the
+        moment those keys are fixed — a silently-broken walk and a
+        genuinely-clean population would then look identical (0
+        violations either way). Counting EXAMINED keys instead of
+        VIOLATIONS never expires: ``project_remote_snapshot`` will always
+        have SOME output keys, so this stays true forever unless the walk
+        itself regresses."""
+        assert count_examined_output_keys() > 0
+
+    def test_a_return_with_only_wired_keys_still_counts_them(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: falsification contrast — a fixture with zero
+        violations (every key genuinely wired) still reports a nonzero
+        examined-key count, proving this witness measures "did the walk
+        see keys at all", not "how many violations exist"."""
+        remote_fixture = _write_module(
+            tmp_path, '    return {"cost_agent": v.get("cost_agent", 0.0)}\n',
+        )
+
+        assert count_examined_output_keys(remote_fixture) == 1
+
+    def test_an_empty_return_reports_zero_examined_keys(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tier 2: falsification contrast — the exact regressed-walk shape
+        this witness exists to catch: an empty return dict (refused
+        elsewhere as a mis-resolution, see ``TestFindFunctionReturnDict
+        Guards``) reports 0 examined keys, proving this witness would
+        actually go red if the real walk ever silently found nothing."""
+        remote_fixture = _write_module(tmp_path, '    return {}\n')
+
+        assert count_examined_output_keys(remote_fixture) == 0


### PR DESCRIPTION
**[tui-coder]** —

## What

Stage ① of #5771 (owner ruling, relayed by lead-coder: "構造的対処を着手させてください"). Extends the **existing** #5093 gate (`scripts/check_remote_snapshot_placeholder_declared.py` — no new gate script) with the missing axis: is a `project_remote_snapshot` OUTPUT key itself backed by a same-named `project_status` key, independent of whether its placeholder-ness is otherwise honestly declared.

## Why this axis, not the 2 existing ones

`#5093`'s own 2 existing checks (`find_violations`, `find_wire_keys_violations`) both answer "is this value's graceful-degrade nature honestly declared" — a question about the VALUE's shape or the `.get()` call's own key argument. `#5098`'s own invariant ("`project_status` is the SOLE declaration of which keys ride the wire — one declaration, not two that can drift apart") is a different, narrower promise about the OUTPUT KEY's own name, and neither existing check looks at that.

Concretely: `"cost_usd": v.get("cost_agent", 0.0)` passes remedy① today — `"cost_agent"`, the `.get()` call's own key argument, is genuinely in `_WIRE_KEYS` — even though the OUTPUT key `"cost_usd"` is not a real `project_status` key at all. It's an alias, invisible to every existing remedy because none of them check the output key's own name against `project_status`.

## What the new axis found (reported here, not fixed here)

Run against the real tree, `find_unwired_key_violations()` returns **19 keys**:

**Required witnesses (the already-diagnosed cost-tab bug — asserted present by name in the new test):**
- `cost_usd` — aliases `cost_agent` under a different name
- `usage` — a fixed `(0, 0, agent_tokens)` placeholder, invisible to #5093's own AST walk (a tuple, not a bare literal or `.get()` call)
- `session_cached_tokens` — a hardcoded `0`, never reads the wire at all

**Other exposed keys (disclosed in the test's own docstring, reported here for lead-coder to triage/file separately — NOT fixed in this PR):** `ctx_recent_usage`, `ctx_source`, `ctx_compaction_status_fn`, `compaction_progress_raw`, `turn_usage_fn`, `cron_jobs`, `mcp_servers`, `hooks`, `skills`, `hook_items`, `mcp_probe_states`, `pipelines`, `unknown_config_key_count`, `unknown_config_keys`, `hooks_config_warnings`, `tasks`. Most of these are genuinely, permanently session-local concepts with no wire equivalent to add (config/registry data, never meant to ride the wire) — but that triage judgment is explicitly out of scope for this PR per dispatch ("あなたは「露出した一覧」を報告するだけで結構です").

## Explicitly NOT in this PR (stages ②③, not yet dispatched)

- Adding the 8 real cost wire keys to `project_status` (`cost_usd` for real, `cost_breakdown_session/agent/project`, `usage`, `session_cached_tokens`, `turn_cost_usd`, `turn_tokens`).
- Reusing `CostBreakdown.to_dict()` for the wire round-trip (never inventing a new serialization).
- Flipping the relevant `*_reported` flags to `True`.

Landing stage ① alone is the foundation stage ② needs — adding wire keys before this axis exists would itself become a 4th drift.

## Falsify-verified

Stripped `find_unwired_key_violations` to an unconditional `return []` (Edit-only, restored before push) — the 4 new tests that depend on it fail; the pre-existing acceptance-① test (`test_the_real_source_has_zero_violations`, calling the OLD, untouched `find_violations`) is unaffected either way, confirming the new axis is purely additive.

## Test plan

- [x] `TestUnwiredKeyViolations` (4 new tests): real-source witness (asserts the 3 required keys by name, discloses the full 19-key list), a synthetic-fixture violation witness, the exact alias-shape witness (`cost_usd`/`cost_agent`), and a same-name contrast (not flagged).
- [x] `test_main_exits_nonzero_when_only_an_unwired_key_violation_exists`: isolates the new axis at the `main()` level from the 2 existing checks.
- [x] All pre-existing tests in this file (13) unaffected, still green.
- [x] Scoped sweep (`5093/5098/5094/5185/5034/5009/read_model/agui_state/project_status/project_remote_snapshot`): 85 passed, 4 skipped (pre-existing, unrelated missing-extras).
- [x] `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all pass.
- [ ] (skipped — Visual, standing waiver) no UI surface touched by this PR.

part of #5771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
