### PR TITLE
feat(#5774): wire mcp_probe_states, hooks_config_warnings, ctx_recent_usage to remote

### DIFF
--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -637,6 +637,11 @@ def _resolve_reported_snapshot_keys_spread(node: "ast.expr") -> "list[str] | Non
 #: makes the repair-obligation message in :func:`find_new_unwired_key_
 #: violations` mechanically askable per key, not just a generic reminder.
 _LOCAL = "LOCAL"
+#: #5774 wired every key this baseline had marked PENDING — no entry uses
+#: this disposition right now. Kept defined (not deleted): the NEXT
+#: genuinely-real-but-not-yet-wired key found needs it, and re-adding a
+#: whole disposition vocabulary from scratch is a worse failure mode than
+#: one temporarily-unused constant.
 _PENDING = "PENDING"
 
 #: #5771 (lead-coder BLOCKING, PR #5773 head 2c59bbfc0): "①に無い key を②が
@@ -654,15 +659,12 @@ _PENDING = "PENDING"
 #: flagged — encouraged, not required, so a fix elsewhere never needs to
 #: touch this file.
 #:
-#: 38 entries (was 40 — #5771 stage② wired ``cost_usd``/``usage``/
-#: ``session_cached_tokens`` for real and removed them here, then added 1
-#: new spread field, ``session_cache_usage_reported``, split off ``cache_
-#: usage_reported`` on the SAME PR; a wired key is no longer unwired-key
-#: drift at all, so a baseline entry for it would be a standing lie about
-#: the gate's own findings). PENDING (2): ``hooks_config_warnings``/
-#: ``mcp_probe_states`` — real session data, not yet wired, filed on
-#: #5774 for triage (see their own entries below for the citation).
-#: LOCAL (36): 14 literal
+#: 35 entries (was 38 — #5774 wired ``mcp_probe_states``/``hooks_config_
+#: warnings``/``ctx_recent_usage`` for real and removed them here; a
+#: wired key is no longer unwired-key drift at all, so a baseline entry
+#: for it would be a standing lie about the gate's own findings). PENDING
+#: (0): none remain — #5774 closed both entries #5773's own baseline had
+#: filed on it. LOCAL (35): 13 literal
 #: output keys whose OWN inline comment in ``project_remote_snapshot``
 #: already says the underlying data is session-local/client-local by
 #: construction (``skills``/``mcp_servers``/``turn_usage_fn`` already sit
@@ -681,31 +683,24 @@ _PENDING = "PENDING"
 #: reported``/``visibility_items_reported``/``mcp_subscriptions_
 #: reported`` — since what they report reflects reaches the wire under
 #: OTHER, real key names, e.g. ``agent_names``/``session_tree``, never
-#: under the flag's own name). ``hooks_config_warnings`` and ``mcp_probe_
-#: states`` are marked PENDING, not LOCAL, DESPITE looking like the other
-#: session-local literal keys above — their own inline comments in
-#: ``project_remote_snapshot`` explicitly say "not wired onto the wire
-#: YET" (not "structurally cannot exist"), the opposite framing the LOCAL
-#: entries' own comments use — genuinely different from the other 36,
-#: filed on #5774 for real triage rather than guessed here.
+#: under the flag's own name). Note: ``mcp_probe_states_reported``/
+#: ``hooks_config_warnings_reported`` (the SPREAD FLAG names) stay LOCAL
+#: below even though their own underlying DATA keys (``mcp_probe_
+#: states``/``hooks_config_warnings``) are wired now — the flag's own
+#: name is still never itself a ``project_status`` key, same reasoning
+#: as every other spread field.
+#:
+#: #5774 (lead-coder's own correction): the PENDING entries this baseline
+#: used to carry for ``hooks_config_warnings``/``mcp_probe_states`` — and
+#: ``ctx_recent_usage``'s own LOCAL entry — were reached by conflating
+#: "this gate's shape-detector can't parse a tuple" (a #5093-era disclosed
+#: gap, ``ctx_recent_usage`` specifically) with "no real wiring is
+#: needed" — two different questions. All 3 are real, per-connection data
+#: with a genuine consumer; #5774 wired them for real rather than leaving
+#: them as disclosed debt.
 _UNWIRED_KEY_VIOLATIONS_BASELINE: "dict[str, str]" = {
-    # #5771 stage②: "cost_usd"/"usage"/"session_cached_tokens" REMOVED —
-    # all 3 are now genuinely, unconditionally on the wire (project_status
-    # emits them for real); find_unwired_key_violations no longer flags
-    # them at all, so a baseline entry for them would be a standing lie
-    # (lead-coder's own instruction on the stage② dispatch: "残すと gate
-    # は緑のまま宣言が嘘になります" — leaving it would keep the gate green
-    # while the declaration itself became false).
-    #
-    # PENDING — real session data, explicitly "not wired onto the wire
-    # YET" per project_remote_snapshot's own inline comment (unlike the
-    # LOCAL entries below, whose own comments say the opposite) -- #5774
-    # triage, not guessed here.
-    "hooks_config_warnings": _PENDING,
-    "mcp_probe_states": _PENDING,
     # LOCAL — genuinely, permanently session-local per each key's own
     # inline comment in project_remote_snapshot.
-    "ctx_recent_usage": _LOCAL,
     "ctx_source": _LOCAL,
     "ctx_compaction_status_fn": _LOCAL,
     "compaction_progress_raw": _LOCAL,

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -430,11 +430,13 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     has_command_ui_region=False,
     conversation_history=False,
     load_older_conversation_history=False,
-    # #5771 stage②: ctx_recent_usage (this field's own sole remaining
-    # consumer, the Ctx pane's recent-call cache line — see the field's
-    # own docstring for the split) is NOT one of stage②'s 8 wired keys —
-    # stays False.
-    cache_usage_reported=False,
+    # #5774: ctx_recent_usage (this field's own sole remaining consumer
+    # after #5771 stage②'s split — the Ctx pane's recent-call cache
+    # line) is wired for real now too — True, not False. (lead-coder's
+    # own correction: this key had been read as "the gate's shape-
+    # detector can't parse a tuple, so no wiring is needed" — the
+    # detector gap and the wiring gap were never the same question.)
+    cache_usage_reported=True,
     cron_jobs_reported=False,
     # #5771 stage②: usage (prompt/completion/total) is now genuinely
     # wired — was a fixed (0, 0, agent_tokens) placeholder before this PR.
@@ -447,13 +449,19 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     attached_name_reported=True,
     visibility_items_reported=True,
     mcp_subscriptions_reported=True,
-    # #4401 ②: not yet wired onto the AG-UI wire (see the field's own
-    # docstring) — False, not True.
-    mcp_probe_states_reported=False,
-    # #5100/#5272: not yet wired onto the AG-UI wire (no producer projects
-    # the server session's real hooks_config_warnings for a remote
-    # client to read) -- False, not True; see the field's own docstring.
-    hooks_config_warnings_reported=False,
+    # #5774: wired onto the AG-UI wire for real now (project_remote_
+    # snapshot's own "mcp_probe_states" reads the real key) — True, not
+    # False. NOTE: the RETRY ACTION itself (AgUiTransport.
+    # request_mcp_retry) is a SEPARATE, still-unwired gap (no real server
+    # op yet) — a remote mcp pane now shows the real probe state,
+    # including a genuinely "failed" row, but retrying it from a remote
+    # client is still a no-op on this transport; see that method's own
+    # docstring.
+    mcp_probe_states_reported=True,
+    # #5774: wired onto the AG-UI wire for real now (project_remote_
+    # snapshot's own "hooks_config_warnings" reads the real key) — True,
+    # not False.
+    hooks_config_warnings_reported=True,
     compaction_progress_reported=False,
     tasks_reported=False,
     # #5771 stage②: session_cached_tokens is now genuinely wired — see
@@ -931,6 +939,10 @@ _WIRE_KEYS = frozenset({
     "ctx_window", "queue", "turn_active", "queue_seq",
     "cost_breakdown_session", "cost_breakdown_agent", "cost_breakdown_project",
     "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens",
+    # #5774: mcp_probe_states/hooks_config_warnings/ctx_recent_usage all
+    # joined the same way — real data, project_status now unconditionally
+    # emits every one of them.
+    "mcp_probe_states", "hooks_config_warnings", "ctx_recent_usage",
 })
 
 
@@ -1032,19 +1044,22 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # below is not). Consulted by `chrome.py`'s cost-pane cache line
         # only; the ctx-pane one keeps reading ``cache_usage_reported``.
         "session_cached_tokens": v.get("session_cached_tokens", 0),
-        # `(0, 0)` below is the correct graceful-degrade VALUE (neither
-        # is projected onto the AG-UI wire — cache-hit accounting is
-        # session-local); gated by ``cache_usage_reported`` above,
-        # consulted by `chrome.py`'s `_cache_hit_line` for the Ctx pane's
-        # recent-call line, so it renders a "not reported" line instead
-        # of a fabricated "0% hit (0 / 0)".
-        #
-        # Scope, explicit (architect, #5009): this is NOT the owner's actual
-        # "cache stuck at 0%" observation — that was measured on a LOCAL
-        # session (owner-confirmed) and is a separate, still-unresolved
-        # symptom this key does not touch. This key only makes the REMOTE
-        # "0 could mean unsupported" case honestly say so.
-        "ctx_recent_usage": (0, 0),
+        # #5774: real wire data now — (recent_prompt, recent_cached), the
+        # single most-recent call's own cache figures (Session.
+        # last_call_usage). Was the LAST key #5773's own axis-split left
+        # behind: cache_usage_reported used to cover this key AND
+        # session_cached_tokens together (#5009); #5771 stage② wired only
+        # the latter for real and split off session_cache_usage_reported
+        # for it, leaving cache_usage_reported (this key's own, now sole,
+        # axis) still False — the exact "same cache stat reaches the Cost
+        # pane as real data, stays 'not reported' on the Ctx pane" gap
+        # lead-coder's own #5774 follow-up named (correcting an earlier
+        # "the gate's shape-detector can't parse a tuple" read as "no
+        # wiring needed" — the detector gap and the wiring gap were never
+        # the same question). Gated by ``cache_usage_reported`` above,
+        # now ``True`` for remote, consulted by `chrome.py`'s
+        # `_cache_hit_line` for the Ctx pane's recent-call line.
+        "ctx_recent_usage": v.get("ctx_recent_usage", (0, 0)),
         "ctx_source": "remote",
         # #5771 stage②: the current/most-recent turn's own total — real
         # wire data (agui/state.py's own ``project_status``), ``None``
@@ -1117,12 +1132,16 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # so `[]` is the correct default for BOTH "genuinely no
         # subscriptions" and "key not yet on the wire" here.
         "mcp_subscriptions": v.get("mcp_subscriptions", []),
-        # `[]` below is correct (per-server probe state is not on the wire
-        # yet — RouterHostAdapter.mcp_probe_snapshot() is session-local,
-        # #4401 ②); gated by ``mcp_probe_states_reported`` above so the mcp
-        # pane renders "not reported" instead of a fabricated "not_probed"
-        # row for every server.
-        "mcp_probe_states": [],
+        # #5774: real wire data now — RouterHostAdapter.mcp_probe_
+        # snapshot() (#4401 ②③) rides the wire the same way agent_names/
+        # session_tree do (#5094's own pattern); gated by
+        # ``mcp_probe_states_reported`` above, now ``True`` for remote
+        # (see REMOTE_CHAT_READ_CAPABILITIES) so the mcp pane renders the
+        # real per-server state instead of "not reported". Owner's own
+        # stated purpose for #4401 ("tui mcp tab でユーザは気付けて対処
+        # できる") was silently unmet for a remote attach until this key
+        # rode the wire — a probe failure was invisible there.
+        "mcp_probe_states": v.get("mcp_probe_states", []),
         # `[]` below is correct (pipeline registry is not on the wire);
         # gated by ``pipelines_reported`` above so `pipe_pane_lines`
         # renders "not reported" instead of its own `["(none)"]` fallback
@@ -1151,14 +1170,14 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         # count-only (here, no-indicator-at-all) fallback in
         # config_warning_text, never a fabricated key list.
         "unknown_config_keys": {},
-        # `[]` below is correct (per-session hooks.yaml parsing lives on the
-        # SERVER's Session, not projected onto the wire); gated by
-        # `hooks_config_warnings_reported` above so `config_warning_text`
-        # can tell "genuinely no warnings" apart from "this connection
-        # can't report them" — unlike `unknown_config_key_count`/
+        # #5774: real wire data now — Session.hooks_config_warnings is
+        # per-session SERVER state (unlike `unknown_config_key_count`/
         # `unknown_config_keys` just above, which name the CLIENT's own
-        # reyn.yaml and are structurally absent on a remote connection.
-        "hooks_config_warnings": [],
+        # reyn.yaml and stay structurally absent on a remote connection);
+        # gated by `hooks_config_warnings_reported` above, now ``True``
+        # for remote so `config_warning_text` shows the real warnings
+        # instead of degrading to "not reported".
+        "hooks_config_warnings": v.get("hooks_config_warnings", []),
         # `[]` below is correct (task substrate is session-local, never on
         # the wire); gated by ``tasks_reported`` above so the Task pane
         # renders "not reported" instead of a `[]` that would be

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -342,9 +342,20 @@ class ChatReadModelCapabilities:
     # that ITS data is real too — the same "one spelling, two facts"
     # shape architect flagged on #5773's baseline during this same PR's
     # own review. `cache_usage_reported` keeps its EXISTING name and
-    # scope (the Ctx pane's recent-call line only, still False for
-    # remote); this new field covers ONLY the Cost pane's cumulative
-    # cache line (`chrome.py`'s OTHER `_cache_hit_line` call site).
+    # scope (the Ctx pane's recent-call line only) — this new field
+    # covers ONLY the Cost pane's cumulative cache line (`chrome.py`'s
+    # OTHER `_cache_hit_line` call site).
+    #
+    # #5774 (lead-coder BLOCKING, PR #5780): both flags are `True` for
+    # REMOTE now (`cache_usage_reported`'s own `ctx_recent_usage` got
+    # wired too, on this same PR) — this does NOT make the split
+    # pointless. The two answer DIFFERENT questions (Ctx pane's
+    # most-recent-call figure vs. Cost pane's session-cumulative figure)
+    # and can go out of sync independently in the future — either one
+    # could regress to unwired on its own without the other moving. The
+    # split is a structural fact about what each flag MEANS, not a
+    # description of today's VALUES; do not re-merge them just because
+    # both happen to read `True` right now.
     session_cache_usage_reported: bool
 
 
@@ -466,7 +477,12 @@ REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     tasks_reported=False,
     # #5771 stage②: session_cached_tokens is now genuinely wired — see
     # the field's own docstring for why this is a SPLIT from
-    # cache_usage_reported (which stays False above), not the same flag.
+    # cache_usage_reported above, not the same flag. #5774 later wired
+    # cache_usage_reported's own key (ctx_recent_usage) too, so both now
+    # read True — that is a coincidence of TODAY's state, not a reason to
+    # merge them back: they answer different questions (Ctx pane
+    # most-recent-call vs. Cost pane session-cumulative) and can drift
+    # apart again independently — see the field's own docstring.
     session_cache_usage_reported=True,
 )
 

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -744,15 +744,16 @@ class AgUiTransport(ClientTransport):
         return bool(await self._send({"type": "cancel_queued", "msg_id": msg_id}))
 
     async def request_mcp_retry(self, server: str) -> bool:
-        # #4401 ③: NOT wired to a real server op yet — #4401 ②'s own
-        # `mcp_probe_states` never reaches this wire either
-        # (`mcp_probe_states_reported=False` for REMOTE, read_model.py),
-        # so a remote client's mcp pane never shows the retry row that
-        # would call this in the first place; only someone typing the
-        # command by hand on a --connect client reaches here. ``False`` —
-        # "did not happen here" — same disclosed-gap shape #4401 ②
-        # already committed to for remote, not a silent no-op invented
-        # for this method alone.
+        # #4401 ③: NOT wired to a real server op yet. #5774 wired #4401
+        # ②'s own `mcp_probe_states` data onto the wire for real
+        # (`mcp_probe_states_reported=True` for REMOTE, read_model.py) —
+        # a remote client's mcp pane DOES now show the real per-server
+        # probe state, including a genuinely "failed" row with its own
+        # retry affordance. Calling THIS method from that row is still a
+        # no-op, though: the retry ACTION itself has no real server-side
+        # RPC on this transport yet, a separate gap from the DATA gap
+        # #5774 closed. ``False`` — "did not happen here" — same
+        # disclosed-gap shape as before, now scoped to the action only.
         return False
 
     async def clear_pending_command_ui(self) -> None:

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -104,6 +104,23 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         # narrowed" the moment this key happened to be absent from `snap`.
         "visibility_items": snap.get("visibility_items"),
         "mcp_subscriptions": snap.get("mcp_subscriptions", []),
+        # #5774: the mcp pane's per-server 3(+1)-state probe display
+        # (#4401 ②③ — "answered"/"failed"/"not_probed"/"retrying") — a
+        # plain list of small dicts (name/state/tool_count/reason/
+        # detail), already JSON-safe as-is, no encode step needed. Real,
+        # per-connection data (RouterHostAdapter.mcp_probe_snapshot());
+        # owner's own stated purpose for #4401 ("tui mcp tab でユーザは
+        # 気付けて対処できる") was silently unmet for a remote attach
+        # until this key rode the wire — see project_remote_snapshot's
+        # own comment for the *_reported flip this pairs with.
+        "mcp_probe_states": snap.get("mcp_probe_states", []),
+        # #5774: per-session hooks.yaml parse warnings — a plain list of
+        # strings, already JSON-safe. Real SESSION state (`Session.
+        # hooks_config_warnings`) — unlike `unknown_config_key_count`/
+        # `unknown_config_keys` (project_remote_snapshot's own client-
+        # local keys, which name the CLIENT's own reyn.yaml and never
+        # appear here at all), this one genuinely belongs on the wire.
+        "hooks_config_warnings": snap.get("hooks_config_warnings", []),
         "cost_agent": snap.get("cost_agent", 0.0),
         "cost_total": snap.get("cost_total", 0.0),
         # #5771 stage②: the session-cumulative TOTAL (a different fact
@@ -129,6 +146,13 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         "agent_tokens": snap.get("agent_tokens", 0),
         "ctx_used": snap.get("ctx_used", 0),
         "ctx_window": snap.get("ctx_window", 0),
+        # #5774: the single most-recent call's own cache figures
+        # (Session.last_call_usage) — a plain int pair, already JSON-safe.
+        # This is the LAST key #5773's own axis-split left behind (see
+        # read_model.py's own comment at this key for the full "one
+        # spelling, two facts" history lead-coder's #5774 follow-up
+        # corrected).
+        "ctx_recent_usage": snap.get("ctx_recent_usage", (0, 0)),
         # #5771 stage②: cache-hit accounting is genuinely measured
         # LOCALLY (status.py's own inline comment at this key) — now
         # forwarded for real, the same pattern #5094/#5185 already used

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -255,11 +255,13 @@ class ClientTransport(ABC):
         (the slash handler) needs the real outcome to report.
 
         ``False`` means "did not happen here" (no attached session locally,
-        or not yet supported on this transport — #4401's own scope: remote/
-        AG-UI does not carry `mcp_probe_states` on the wire yet either, so a
-        remote client's mcp pane never shows the retry row in the first
-        place; this only matters for someone typing the command by hand) —
-        mirrors :meth:`cancel_queued`'s own convention.
+        or not yet supported on this transport — #5774 wired `mcp_probe_
+        states` itself onto the AG-UI wire for real, so a remote mcp pane
+        DOES now show a genuinely "failed" row with its own retry
+        affordance; the RETRY ACTION here is a separate, still-unwired
+        gap — no real server-side RPC on this transport yet, #4401 ③'s
+        own remaining scope) — mirrors :meth:`cancel_queued`'s own
+        convention.
 
         Abstract: the no-op-``False`` default body lives on
         :class:`ClientTransportStub`; ``InProcessTransport`` overrides it

--- a/tests/interfaces/test_5009_cache_reported_declaration.py
+++ b/tests/interfaces/test_5009_cache_reported_declaration.py
@@ -81,9 +81,17 @@ from reyn.interfaces.repl.read_model import (
 
 def test_capabilities_declare_cache_usage_reported():
     """Tier 1: the declaration itself, on both constants — the SSoT every
-    `snapshot()` producer must derive from rather than hand-type."""
+    `snapshot()` producer must derive from rather than hand-type.
+
+    #5774: `cache_usage_reported` (this key's own SOLE remaining
+    consumer after #5771 stage②'s axis split — the Ctx pane's recent-
+    call cache line, `ctx_recent_usage`) flips to `True` for remote too
+    — real wire data now (lead-coder's own correction: this key's tuple
+    shape being invisible to #5093's own AST walk had been misread as
+    "no wiring needed", a different question from whether the data is
+    real)."""
     assert LOCAL_CHAT_READ_CAPABILITIES.cache_usage_reported is True
-    assert REMOTE_CHAT_READ_CAPABILITIES.cache_usage_reported is False
+    assert REMOTE_CHAT_READ_CAPABILITIES.cache_usage_reported is True
 
 
 def test_the_snapshot_key_helper_derives_from_the_capabilities_it_is_given():
@@ -93,17 +101,26 @@ def test_the_snapshot_key_helper_derives_from_the_capabilities_it_is_given():
     key` — see that function's own docstring) — its `cache_usage_
     reported` entry always matches the source it was given, nothing
     hand-typed alongside it. Both real producers call this (see the
-    tests below), so this pins the ONE function they both depend on."""
+    tests below), so this pins the ONE function they both depend on.
+
+    #5774: `True` for remote now — see `test_capabilities_declare_
+    cache_usage_reported` above for why."""
     assert reported_snapshot_keys(LOCAL_CHAT_READ_CAPABILITIES)["cache_usage_reported"] is True
-    assert reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)["cache_usage_reported"] is False
+    assert reported_snapshot_keys(REMOTE_CHAT_READ_CAPABILITIES)["cache_usage_reported"] is True
 
 
-def test_remote_snapshot_declares_cache_usage_unreported():
+def test_remote_snapshot_declares_cache_usage_reported_now():
     """Tier 1: the REAL producer — `project_remote_snapshot` — carries the
-    declaration through to its own output, paired with the graceful
-    `0`/`(0, 0)` values those same 2 keys already carried."""
+    declaration through to its own output.
+
+    #5774: renamed from `..._declares_cache_usage_unreported` — both
+    `session_cached_tokens` (#5771 stage②) and `ctx_recent_usage`
+    (#5774) are real wire data now, so this producer's own `(0, 0)` for
+    `ctx_recent_usage` here is the genuine graceful degrade for an EMPTY
+    ``values`` dict (no server data at all), not a permanent "unreported"
+    default — the axis itself is `True`."""
     snap = project_remote_snapshot({})
-    assert snap["cache_usage_reported"] is False
+    assert snap["cache_usage_reported"] is True
     assert snap["session_cached_tokens"] == 0
     assert snap["ctx_recent_usage"] == (0, 0)
 

--- a/tests/interfaces/test_5771_cost_tab_wired_to_remote.py
+++ b/tests/interfaces/test_5771_cost_tab_wired_to_remote.py
@@ -144,8 +144,12 @@ def test_the_8_reported_axes_flip_true_for_remote_once_wired() -> None:
     remote_snap = project_remote_snapshot(wire_values)
     assert remote_snap["usage_breakdown_reported"] is True
     assert remote_snap["session_cache_usage_reported"] is True
-    # ctx_recent_usage's own axis is UNCHANGED by this stage — still False.
-    assert remote_snap["cache_usage_reported"] is False
+    # #5774: ctx_recent_usage (this axis's own sole remaining consumer
+    # after this stage's own split) is wired for real too, on a LATER PR
+    # — see test_5774_mcp_hooks_ctx_wired_to_remote.py for that stage's
+    # own assertions; this file's own claim here is scoped to what THIS
+    # stage (#5771) actually flipped.
+    assert remote_snap["cache_usage_reported"] is True
 
 
 def test_an_old_server_that_never_sent_the_new_keys_degrades_gracefully() -> None:

--- a/tests/interfaces/test_5774_mcp_hooks_ctx_wired_to_remote.py
+++ b/tests/interfaces/test_5774_mcp_hooks_ctx_wired_to_remote.py
@@ -1,0 +1,124 @@
+"""Tier 2: #5774 — the 3 remaining #5773-exposed keys reach a remote client.
+
+lead-coder's own follow-up dispatch after #5771 landed: mcp_probe_states
+(#4401 ②③'s own per-server probe display — owner's stated purpose, "tui mcp
+tab でユーザは気付けて対処できる", was silently unmet for a remote attach)
+and hooks_config_warnings were both real, per-connection server state that
+had been mis-triaged as permanently session-local. ctx_recent_usage was a
+THIRD case found mid-review: #5771 stage②'s own axis split
+(cache_usage_reported -> session_cache_usage_reported) fixed the Cost
+pane's cache-hit figure but left the Ctx pane's sibling figure on the same
+old, now-stale "not reported" axis value.
+
+Real project_status/project_remote_snapshot throughout — no mocks.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.textual_chat.chrome import config_warning_text, ctx_pane_lines
+from reyn.interfaces.repl.read_model import project_remote_snapshot
+from reyn.interfaces.transport.agui.state import project_status
+
+
+def _local_snapshot() -> dict:
+    """A LOCAL _snapshot()-shaped dict carrying the 3 fields status.py's
+    real producer already builds."""
+    return {
+        "mcp_probe_states": [
+            {"name": "server-a", "state": "answered", "tool_count": 5},
+            {"name": "server-b", "state": "failed", "reason": "timeout"},
+            {"name": "server-c", "state": "not_probed"},
+        ],
+        "hooks_config_warnings": ["hooks.yaml could not be read: bad.yaml (~/.reyn/agents/x)"],
+        "ctx_window": 200000,
+        "ctx_used": 48120,
+        "ctx_recent_usage": (48120, 14900),
+    }
+
+
+def test_project_status_carries_the_3_keys_for_real() -> None:
+    """Tier 2: agui/state.py's project_status emits real values, not a
+    placeholder, for all 3."""
+    out = project_status(_local_snapshot())
+    assert "mcp_probe_states" in out
+    assert out["mcp_probe_states"] == [
+        {"name": "server-a", "state": "answered", "tool_count": 5},
+        {"name": "server-b", "state": "failed", "reason": "timeout"},
+        {"name": "server-c", "state": "not_probed"},
+    ]
+    assert out["hooks_config_warnings"] == [
+        "hooks.yaml could not be read: bad.yaml (~/.reyn/agents/x)",
+    ]
+    assert out["ctx_recent_usage"] == (48120, 14900)
+
+
+def test_project_remote_snapshot_carries_all_3_through() -> None:
+    """Tier 2: the wire round-trip — no more fixed [] / [] / (0, 0)
+    placeholders (#5773's own root cause, extended to these 3 by #5774)."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+
+    assert remote_snap["mcp_probe_states"] == [
+        {"name": "server-a", "state": "answered", "tool_count": 5},
+        {"name": "server-b", "state": "failed", "reason": "timeout"},
+        {"name": "server-c", "state": "not_probed"},
+    ]
+    assert remote_snap["hooks_config_warnings"] == [
+        "hooks.yaml could not be read: bad.yaml (~/.reyn/agents/x)",
+    ]
+    assert remote_snap["ctx_recent_usage"] == (48120, 14900)
+
+
+def test_the_3_reported_axes_flip_true_for_remote() -> None:
+    """Tier 2: the *_reported declarations gating these keys' own
+    consumers (chrome.py) are genuinely True for remote now."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+    assert remote_snap["mcp_probe_states_reported"] is True
+    assert remote_snap["hooks_config_warnings_reported"] is True
+    assert remote_snap["cache_usage_reported"] is True
+
+
+def test_an_old_server_that_never_sent_these_3_keys_degrades_gracefully() -> None:
+    """Tier 2: backward compat — an empty ``values`` dict simulates a
+    pre-#5774 server's own STATE_SNAPSHOT (never populated these keys).
+    project_remote_snapshot must fall back to the SAME graceful-degrade
+    values the pre-#5774 placeholders already used."""
+    remote_snap = project_remote_snapshot({})
+    assert remote_snap["mcp_probe_states"] == []
+    assert remote_snap["hooks_config_warnings"] == []
+    assert remote_snap["ctx_recent_usage"] == (0, 0)
+
+
+def test_ctx_pane_renders_the_real_recent_cache_figure_once_wired() -> None:
+    """Tier 2: end-to-end witness (chrome.py's own consumer, not just the
+    read-model layer) — the Ctx pane's recent-call cache line renders a
+    real percentage now that cache_usage_reported is True for remote,
+    mirroring test_5011_ctx_cache_line_note.py's own established
+    assertions but driven off the real project_remote_snapshot output.
+
+    Scoped to the CACHE line specifically (#5588's own established
+    caution, test_5009_cache_reported_declaration.py's own docstring): a
+    blanket "not reported" not in blob would also trip on this pane's
+    OTHER, independently-gated rows (compaction/folded) that are
+    genuinely unreported here and out of this test's own scope."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+    blob = "\n".join(ctx_pane_lines(remote_snap))
+    assert "31% hit" in blob, blob
+    (cache_line,) = [ln for ln in ctx_pane_lines(remote_snap) if ln.strip().startswith("cache")]
+    assert "not reported" not in cache_line, cache_line
+
+
+def test_config_warning_text_renders_the_real_hooks_warning_once_wired() -> None:
+    """Tier 2: end-to-end witness — config_warning_text (chrome.py) shows
+    the real hooks.yaml warning text now that hooks_config_warnings_
+    reported is True for remote, instead of degrading."""
+    wire_values = project_status(_local_snapshot())
+    remote_snap = project_remote_snapshot(wire_values)
+    text = config_warning_text(
+        0, keys=None,
+        hooks_warnings=remote_snap["hooks_config_warnings"],
+        hooks_warnings_reported=remote_snap["hooks_config_warnings_reported"],
+    )
+    assert text is not None
+    assert "bad.yaml" in text

--- a/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
+++ b/tests/scripts/test_5093_remote_snapshot_placeholder_declared.py
@@ -212,7 +212,8 @@ def test_main_exits_nonzero_when_only_an_unwired_key_violation_exists(
         ["model", "cost_agent", "cost_total", "cost_usd", "agent_tokens",
          "ctx_used", "ctx_window", "queue", "turn_active", "queue_seq",
          "cost_breakdown_session", "cost_breakdown_agent", "cost_breakdown_project",
-         "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens"],
+         "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens",
+         "mcp_probe_states", "hooks_config_warnings", "ctx_recent_usage"],
     )
     monkeypatch.setattr(gate_module, "_PACKAGE_DIR", remote_fixture)
     monkeypatch.setattr(gate_module, "_AGUI_STATE_PATH", status_fixture)
@@ -280,6 +281,7 @@ def test_project_status_emitting_every_wire_key_is_not_flagged(tmp_path: Path) -
          "ctx_window", "queue", "turn_active", "queue_seq",
          "cost_breakdown_session", "cost_breakdown_agent", "cost_breakdown_project",
          "usage", "session_cached_tokens", "turn_cost_usd", "turn_tokens",
+         "mcp_probe_states", "hooks_config_warnings", "ctx_recent_usage",
          "some_unrelated_extra_key"],
     )
 


### PR DESCRIPTION
**[tui-coder]** —

## What

lead-coder dispatch: #5773's own baseline (`_UNWIRED_KEY_VIOLATIONS_BASELINE`) landed with 2 `PENDING` entries after main was measured (36 LOCAL + 2 PENDING). This PR wires both, plus a 3rd found mid-review. Same procedure as #5771 stage②: real key on `project_status` → stop the `project_remote_snapshot` placeholder → flip the `*_reported` axis to `True` (axis never removed).

- **`mcp_probe_states`** (#4401 ②③'s own per-server probe display — `"answered"`/`"failed"`/`"not_probed"`/`"retrying"`). Owner's stated purpose for #4401 ("tui mcp tab でユーザは気付けて対処できる") was silently unmet for a remote attach — a probe failure was invisible there. Already a plain list of small JSON-safe dicts, no encode/decode step needed.
- **`hooks_config_warnings`**: real per-session server state (`Session.hooks_config_warnings`), not client-local config — same shape.
- **`ctx_recent_usage`** — a 3rd case found mid-review, not in the original 2-item dispatch: #5771 stage②'s own axis split (`cache_usage_reported` → `session_cache_usage_reported`) fixed the Cost pane's cache figure but left the Ctx pane's sibling figure on the stale axis value — the same cache stat reached the Cost pane as real data while the Ctx pane kept rendering "not reported". Root cause (lead-coder's own correction): this key's tuple shape being invisible to #5093's own AST detector had been read as "no wiring needed" — the detector gap and the wiring gap were never the same question.

## A gap this PR does NOT close (documented, not silently left)

The retry ACTION itself (`AgUiTransport.request_mcp_retry`) has no real server-side RPC yet — a remote mcp pane now shows a genuinely "failed" row with its own retry affordance, but clicking it there is still a no-op on this transport. Updated the 2 stale comments (`client.py`, `client_transport.py`) that claimed the probe *data* itself never reaches the wire — that claim is now false; the action-not-wired claim is what remains true.

## Baseline maintenance

`_UNWIRED_KEY_VIOLATIONS_BASELINE`: all 3 entries removed (2 `PENDING`, 1 `LOCAL`) — none of the 3 are unwired-key drift any more, so leaving them would keep the gate green while its own declaration became false. The `PENDING` disposition tag is unused now (0 entries) but kept defined for the next real one.

## UI surface touched — stated plainly

`chrome.py`'s `ctx_pane_lines` cache line and `config_warning_text` now render real data instead of degrading. Driven end-to-end tests added for both (not just the read-model layer). Visual box stays unticked (standing waiver).

## Falsify-verified

The `mcp_probe_states` wiring and the `cache_usage_reported` flip each have a dedicated test that fails when reverted (Edit-only strip/restore before push).

## Test plan

- [x] 6 new tests (`test_5774_mcp_hooks_ctx_wired_to_remote.py`): all 3 keys real, `*_reported` axes flip, old-server backward compat, 2 end-to-end `chrome.py` witnesses.
- [x] Updated 3 existing test files (`test_5009_cache_reported_declaration.py`, `test_5771_cost_tab_wired_to_remote.py`, `test_5093_remote_snapshot_placeholder_declared.py`) for the axis flip / `_WIRE_KEYS` growth.
- [x] Scoped sweep: 169 passed (interfaces/mcp/read_model/agui/config_warning/mcp_probe/client_transport-related). Broader `tests/interfaces/ tests/mcp/` sweep: 2488 passed, 1 pre-existing/environmental failure unrelated to this diff (a local-venv `fastmcp` install state, not caused by this change).
- [x] All 9 standard gates green.
- [ ] (skipped — Visual, standing waiver) — UI surface IS touched (see above); Visual itself stays unticked per the standing waiver, not because nothing changed.

part of #5774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
