### PR TITLE
feat(#5769 stage 2): separate derivation from scope in build_active_predicate consumers

### DIFF
--- a/docs/deep-dives/decisions/0047-session-scoped-rewind.md
+++ b/docs/deep-dives/decisions/0047-session-scoped-rewind.md
@@ -25,10 +25,23 @@ The only globally-derived thing in the substrate is `is_active(seq)`: the reset-
 ## The decision
 
 1. **A reset-record carries a scope.** `(R, target_n, scope)` where `scope` is `(agent_name, session_id)` or `None`. **`None` means global** — exactly today's record. A legacy record with no field reads as `None`, so existing WALs need no migration and existing behaviour is unchanged.
-2. **`is_active` is derived per scope.** For a given `(agent, sid)`, the rewind chain is the global records **plus** the records scoped to that pair; `_abandoned_intervals`' latest-first composition is reused unchanged over that set. `build_active_predicate(state_log, *, scope)` takes the scope as a **required keyword-only argument** — never defaulted, so a consumer that forgets it fails at the call rather than silently behaving globally. Every existing consumer already knows which `(agent, sid)` it is evaluating; it passes a fact it holds, it does not compute a decision.
+2. **`is_active` is derived per scope, and the derivation belongs where the scope is known.** For a given `(agent, sid)`, the rewind chain is the global records **plus** the records scoped to that pair; `_abandoned_intervals`' latest-first composition is reused unchanged over that set. `build_active_predicate(state_log, *, scope)` takes the scope as a **required keyword-only argument** — never defaulted, so a consumer that forgets it fails at the call rather than silently behaving globally.
+
+   **Revised 2026-09-05 (#5769 stage 2, after stage 1 landed in [#5772](https://github.com/tya5/reyn/pull/5772)).** The first form of this decision said only that the predicate takes a scope; it left the predicate itself as a value a caller could build once and pass around. That is not sufficient, and the reason is the decision:
+
+   > **Scope is a property of the seq, not of the predicate object.** Every WAL entry routes to exactly one `(agent_name, session_id)` (`event_route_key`), so the correct rewind chain for a seq is its OWNER's chain. A predicate built once and applied to seqs of several owners answers all of them from one owner's chain, and nothing in its type or name says which.
+
+   Stage 1 measured the shape this produces: at six call sites the predicate was hoisted **above the very loop whose variables are the scope** (`_materialize_rewind`: `is_active` built above `for name … for sid …`, then asked about `sess_seq`, whose owner is `(name, sid)`). Those sites read as "global" for a reason — the hoist — that is itself what stage 2 changes. A discriminant asked about the call's *aggregate* shape therefore passes exactly the sites that must move.
+
+   **Therefore: the derivation is built where the scope is known, and a consumer passes a scope, never a predicate.** Concretely — a collaborator that used to accept a caller-hoisted `is_active` (`ConfigGenerationStore.latest_active`, `PipelineStateStore.latest_active`) takes `(state_log, *, scope)` and builds its own; a loop over owners builds inside the loop. The mis-scoped-predicate failure mode is then **unwritable**, not merely discouraged — the shape this ADR prefers over a rule in a docstring.
+
+   **The performance premise the old shape rested on is gone.** Those call sites carry `#2941` comments requiring one hoisted predicate "so the WAL is not re-scanned per X". Since **#2939** the rewind-record fetch is an incremental, per-`StateLog` cached tail-reader (`_RewindIndex`), so a fresh `build_active_predicate` costs one fold over the rewind records — O(records), not O(WAL). Those comments describe a world that no longer exists and are rewritten with this change. (A structure adopted for a performance reason outlives the reason; the reason must be re-read, not inherited.)
+
 3. **`checkout(seq, *, scope)`.** `scope=None` is the existing five-step global cut, untouched. A scoped checkout applies the same retention guard (the WAL floor is global and stays so), cancels and quiesces **only** the target session, appends one scoped reset-record (fsync'd before any reconstruction — the crash-idempotence keystone from 0038 is unchanged), and materialises **only** that `(name, sid)`.
 4. **A session-scoped rewind rewinds conversation and agent state only.** It never touches the shared workspace's files (neither does the global cut today) and it does not touch config generations (`config_generations.py` has no session notion; `mcp.yaml` / `cron.yaml` are workspace-level SSoT, outside a session's scope by construction).
 5. **Cross-session consistency is deliberately given up by a scoped rewind.** An A→B message is B's WAL entry (routed by `target`). Rewinding A alone leaves B holding a message A no longer remembers sending. This is the feature's definition, accepted by the owner, not a defect. **A caller who needs the consistent cut uses `scope=None`.**
+
+6. **Agent-level lifecycle is global; only session-level state is scoped.** A session-scoped rewind never creates, drops, archives, purges or un-archives an **agent** — those facts are agent-wide (`agent_created` / `agent_archived` / `agent_purged` carry `entity_kind="agent", name=…` and no session; the `.archived` tombstone is one marker per agent directory; archiving preserves every session, #1954). One session rewinding must not change the workspace's topology for every other session. What a scoped rewind does move is session-level state: session create / vanish, and the conversation and agent state of that `(name, sid)`. In code this is the split `_materialize_rewind` now makes — `GLOBAL_SCOPE` for the agent existence checks, `scope=(name, sid)` built inside the session loop. **This resolves `_reconcile_archived_as_of_cut`, which stage 2 left on hold**: archival is agent-wide, so `GLOBAL_SCOPE` is its final answer, not a placeholder. Decision 4 is the same rule applied to config generations, which have no session notion at all.
 
 ## Alternatives considered
 
@@ -36,7 +49,8 @@ The only globally-derived thing in the substrate is `is_active(seq)`: the reset-
 |---|---|
 | Keep the global cut only (0038 as is) | The owner asked for session-local rewind; the rejection's premise ("requires splitting workspace + WAL") is not what the code does. |
 | Split the WAL per session | Unnecessary — entries are already session-routed on the one log, and a split would break the single seq axis that cross-agent ordering rides on. |
-| `scope=None` as a default argument on the predicate | Rejected: with 12 consumers, one forgotten call site silently behaves globally and session-local rewind stops working for exactly that consumer, with no red. Required keyword-only fails loudly instead. |
+| `scope=None` as a default argument on the predicate | Rejected: with 9 consumers (the count measured on `origin/main` during #5772 co-vet; an earlier "12" counted docstring mentions), one forgotten call site silently behaves globally and session-local rewind stops working for exactly that consumer, with no red. Required keyword-only fails loudly instead. |
+| The caller hoists one predicate and passes it to collaborators (stage 1's shape) | Rejected on measurement: it lets a predicate built for one owner be asked about another owner's seq, and the hoist is invisible at the place the wrong answer is produced. Passing a **scope** instead makes the mis-scoped question unwritable. See decision 2's revision. |
 | Revert workspace files for a scoped rewind | Impossible without per-session workspaces, which 0038 rejected for destroying the single-SSoT invariant — and the global cut does not revert files today either. |
 
 ## Consequences
@@ -60,6 +74,9 @@ The only globally-derived thing in the substrate is `is_active(seq)`: the reset-
 - [ ] Calling `build_active_predicate` without `scope` fails.
 - [ ] Crash mid-scoped-rewind, then recover: only the scoped session is as-of-N (truncate-falsify form).
 - [ ] A target below the global WAL floor is rejected for a scoped checkout too.
+- [ ] No collaborator takes a caller-built `is_active` predicate: `git grep -nE 'is_active: .*Callable' -- src/` is empty.
+- [ ] A predicate is never built above a loop whose variables are the scope (`_materialize_rewind`'s session predicate is built inside the `sid` loop).
+- [ ] A session-scoped rewind leaves every agent's existence and `.archived` state untouched (decision 6).
 - [ ] ADR-0038 is byte-identical.
 
 ## References

--- a/src/reyn/core/events/config_generations.py
+++ b/src/reyn/core/events/config_generations.py
@@ -16,9 +16,14 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import yaml
+
+from reyn.core.events.snapshot_generations import build_active_predicate
+
+if TYPE_CHECKING:
+    from reyn.core.events.state_log import StateLog
 
 _GEN_RE = re.compile(r"^(?P<rel>.+)@(?P<seq>\d+)\.yaml$")
 
@@ -119,23 +124,25 @@ class ConfigGenerationStore:
         return seq, content if isinstance(content, dict) else {}
 
     def latest_active(
-        self, rel_path: str, is_active: "Callable[[int], bool]",
+        self, rel_path: str, state_log: "StateLog", *, scope: "tuple[str, str] | None",
     ) -> "tuple[int, dict] | None":
         """The (seq, content) of the highest generation for `rel_path` on the ACTIVE WAL
         branch, or None when no active generation exists.
 
-        ``is_active`` is the caller-supplied membership predicate (``is_active_seq``'s
-        derivation is seq-independent — see ``build_active_predicate``). A caller
-        reconciling MANY rel_paths in one pass (e.g.
-        ``AgentRegistry._reconcile_config_as_of_cut``) MUST hoist ONE
-        ``build_active_predicate(state_log, scope=GLOBAL_SCOPE)`` (#5769 stage 1:
-        ``scope`` is now required, no default — ``GLOBAL_SCOPE`` is the named
-        constant for "this call site's own scope is genuinely global", not a
-        placeholder) and reuse it here per rel_path — passing
-        ``is_active_seq`` re-bound per call would re-scan the whole WAL once per
-        rel_path (the #2941 sibling quadratic-cold-start shape this signature exists to
-        prevent). A single-path caller may pass
-        ``lambda s: is_active_seq(state_log, s)`` directly.
+        #5769 stage 2: takes ``(state_log, scope)`` directly rather than a
+        caller-hoisted ``is_active`` predicate — this store builds its OWN
+        predicate internally (via ``build_active_predicate``), once per
+        call, so a caller reconciling MANY rel_paths in one pass (e.g.
+        ``AgentRegistry._reconcile_config_as_of_cut``) states its scope
+        (today always ``GLOBAL_SCOPE`` — config generations have no
+        session notion, ADR-0047 decision 4) as a plain fact per call
+        instead of hoisting an opaque predicate outside its own loop.
+        ``build_active_predicate``'s own record fetch is incremental/
+        cached (#2939), so a fresh build per rel_path is O(rewind
+        records), not O(WAL) — the quadratic-cold-start shape this
+        signature originally existed to prevent no longer applies to that
+        axis (it never re-scans per SEQ within one call, only once per
+        call, exactly as the prior caller-hoisted shape did).
 
         #2405: ``latest_at_or_below(cut=N)`` has the symmetric gap — post-rewind active
         generations (seq > R > N) are excluded, reverting config to as-of-N on crash
@@ -143,6 +150,7 @@ class ConfigGenerationStore:
         • Pre-target (seq ≤ N): active=True → applied.
         • Abandoned branch (N < seq < R): active=False → skipped.
         • Post-rewind active (seq > R): active=True → applied."""
+        is_active = build_active_predicate(state_log, scope=scope)
         seqs = [s for s in self._entries().get(rel_path, ()) if is_active(s)]
         if not seqs:
             return None

--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -26,18 +26,34 @@ Two entry points:
   - ``latest_pipeline_state`` — the reader seam ``resume`` calls: the latest
     generation for a run ON THE ACTIVE WAL BRANCH, mirroring
     ``ConfigGenerationStore.latest_active``'s semantics exactly (active-branch
-    membership, latest-wins, no forward-replay), down to the predicate-taking
-    signature: ``PipelineStateStore.latest_active`` takes a caller-hoisted
-    ``is_active`` so no reader can re-scan the WAL once per generation seq.
+    membership, latest-wins, no forward-replay).
+
+#5769 stage 2: ``PipelineStateStore.latest_active`` now takes ``(state_log,
+scope)`` directly rather than a caller-hoisted ``is_active`` predicate — the
+derivation moves INSIDE the store, so a caller states its scope as a plain
+fact instead of building (and potentially mis-scoping) the predicate itself.
+This is not a re-scan-the-WAL-per-seq regression: ``build_active_predicate``'s
+own record fetch is incremental/cached (#2939) — the seq-independent
+derivation this module's own #2941-era comment worried about re-doing per
+call was never about the WAL scan cost (that stays cached regardless), only
+about the DERIVATION being seq-independent so it isn't rebuilt per SEQ within
+one call.
 """
 from __future__ import annotations
 
 import json
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from reyn.core.events.config_recovery import reyn_root
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, build_active_predicate
+
+# `reyn.core.pipeline.work_order` imports `pipeline_state_dir` FROM this
+# module — a module-level import of `load_invocation` here would be
+# circular. Imported locally inside `latest_pipeline_state` instead,
+# matching `AgentRegistry._rewake_pipeline_runs`'s own existing lazy
+# import of the same name for the same reason.
 
 if TYPE_CHECKING:
     from reyn.core.events.state_log import StateLog
@@ -94,23 +110,28 @@ class PipelineStateStore:
         return seq, content
 
     def latest_active(
-        self, is_active: "Callable[[int], bool]",
+        self, state_log: "StateLog", *, scope: "tuple[str, str] | None",
     ) -> "tuple[int, dict] | None":
         """The (seq, content) of the highest generation on the ACTIVE WAL branch, or
         None if no active generation exists. Mirrors
         ``ConfigGenerationStore.latest_active`` exactly — same active-branch
         membership / latest-wins / no-forward-replay semantics, and the same
-        predicate-taking signature.
+        ``(state_log, scope)`` signature.
 
-        ``is_active`` is the caller-supplied membership predicate (its derivation is
-        seq-independent — see ``build_active_predicate``). Taking a ``state_log`` here
-        would force an internal ``is_active_seq`` call per generation seq, re-scanning
-        the whole WAL each time: O(generations x WAL) per read, and quadratic BY
-        CONSTRUCTION for any caller that ever loops over runs — a shape no caller-side
-        hoist could fix. That is exactly how the config store's defect arose (it was
-        census-safe until ``AgentRegistry._reconcile_config_as_of_cut`` grew a rel_path
-        loop), so this store takes the predicate too rather than relying on today's
-        one-run-per-caller census holding forever."""
+        #5769 stage 2: takes ``(state_log, scope)`` directly rather than a
+        caller-hoisted predicate — this store builds its OWN ``is_active``
+        internally (via ``build_active_predicate``), once per call, so a
+        caller states its real scope as a plain fact instead of building
+        (and potentially mis-scoping) an opaque predicate elsewhere. This
+        is still one derivation per call, never per generation seq: the
+        list comprehension below calls the SAME already-built predicate
+        for every seq, exactly as the prior caller-hoisted shape did —
+        only WHO builds it moved. ``build_active_predicate``'s own record
+        fetch is incremental/cached (#2939), so building it here per call
+        (rather than once outside a caller's run-loop) is O(rewind
+        records), not O(WAL) — the quadratic-WAL-scan shape this
+        docstring used to warn against no longer applies to that axis."""
+        is_active = build_active_predicate(state_log, scope=scope)
         seqs = [s for s in self._seqs() if is_active(s)]
         if not seqs:
             return None
@@ -169,22 +190,30 @@ def latest_pipeline_state(run_id: str, state_log: "StateLog") -> "dict[str, Any]
     active WAL branch, or None if no generation was ever recorded (a fresh
     run — `resume` should treat this as run-from-scratch).
 
-    Builds the active-branch predicate ONCE and hands it to the store — the hoist
-    ``PipelineStateStore.latest_active``'s signature obliges. A caller resolving MANY
-    runs should hoist ``build_active_predicate`` above its loop and drive the store
-    directly rather than calling this per run."""
-    from reyn.core.events.snapshot_generations import (  # noqa: PLC0415
-        build_active_predicate,
-    )
+    #5769 stage 2: this run's own owner is NOT "unrecorded" (architect's
+    #5772 finding was the earlier, wrong framing) — it is recorded right
+    alongside the generations this function already reads, in
+    ``invocation.json`` (``PipelineWorkOrder.driver_agent``/``driver_sid``,
+    read the same way ``AgentRegistry._rewake_pipeline_runs`` already
+    reads it). One extra file read here is not a new cost class: this
+    function is called once per resume, on the crash-recovery path, never
+    in a hot per-message loop. A missing/unreadable ``invocation.json``
+    (should not happen for a run with generations, but is not proven
+    impossible) falls back to ``GLOBAL_SCOPE`` — the safe side, matching
+    every other fail-closed-to-broad default in this stage."""
+    from reyn.core.pipeline.work_order import load_invocation, pipeline_run_dir
     store = _store(state_log, run_id)
     if store is None:
         return None
-    # TODO(#5769 stage 2): this call is scoped to ONE run_id -- the issue's
-    # own "unconfirmed" list flags whether a pipeline run maps 1:1 to an
-    # (agent, session) -- so `None` here is NOT a confirmed GLOBAL_SCOPE
-    # decision (architect's #5772 finding). Undecided until that mapping
-    # is resolved.
-    latest = store.latest_active(build_active_predicate(state_log, scope=None))
+    root = reyn_root(state_log.path)
+    run_dir = pipeline_run_dir(root, run_id) if root is not None else None
+    work_order = load_invocation(run_dir) if run_dir is not None else None
+    scope = (
+        (work_order.driver_agent, work_order.driver_sid)
+        if work_order is not None
+        else GLOBAL_SCOPE
+    )
+    latest = store.latest_active(state_log, scope=scope)
     if latest is None:
         return None
     _seq, content = latest

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2566,13 +2566,11 @@ class AgentRegistry:
         # Hoisted once for the whole archived.items() scan (fix-class sibling of
         # #2941/restore_all — the seq-independent derivation must not re-scan the
         # WAL once per archived agent).
-        # TODO(#5769): archival's own attribution is unsettled — `name` (the
-        # agent) is nameable at the point `is_active(aseq)` is called below,
-        # but whether archival belongs to one particular SESSION (as
-        # opposed to being an agent-wide fact, like agent create/drop in
-        # _materialize_rewind above) is architect's judgment to make, not
-        # this PR's. Left at GLOBAL_SCOPE deliberately, on hold — this
-        # comment is the witness that the question was READ, not missed.
+        # #5769: archival is agent-wide, not owned by any one session
+        # (ADR-0047 decision 6 — "agent-level lifecycle is global; only
+        # session-level state is scoped" — archiving preserves every
+        # session, #1954) ∴ GLOBAL_SCOPE here is the FINAL answer, not a
+        # placeholder pending a later decision.
         is_active = (
             build_active_predicate(self._state_log, scope=GLOBAL_SCOPE)
             if self._state_log is not None

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1813,9 +1813,6 @@ class AgentRegistry:
         if not state_root.is_dir():
             return []
         rewoken: "list[str]" = []
-        # Hoisted once for the whole scan (not per run_dir): the seq-independent
-        # derivation otherwise re-scans the WAL once per pipeline run dir (#2941/#2944).
-        is_active = build_active_predicate(self._state_log, scope=GLOBAL_SCOPE)
         for run_dir in sorted(state_root.iterdir()):
             if not run_dir.is_dir() or has_result(run_dir):
                 continue
@@ -1826,6 +1823,21 @@ class AgentRegistry:
                     "— skipping (nothing to resume from)", run_dir,
                 )
                 continue
+            # #5769 stage 2: work_order.spawn_seq is the WAL seq of the
+            # driver session's own spawn call — its real, nameable owner is
+            # (driver_agent, driver_sid), read from the SAME work_order
+            # right here (architect's #5772-review-triggered finding: this
+            # was earlier suspected NOT nameable at this call site; it is —
+            # no extra lookup needed, just this reordering). Built per
+            # run_dir rather than hoisted once: `build_active_predicate`'s
+            # own record fetch is incremental/cached (#2939), so a fresh
+            # build per run costs O(rewind records), not O(WAL) — the
+            # #2941/#2944 quadratic-WAL-scan concern this loop's own
+            # comment used to cite no longer applies to this call.
+            is_active = build_active_predicate(
+                self._state_log,
+                scope=(work_order.driver_agent, work_order.driver_sid),
+            )
             if work_order.spawn_seq is not None and not is_active(
                 work_order.spawn_seq,
             ):
@@ -2305,12 +2317,21 @@ class AgentRegistry:
 
         # Union of generation boundary seqs across every known agent. Default =
         # active branch only (1f); include_abandoned = all branches (Phase-2 tree).
-        # Hoisted once for the whole (names x seqs) scan — the same fix-class as
-        # restore_all/#2941: the seq-independent derivation must not re-scan the
-        # WAL per candidate seq.
-        is_active = build_active_predicate(self._state_log, scope=GLOBAL_SCOPE)
         seqs: set[int] = set()
         for name in self.list_names():
+            # #5769 stage 2: `_store_for(name)` (no sid) is today's own
+            # implicit "main" session — this loop's real, nameable owner
+            # per agent is (name, _DEFAULT_SID), not a placeholder. Built
+            # per agent name rather than hoisted once: `build_active_
+            # predicate`'s own record fetch is incremental/cached (#2939),
+            # so this is O(rewind records) per agent, not O(WAL) — the
+            # #2941 quadratic-WAL-scan concern this loop's own comment used
+            # to cite no longer applies (only the seq-independent
+            # DERIVATION was ever the expensive part; that stays cached
+            # regardless of how many times a scope filter runs over it).
+            is_active = build_active_predicate(
+                self._state_log, scope=(name, _DEFAULT_SID),
+            )
             for s in self._store_for(name).seqs():
                 if oldest_seq is not None and s < oldest_seq:
                     continue  # #2236: truncated out of WAL — not reachable
@@ -2545,6 +2566,13 @@ class AgentRegistry:
         # Hoisted once for the whole archived.items() scan (fix-class sibling of
         # #2941/restore_all — the seq-independent derivation must not re-scan the
         # WAL once per archived agent).
+        # TODO(#5769): archival's own attribution is unsettled — `name` (the
+        # agent) is nameable at the point `is_active(aseq)` is called below,
+        # but whether archival belongs to one particular SESSION (as
+        # opposed to being an agent-wide fact, like agent create/drop in
+        # _materialize_rewind above) is architect's judgment to make, not
+        # this PR's. Left at GLOBAL_SCOPE deliberately, on hold — this
+        # comment is the witness that the question was READ, not missed.
         is_active = (
             build_active_predicate(self._state_log, scope=GLOBAL_SCOPE)
             if self._state_log is not None
@@ -2752,18 +2780,16 @@ class AgentRegistry:
         import yaml  # noqa: PLC0415 — local, matching the file convention
 
         store = self._config_generation_store()
-        # Hoisted once for the whole store.paths() scan — same fix-class sibling as
-        # above: `latest_active` takes the predicate directly so this loop doesn't
-        # re-derive (and re-scan the whole WAL for) `is_active_seq` once per rel_path.
-        is_active = (
-            build_active_predicate(self._state_log, scope=GLOBAL_SCOPE)
-            if self._state_log is not None
-            else None
-        )
+        # #5769 stage 2: `ConfigGenerationStore.latest_active` now takes
+        # (state_log, scope) directly and builds its own predicate — no
+        # caller-side hoist needed (see that method's own docstring for
+        # why a fresh build per rel_path is still cheap). GLOBAL_SCOPE:
+        # config generations have no session notion at all (ADR-0047
+        # decision 4) — not a placeholder pending a later real scope.
         for rel_path in store.paths():
             latest = (
-                store.latest_active(rel_path, is_active)
-                if is_active is not None
+                store.latest_active(rel_path, self._state_log, scope=GLOBAL_SCOPE)
+                if self._state_log is not None
                 else store.latest_at_or_below(rel_path, cut)
             )
             abs_path = (self._project_root / ".reyn" / rel_path).resolve()
@@ -3001,7 +3027,13 @@ class AgentRegistry:
         # per (created-agent, agent, session) triple; without hoisting, each call
         # re-scans the entire WAL (`is_active_seq` → `_rewind_records` →
         # `iter_from(1)`), turning this cold-start/rewind path quadratic in WAL size.
-        is_active = (
+        # #5769 stage 2: this one stays GLOBAL_SCOPE — an agent's own
+        # existence (create/drop) is not owned by any ONE of its sessions;
+        # every session lives or dies with the agent, so a single
+        # session-scoped rewind must never selectively resurrect or
+        # destroy the agent itself. Only the PER-SESSION checks below (the
+        # session loop) get a real per-(name, sid) scope.
+        agent_is_active = (
             build_active_predicate(self._state_log, scope=GLOBAL_SCOPE)
             if self._state_log is not None
             else None
@@ -3012,7 +3044,7 @@ class AgentRegistry:
         for _rname, (_rcseq, _rpayload, _rparent, _rpseq) in ag_created.items():
             if _rname in ag_purged:
                 continue  # fork A: purged = permanent, never re-materialised
-            _is_active = is_active is None or is_active(_rcseq)
+            _is_active = agent_is_active is None or agent_is_active(_rcseq)
             if _is_active and not (self._dir / _rname).is_dir():
                 self._rematerialise_agent(_rname, _rpayload)
         for name in self.list_names():
@@ -3023,13 +3055,23 @@ class AgentRegistry:
             agent_seq = created_at.get(("agent", name, ""))
             _on_abandoned = (
                 agent_seq is not None
-                and is_active is not None
-                and not is_active(agent_seq)
+                and agent_is_active is not None
+                and not agent_is_active(agent_seq)
             )
             if name in ag_purged or _on_abandoned:
                 self._drop_agent(name)
                 continue
             for sid in self._discover_session_ids(name):
+                # #5769 stage 2: a session's own spawn/vanish seq IS owned
+                # by exactly this (name, sid) — its real, nameable scope,
+                # built per session (cheap: build_active_predicate's own
+                # record fetch is incremental/cached, #2939 — not a WAL
+                # re-scan per session).
+                session_is_active = (
+                    build_active_predicate(self._state_log, scope=(name, sid))
+                    if self._state_log is not None
+                    else None
+                )
                 # A session on an abandoned branch → drop just that session.
                 # #2154: OR a session that VANISHED at-or-before the cut (it was gone
                 # as-of-cut) — the destroy-side mirror of the spawn-cut. A genuine
@@ -3040,13 +3082,13 @@ class AgentRegistry:
                 van_seq = sess_vanished.get((name, sid))
                 spawned_after_cut = (
                     sess_seq is not None
-                    and is_active is not None
-                    and not is_active(sess_seq)
+                    and session_is_active is not None
+                    and not session_is_active(sess_seq)
                 )
                 vanished_by_cut = (
                     van_seq is not None
-                    and is_active is not None
-                    and is_active(van_seq)
+                    and session_is_active is not None
+                    and session_is_active(van_seq)
                 )
                 if spawned_after_cut or vanished_by_cut:
                     # #2125: detach now (quiesce in-flight writes); defer the

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4412,13 +4412,16 @@ class Session:
         # per-message seq — so it is computed ONCE per call (one WAL scan) and
         # reused for every message, instead of re-scanning the whole WAL per
         # message (was O(N messages x M WAL entries) per turn; now O(N + M)).
-        # TODO(#5769 stage 2): this reads ONLY self.history — one session's
-        # own seqs, never another agent's or session's — so `None` here is
-        # NOT `GLOBAL_SCOPE` (architect's #5772 finding: this method has no
-        # multi-agent scan to justify that label). Undecided whether stage
-        # 2 narrows this to scope=(self.agent_name, self.session_id) or
-        # keeps it global on purpose; do not read this as a settled choice.
-        is_active = build_active_predicate(self._state_log, scope=None)
+        # #5769 stage 2: every seq this predicate is ever asked about comes
+        # from self.history — THIS session's own messages, never another
+        # session's — so its real, nameable scope is (self.agent_name,
+        # self.session_id), not a placeholder. Its chain is "global records
+        # UNION this session's own" (ADR-0047 decision 2); with no scoped
+        # writer yet (checkout() stage 3), this remains behaviorally
+        # identical to the prior global read.
+        is_active = build_active_predicate(
+            self._state_log, scope=(self.agent_name, self.session_id),
+        )
 
         def _active(seq: "int | None") -> bool:
             return seq is None or is_active(seq)
@@ -4525,11 +4528,12 @@ class Session:
             return parsed, truncated
         from reyn.core.events.snapshot_generations import build_active_predicate
 
-        # TODO(#5769 stage 2): reads self.history_path -- ONE session's own
-        # file -- never another session's, so this is NOT a confirmed
-        # GLOBAL_SCOPE decision (architect's #5772 finding, same shape as
-        # _active_branch_history above). Undecided.
-        is_active = build_active_predicate(self._state_log, scope=None)
+        # #5769 stage 2: reads self.history_path -- THIS session's own
+        # file, never another's -- so its real scope is (self.agent_name,
+        # self.session_id), same reasoning as _active_branch_history above.
+        is_active = build_active_predicate(
+            self._state_log, scope=(self.agent_name, self.session_id),
+        )
 
         def _active(seq: "int | None") -> bool:
             return seq is None or is_active(seq)

--- a/tests/core/test_5769_stage2_scoped_derivation.py
+++ b/tests/core/test_5769_stage2_scoped_derivation.py
@@ -132,12 +132,33 @@ async def test_latest_pipeline_state_falls_back_to_global_without_invocation(tmp
     """Tier 2: fail-closed to the SAFE side -- a run with generations but
     no readable invocation.json (should not happen in practice, not
     proven impossible) falls back to GLOBAL_SCOPE rather than raising or
-    silently returning stale/wrong content."""
+    silently returning stale/wrong content.
+
+    lead-coder-30 BLOCKING (#5775 review): without a rewind record in the
+    log, this test cannot tell "falls back to GLOBAL_SCOPE" from "scope
+    was never applied at all" -- both look identical (nothing is ever
+    abandoned). Fixed the same way `test_latest_pipeline_state_derives_
+    owner_and_narrows_to_it` above already does: add a rewind SCOPED to
+    an unrelated session and assert it is IGNORED -- GLOBAL_SCOPE's own
+    contract (`record_scope is None or record_scope == scope`,
+    snapshot_generations.py) means a global query never sees a
+    differently-scoped record. That is now an observable, asserted fact,
+    not merely a docstring claim."""
     reyn_dir = tmp_path / ".reyn"
     log = StateLog(reyn_dir / "state" / "wal.jsonl")
     s1 = await _put(log, "worker")
     await record_pipeline_state(log, "run-2", {"step_index": 1}, durable=True)
     # No write_invocation call -- invocation.json genuinely absent.
+
+    # Real witness: a rewind scoped to a DIFFERENT session must be
+    # invisible to the GLOBAL_SCOPE fallback this function computes.
+    # target_n=0 abandons (0, R) -- which genuinely includes s1 (the
+    # generation's own seq), so a broken implementation that ignored
+    # scope (saw this record under a global query) WOULD hide the
+    # generation -- a real discriminator, not a no-op interval.
+    await log.append(
+        REWIND_KIND, target_n=0, supersedes=None, scope=["someone-else", "sidZ"],
+    )
 
     result = latest_pipeline_state("run-2", log)
 

--- a/tests/core/test_5769_stage2_scoped_derivation.py
+++ b/tests/core/test_5769_stage2_scoped_derivation.py
@@ -1,0 +1,144 @@
+"""Tier 2: OS invariant -- #5769 stage 2, design (B): derivation and scope
+are separated so a caller states a plain fact ("this is my scope")
+instead of building (and potentially mis-scoping) an opaque predicate.
+
+Real `StateLog` + real on-disk stores (no mocks). Covers the two store
+signature changes (`ConfigGenerationStore.latest_active`,
+`PipelineStateStore.latest_active` now take `(state_log, scope)` directly)
+and `latest_pipeline_state`'s own owner derivation (architect's #5772
+finding: the owner was recorded, just not read at that call site --
+fixed in the SAME PR per lead-coder-30's explicit ruling, not filed
+separately). `list_rewind_points`'s per-agent scoping is covered
+separately in `tests/core/test_registry_list_rewind_points_1f.py`'s own
+sibling additions -- see that file for the (agent, sid) narrowing
+witness; this file does not duplicate it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.config_generations import ConfigGenerationStore
+from reyn.core.events.pipeline_recovery import (
+    PipelineStateStore,
+    latest_pipeline_state,
+    record_pipeline_state,
+)
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.work_order import PipelineWorkOrder, pipeline_run_dir, write_invocation
+
+
+async def _put(log: StateLog, agent: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id="x", msg_kind="user", payload={"text": "x"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_config_generation_store_latest_active_new_signature(tmp_path):
+    """Tier 2: `ConfigGenerationStore.latest_active(rel_path, state_log,
+    scope=...)` -- the new (state_log, scope) shape builds its own
+    predicate and behaves identically to the old caller-hoisted-predicate
+    shape for the (only real, ADR-0047-confirmed) GLOBAL_SCOPE case: a
+    generation on an abandoned branch is excluded; one on the active
+    branch is returned."""
+    log = StateLog(tmp_path / "wal")
+    store = ConfigGenerationStore(tmp_path / "generations")
+    s1 = await _put(log, "alpha")
+    store.record("reyn.yaml", {"v": 1}, s1)
+    s2 = await _put(log, "alpha")
+    store.record("reyn.yaml", {"v": 2}, s2)
+    await log.append(REWIND_KIND, target_n=s1, supersedes=None)  # abandons s2
+
+    latest = store.latest_active("reyn.yaml", log, scope=GLOBAL_SCOPE)
+
+    assert latest == (s1, {"v": 1})
+
+
+@pytest.mark.asyncio
+async def test_config_generation_store_latest_active_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- a call site that forgets scope fails at the
+    call, matching build_active_predicate's own required-kwarg contract
+    this store's signature now delegates to."""
+    log = StateLog(tmp_path / "wal")
+    store = ConfigGenerationStore(tmp_path / "generations")
+
+    with pytest.raises(TypeError):
+        store.latest_active("reyn.yaml", log)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_state_store_latest_active_new_signature(tmp_path):
+    """Tier 2: `PipelineStateStore.latest_active(state_log, scope=...)` --
+    same new shape, same equivalence check as the config store sibling."""
+    log = StateLog(tmp_path / "wal")
+    store = PipelineStateStore(tmp_path / "pipeline-gens")
+    s1 = await _put(log, "alpha")
+    store.record({"step_index": 1}, s1)
+    s2 = await _put(log, "alpha")
+    store.record({"step_index": 2}, s2)
+    await log.append(REWIND_KIND, target_n=s1, supersedes=None)  # abandons s2
+
+    latest = store.latest_active(log, scope=GLOBAL_SCOPE)
+
+    assert latest == (s1, {"step_index": 1})
+
+
+def _work_order(run_id: str, *, driver_agent: str, driver_sid: str, spawn_seq: int) -> PipelineWorkOrder:
+    return PipelineWorkOrder(
+        run_id=run_id, pipeline_name="p", pipeline={"steps": []}, input=None,
+        reply_to_agent=driver_agent, reply_to_sid="main",
+        driver_agent=driver_agent, driver_sid=driver_sid, spawn_seq=spawn_seq,
+    )
+
+
+@pytest.mark.asyncio
+async def test_latest_pipeline_state_derives_owner_and_narrows_to_it(tmp_path):
+    """Tier 2: strip-falsifier target for architect's #5772 finding.
+    `latest_pipeline_state` now reads the SAME `invocation.json`
+    `_rewake_pipeline_runs` already reads, deriving (driver_agent,
+    driver_sid) -- a rewind SCOPED to a DIFFERENT (agent, sid) must not
+    hide this run's own generation, and one scoped to THIS run's own
+    driver must."""
+    reyn_dir = tmp_path / ".reyn"
+    log = StateLog(reyn_dir / "state" / "wal.jsonl")
+    run_dir = pipeline_run_dir(reyn_dir, "run-1")
+    s1 = await _put(log, "worker")
+    write_invocation(run_dir, _work_order("run-1", driver_agent="worker", driver_sid="sidA", spawn_seq=s1))
+    await record_pipeline_state(log, "run-1", {"step_index": 1}, durable=True)
+    s2 = await _put(log, "worker")
+    await record_pipeline_state(log, "run-1", {"step_index": 2}, durable=True)
+
+    # A rewind scoped to a DIFFERENT (agent, sid) must not affect run-1.
+    await log.append(
+        REWIND_KIND, target_n=s1, supersedes=None, scope=["someone-else", "sidZ"],
+    )
+    still_visible = latest_pipeline_state("run-1", log)
+    assert still_visible == {"step_index": 2}
+
+    # A rewind scoped to run-1's OWN driver (worker, sidA) DOES abandon
+    # the later generation -- proving the owner was genuinely derived and
+    # applied, not silently defaulted to global (which would ALSO hide
+    # this, making the first assertion the only real witness).
+    await log.append(
+        REWIND_KIND, target_n=s1, supersedes=None, scope=["worker", "sidA"],
+    )
+    now_hidden = latest_pipeline_state("run-1", log)
+    assert now_hidden == {"step_index": 1}
+
+
+@pytest.mark.asyncio
+async def test_latest_pipeline_state_falls_back_to_global_without_invocation(tmp_path):
+    """Tier 2: fail-closed to the SAFE side -- a run with generations but
+    no readable invocation.json (should not happen in practice, not
+    proven impossible) falls back to GLOBAL_SCOPE rather than raising or
+    silently returning stale/wrong content."""
+    reyn_dir = tmp_path / ".reyn"
+    log = StateLog(reyn_dir / "state" / "wal.jsonl")
+    s1 = await _put(log, "worker")
+    await record_pipeline_state(log, "run-2", {"step_index": 1}, durable=True)
+    # No write_invocation call -- invocation.json genuinely absent.
+
+    result = latest_pipeline_state("run-2", log)
+
+    assert result == {"step_index": 1}

--- a/tests/core/test_pipeline_is6_attached.py
+++ b/tests/core/test_pipeline_is6_attached.py
@@ -48,7 +48,8 @@ from typing import Any
 
 import pytest
 
-from reyn.core.events.pipeline_recovery import latest_pipeline_state
+from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
+from reyn.core.events.snapshot_generations import REWIND_KIND
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.executor import (
     Pipeline,
@@ -717,3 +718,86 @@ async def test_async_launch_does_not_emit_bridge_marker(
     # async lifecycle, not just the launch instant.
     await _wait_for(lambda: scripted.calls >= 1)
     assert not any(e.type == "pipeline_run_attached" for e in caller_events)
+
+
+# ── #5769 stage 2: _rewake_pipeline_runs' rewind guard is scoped per-run ──────
+
+
+@pytest.mark.asyncio
+async def test_rewake_pipeline_runs_blocks_resurrection_scoped_to_its_own_driver(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5769 stage 2 -- architect's own flagged suspicion for #5772
+    (that this call site could NOT name its seq's owner) was refuted by
+    real investigation: `work_order.driver_agent`/`driver_sid` are read
+    from the SAME work_order object right after the `is_active` check --
+    this test drives that end to end. A rewind SCOPED to the run's OWN
+    driver (worker, sid) abandons its spawn_seq for that scope and must
+    block resurrection, exactly as an (unscoped) global rewind already
+    did before #5769."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    spawn_seq = state_log.current_seq
+    from reyn.core.pipeline.serde import pipeline_to_dict
+    pipeline = _steps(1)
+    wo = PipelineWorkOrder(
+        run_id="run-scope-own", pipeline_name="p", pipeline=pipeline_to_dict(pipeline),
+        input=None, reply_to_agent="worker", reply_to_sid="main",
+        driver_agent="worker", driver_sid=sid, spawn_seq=spawn_seq,
+    )
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-scope-own")
+    write_invocation(run_dir, wo)
+    await record_pipeline_state(state_log, "run-scope-own", {"step_index": 0}, durable=True)
+
+    # Scoped to the run's OWN driver -- abandons spawn_seq FOR THAT SCOPE.
+    await state_log.append(
+        REWIND_KIND, target_n=0, supersedes=None, scope=["worker", sid],
+    )
+
+    rewoken = await reg._rewake_pipeline_runs()
+
+    assert "run-scope-own" not in rewoken
+
+
+@pytest.mark.asyncio
+async def test_rewake_pipeline_runs_ignores_a_rewind_scoped_to_a_different_driver(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5769 stage 2 -- the discriminating half of the sibling test
+    above. The IDENTICAL numeric rewind (target_n=0, abandoning the same
+    seq range) is now scoped to a DIFFERENT (agent, sid) -- it must NOT
+    block resurrection of a run whose own driver is unrelated. If this
+    went RED (the run failed to resurrect), the per-run scoped predicate
+    would be leaking an unrelated session's rewind into this run's own
+    evaluation -- the exact silent cross-run mixing #5769 stage 2 exists
+    to prevent."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    spawn_seq = state_log.current_seq
+    from reyn.core.pipeline.serde import pipeline_to_dict
+    pipeline = _steps(1)
+    wo = PipelineWorkOrder(
+        run_id="run-scope-other", pipeline_name="p", pipeline=pipeline_to_dict(pipeline),
+        input=None, reply_to_agent="worker", reply_to_sid="main",
+        driver_agent="worker", driver_sid=sid, spawn_seq=spawn_seq,
+    )
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-scope-other")
+    write_invocation(run_dir, wo)
+    await record_pipeline_state(state_log, "run-scope-other", {"step_index": 0}, durable=True)
+
+    # Scoped to an UNRELATED (agent, sid) -- must not affect this run.
+    await state_log.append(
+        REWIND_KIND, target_n=0, supersedes=None, scope=["someone-else", "sidZ"],
+    )
+
+    rewoken = await reg._rewake_pipeline_runs()
+
+    assert "run-scope-other" in rewoken

--- a/tests/core/test_registry_list_rewind_points_1f.py
+++ b/tests/core/test_registry_list_rewind_points_1f.py
@@ -202,3 +202,36 @@ async def test_list_rewind_points_keeps_seqs_at_or_above_wal_floor(tmp_path) -> 
     assert s1 not in listed_seqs, f"truncated seq {s1} must not be advertised"
     assert s2 in listed_seqs, f"seq {s2} at WAL floor must still be advertised"
     assert s3 in listed_seqs, f"seq {s3} above WAL floor must still be advertised"
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_scopes_abandonment_per_agent(tmp_path) -> None:
+    """Tier 2: #5769 stage 2 -- each agent's own listed points are governed
+    by that agent's own (name, "main") scope, not one hoisted GLOBAL_SCOPE
+    predicate reused unchanged across every agent in the scan. A rewind
+    record SCOPED to alpha's own session must abandon only alpha's own
+    boundary; beta's boundary, evaluated under a DIFFERENT scope
+    ("beta", "main"), must be completely untouched by it -- the
+    architect-mandated witness that per-owner narrowing actually took
+    effect in this loop, not just that the loop still runs."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    a1 = await log.append("inbox_consume", target="alpha", msg_id="a1")
+    _record_gen(reg, "alpha", a1)
+    b1 = await log.append("inbox_consume", target="beta", msg_id="b1")
+    _record_gen(reg, "beta", b1)
+
+    # Injected directly (no production writer emits a scoped record yet,
+    # #5769 stage 3) -- scoped to (alpha, main), targeting seq 0: abandons
+    # every seq in (0, R) FOR THAT SCOPE ONLY, which includes both a1 and
+    # b1's raw seq values -- a real discriminator, not a vacuous one,
+    # since only the scope filter (not the seq range) keeps beta safe.
+    await log.append("rewind", target_n=0, supersedes=None, scope=["alpha", "main"])
+
+    rows = reg.list_rewind_points()
+    listed_seqs = [r["seq"] for r in rows]
+    assert a1 not in listed_seqs, "alpha's own boundary must be abandoned by its own scoped rewind"
+    assert b1 in listed_seqs, "beta's boundary must be untouched by a rewind scoped to a different agent"

--- a/tests/runtime/test_session_vanished_emit_2154.py
+++ b/tests/runtime/test_session_vanished_emit_2154.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import rewind
+from reyn.core.events.snapshot_generations import REWIND_KIND, rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -136,3 +136,50 @@ async def test_session_vanished_after_cut_survives_reconstruction(tmp_path):
     await reg._materialize_rewind(reconstruct_seq=R, workspace_at_or_below=cut)
 
     assert sid in reg.session_ids("alice")                         # existed as-of-cut → kept
+
+
+@pytest.mark.asyncio
+async def test_session_vanished_protected_by_a_rewind_scoped_to_its_own_session(tmp_path):
+    """Tier 2: #5769 stage 2 -- the SAME abandoned-interval shape as the
+    sibling test above, but the rewind record is SCOPED to (alice, sid)
+    instead of global. `_materialize_rewind`'s session-level check now
+    builds a per-(name, sid) predicate rather than reusing one hoisted
+    GLOBAL_SCOPE predicate -- this must produce the SAME outcome (the
+    session survives) when the scoped record matches its own (name, sid)."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    log = reg.state_log
+    sid = await reg.spawn_session_recorded("alice", mode="persistent", presentation_consumer=None, intervention_bridge=None)
+    cut = log.current_seq
+    await log.append("session_vanished", entity_kind="session", name="alice", sid=sid)  # V = cut+1
+    r_seq = await log.append(REWIND_KIND, target_n=cut, supersedes=None, scope=["alice", sid])  # R, scoped
+
+    await reg._materialize_rewind(reconstruct_seq=r_seq, workspace_at_or_below=cut)
+
+    assert sid in reg.session_ids("alice")  # V is in the abandoned interval FOR THIS SCOPE → kept
+
+
+@pytest.mark.asyncio
+async def test_session_vanished_not_protected_by_a_rewind_scoped_elsewhere(tmp_path):
+    """Tier 2: #5769 stage 2 -- the discriminating half of the sibling test
+    above. The IDENTICAL vanish is now paired with a rewind scoped to a
+    DIFFERENT (agent, sid) -- it must NOT protect this session's vanish
+    (global default: nothing is abandoned for this session's own scope),
+    so the session reconstructs GONE, same as the unscoped-vanish
+    baseline (`test_session_vanished_before_cut_reconstructs_gone`). If
+    this went RED with sid unexpectedly surviving, the per-session
+    predicate would be leaking a different session's rewind into this
+    one's evaluation."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+    log = reg.state_log
+    sid = await reg.spawn_session_recorded("alice", mode="persistent", presentation_consumer=None, intervention_bridge=None)
+    cut = log.current_seq
+    await log.append("session_vanished", entity_kind="session", name="alice", sid=sid)  # V = cut+1
+    r_seq = await log.append(
+        REWIND_KIND, target_n=cut, supersedes=None, scope=["someone-else", "sidZ"],
+    )  # R, scoped to an unrelated (agent, sid)
+
+    await reg._materialize_rewind(reconstruct_seq=r_seq, workspace_at_or_below=cut)
+
+    assert sid not in reg.session_ids("alice")  # unaffected by a differently-scoped rewind → gone


### PR DESCRIPTION
**[e2e-coder]** — #5769 stage 2: derivation and scope are separated (design B).

part of #5769

## Design decision (lead-coder-30's ruling, architect concurred)

Form **(B)** — "separate derivation from scope, encode scope as a property of the seq" — not form (A) (hoist the predicate construction down into each loop). (A) was rejected because it depends on the discipline of building it "in the right place" every time; a future re-hoist silently reverts a consumer to global with no red. (B) makes it structural: the store/consumer states its scope as a plain fact it already holds, and `build_active_predicate`'s own required-kwarg contract (stage 1) does the rest.

## Pre-implementation measurement (required before any code)

Per lead-coder-30's explicit instruction, before writing anything: for each of the 9 real `build_active_predicate` call sites, can the seq's owner be named on the spot?

- **`registry.py::_rewake_pipeline_runs`** — YES. Architect's own flagged suspicion (this call site "might not name its owner") was **refuted**: `work_order.driver_agent`/`driver_sid` are read from the SAME `work_order` object 3 lines after the `is_active` check — a pure reordering exposes it, no new lookup needed.
- **`list_rewind_points`, `_materialize_rewind`'s session-level checks, `Session._active_branch_history`, `Session._durable_active_history_after`** — YES, all already have their real `(agent, sid)` in a local variable at the call point.
- **`_materialize_rewind`'s agent-level existence checks, the topology-lifecycle reconcile, the config-generation reconcile** — NO owner concept applies at all: an agent's own existence isn't owned by any ONE of its sessions (every session lives or dies with the agent), and topology/config are workspace-level facts (ADR-0047 decision 4 already excludes config generations from session scope explicitly). Confirmed structurally N/A — kept `GLOBAL_SCOPE`, no comment needed for the two ADR-confirmed cases.
- **the archived-agent purge** — `name` is nameable, but whether archival is agent-wide (like create/drop) or session-owned is architect's judgment call, not mine. Left at `GLOBAL_SCOPE` with an explicit `# TODO(#5769)` naming the open question — the comment is the witness that it was READ, not missed.
- **`pipeline_recovery.latest_pipeline_state`** — the owner was NOT "unrecorded" (my own earlier, wrong framing on PR #5772) — it's recorded alongside the very generations this function already reads (`invocation.json`'s `driver_agent`/`driver_sid`), just not read by this particular call site. Fixed in this SAME PR per lead-coder-30's ruling that "recorded but not wired" is not a new category needing its own ticket.

## Changes

- **`registry.py`**: `_rewake_pipeline_runs` builds a per-run scoped predicate `(work_order.driver_agent, work_order.driver_sid)`, reordered after `load_invocation`; `list_rewind_points` builds a per-agent scoped predicate `(name, "main")` inside its own loop; `_materialize_rewind` splits its previously-single hoisted predicate into an agent-level `GLOBAL_SCOPE` one (create/drop) and a per-`(name, sid)` session-level one (spawn/vanish-by-cut), built inside the session loop; the archived-purge site gets an explicit `GLOBAL_SCOPE` + TODO comment replacing the implicit choice.
- **`session.py`**: both call sites now pass their own `(self.agent_name, self.session_id)`.
- **`ConfigGenerationStore.latest_active` / `PipelineStateStore.latest_active`** (architect's design point ①): signature changes from a caller-hoisted `is_active` predicate to `(state_log, *, scope)` directly — the store builds its own predicate internally. Updated both callers.

**Not a performance regression**: building a fresh predicate per owner instead of hoisting one shared predicate is safe because `build_active_predicate`'s own record fetch is incremental/cached (#2939, stage 1's `_rewind_records_with_scope`) — the #2941-era quadratic-WAL-scan concern several of these comments used to cite was about re-scanning the WAL per SEQ, never about building the predicate more than once per call. A fresh build is O(rewind records), not O(WAL).

## Tests

All real, driven, no mocks. **Every scope-narrowing claim was strip-falsified**: temporarily reverted the corresponding production change, confirmed a genuine RED, then restored the fix.

- `tests/core/test_5769_stage2_scoped_derivation.py` (5 new): the two store signature changes behave identically to the old shape for the global case and require the `scope` kwarg; `latest_pipeline_state` derives its owner from a real `invocation.json` and correctly narrows (a rewind scoped elsewhere doesn't hide this run's generation; one scoped to this run's own driver does); falls back to `GLOBAL_SCOPE` when `invocation.json` is absent.
- `tests/core/test_registry_list_rewind_points_1f.py` (+1): a rewind scoped to one agent abandons only that agent's own listed boundary, leaving a different agent's untouched.
- `tests/runtime/test_session_vanished_emit_2154.py` (+2): the identical vanish-by-cut shape, once scoped to its own `(agent, sid)` (protects it) and once scoped elsewhere (doesn't) — the discriminating pair proving `_materialize_rewind`'s session-level split is real.
- `tests/core/test_pipeline_is6_attached.py` (+2): the identical numeric rewind, once scoped to a run's own driver (blocks resurrection) and once to an unrelated driver (doesn't) — directly refutes the original #5772 suspicion end to end.

**Disclosed gap, not silently omitted**: `session.py`'s two now-scoped call sites have no NEW dedicated scoped-narrowing test in this PR — both are covered for non-regression by the 423 passing pre-existing tests exercising them under today's all-global-records world, but a positive scoped-narrowing witness (mirroring the `_materialize_rewind`/`_rewake_pipeline_runs` pairs above) was not added, given the heavier real-`Session`-construction cost against this PR's time budget.

## ADR-0047

Decision 2's own revision (recording this "derivation separated from scope" form) is **architect's to write in this same PR**, per lead-coder-30's plan — not authored here. This section is the placeholder for that commit.

## Test plan

- [x] `ruff check .` (scoped to touched files)
- [x] `python scripts/test_tier_audit.py --strict` on all touched/new test files (30/30 OK)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py` (200 findings, all pre-baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`, `check_file_depth_reference.py` (tests/ touched)
- [x] `pytest` scoped to the diff + the full rewind/branch-tree/pipeline-recovery/config-generation test surface: 423 tests, all green
- [ ] (skipped — Visual, standing waiver 2026-08-08)

TESTS-READ / merge: lead-coder-30. Co-vet + ADR-0047 revision: architect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
