### PR TITLE
feat(#5769 stage 3): checkout writes a scoped reset-record, recovery reads it

### DIFF
--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -42,21 +42,12 @@ one call.
 from __future__ import annotations
 
 import json
-import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from reyn.core.events.config_recovery import reyn_root
-from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, build_active_predicate
-
-logger = logging.getLogger(__name__)
-
-# `reyn.core.pipeline.work_order` imports `pipeline_state_dir` FROM this
-# module — a module-level import of `load_invocation` here would be
-# circular. Imported locally inside `latest_pipeline_state` instead,
-# matching `AgentRegistry._rewake_pipeline_runs`'s own existing lazy
-# import of the same name for the same reason.
+from reyn.core.events.snapshot_generations import build_active_predicate
 
 if TYPE_CHECKING:
     from reyn.core.events.state_log import StateLog
@@ -188,64 +179,30 @@ async def record_pipeline_state(
         state_log.submit_durable_nowait(_record)
 
 
-def latest_pipeline_state(run_id: str, state_log: "StateLog") -> "dict[str, Any] | None":
+def latest_pipeline_state(
+    run_id: str, state_log: "StateLog", *, scope: "tuple[str, str] | None",
+) -> "dict[str, Any] | None":
     """The latest pipeline control-plane-state generation for `run_id` on the
     active WAL branch, or None if no generation was ever recorded (a fresh
     run — `resume` should treat this as run-from-scratch).
 
-    #5769 stage 2: this run's own owner is NOT "unrecorded" (architect's
-    #5772 finding was the earlier, wrong framing) — it is recorded right
-    alongside the generations this function already reads, in
-    ``invocation.json`` (``PipelineWorkOrder.driver_agent``/``driver_sid``,
-    read the same way ``AgentRegistry._rewake_pipeline_runs`` already
-    reads it). One extra file read here is not a new cost class: this
-    function is called once per resume, on the crash-recovery path, never
-    in a hot per-message loop.
-
-    #5769 stage 3 (ADR-0047 decision 7, disclosed deliberate deviation):
-    decision 7 says an item whose owner cannot be named should be
-    "observably skipped, never silently defaulted to global" —
-    ``_rewake_pipeline_runs``'s own ``continue`` (leave the run alone,
-    log a warning) is the named reference shape. This function CANNOT
-    follow that shape literally: returning ``None`` here means "no
-    generation was ever recorded" to its one caller
-    (``PipelineExecutor.resume``), which responds by running the WHOLE
-    pipeline from scratch — re-executing every already-completed
-    side-effecting (``tool``/``shell``) step. That is a MUCH worse
-    failure than showing a possibly-not-maximally-narrowed answer: it
-    breaks the exactly-once guarantee R4 exists to provide, for a
-    condition (``invocation.json`` unreadable for a run that HAS
-    generations) already documented as "should not happen... not proven
-    impossible" — i.e. speculative, not measured. Chose the safer
-    concrete behavior instead: log a warning (satisfies "observable, not
-    silent") and keep the ``GLOBAL_SCOPE`` fallback (safe: a global query
-    is still CORRECT for genuine global rewinds, only not narrowed by an
-    undeterminable scoped one — the true unsafe direction, "wrongly
-    resurrecting a run a scoped rewind should have hidden," has no
-    real writer yet since this PR is what first makes scoped rewind
-    exist). Flagged for lead-coder-30/architect's explicit read — this
-    is a genuine, measured deviation from decision 7's literal shape,
-    not a silent one."""
-    from reyn.core.pipeline.work_order import load_invocation, pipeline_run_dir
+    #5769 stage 3 (ADR-0047 decision 7, architect's (c) ruling on the PR
+    #5778 review, replacing an earlier, disclosed (a)/(b)-shaped deviation
+    this docstring used to carry): ``scope`` is now the CALLER's own
+    responsibility, not something this function discovers by re-reading
+    ``invocation.json``. Both real call sites already hold the run's own
+    ``PipelineWorkOrder`` when they call this — ``PipelineExecutorDriver.
+    run_turn`` (direct call) and ``PipelineExecutor.resume`` (which now
+    forwards its own ``scope`` parameter here) — so passing ``scope`` is
+    "hand over a fact you already have", not a new derivation. This
+    removes the whole class of problem the earlier version had: no
+    ``invocation.json`` re-read, no warning log, no ``GLOBAL_SCOPE``
+    fallback, no decision-7 exception to disclose — the caller's own
+    scope is simply the truth, always, with no cases to reconcile.
+    """
     store = _store(state_log, run_id)
     if store is None:
         return None
-    root = reyn_root(state_log.path)
-    run_dir = pipeline_run_dir(root, run_id) if root is not None else None
-    work_order = load_invocation(run_dir) if run_dir is not None else None
-    if work_order is None:
-        logger.warning(
-            "pipeline recovery: run %r has generations but no readable "
-            "invocation.json -- cannot determine its own (agent, sid) scope; "
-            "falling back to GLOBAL_SCOPE (see this function's own docstring "
-            "for why this deviates from ADR-0047 decision 7's literal shape)",
-            run_id,
-        )
-    scope = (
-        (work_order.driver_agent, work_order.driver_sid)
-        if work_order is not None
-        else GLOBAL_SCOPE
-    )
     latest = store.latest_active(state_log, scope=scope)
     if latest is None:
         return None

--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -42,12 +42,15 @@ one call.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from reyn.core.events.config_recovery import reyn_root
 from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, build_active_predicate
+
+logger = logging.getLogger(__name__)
 
 # `reyn.core.pipeline.work_order` imports `pipeline_state_dir` FROM this
 # module — a module-level import of `load_invocation` here would be
@@ -197,10 +200,32 @@ def latest_pipeline_state(run_id: str, state_log: "StateLog") -> "dict[str, Any]
     read the same way ``AgentRegistry._rewake_pipeline_runs`` already
     reads it). One extra file read here is not a new cost class: this
     function is called once per resume, on the crash-recovery path, never
-    in a hot per-message loop. A missing/unreadable ``invocation.json``
-    (should not happen for a run with generations, but is not proven
-    impossible) falls back to ``GLOBAL_SCOPE`` — the safe side, matching
-    every other fail-closed-to-broad default in this stage."""
+    in a hot per-message loop.
+
+    #5769 stage 3 (ADR-0047 decision 7, disclosed deliberate deviation):
+    decision 7 says an item whose owner cannot be named should be
+    "observably skipped, never silently defaulted to global" —
+    ``_rewake_pipeline_runs``'s own ``continue`` (leave the run alone,
+    log a warning) is the named reference shape. This function CANNOT
+    follow that shape literally: returning ``None`` here means "no
+    generation was ever recorded" to its one caller
+    (``PipelineExecutor.resume``), which responds by running the WHOLE
+    pipeline from scratch — re-executing every already-completed
+    side-effecting (``tool``/``shell``) step. That is a MUCH worse
+    failure than showing a possibly-not-maximally-narrowed answer: it
+    breaks the exactly-once guarantee R4 exists to provide, for a
+    condition (``invocation.json`` unreadable for a run that HAS
+    generations) already documented as "should not happen... not proven
+    impossible" — i.e. speculative, not measured. Chose the safer
+    concrete behavior instead: log a warning (satisfies "observable, not
+    silent") and keep the ``GLOBAL_SCOPE`` fallback (safe: a global query
+    is still CORRECT for genuine global rewinds, only not narrowed by an
+    undeterminable scoped one — the true unsafe direction, "wrongly
+    resurrecting a run a scoped rewind should have hidden," has no
+    real writer yet since this PR is what first makes scoped rewind
+    exist). Flagged for lead-coder-30/architect's explicit read — this
+    is a genuine, measured deviation from decision 7's literal shape,
+    not a silent one."""
     from reyn.core.pipeline.work_order import load_invocation, pipeline_run_dir
     store = _store(state_log, run_id)
     if store is None:
@@ -208,6 +233,14 @@ def latest_pipeline_state(run_id: str, state_log: "StateLog") -> "dict[str, Any]
     root = reyn_root(state_log.path)
     run_dir = pipeline_run_dir(root, run_id) if root is not None else None
     work_order = load_invocation(run_dir) if run_dir is not None else None
+    if work_order is None:
+        logger.warning(
+            "pipeline recovery: run %r has generations but no readable "
+            "invocation.json -- cannot determine its own (agent, sid) scope; "
+            "falling back to GLOBAL_SCOPE (see this function's own docstring "
+            "for why this deviates from ADR-0047 decision 7's literal shape)",
+            run_id,
+        )
     scope = (
         (work_order.driver_agent, work_order.driver_sid)
         if work_order is not None

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -408,6 +408,27 @@ def active_rewind_target(state_log: StateLog) -> int | None:
     return max(records, key=lambda t: t[0])[1]
 
 
+def active_rewind_target_with_scope(
+    state_log: StateLog,
+) -> "tuple[int, tuple[str, str] | None] | None":
+    """``(target_n, scope)`` of the active reset-record, or ``None`` when no
+    rewind exists — #5769 stage 3's scope-aware sibling of
+    :func:`active_rewind_target` above.
+
+    Crash recovery needs not just WHERE the active rewind points but WHOSE
+    scope it was written under, to materialise only that ``(name, sid)`` on
+    a scoped crash-recovery (ADR-0047 decision 3's own recovery half) —
+    ``active_rewind_target`` itself stays unchanged (it still has its own
+    caller-independent contract; this is a genuinely new question, not a
+    replacement). Same latest-wins rule: the active reset-record is the
+    highest-seq one."""
+    records = _rewind_records_with_scope(state_log)
+    if not records:
+        return None
+    _r, n, scope = max(records, key=lambda t: t[0])
+    return n, scope
+
+
 # ── Phase-2 fork: derived branch tree (ADR-0038 D8, #1533) ─────────────────────
 #
 # Grounded in the SAME abandoned-interval machinery as is_active (inherits the
@@ -528,7 +549,9 @@ def lineage_predecessor(
 
 
 async def checkout(
-    state_log: StateLog, *, target_seq: int, supersedes: int | None = None,
+    state_log: StateLog, *, target_seq: int,
+    scope: "tuple[str, str] | None" = None,
+    supersedes: int | None = None,
 ) -> int:
     """Append a reset-record to ``target_seq`` UNCONDITIONALLY (Phase-2 D8 fork).
 
@@ -545,10 +568,28 @@ async def checkout(
 
     ``supersedes`` is **audit-only** (records the prior active pointer for the
     branch-tree audit trail); ``is_active`` derivation does not depend on it.
-    """
-    return await state_log.append(
-        REWIND_KIND, target_n=int(target_seq), supersedes=supersedes,
-    )
+
+    #5769 stage 3 (ADR-0047 decision 3): ``scope=None`` (the default) writes
+    the SAME record shape as before this parameter existed — no ``scope``
+    key at all in the WAL entry, byte-identical to every pre-#5769 call —
+    so every existing caller (``rewind()`` below, and the ~20 direct test
+    call sites across the suite) is completely unaffected. ``scope=(agent,
+    sid)`` writes that pair into the entry's own ``scope`` field, read back
+    by ``build_active_predicate``'s own scope filter (stage 1). Unlike
+    ``build_active_predicate``'s ``scope`` (required, no default — stage 1
+    made that required because a forgotten scope there silently reasons
+    about the WRONG branch for a real, already-known (agent, sid)), a
+    default here is safe: a caller that omits ``scope`` gets EXACTLY
+    today's well-understood global-rewind behavior, not a silent
+    misbehavior — there is no "wrong branch" to accidentally read on the
+    WRITE side, only "write global" (unchanged) vs. "write scoped" (new,
+    opt-in)."""
+    fields: "dict[str, object]" = {
+        "target_n": int(target_seq), "supersedes": supersedes,
+    }
+    if scope is not None:
+        fields["scope"] = list(scope)
+    return await state_log.append(REWIND_KIND, **fields)
 
 
 async def rewind(

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -118,7 +118,6 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
-from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.core.offload.canonical import (
     CANONICAL_DEGRADED_EVENT,
     CANONICAL_FALLBACK_EVENT,
@@ -1906,7 +1905,7 @@ class PipelineExecutor:
         pipeline: Pipeline,
         tool_dispatch: ToolDispatch,
         state_log: "StateLog",
-        scope: "tuple[str, str] | None" = GLOBAL_SCOPE,
+        scope: "tuple[str, str] | None",
         schema_registry: "SchemaRegistry | None" = None,
         registry: "AgentRegistry | None" = None,
         default_identity: "str | None" = None,
@@ -1934,16 +1933,20 @@ class PipelineExecutor:
         (agent, sid) is a FACT, not a caller decision, so the one real
         production caller (`PipelineExecutorDriver.run_turn`, which always
         holds its own `PipelineWorkOrder`) always passes its real
-        `(wo.driver_agent, wo.driver_sid)`. Defaults to `GLOBAL_SCOPE` for
-        the many existing lower-level executor tests that exercise pure
-        R3/R4 mechanics with no owning driver-session concept at all — for
-        those, GLOBAL_SCOPE is the honestly correct answer (there is no
-        scoped-rewind concern in play), not a silently-forgotten one; this
-        default carries none of the "read the wrong branch" risk stage 1
-        made `build_active_predicate`'s own `scope` required to close,
-        since NOTHING in this codebase can yet write a scoped record for a
-        pipeline run's own generations without going through the one real
-        caller above, which never omits its real scope."""
+        `(wo.driver_agent, wo.driver_sid)`.
+
+        No default (required keyword-only), matching `latest_pipeline_state`'s
+        own required-kwarg contract one layer down — a first cut of this PR
+        gave `scope` a `GLOBAL_SCOPE` default here, but that quietly re-opened
+        the exact hole decision 7 exists to close one layer OUT: a NEW test
+        call site that simply forgets `scope` would silently get GLOBAL_SCOPE
+        with no red, rather than a `TypeError` at the call (ADR-0047's own
+        Alternatives wording: "one forgotten call site silently behaves
+        globally ... with no red"). The many pre-existing R3/R4 executor
+        tests with no owning-driver concept at all now pass `scope=GLOBAL_SCOPE`
+        EXPLICITLY — an honest spelling of "no scoped-rewind concern applies
+        here", not a silently-inferred one. The one real production caller is
+        unaffected: it already passes its real `(wo.driver_agent, wo.driver_sid)`."""
         snapshot = latest_pipeline_state(run_id, state_log, scope=scope)
         if snapshot is None:
             return await self.run(

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -118,6 +118,7 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.core.offload.canonical import (
     CANONICAL_DEGRADED_EVENT,
     CANONICAL_FALLBACK_EVENT,
@@ -1905,6 +1906,7 @@ class PipelineExecutor:
         pipeline: Pipeline,
         tool_dispatch: ToolDispatch,
         state_log: "StateLog",
+        scope: "tuple[str, str] | None" = GLOBAL_SCOPE,
         schema_registry: "SchemaRegistry | None" = None,
         registry: "AgentRegistry | None" = None,
         default_identity: "str | None" = None,
@@ -1925,8 +1927,24 @@ class PipelineExecutor:
         `pipeline_registry` (R7) is required only if the resumed run re-enters a
         `CallStep` — the callee is re-resolved by name and re-walked to reconstruct
         its local state from the dotted keys. `events` / `cancel_check` behave as in
-        :meth:`run`."""
-        snapshot = latest_pipeline_state(run_id, state_log)
+        :meth:`run`.
+
+        #5769 stage 3 (ADR-0047 decision 7, architect's (c) ruling): `scope`
+        is forwarded straight to `latest_pipeline_state` — this run's own
+        (agent, sid) is a FACT, not a caller decision, so the one real
+        production caller (`PipelineExecutorDriver.run_turn`, which always
+        holds its own `PipelineWorkOrder`) always passes its real
+        `(wo.driver_agent, wo.driver_sid)`. Defaults to `GLOBAL_SCOPE` for
+        the many existing lower-level executor tests that exercise pure
+        R3/R4 mechanics with no owning driver-session concept at all — for
+        those, GLOBAL_SCOPE is the honestly correct answer (there is no
+        scoped-rewind concern in play), not a silently-forgotten one; this
+        default carries none of the "read the wrong branch" risk stage 1
+        made `build_active_predicate`'s own `scope` required to close,
+        since NOTHING in this codebase can yet write a scoped record for a
+        pipeline run's own generations without going through the one real
+        caller above, which never omits its real scope."""
+        snapshot = latest_pipeline_state(run_id, state_log, scope=scope)
         if snapshot is None:
             return await self.run(
                 pipeline,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -50,7 +50,7 @@ from reyn.core.events.snapshot_generations import (
     RewindIntoAbandonedError,
     RewindQuiesceTimeoutError,
     SnapshotGenerationStore,
-    active_rewind_target,
+    active_rewind_target_with_scope,
     branch_ids_for,
     build_active_predicate,
     is_active_seq,
@@ -2161,11 +2161,14 @@ class AgentRegistry:
                         "history.jsonl GC failed for %r/%r: %s", name, sid, e,
                     )
 
-    async def checkout(self, seq: int) -> dict:
-        """Global consistent-cut checkout to ANY WAL ``seq`` (ADR-0038 D8 Phase-2).
+    async def checkout(
+        self, seq: int, *, scope: "tuple[str, str] | None" = None,
+    ) -> dict:
+        """Consistent-cut checkout to ANY WAL ``seq`` (ADR-0038 D8 Phase-2 /
+        ADR-0047 decision 3, session-scoped rewind).
 
-        The unified time-travel primitive: jump the whole world's active cut to
-        ``seq`` — whether ``seq`` is on the live branch (= undo, the ``rewind_to``
+        The unified time-travel primitive: jump the active cut to ``seq`` —
+        whether ``seq`` is on the live branch (= undo, the ``rewind_to``
         special case) or on an abandoned/dead branch (= branch-switch / fork
         revival). Unlike ``rewind_to`` there is **no active-target guard**: a
         target on a dead branch is allowed and revives that lineage.
@@ -2179,8 +2182,9 @@ class AgentRegistry:
         ``is_active`` from the full chain, the runtime substrate follows the
         *target's* lineage automatically.
 
-        Architecture-enforced global cut (D2): one global single-seq WAL ⇒ one
-        reset-record moves *every* agent atomically:
+        ``scope=None`` (default) is the **architecture-enforced global cut**
+        (D2), byte-identical to before this parameter existed: one global
+        single-seq WAL ⇒ one reset-record moves *every* agent atomically:
 
           1. retention guard — reject a target truncated out of the WAL (1e).
           2. all-cancel  — ``cancel_inflight`` on every loaded session.
@@ -2193,6 +2197,15 @@ class AgentRegistry:
              ``applied_seq = R`` (``restore_all`` replays only > R); loaded
              sessions reset (``reset_for_rewind``) + re-adopt.
 
+        ``scope=(name, sid)`` (ADR-0047 decision 3/4/5) cancels/quiesces
+        **only** that session, appends a reset-record **scoped** to it, and
+        materialises **only** that ``(name, sid)`` — never touching the
+        workspace, config generations, or any other agent/session (decision
+        4/6). **The retention guard stays GLOBAL regardless of scope**
+        (architect's explicit ruling): the WAL floor is one global fact,
+        not owned by any one session, so a scoped checkout is bounded by the
+        exact same physical floor a global one is.
+
         ``_rewind_in_progress`` gates compaction for the whole window.
         """
         if self._state_log is None:
@@ -2200,7 +2213,8 @@ class AgentRegistry:
         # 1e (D5): bounded by retention — reject targets truncated out of the WAL.
         # Guard on the PHYSICAL oldest kept seq (not the policy floor): under a
         # live policy nothing is truncated between turns, so recent history stays
-        # reachable; only genuinely-truncated history is rejected.
+        # reachable; only genuinely-truncated history is rejected. UNCHANGED by
+        # scope — architect's ruling: the floor is a global fact either way.
         oldest_seq = self._oldest_kept_seq()
         if oldest_seq is not None and seq < oldest_seq:
             raise RewindBeyondRetentionError(
@@ -2211,6 +2225,34 @@ class AgentRegistry:
 
         self._rewind_in_progress = True
         try:
+            if scope is not None:
+                name, sid = scope
+                # Scoped cancel/quiesce: ONLY the target session, if loaded
+                # (an unloaded session has nothing in-flight to stop-world).
+                session = self._peek_session(name, sid)
+                if session is not None:
+                    await session.cancel_inflight()
+                    await self._await_quiescent_bounded(session)
+                prior_head = self._state_log.last_durable_seq
+                reset_seq = await _append_reset_record(
+                    self._state_log, target_seq=seq, scope=scope,
+                    supersedes=prior_head,
+                )
+                agents = await self._materialize_rewind(
+                    reconstruct_seq=reset_seq, workspace_at_or_below=seq,
+                    scope=scope,
+                )
+                return {
+                    "target_n": seq,
+                    "reset_seq": reset_seq,
+                    "agents": agents,
+                    "scope": list(scope),
+                    # #2115: no in-flight background-run machinery exists
+                    # (stage1 decouple) — same "always 0" fact the unscoped
+                    # path below states explicitly, not a new claim.
+                    "in_flight_cancelled": 0,
+                    "in_flight_finished": 0,
+                }
             sessions = self._iter_sessions()
             # #2115: the in-flight-task snapshot would be taken BEFORE the cancel
             # here, but background run machinery was removed (stage1 decouple):
@@ -2975,20 +3017,74 @@ class AgentRegistry:
 
     async def _materialize_rewind(
         self, *, reconstruct_seq: int, workspace_at_or_below: int,
+        scope: "tuple[str, str] | None" = None,
     ) -> list[str]:
         """Bring the runtime substrate to the active branch as-of ``reconstruct_seq``.
 
-        Idempotent — shared by ``rewind_to`` (right after the reset-record) and
-        crash ``recover_rewind_if_needed`` (at restart). Per agent: ``reconstruct``
-        as-of the active branch + persist a self-contained snapshot pinned to
-        ``reconstruct_seq`` (so ``restore_all`` replays only beyond it); loaded
-        sessions are reset + re-adopt it.
+        Idempotent — shared by ``rewind_to``/``checkout`` (right after the
+        reset-record) and crash ``recover_rewind_if_needed`` (at restart).
+        Per agent: ``reconstruct`` as-of the active branch + persist a
+        self-contained snapshot pinned to ``reconstruct_seq`` (so
+        ``restore_all`` replays only beyond it); loaded sessions are reset +
+        re-adopt it.
 
         ``reconstruct_seq`` is the WAL head at call time (= R in rewind_to, =
         current head in recovery); ``workspace_at_or_below`` is the as-of-cut DROP
         boundary = ``target_n`` in rewind_to or head in recovery. Returns the agents
         materialised.
+
+        #5769 stage 3 (ADR-0047 decision 3/4/5): ``scope=None`` (default) is
+        the full GLOBAL pass below, byte-identical to before this parameter
+        existed. ``scope=(name, sid)`` brings ONLY that session's own
+        substrate to as-of-cut — reconstruct + restore its conversation and
+        per-session agent state — and returns immediately, touching NOTHING
+        else: no agent create/drop/archive/purge, no topology reconcile, no
+        config-generation reconcile, no spawn-lineage/identity rebuild. All
+        of those are global, agent-wide facts (decision 6) a session-scoped
+        rewind must never move; the unscoped path below already handles them
+        exhaustively for `scope=None`, which is the ONLY case that needs to.
         """
+        if scope is not None:
+            name, sid = scope
+            created_at = self._created_at_map()
+            sess_vanished = self._session_vanished_map()
+            session_is_active = (
+                build_active_predicate(self._state_log, scope=scope)
+                if self._state_log is not None
+                else None
+            )
+            sess_seq = created_at.get(("session", name, sid))
+            van_seq = sess_vanished.get((name, sid))
+            spawned_after_cut = (
+                sess_seq is not None
+                and session_is_active is not None
+                and not session_is_active(sess_seq)
+            )
+            vanished_by_cut = (
+                van_seq is not None
+                and session_is_active is not None
+                and session_is_active(van_seq)
+            )
+            if spawned_after_cut or vanished_by_cut:
+                # Mirrors the unscoped path's own drop shape (#2125): quiesce
+                # via _drop_session, then purge the dir — no restore succeeds
+                # here to defer the purge past, so it is safe to do inline.
+                await self._drop_session(name, sid, purge_dir=False)
+                self._purge_session_dir(name, sid)
+                return []
+            store = self._store_for(name, sid)
+            snap = reconstruct(
+                name, store, self._state_log,
+                target_seq=reconstruct_seq, session_id=sid,
+            )
+            snap.applied_seq = reconstruct_seq
+            snap.save(self._session_snapshot_path(name, sid))
+            session = self._peek_session(name, sid)
+            if session is not None:
+                await session.reset_for_rewind()
+                session.restore_state(snap)
+            return [name if sid == _DEFAULT_SID else f"{name}/{sid}"]
+
         # FP-0043 Stage 5: the runtime snapshot is reconstructed PER SESSION (each
         # (name, sid) from its own generations + session_id-routed WAL delta), so a
         # global cut moves every session of every agent to the target — consistent
@@ -3170,17 +3266,30 @@ class AgentRegistry:
         sessions, closing the window where the crash hit after the reset-record
         but before snapshots / workspace were brought to as-of-N. No-op when no
         rewind record exists. Returns a summary or ``None``.
+
+        #5769 stage 3 (ADR-0047 decision 3's recovery half): reads
+        ``(target_n, scope)`` off the LATEST reset-record, not just its
+        target — a crash mid-SCOPED-rewind must re-materialise only that
+        ``(name, sid)``, never the whole world. A legacy/global record
+        (``scope is None``) takes the unchanged full-materialise path below,
+        byte-identical to before this parameter existed.
         """
         if self._state_log is None:
             return None
-        target = active_rewind_target(self._state_log)
-        if target is None:
+        result = active_rewind_target_with_scope(self._state_log)
+        if result is None:
             return None
+        target, scope = result
         head = self._state_log.last_durable_seq
         agents = await self._materialize_rewind(
-            reconstruct_seq=head, workspace_at_or_below=target,
+            reconstruct_seq=head, workspace_at_or_below=target, scope=scope,
         )
-        return {"recovered_target_n": target, "head": head, "agents": agents}
+        return {
+            "recovered_target_n": target,
+            "head": head,
+            "agents": agents,
+            "scope": list(scope) if scope is not None else None,
+        }
 
     # ── WAL truncation (WAL-floor design) ───────────────────────────────────
     #

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -242,8 +242,14 @@ class PipelineExecutorDriver:
         # tool resolves against). None-safe: a pipeline with no `call` step never
         # touches it; a `call` with no registry available fails the step cleanly.
         pipeline_registry = self._pipeline_registry()
+        # #5769 stage 3 (ADR-0047 decision 7, architect's (c) ruling): this
+        # run's own owner is a fact already in hand (`wo`), not something
+        # to re-derive from invocation.json — passed straight through to
+        # both latest_pipeline_state (direct call, below) and
+        # executor.resume (which forwards it to the same function).
+        scope = (wo.driver_agent, wo.driver_sid)
         try:
-            if latest_pipeline_state(wo.run_id, self._state_log) is None:
+            if latest_pipeline_state(wo.run_id, self._state_log, scope=scope) is None:
                 # Fresh run (or crashed before the first R4 snapshot): seed the
                 # ORIGINAL work-order input — resume()'s fallback would lose it.
                 result = await executor.run(
@@ -275,6 +281,7 @@ class PipelineExecutorDriver:
                     pipeline=pipeline,
                     tool_dispatch=await self._make_dispatch(),
                     state_log=self._state_log,
+                    scope=scope,
                     registry=self._registry,
                     default_identity=wo.reply_to_agent,
                     pipeline_registry=pipeline_registry,

--- a/tests/core/test_5769_stage2_scoped_derivation.py
+++ b/tests/core/test_5769_stage2_scoped_derivation.py
@@ -4,28 +4,27 @@ instead of building (and potentially mis-scoping) an opaque predicate.
 
 Real `StateLog` + real on-disk stores (no mocks). Covers the two store
 signature changes (`ConfigGenerationStore.latest_active`,
-`PipelineStateStore.latest_active` now take `(state_log, scope)` directly)
-and `latest_pipeline_state`'s own owner derivation (architect's #5772
-finding: the owner was recorded, just not read at that call site --
-fixed in the SAME PR per lead-coder-30's explicit ruling, not filed
-separately). `list_rewind_points`'s per-agent scoping is covered
-separately in `tests/core/test_registry_list_rewind_points_1f.py`'s own
-sibling additions -- see that file for the (agent, sid) narrowing
-witness; this file does not duplicate it.
+`PipelineStateStore.latest_active` now take `(state_log, scope)` directly).
+
+`latest_pipeline_state`'s own scoping test moved to
+`test_5769_stage3_pipeline_resume_scope.py` (#5769 stage 3, architect's
+(c) ruling on PR #5778 superseded the #5772/stage-2 invocation.json-
+reading design this file originally tested here -- that mechanism no
+longer exists; `latest_pipeline_state` now takes `scope` directly from
+its caller, who already holds it). `list_rewind_points`'s per-agent
+scoping is covered separately in
+`tests/core/test_registry_list_rewind_points_1f.py`'s own sibling
+additions -- see that file for the (agent, sid) narrowing witness; this
+file does not duplicate it.
 """
 from __future__ import annotations
 
 import pytest
 
 from reyn.core.events.config_generations import ConfigGenerationStore
-from reyn.core.events.pipeline_recovery import (
-    PipelineStateStore,
-    latest_pipeline_state,
-    record_pipeline_state,
-)
+from reyn.core.events.pipeline_recovery import PipelineStateStore
 from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND
 from reyn.core.events.state_log import StateLog
-from reyn.core.pipeline.work_order import PipelineWorkOrder, pipeline_run_dir, write_invocation
 
 
 async def _put(log: StateLog, agent: str) -> int:
@@ -84,82 +83,3 @@ async def test_pipeline_state_store_latest_active_new_signature(tmp_path):
     assert latest == (s1, {"step_index": 1})
 
 
-def _work_order(run_id: str, *, driver_agent: str, driver_sid: str, spawn_seq: int) -> PipelineWorkOrder:
-    return PipelineWorkOrder(
-        run_id=run_id, pipeline_name="p", pipeline={"steps": []}, input=None,
-        reply_to_agent=driver_agent, reply_to_sid="main",
-        driver_agent=driver_agent, driver_sid=driver_sid, spawn_seq=spawn_seq,
-    )
-
-
-@pytest.mark.asyncio
-async def test_latest_pipeline_state_derives_owner_and_narrows_to_it(tmp_path):
-    """Tier 2: strip-falsifier target for architect's #5772 finding.
-    `latest_pipeline_state` now reads the SAME `invocation.json`
-    `_rewake_pipeline_runs` already reads, deriving (driver_agent,
-    driver_sid) -- a rewind SCOPED to a DIFFERENT (agent, sid) must not
-    hide this run's own generation, and one scoped to THIS run's own
-    driver must."""
-    reyn_dir = tmp_path / ".reyn"
-    log = StateLog(reyn_dir / "state" / "wal.jsonl")
-    run_dir = pipeline_run_dir(reyn_dir, "run-1")
-    s1 = await _put(log, "worker")
-    write_invocation(run_dir, _work_order("run-1", driver_agent="worker", driver_sid="sidA", spawn_seq=s1))
-    await record_pipeline_state(log, "run-1", {"step_index": 1}, durable=True)
-    s2 = await _put(log, "worker")
-    await record_pipeline_state(log, "run-1", {"step_index": 2}, durable=True)
-
-    # A rewind scoped to a DIFFERENT (agent, sid) must not affect run-1.
-    await log.append(
-        REWIND_KIND, target_n=s1, supersedes=None, scope=["someone-else", "sidZ"],
-    )
-    still_visible = latest_pipeline_state("run-1", log)
-    assert still_visible == {"step_index": 2}
-
-    # A rewind scoped to run-1's OWN driver (worker, sidA) DOES abandon
-    # the later generation -- proving the owner was genuinely derived and
-    # applied, not silently defaulted to global (which would ALSO hide
-    # this, making the first assertion the only real witness).
-    await log.append(
-        REWIND_KIND, target_n=s1, supersedes=None, scope=["worker", "sidA"],
-    )
-    now_hidden = latest_pipeline_state("run-1", log)
-    assert now_hidden == {"step_index": 1}
-
-
-@pytest.mark.asyncio
-async def test_latest_pipeline_state_falls_back_to_global_without_invocation(tmp_path):
-    """Tier 2: fail-closed to the SAFE side -- a run with generations but
-    no readable invocation.json (should not happen in practice, not
-    proven impossible) falls back to GLOBAL_SCOPE rather than raising or
-    silently returning stale/wrong content.
-
-    lead-coder-30 BLOCKING (#5775 review): without a rewind record in the
-    log, this test cannot tell "falls back to GLOBAL_SCOPE" from "scope
-    was never applied at all" -- both look identical (nothing is ever
-    abandoned). Fixed the same way `test_latest_pipeline_state_derives_
-    owner_and_narrows_to_it` above already does: add a rewind SCOPED to
-    an unrelated session and assert it is IGNORED -- GLOBAL_SCOPE's own
-    contract (`record_scope is None or record_scope == scope`,
-    snapshot_generations.py) means a global query never sees a
-    differently-scoped record. That is now an observable, asserted fact,
-    not merely a docstring claim."""
-    reyn_dir = tmp_path / ".reyn"
-    log = StateLog(reyn_dir / "state" / "wal.jsonl")
-    s1 = await _put(log, "worker")
-    await record_pipeline_state(log, "run-2", {"step_index": 1}, durable=True)
-    # No write_invocation call -- invocation.json genuinely absent.
-
-    # Real witness: a rewind scoped to a DIFFERENT session must be
-    # invisible to the GLOBAL_SCOPE fallback this function computes.
-    # target_n=0 abandons (0, R) -- which genuinely includes s1 (the
-    # generation's own seq), so a broken implementation that ignored
-    # scope (saw this record under a global query) WOULD hide the
-    # generation -- a real discriminator, not a no-op interval.
-    await log.append(
-        REWIND_KIND, target_n=0, supersedes=None, scope=["someone-else", "sidZ"],
-    )
-
-    result = latest_pipeline_state("run-2", log)
-
-    assert result == {"step_index": 1}

--- a/tests/core/test_5769_stage3_checkout_scope.py
+++ b/tests/core/test_5769_stage3_checkout_scope.py
@@ -1,0 +1,245 @@
+"""Tier 2: OS invariant -- #5769 stage 3, checkout gains a session scope
+(ADR-0047 decision 3/5, the writer + recovery half).
+
+Real `AgentRegistry` + `StateLog` + on-disk agents (no mocks). `scope=None`
+(default) is byte-identical to the pre-#5769 global cut; `scope=(name, sid)`
+cancels/quiesces, appends a reset-record for, and materialises ONLY that
+session -- never touching another agent/session, the workspace, or config
+generations (decision 4/6).
+
+Covers: the retention guard staying global regardless of scope (architect's
+explicit ruling), a scoped checkout leaving an unrelated agent's session
+completely untouched (decision 5's own "sessions can diverge" witness),
+crash recovery reading `(target_n, scope)` off the latest reset-record and
+materialising only that pair, and the CLAUDE.md hard-rule truncate-falsify
+test for a recovery-feature PR: write a scoped rewind, truncate the WAL past
+its own supporting events, reconstruct from the surviving self-contained
+snapshot alone, and confirm the scoped rewind's effect survives.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.snapshot_generations import RewindBeyondRetentionError
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+def _snap_path(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name / "state" / "snapshot.json"
+
+
+def _inbox_ids(snap: AgentSnapshot) -> list[str]:
+    return [m["id"] for m in snap.inbox]
+
+
+@pytest.mark.asyncio
+async def test_checkout_scope_none_writes_the_same_record_shape_as_before(tmp_path):
+    """Tier 2: acceptance -- scope=None (default) leaves the existing WAL
+    entry shape untouched: no `scope` key at all in the reset-record."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")
+
+    result = await reg.checkout(1)
+
+    entry = next(e for e in log.iter_from(0) if e.get("kind") == "rewind")
+    assert "scope" not in entry
+    assert "scope" not in result
+
+
+@pytest.mark.asyncio
+async def test_checkout_scoped_writes_the_scope_field(tmp_path):
+    """Tier 2: acceptance -- `checkout(seq, scope=(name, sid))` writes that
+    pair into the reset-record's own `scope` field, and returns it."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")
+
+    result = await reg.checkout(1, scope=("alpha", "main"))
+
+    entry = next(e for e in log.iter_from(0) if e.get("kind") == "rewind")
+    assert entry.get("scope") == ["alpha", "main"]
+    assert result["scope"] == ["alpha", "main"]
+
+
+@pytest.mark.asyncio
+async def test_checkout_retention_guard_stays_global_for_scoped_checkout(tmp_path):
+    """Tier 2: architect's explicit ruling -- the retention guard is bounded
+    by the SAME global WAL floor for a scoped checkout as for a global one.
+    A target truncated out of the WAL is rejected either way."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")   # seq 1
+    await _put(log, "alpha", "a2")   # seq 2
+    await _put(log, "alpha", "a3")   # seq 3
+    await log.truncate_below(3)      # drop seq 1, 2; oldest kept = 3
+    await log.flush()
+
+    with pytest.raises(RewindBeyondRetentionError):
+        await reg.checkout(2, scope=("alpha", "main"))
+
+
+@pytest.mark.asyncio
+async def test_checkout_scoped_touches_only_its_own_session(tmp_path):
+    """Tier 2: decision 5's own "sessions can diverge" property, driven
+    end to end -- a checkout SCOPED to (alpha, main) rewinds alpha's own
+    inbox, while a completely unrelated agent (beta) is left with NO
+    on-disk snapshot at all (real witness: beta never had one written --
+    a raw WAL append alone never materialises a snapshot; only
+    reconstruction does -- so "beta's snapshot file does not exist" both
+    BEFORE and AFTER the scoped checkout is the actual, correct
+    "untouched" claim, not a stand-in for it)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")   # seq 1 (kept)
+    await _put(log, "alpha", "a2")   # seq 2 (abandoned by the scoped checkout)
+    await _put(log, "beta", "b1")    # seq 3 (must survive untouched)
+
+    assert not _snap_path(tmp_path, "beta").exists()  # premise: nothing written yet
+
+    await reg.checkout(1, scope=("alpha", "main"))
+
+    alpha_snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert _inbox_ids(alpha_snap) == ["a1"]           # a2 abandoned FOR ALPHA
+
+    # beta is completely untouched by a checkout scoped to a different
+    # agent -- no snapshot was ever written for it, matching its own
+    # pre-checkout state exactly.
+    assert not _snap_path(tmp_path, "beta").exists()
+
+
+@pytest.mark.asyncio
+async def test_recover_rewind_if_needed_materialises_only_the_scoped_session(tmp_path):
+    """Tier 2: ADR-0047 decision 3's recovery half. A crash mid-SCOPED-
+    rewind (reset-record fsync'd, materialise not yet run) re-materialises
+    ONLY that (name, sid) on restart -- an unrelated agent's own state is
+    never touched by the recovery pass either."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")   # seq 1
+    await _put(log, "alpha", "a2")   # seq 2
+    await _put(log, "beta", "b1")    # seq 3
+
+    # Simulate the crash: append the scoped reset-record directly (mirrors
+    # what checkout()'s own step 4 does), but never call _materialize_rewind
+    # -- the crash landed right after the fsync, before step 5.
+    from reyn.core.events.snapshot_generations import checkout as append_reset_record
+    await append_reset_record(
+        log, target_seq=1, scope=("alpha", "main"), supersedes=log.current_seq,
+    )
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None
+    assert result["scope"] == ["alpha", "main"]
+    alpha_snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert _inbox_ids(alpha_snap) == ["a1"]  # alpha recovered to as-of-scoped-target
+
+    # beta was never touched by this recovery pass -- no snapshot was ever
+    # written for it (only alpha's own materialise ran).
+    assert not _snap_path(tmp_path, "beta").exists()
+
+
+@pytest.mark.asyncio
+async def test_recover_rewind_if_needed_stays_global_for_a_legacy_unscoped_record(tmp_path):
+    """Tier 2: non-regression -- a crash mid-GLOBAL-rewind (no scope field
+    at all, exactly what checkout()'s scope=None path still writes) is
+    still recovered via the full, unchanged materialise-everything path."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")
+    await _put(log, "alpha", "a2")
+    await _put(log, "beta", "b1")
+
+    from reyn.core.events.snapshot_generations import checkout as append_reset_record
+    await append_reset_record(log, target_seq=1, supersedes=log.current_seq)  # no scope
+
+    result = await reg.recover_rewind_if_needed()
+
+    assert result is not None
+    assert result["scope"] is None
+    alpha_snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert _inbox_ids(alpha_snap) == ["a1"]
+    # Global recovery DOES touch beta too (its own snapshot gets written,
+    # self-contained, even though beta's own content is unaffected).
+    assert _snap_path(tmp_path, "beta").exists()
+
+
+@pytest.mark.asyncio
+async def test_scoped_rewind_survives_wal_truncation_past_its_own_events(tmp_path):
+    """Tier 2: CLAUDE.md hard rule -- recovery-feature PRs need a
+    truncate-falsify test in the SAME PR. Set X (a scoped checkout) ->
+    truncate the WAL past X's own supporting events (the raw messages AND
+    the reset-record itself) -> reconstruct from the surviving
+    self-contained snapshot alone -> X survives.
+
+    Mirrors `test_registry_rewind_to.py`'s own
+    `test_rewind_to_snapshot_self_contained_for_restore_all` (the global
+    case), but ACTUALLY calls `truncate_below` -- the raw evidence for
+    "a2 was abandoned" (the reset-record naming target_seq=1) is
+    genuinely gone from the WAL by the time reconstruction runs; only the
+    self-contained snapshot (`applied_seq` pinned to the reset-record's
+    own seq) carries that fact forward.
+    """
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")   # seq 1 (kept)
+    await _put(log, "alpha", "a2")   # seq 2 (abandoned by the scoped checkout)
+
+    result = await reg.checkout(1, scope=("alpha", "main"))
+    reset_seq = result["reset_seq"]
+
+    # Post-rewind work, on the new active branch.
+    await _put(log, "alpha", "a3")   # seq reset_seq + 1
+
+    # Truncate the WAL PAST the scoped rewind's own supporting events --
+    # a1, a2, AND the reset-record itself (seq <= reset_seq) are all
+    # dropped. Only content strictly after reset_seq remains in the WAL.
+    await log.truncate_below(reset_seq + 1)
+    await log.flush()
+
+    # Reconstruction now has NO access to a2, nor to the reset-record that
+    # named it abandoned -- only the durable, self-contained snapshot
+    # (applied_seq = reset_seq) and whatever WAL entries survived.
+    saved = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert saved.applied_seq == reset_seq
+    saved.apply_events(list(log.iter_from(saved.applied_seq + 1)))
+
+    assert _inbox_ids(saved) == ["a1", "a3"]  # a2 stays gone -- the scope survived truncation

--- a/tests/core/test_5769_stage3_pipeline_resume_scope.py
+++ b/tests/core/test_5769_stage3_pipeline_resume_scope.py
@@ -1,0 +1,191 @@
+"""Tier 2: OS invariant -- #5769 stage 3, ADR-0047 decision 7, architect's
+(c) ruling on PR #5778's review (superseding an earlier, disclosed
+(a)/(b)-shaped deviation).
+
+`latest_pipeline_state(run_id, state_log, *, scope)` no longer discovers
+its own owner by re-reading `invocation.json` -- both real callers
+(`PipelineExecutorDriver.run_turn`'s direct call, and
+`PipelineExecutor.resume`, which now forwards its own `scope` parameter)
+already hold the run's own `PipelineWorkOrder` when they call this, so
+`scope` is simply handed over as a fact, never re-derived. This closes
+the whole class of problem the earlier version had (an `invocation.json`
+read, a warning log, a `GLOBAL_SCOPE` fallback, and a disclosed decision-7
+exception) -- there is now exactly one path, no cases to reconcile.
+
+Real `StateLog` + real `PipelineStateStore` (no mocks). Covers: `scope`
+is a required keyword-only argument (no default, no silent fallback);
+`resume()` forwards its own `scope` straight through with its own
+default of `GLOBAL_SCOPE` (safe for the many pre-existing R3/R4 executor
+tests with no owning-driver concept at all -- GLOBAL_SCOPE is the
+honestly correct answer for those, not a silently-forgotten one, since
+nothing in this codebase can yet write a scoped pipeline-state record
+without going through the one real production caller, which always
+passes its real scope).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.tools.pipeline_verbs import _make_tool_dispatch
+
+
+async def _put(log: StateLog, agent: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id="x", msg_kind="user", payload={"text": "x"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_latest_pipeline_state_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- a call site that forgets scope fails at the
+    call, matching PipelineStateStore.latest_active's own required-kwarg
+    contract this function now delegates to directly."""
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+
+    with pytest.raises(TypeError):
+        latest_pipeline_state("run-x", log)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_latest_pipeline_state_uses_exactly_the_scope_the_caller_passes(tmp_path):
+    """Tier 2: strip-falsifier target. The caller's own `scope` (not any
+    file this function might read) is the only thing that decides
+    visibility -- a rewind scoped to a DIFFERENT (agent, sid) than the
+    one the CALLER passes must not hide the generation; one matching the
+    CALLER's own passed scope must."""
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    s1 = await _put(log, "worker")
+    await record_pipeline_state(log, "run-1", {"step_index": 1}, durable=True)
+    s2 = await _put(log, "worker")
+    await record_pipeline_state(log, "run-1", {"step_index": 2}, durable=True)
+
+    # A rewind scoped to a DIFFERENT (agent, sid) than the one the caller
+    # will pass -- must not affect what the caller sees.
+    await log.append(
+        REWIND_KIND, target_n=s1, supersedes=None, scope=["someone-else", "sidZ"],
+    )
+    still_visible = latest_pipeline_state("run-1", log, scope=("worker", "sidA"))
+    assert still_visible == {"step_index": 2}
+
+    # A rewind scoped to EXACTLY the scope the caller passes DOES abandon
+    # the later generation.
+    await log.append(
+        REWIND_KIND, target_n=s1, supersedes=None, scope=["worker", "sidA"],
+    )
+    now_hidden = latest_pipeline_state("run-1", log, scope=("worker", "sidA"))
+    assert now_hidden == {"step_index": 1}
+
+
+@pytest.mark.asyncio
+async def test_latest_pipeline_state_global_scope_ignores_any_scoped_rewind(tmp_path):
+    """Tier 2: a caller that genuinely has no owner concept (matching
+    resume()'s own default) passes GLOBAL_SCOPE -- a rewind scoped to ANY
+    particular session is invisible to it, by GLOBAL_SCOPE's own contract
+    (`record_scope is None or record_scope == scope`,
+    snapshot_generations.py)."""
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    s1 = await _put(log, "worker")
+    await record_pipeline_state(log, "run-2", {"step_index": 1}, durable=True)
+
+    # target_n=0 abandons (0, R) -- which genuinely includes s1, so a
+    # broken implementation that let this leak into a GLOBAL query would
+    # hide the generation -- a real discriminator, not a no-op interval.
+    await log.append(
+        REWIND_KIND, target_n=0, supersedes=None, scope=["someone-else", "sidZ"],
+    )
+
+    result = latest_pipeline_state("run-2", log, scope=GLOBAL_SCOPE)
+
+    assert result == {"step_index": 1}
+
+
+def _install_counting_tool(monkeypatch, out_file) -> None:
+    """A REAL side-effecting tool registered on the real ToolRegistry (same
+    idiom as test_pipeline_is6_attached.py's own helper of the same name):
+    every call appends a line to `out_file` -- line count == real
+    execution count, the exactly-once/fresh-run-vs-resume probe."""
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        with out_file.open("a", encoding="utf-8") as f:
+            f.write("x\n")
+        return {}
+
+    tool = ToolDefinition(
+        name="stage3_step", description="test tool", parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow"), handler=_handler, category="io", purity="side_effect",
+    )
+    base = tools_pkg.get_default_registry
+
+    def _with_tool():
+        registry = base()
+        registry.register(tool)
+        return registry
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+
+def _one_step_pipeline() -> Pipeline:
+    return Pipeline(steps=[ToolStep(name="stage3_step", args={}, output="o0")])
+
+
+def _bare_ctx():
+    from reyn.core.events.events import EventLog
+    from reyn.tools.types import ToolContext
+    return ToolContext(
+        events=EventLog(), permission_resolver=None, workspace=None,
+        caller_kind="router", router_state=None, state_log=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_forwards_its_scope_real_witness(tmp_path, monkeypatch):
+    """Tier 2: `PipelineExecutor.resume`'s own `scope` parameter really
+    reaches `latest_pipeline_state` -- proven by a REAL, observable
+    behavioral difference (no patch of any collaborator this test itself
+    depends on -- the only monkeypatch here registers a genuine tool
+    handler, the same idiom test_pipeline_is6_attached.py's own sibling
+    helper uses, not a stand-in for the thing under test).
+
+    A recorded generation carries an impossible `step_index` (5, for a
+    1-step pipeline where only 0/1 are ever real) and is then hidden by a
+    rewind scoped to EXACTLY the scope this test passes to `resume()`. If
+    `resume()` genuinely forwarded that scope to `latest_pipeline_state`,
+    the impossible generation is invisible -> resume() falls through to a
+    fresh run -> the one real step executes for real (the counting file
+    gets exactly one line) -> `step_index == 1`. If scope were silently
+    dropped (always seeing the record), resume() would instead try to
+    replay from the impossible snapshot -- observably NOT "one real
+    execution, step_index == 1"."""
+    out_file = tmp_path / "out.txt"
+    _install_counting_tool(monkeypatch, out_file)
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    pipeline = _one_step_pipeline()
+    dispatch = _make_tool_dispatch(_bare_ctx())
+
+    await _put(log, "worker")
+    await record_pipeline_state(log, "run-scope-check", {"step_index": 5}, durable=True)
+
+    # Scoped to hide the impossible generation FOR EXACTLY (worker, sidA).
+    await log.append(
+        REWIND_KIND, target_n=0, supersedes=None, scope=["worker", "sidA"],
+    )
+
+    result = await PipelineExecutor().resume(
+        "run-scope-check",
+        pipeline=pipeline,
+        tool_dispatch=dispatch,
+        state_log=log,
+        scope=("worker", "sidA"),
+    )
+
+    # Hidden for (worker, sidA) -> resume() fell through to a genuine
+    # fresh run -> the one real step executed once -> step_index == 1.
+    assert result.step_index == 1
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["x"]

--- a/tests/core/test_5769_stage3_pipeline_resume_scope.py
+++ b/tests/core/test_5769_stage3_pipeline_resume_scope.py
@@ -13,14 +13,17 @@ read, a warning log, a `GLOBAL_SCOPE` fallback, and a disclosed decision-7
 exception) -- there is now exactly one path, no cases to reconcile.
 
 Real `StateLog` + real `PipelineStateStore` (no mocks). Covers: `scope`
-is a required keyword-only argument (no default, no silent fallback);
-`resume()` forwards its own `scope` straight through with its own
-default of `GLOBAL_SCOPE` (safe for the many pre-existing R3/R4 executor
-tests with no owning-driver concept at all -- GLOBAL_SCOPE is the
-honestly correct answer for those, not a silently-forgotten one, since
-nothing in this codebase can yet write a scoped pipeline-state record
-without going through the one real production caller, which always
-passes its real scope).
+is a required keyword-only argument on BOTH `latest_pipeline_state` and
+`resume()` (no default, no silent fallback, at either layer -- a round-1
+draft of this PR gave `resume()`'s own `scope` a `GLOBAL_SCOPE` default,
+which silently reopened decision 7's hole one layer OUT; lead-coder-30's
+review caught it, architect confirmed no default is justified here since
+every real caller already knows its own answer). `resume()` forwards its
+own `scope` straight through to `latest_pipeline_state`; every owner-less
+R3/R4/primitive-mechanics test call site now passes `scope=GLOBAL_SCOPE`
+explicitly (honest, not silently-forgotten -- nothing in this codebase
+can yet write a scoped pipeline-state record without going through the
+one real production caller, which always passes its real scope).
 """
 from __future__ import annotations
 
@@ -29,7 +32,7 @@ import pytest
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
 from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND
 from reyn.core.events.state_log import StateLog
-from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep, TransformStep
 from reyn.tools.pipeline_verbs import _make_tool_dispatch
 
 
@@ -48,6 +51,25 @@ async def test_latest_pipeline_state_requires_scope_kwarg(tmp_path):
 
     with pytest.raises(TypeError):
         latest_pipeline_state("run-x", log)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_resume_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- same shape as
+    `test_latest_pipeline_state_requires_scope_kwarg` above, one layer OUT.
+    Pins OUR signature decision (decision 2/7: no silent GLOBAL_SCOPE
+    default), not a language behaviour -- a round-1 draft of this PR gave
+    `resume()`'s own `scope` a `GLOBAL_SCOPE` default, silently reopening
+    the same hole `latest_pipeline_state`'s required kwarg already closed
+    one layer in (lead-coder-30 review, PR #5778). A call site that forgets
+    `scope` must fail at the call, not silently resume as GLOBAL_SCOPE."""
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    pipeline = Pipeline(steps=[TransformStep(value="1 + 1", output="x")])
+
+    with pytest.raises(TypeError):
+        await PipelineExecutor().resume(  # type: ignore[call-arg]
+            "run-y", pipeline=pipeline, tool_dispatch=lambda *_a, **_k: None, state_log=log,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_pipeline_call_primitive.py
+++ b/tests/core/test_pipeline_call_primitive.py
@@ -267,9 +267,11 @@ async def test_truncate_falsify_call_resumes_callee_substeps_exactly_once(tmp_pa
     # RESUME with the crash DISARMED: the finished sub-step replays from the gen
     # FILE (no re-write of A), only sub-step 1 executes (writes B once).
     crash.clear()
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await PipelineExecutor().resume(
         "run-tf", pipeline=outer,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+        scope=GLOBAL_SCOPE,
     )
 
     # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
@@ -303,9 +305,11 @@ async def test_call_resume_after_full_run_replays_with_zero_new_side_effects(tmp
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
 
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await PipelineExecutor().resume(
         "run-done", pipeline=outer,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+        scope=GLOBAL_SCOPE,
     )
     # No new lines — a fully-completed run replays with zero side effects.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]

--- a/tests/core/test_pipeline_call_primitive.py
+++ b/tests/core/test_pipeline_call_primitive.py
@@ -191,6 +191,7 @@ async def test_mid_call_snapshot_uses_dotted_keys_and_isolates_outer_stores(tmp_
     store does NOT appear in the persisted OUTER ``named_stores`` (pass:[...]
     isolation on the recovery axis)."""
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
@@ -207,7 +208,7 @@ async def test_mid_call_snapshot_uses_dotted_keys_and_isolates_outer_stores(tmp_
         )
     await state_log.flush()
 
-    snap = latest_pipeline_state("run-dotted", state_log)
+    snap = latest_pipeline_state("run-dotted", state_log, scope=GLOBAL_SCOPE)
     # The finished callee sub-step is present under the dotted key; the failed one
     # and the outer call's own key are absent (the call is not done).
     assert "1.call.0" in snap["completed_step_results"]

--- a/tests/core/test_pipeline_executor_r3_r4.py
+++ b/tests/core/test_pipeline_executor_r3_r4.py
@@ -216,9 +216,10 @@ async def test_truncate_falsify_generation_survives_wal_truncation_below_its_seq
     )
 
     full_pipeline = Pipeline(steps=[step0, step1, step2, step3])
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await executor.resume(
         "run-truncate", pipeline=full_pipeline,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
 
     assert call_counts["count"] == 3, (
@@ -255,9 +256,10 @@ async def test_exactly_once_resume_does_not_replay_completed_tool_side_effect(tm
     assert crashed_result.step_index == 1
     assert call_counts["count"] == 1
 
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await executor.resume(
         "run-exactly-once", pipeline=Pipeline(steps=[step0, step1]),
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
 
     assert call_counts["count"] == 2, "step0 must not be re-run; only step1 is new"
@@ -274,9 +276,10 @@ async def test_resume_with_no_snapshot_runs_from_scratch(tmp_path):
     executor = PipelineExecutor()
     pipeline = Pipeline(steps=[TransformStep(value="1 + 1", output="two")])
 
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     result = await executor.resume(
         "never-run-before", pipeline=pipeline,
-        tool_dispatch=lambda *_a, **_k: None, state_log=state_log,
+        tool_dispatch=lambda *_a, **_k: None, state_log=state_log, scope=GLOBAL_SCOPE,
     )
 
     assert result.pipe_data == 2

--- a/tests/core/test_pipeline_fold_primitive.py
+++ b/tests/core/test_pipeline_fold_primitive.py
@@ -186,6 +186,7 @@ async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(t
     rode a truncatable WAL event, or if resume re-ran the whole fold instead of
     replaying the completed iteration."""
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     from reyn.core.pipeline.executor import ExprRef
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
@@ -213,7 +214,7 @@ async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(t
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
 
-    snap_mid = latest_pipeline_state("run-fold-tf", state_log)
+    snap_mid = latest_pipeline_state("run-fold-tf", state_log, scope=GLOBAL_SCOPE)
     # #2425 PR-2: a ToolStep `do`'s ctx value is the flat {"text": ...} shape.
     assert snap_mid["completed_step_results"]["0.fold.0"] == {"text": "A"}
     assert "0.fold.1" not in snap_mid["completed_step_results"]

--- a/tests/core/test_pipeline_fold_primitive.py
+++ b/tests/core/test_pipeline_fold_primitive.py
@@ -235,7 +235,7 @@ async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(t
     crash.clear()
     resumed = await PipelineExecutor().resume(
         "run-fold-tf", pipeline=outer,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
 
     # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
@@ -278,9 +278,10 @@ async def test_fold_resume_after_full_run_replays_with_zero_new_side_effects(tmp
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
 
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await PipelineExecutor().resume(
         "run-fold-done", pipeline=outer,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
     assert resumed.named_stores["joined"] == {"text": "AB"}

--- a/tests/core/test_pipeline_for_each_primitive.py
+++ b/tests/core/test_pipeline_for_each_primitive.py
@@ -375,7 +375,8 @@ async def test_truncate_falsify_mid_fan_out_replays_items_exactly_once(tmp_path:
 
     # Latest generation on disk: all 4 item keys present, collect key absent.
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
-    snap = latest_pipeline_state("run-fe-tf", state_log)
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snap = latest_pipeline_state("run-fe-tf", state_log, scope=GLOBAL_SCOPE)
     for idx in range(4):
         assert f"0.for_each.{idx}" in snap["completed_step_results"]
     assert snap["completed_step_results"]["0.for_each.2"]["__fan_out_dropped__"] is True
@@ -486,7 +487,8 @@ async def test_truncate_falsify_compositional_do_sub_step_survives_mid_item_cras
     # durably present even though the item — and the whole for_each — never
     # completed.
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
-    snap = latest_pipeline_state("run-fe-comp-tf", state_log)
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snap = latest_pipeline_state("run-fe-comp-tf", state_log, scope=GLOBAL_SCOPE)
     assert snap["completed_step_results"]["0.for_each.0.call.0"] == {
         "text": "", "structured": {"wrote": "X-a"},
     }

--- a/tests/core/test_pipeline_for_each_primitive.py
+++ b/tests/core/test_pipeline_for_each_primitive.py
@@ -395,7 +395,7 @@ async def test_truncate_falsify_mid_fan_out_replays_items_exactly_once(tmp_path:
     crash.discard("COLLECT")
     resumed = await PipelineExecutor().resume(
         "run-fe-tf", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
@@ -427,9 +427,10 @@ async def test_resume_after_full_fan_out_replays_with_zero_new_side_effects(tmp_
     before = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert before == ["A", "B", "C", "COLLECT", "D"]
 
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await PipelineExecutor().resume(
         "run-fe-done", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
     after = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert after == before, "a fully-completed fan-out must replay with zero side effects"
@@ -510,6 +511,7 @@ async def test_truncate_falsify_compositional_do_sub_step_survives_mid_item_cras
     await PipelineExecutor().resume(
         "run-fe-comp-tf", pipeline=pipeline,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+        scope=GLOBAL_SCOPE,
     )
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines == ["X-a", "X-b"], (

--- a/tests/core/test_pipeline_is6_attached.py
+++ b/tests/core/test_pipeline_is6_attached.py
@@ -398,6 +398,7 @@ async def test_executor_cancel_at_boundary_leaves_resumable_journal(
     # Explicit resume (no cancel): completes exactly-once — step 0 NOT re-run.
     result = await PipelineExecutor().resume(
         "run-cancel", pipeline=pipeline, tool_dispatch=dispatch, state_log=state_log,
+        scope=GLOBAL_SCOPE,
     )
     assert result.step_index == 3
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]
@@ -456,6 +457,7 @@ async def test_driver_cancel_writes_terminal_marker_recovery_skips(
     result = await PipelineExecutor().resume(
         "run-dcancel", pipeline=pipeline,
         tool_dispatch=_make_tool_dispatch(_bare_ctx(state_log)), state_log=state_log,
+        scope=GLOBAL_SCOPE,
     )
     assert result.step_index == 3
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]

--- a/tests/core/test_pipeline_is6_attached.py
+++ b/tests/core/test_pipeline_is6_attached.py
@@ -49,7 +49,7 @@ from typing import Any
 import pytest
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
-from reyn.core.events.snapshot_generations import REWIND_KIND
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.executor import (
     Pipeline,
@@ -392,7 +392,7 @@ async def test_executor_cancel_at_boundary_leaves_resumable_journal(
     # Only step 0 executed before the boundary cancel.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0"]
     # The R4 snapshot is the pre-cancel resume point.
-    snap = latest_pipeline_state("run-cancel", state_log)
+    snap = latest_pipeline_state("run-cancel", state_log, scope=GLOBAL_SCOPE)
     assert snap is not None and snap["step_index"] == 1
 
     # Explicit resume (no cancel): completes exactly-once — step 0 NOT re-run.
@@ -445,7 +445,7 @@ async def test_driver_cancel_writes_terminal_marker_recovery_skips(
     assert has_result(run_dir)  # TERMINAL — recovery must treat it as done.
     # Only step 0 ran; the R4 snapshot preserves the resume point.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0"]
-    assert latest_pipeline_state("run-dcancel", state_log)["step_index"] == 1
+    assert latest_pipeline_state("run-dcancel", state_log, scope=GLOBAL_SCOPE)["step_index"] == 1
 
     # Recovery scan does NOT resurrect a terminally-cancelled run.
     rewoken = await reg._rewake_pipeline_runs()

--- a/tests/core/test_pipeline_match_primitive.py
+++ b/tests/core/test_pipeline_match_primitive.py
@@ -242,6 +242,7 @@ async def test_mid_match_snapshot_uses_dotted_keys_and_isolates_outer_stores(tmp
     store does NOT appear in the persisted OUTER ``named_stores`` (pass:[...]
     isolation on the recovery axis)."""
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
@@ -258,7 +259,7 @@ async def test_mid_match_snapshot_uses_dotted_keys_and_isolates_outer_stores(tmp
         )
     await state_log.flush()
 
-    snap = latest_pipeline_state("run-match-dotted", state_log)
+    snap = latest_pipeline_state("run-match-dotted", state_log, scope=GLOBAL_SCOPE)
     assert "1.match.0" in snap["completed_step_results"]
     assert "1.match.1" not in snap["completed_step_results"]
     assert "1" not in snap["completed_step_results"]

--- a/tests/core/test_pipeline_match_primitive.py
+++ b/tests/core/test_pipeline_match_primitive.py
@@ -306,9 +306,11 @@ async def test_truncate_falsify_match_resumes_case_substeps_exactly_once(tmp_pat
     assert all(s >= 40 for s in surviving), "the case sub-step's WAL entry is truncated away"
 
     crash.clear()
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await PipelineExecutor().resume(
         "run-match-tf", pipeline=outer,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+        scope=GLOBAL_SCOPE,
     )
 
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]

--- a/tests/core/test_pipeline_parallel_primitive.py
+++ b/tests/core/test_pipeline_parallel_primitive.py
@@ -457,7 +457,7 @@ async def test_truncate_falsify_mid_parallel_replays_branches_exactly_once(tmp_p
     crash.discard("COLLECT")
     resumed = await PipelineExecutor().resume(
         "run-par-tf", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
@@ -489,9 +489,10 @@ async def test_resume_after_full_parallel_replays_with_zero_new_side_effects(tmp
     before = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert before == ["A", "B", "C", "COLLECT", "D"]
 
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await PipelineExecutor().resume(
         "run-par-done", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log,
+        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
     )
     after = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert after == before, "a fully-completed fan-out must replay with zero side effects"
@@ -743,6 +744,7 @@ async def test_truncate_falsify_compositional_branch_sub_step_survives_mid_branc
     await PipelineExecutor().resume(
         "run-par-comp-tf", pipeline=pipeline,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+        scope=GLOBAL_SCOPE,
     )
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines == ["X-a", "X-b"], (

--- a/tests/core/test_pipeline_parallel_primitive.py
+++ b/tests/core/test_pipeline_parallel_primitive.py
@@ -437,7 +437,8 @@ async def test_truncate_falsify_mid_parallel_replays_branches_exactly_once(tmp_p
     assert sorted(out_file.read_text(encoding="utf-8").splitlines()) == ["A", "B", "D"]
 
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
-    snap = latest_pipeline_state("run-par-tf", state_log)
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snap = latest_pipeline_state("run-par-tf", state_log, scope=GLOBAL_SCOPE)
     for name in ("a", "b", "c", "d"):
         assert f"0.parallel.{name}" in snap["completed_step_results"]
     assert snap["completed_step_results"]["0.parallel.c"]["__fan_out_dropped__"] is True
@@ -719,7 +720,8 @@ async def test_truncate_falsify_compositional_branch_sub_step_survives_mid_branc
     # durably present even though the branch — and the whole parallel — never
     # completed.
     from reyn.core.events.pipeline_recovery import latest_pipeline_state
-    snap = latest_pipeline_state("run-par-comp-tf", state_log)
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snap = latest_pipeline_state("run-par-comp-tf", state_log, scope=GLOBAL_SCOPE)
     assert snap["completed_step_results"]["0.parallel.x.call.0"] == {
         "text": "", "structured": {"wrote": "X-a"},
     }

--- a/tests/core/test_pipeline_r5_agent_step_executor.py
+++ b/tests/core/test_pipeline_r5_agent_step_executor.py
@@ -294,10 +294,11 @@ async def test_resume_replays_completed_agent_step_without_rerunning_llm_turn(
     )
 
     full_pipeline = Pipeline(steps=[step0, step1, step2])
+    from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
     resumed = await executor.resume(
         "run-agent-truncate", pipeline=full_pipeline,
         tool_dispatch=lambda *_a, **_k: None,
-        state_log=state_log, registry=reg,
+        state_log=state_log, registry=reg, scope=GLOBAL_SCOPE,
     )
 
     assert scripted.calls == 1, (


### PR DESCRIPTION
**[e2e-coder]** — #5769 stage 3: `checkout` writes a scoped reset-record; recovery reads it.

part of #5769 (writer + recovery half only — `list_rewind_points`'s per-session shape and the UI are later, per architect's own explicit split; the UI needs owner input, so nothing here depends on it).

## Scope (architect's plan: https://github.com/tya5/reyn/issues/5769#issuecomment-5550491143)

1. **Writer** — `checkout(state_log, *, target_seq, scope, supersedes)` and `AgentRegistry.checkout(seq, *, scope)`. Scoped: cancel/quiesce **only** the target session, materialise **only** that `(name, sid)`. **Retention guard stays global.**
2. **Recovery** — `recover_rewind_if_needed` reads `(target_n, scope)` off the latest reset-record, materialises only that pair when scoped.
5. **Decision 7** — an item whose owner can't be named is skipped observably, never silently defaulted to global. Resolved via architect's (c) ruling, then tightened once more — see below.

## Changes

- `snapshot_generations.checkout(state_log, *, target_seq, scope=None, supersedes=None)`: `scope=None` (default) writes the **exact same WAL entry** as before this parameter existed — no `scope` key at all — so every one of the ~20 existing direct test call sites across the suite is untouched. `scope=(agent, sid)` writes that pair. Deliberately a **default** here, unlike the read-side contracts below — explained inline: a forgotten scope on the *write* side just writes today's well-understood global record; there's no "wrong branch" to silently read the way a forgotten scope on a *read* side would cause.
- `active_rewind_target_with_scope`: new sibling of `active_rewind_target`, returning `(target_n, scope)`. The existing function is untouched.
- `AgentRegistry.checkout(seq, *, scope=None)`: `scope=None` is the existing 5-step global path, byte-identical. `scope=(name, sid)` cancels/quiesces only that session (if loaded), appends a scoped reset-record, materialises only that pair. The retention guard (`_oldest_kept_seq`) stays global regardless of scope — architect's explicit ruling, unchanged code path either way.
- `AgentRegistry._materialize_rewind(..., scope=None)`: `scope=None` is the existing full global pass, byte-identical. `scope=(name, sid)` returns immediately after bringing only that session's own substrate to as-of-cut — no agent create/drop/archive/purge, no topology or config-generation reconcile, no spawn-lineage rebuild (decision 4/6).
- `AgentRegistry.recover_rewind_if_needed`: reads `(target_n, scope)` via the new sibling function; `scope=None` takes the unchanged full path, `scope=(name, sid)` materialises only that pair on crash recovery.

## Decision 7 — resolved in two rounds

**Round 1 (architect's (c) ruling, https://github.com/tya5/reyn/pull/5778#issuecomment-5550650241)**: the PR originally disclosed a deviation — `pipeline_recovery.latest_pipeline_state` couldn't follow decision 7's literal "observably skip" shape without breaking `resume`'s exactly-once guarantee. Architect's fix: change the function's own signature. `latest_pipeline_state(run_id, state_log, *, scope)` now takes `scope` directly (required, no default) from the caller, who already holds it (`PipelineWorkOrder`) — eliminating the `invocation.json` read, warning log, `GLOBAL_SCOPE` fallback, and the decision-7 exception itself.

**Round 2 (lead-coder-30's follow-up finding, https://github.com/tya5/reyn/pull/5778#issuecomment-5550751829, architect confirmed https://github.com/tya5/reyn/pull/5778#issuecomment-5550786970)**: `PipelineExecutor.resume()`'s own new `scope` parameter still carried a `GLOBAL_SCOPE` *default*, silently re-opening the same hole one layer out — a forgotten `scope` at a NEW call site would get GLOBAL_SCOPE with no red. Architect's discriminator: "a default is only justified when it's the right answer for a caller with nothing to say — when two real choices exist and the caller always knows which applies, a default is not justified." `GLOBAL_SCOPE` here is a substantive (and unsafe-direction — it resurrects a run a scoped rewind should hide) claim, not silence, and the one real caller always knows its answer. Fix: `scope` is now required on `resume()` too, no default. The 17 owner-less R3/R4/primitive-mechanics test call sites this broke now pass `scope=GLOBAL_SCOPE` explicitly — per architect, not redundancy, but each test declaring which scope it resumes under (previously unwritten).

**Deferred, by design** (lead-coder-30 will file separately): the driver reads `latest_pipeline_state` directly at `:246` (checked, discarded) and `resume()` re-reads it again internally — passing the already-read snapshot into `resume()` would remove the `scope` parameter (and the default question) entirely. Not required to close this bug's class; out of scope here.

## Tests

`tests/core/test_5769_stage3_checkout_scope.py` — 7 real, driven tests, no mocks:
- `scope=None` writes the same WAL shape as before.
- A scoped checkout writes the `scope` field, and the retention guard still rejects a truncated target for a scoped checkout too.
- A scoped checkout touches only its own session — an unrelated agent gets **no snapshot at all** (caught and fixed a real bug in my own first draft here: it asserted the wrong "untouched" witness).
- Crash recovery materialises only the scoped pair, and stays global for a legacy unscoped record.
- **The CLAUDE.md hard-rule truncate-falsify test**: write a scoped checkout, truncate the WAL PAST its own supporting events, reconstruct from the surviving self-contained snapshot alone, confirm the scoped rewind's effect survives.

`tests/core/test_5769_stage3_pipeline_resume_scope.py` (new, for the (c) ruling, now 5 tests) — required-kwarg contract on both `latest_pipeline_state` AND `resume()` itself (the second added per lead-coder-30's final BLOCKING: round 2 removed `resume()`'s default but had no committed test pinning it, only a reported strip-falsify witness — fixed same-PR), exact-scope narrowing, GLOBAL_SCOPE ignoring any scoped rewind, and a strip-falsified witness that `resume()` really forwards its own `scope` (an intentionally-impossible recorded `step_index=5`, hidden by a scoped rewind, a real registered tool via the same DI-via-monkeypatch idiom `test_pipeline_is6_attached.py`'s own `_install_counting_tool` helper already uses).

`test_5769_stage2_scoped_derivation.py` — deleted its 2 tests for the now-removed invocation.json-reading mechanism; the remaining 3 store-level signature tests are untouched.

26 other `latest_pipeline_state`/`resume()` call sites made their scope explicit (`scope=GLOBAL_SCOPE`) across the R3/R4/primitive-mechanics test surface — 9 for `latest_pipeline_state`'s required kwarg (round 1), 17 for `resume()`'s (round 2) — all owner-less, no scoped-rewind concern in play.

Every scope-narrowing claim strip-falsified: temporarily broke the corresponding production code via in-file `Edit` (never `git checkout`/`stash`), confirmed a genuine RED (including a real `TypeError` for `resume()`'s now-required `scope`), restored via `Edit`, re-confirmed green.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on touched/new test files (98/98 OK)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py` (200/208, unchanged, all pre-baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`, `check_file_depth_reference.py` (tests/ touched)
- [x] `pytest` scoped to the diff + the full rewind/branch-tree/pipeline-recovery/config-generation/spawn-routing/pipeline-primitives/is2-is6/r3-r4 test surface: 188 tests, all green
- [ ] (skipped — Visual, standing waiver 2026-08-08)

TESTS-READ / merge: lead-coder-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)