### PR TITLE
feat(#5769): list_rewind_points enumerates every session id (stage 3 ③)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2322,7 +2322,8 @@ class AgentRegistry:
 
         Returns one row per snapshot-generation boundary, ascending by seq::
 
-            [{"seq": int, "ts": str, "kind": str, "anchor": str, "branch_id": int}, ...]
+            [{"seq": int, "ts": str, "kind": str, "anchor": str, "branch_id": int,
+              "sid": str}, ...]
 
         Default (``include_abandoned=False``) keeps only **active-branch** boundaries
         (Phase-1 1f timeline). Phase-2 fork UX passes ``include_abandoned=True`` to
@@ -2346,6 +2347,26 @@ class AgentRegistry:
         the union across known agents is the global rewind-point set. Abandoned
         (rewound-past) boundaries are filtered out via ``is_active_seq``.
 
+        #5769 stage 3 (③, architect scope): ``sid`` — every row's ORIGIN
+        session id, not only the agent's default ("main") one. Before this
+        stage the loop below enumerated only ``_store_for(name)`` (the
+        implicit ``_DEFAULT_SID``), so a checkpoint cut by a spawned
+        subagent session's own generation store was invisible here
+        entirely, not merely unlabeled — ``_discover_session_ids`` (the
+        same disk+in-memory discovery the rewind materialiser already
+        depends on for crash recovery) now supplies every sid to fold
+        in. A boundary seq is always the ORIGIN of exactly one (name,
+        sid) pair — a WAL entry belongs to one session's own turn/step
+        by construction (the same "seq is globally unique per event"
+        property today's per-agent union already relies on) — so ``sid``
+        is looked up per seq with no collision to resolve.
+
+        ⚠️ Scope boundary (explicit, per dispatch): this field only makes
+        the DATA available. Whether/how a caller surfaces ``sid``
+        (grouping, a column, a filter) is a presentation decision left
+        to whoever wires the timeline UI to it (owner-gated) — not
+        decided here.
+
         Empty when there is no WAL or no generations.
         """
         if self._state_log is None:
@@ -2357,28 +2378,37 @@ class AgentRegistry:
         # rejected by checkout — advertising them is misleading.
         oldest_seq = self._oldest_kept_seq()
 
-        # Union of generation boundary seqs across every known agent. Default =
-        # active branch only (1f); include_abandoned = all branches (Phase-2 tree).
+        # Union of generation boundary seqs across every known agent AND every
+        # sid of each (#5769 stage 3 ③ — was agent-default-sid-only through
+        # stage 2). Default = active branch only (1f); include_abandoned =
+        # all branches (Phase-2 tree).
         seqs: set[int] = set()
+        seq_sid: dict[int, str] = {}
         for name in self.list_names():
-            # #5769 stage 2: `_store_for(name)` (no sid) is today's own
-            # implicit "main" session — this loop's real, nameable owner
-            # per agent is (name, _DEFAULT_SID), not a placeholder. Built
-            # per agent name rather than hoisted once: `build_active_
-            # predicate`'s own record fetch is incremental/cached (#2939),
-            # so this is O(rewind records) per agent, not O(WAL) — the
-            # #2941 quadratic-WAL-scan concern this loop's own comment used
-            # to cite no longer applies (only the seq-independent
-            # DERIVATION was ever the expensive part; that stays cached
-            # regardless of how many times a scope filter runs over it).
-            is_active = build_active_predicate(
-                self._state_log, scope=(name, _DEFAULT_SID),
-            )
-            for s in self._store_for(name).seqs():
-                if oldest_seq is not None and s < oldest_seq:
-                    continue  # #2236: truncated out of WAL — not reachable
-                if include_abandoned or is_active(s):
-                    seqs.add(s)
+            # #5769 stage 3: every sid this agent has (main + loaded +
+            # on-disk spawned — the SAME discovery the rewind materialiser
+            # already depends on, `_discover_session_ids`'s own docstring),
+            # not only `_DEFAULT_SID`. Built per (name, sid) rather than
+            # hoisted once: `build_active_predicate`'s own record fetch is
+            # incremental/cached (#2939), so this is O(rewind records) per
+            # (agent, sid), not O(WAL) — the #2941 quadratic-WAL-scan
+            # concern this loop's own comment used to cite no longer
+            # applies (only the seq-independent DERIVATION was ever the
+            # expensive part; that stays cached regardless of how many
+            # times a scope filter runs over it).
+            for sid in self._discover_session_ids(name):
+                is_active = build_active_predicate(
+                    self._state_log, scope=(name, sid),
+                )
+                for s in self._store_for(name, sid).seqs():
+                    if oldest_seq is not None and s < oldest_seq:
+                        continue  # #2236: truncated out of WAL — not reachable
+                    if include_abandoned or is_active(s):
+                        seqs.add(s)
+                        # A boundary seq is the origin of exactly one (name,
+                        # sid) pair (see this method's own docstring) — a
+                        # plain last-write-wins map, no collision to resolve.
+                        seq_sid[s] = sid
         if not seqs:
             return []
 
@@ -2406,6 +2436,12 @@ class AgentRegistry:
                 "anchor": anchors.get(s) if anchors is not None else "",
                 # #1533 2a→2b: the branch this checkpoint belongs to (group by this).
                 "branch_id": branch_of.get(s, 0),
+                # #5769 stage 3 ③: the (name, sid) pair that actually cut
+                # this generation — see the method's own docstring for why
+                # this lookup never collides. Presentation (grouping, a
+                # column, a filter) is a later, owner-gated decision — not
+                # this stage's own scope.
+                "sid": seq_sid.get(s, _DEFAULT_SID),
             })
         return rows
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2323,7 +2323,7 @@ class AgentRegistry:
         Returns one row per snapshot-generation boundary, ascending by seq::
 
             [{"seq": int, "ts": str, "kind": str, "anchor": str, "branch_id": int,
-              "sid": str}, ...]
+              "name": str | None, "sid": str | None}, ...]
 
         Default (``include_abandoned=False``) keeps only **active-branch** boundaries
         (Phase-1 1f timeline). Phase-2 fork UX passes ``include_abandoned=True`` to
@@ -2347,25 +2347,44 @@ class AgentRegistry:
         the union across known agents is the global rewind-point set. Abandoned
         (rewound-past) boundaries are filtered out via ``is_active_seq``.
 
-        #5769 stage 3 (③, architect scope): ``sid`` — every row's ORIGIN
-        session id, not only the agent's default ("main") one. Before this
-        stage the loop below enumerated only ``_store_for(name)`` (the
-        implicit ``_DEFAULT_SID``), so a checkpoint cut by a spawned
-        subagent session's own generation store was invisible here
-        entirely, not merely unlabeled — ``_discover_session_ids`` (the
-        same disk+in-memory discovery the rewind materialiser already
-        depends on for crash recovery) now supplies every sid to fold
-        in. A boundary seq is always the ORIGIN of exactly one (name,
-        sid) pair — a WAL entry belongs to one session's own turn/step
-        by construction (the same "seq is globally unique per event"
-        property today's per-agent union already relies on) — so ``sid``
-        is looked up per seq with no collision to resolve.
+        #5769 stage 3 (③, architect scope): ``name``/``sid`` — every row's
+        ORIGIN ``(agent_name, session_id)`` pair, not only the agent's
+        default ("main") session. Before this stage the loop below
+        enumerated only ``_store_for(name)`` (the implicit
+        ``_DEFAULT_SID``), so a checkpoint cut by a spawned subagent
+        session's own generation store was invisible here entirely, not
+        merely unlabeled — ``_discover_session_ids`` (the same
+        disk+in-memory discovery the rewind materialiser already depends
+        on for crash recovery) now supplies every sid to fold in.
 
-        ⚠️ Scope boundary (explicit, per dispatch): this field only makes
-        the DATA available. Whether/how a caller surfaces ``sid``
-        (grouping, a column, a filter) is a presentation decision left
-        to whoever wires the timeline UI to it (owner-gated) — not
-        decided here.
+        A boundary seq is *architecturally* the origin of exactly one
+        ``(name, sid)`` pair (a WAL entry belongs to one session's own
+        turn/step by construction — the same "seq is globally unique per
+        event" property today's per-agent union already relies on).
+        **Architecturally guaranteed is not the same as checked** (#5782
+        review, architect BLOCKING): this method used to look the pair up
+        with ``.get(s, _DEFAULT_SID)``, which — had the invariant ever been
+        violated by a future bug — would have silently handed back
+        ``"main"``: not a placeholder, a REAL session's own name, wired
+        straight into the row the operator clicks to choose which session
+        to rewind. That is the exact "answer from a fallback instead of
+        admitting the owner can't be named" shape decision 7 (ADR-0047)
+        already forbids — it had simply reappeared inside this row instead
+        of a scope predicate. So the lookup is now checked, not assumed:
+        a seq claimed by two DIFFERING ``(name, sid)`` pairs is logged
+        (this should never happen) and ``name``/``sid`` come back ``None``
+        for that row rather than either owner's real value — an admitted
+        "don't know", never a fabricated one. The pair also travels
+        TOGETHER on one row (not ``sid`` alone) — a consumer that obtained
+        ``name`` from a different source (e.g. "whichever agent tab is
+        open") could otherwise present a ``(name, sid)`` combination that
+        never actually owned this seq; carrying both from the same lookup
+        makes that misattribution unwritable.
+
+        ⚠️ Scope boundary (explicit, per dispatch): these fields only make
+        the DATA available. Whether/how a caller surfaces them (grouping,
+        a column, a filter) is a presentation decision left to whoever
+        wires the timeline UI to it (owner-gated) — not decided here.
 
         Empty when there is no WAL or no generations.
         """
@@ -2383,7 +2402,10 @@ class AgentRegistry:
         # stage 2). Default = active branch only (1f); include_abandoned =
         # all branches (Phase-2 tree).
         seqs: set[int] = set()
-        seq_sid: dict[int, str] = {}
+        # None once written = seen more than one DIFFERING (name, sid) claim
+        # this seq — an admitted "don't know", never a fabricated owner
+        # (#5782 review, architect BLOCKING; see the method's own docstring).
+        seq_owner: dict[int, "tuple[str, str] | None"] = {}
         for name in self.list_names():
             # #5769 stage 3: every sid this agent has (main + loaded +
             # on-disk spawned — the SAME discovery the rewind materialiser
@@ -2406,9 +2428,26 @@ class AgentRegistry:
                     if include_abandoned or is_active(s):
                         seqs.add(s)
                         # A boundary seq is the origin of exactly one (name,
-                        # sid) pair (see this method's own docstring) — a
-                        # plain last-write-wins map, no collision to resolve.
-                        seq_sid[s] = sid
+                        # sid) pair by construction (see this method's own
+                        # docstring) — this SHOULD never fire. #5769 stage 3
+                        # ④ (architect's re-written acceptance item, #5782
+                        # review): a seq without EXACTLY one owner must be
+                        # represented AS SUCH — never a fabricated value, not
+                        # even a first-seen-wins guess. So a second, DIFFERING
+                        # claim flips the entry to ``None`` rather than
+                        # keeping either owner.
+                        claim = (name, sid)
+                        if s not in seq_owner:
+                            seq_owner[s] = claim
+                        elif seq_owner[s] is not None and seq_owner[s] != claim:
+                            logger.warning(
+                                "list_rewind_points: seq %d claimed by both "
+                                "%r and %r — this should be structurally "
+                                "impossible; reporting no owner rather than "
+                                "either guess (see #5769 stage 3 ④)",
+                                s, seq_owner[s], claim,
+                            )
+                            seq_owner[s] = None
         if not seqs:
             return []
 
@@ -2426,6 +2465,19 @@ class AgentRegistry:
         rows: list[dict] = []
         for s in sorted(seqs):
             entry = wal_at.get(s, {})
+            # #5769 stage 3 ③ (re-fixed per #5782 review, architect
+            # BLOCKING): the (name, sid) pair that cut this generation —
+            # carried TOGETHER, off the SAME lookup, never ``sid`` alone
+            # (a consumer sourcing ``name`` separately could otherwise
+            # present a pair that never actually owned this seq). ``None``
+            # for BOTH when ``seq_owner`` never saw exactly one claim for
+            # this seq (structurally shouldn't happen — see the method's
+            # own docstring) — an admitted "don't know", never the old
+            # ``.get(s, _DEFAULT_SID)`` fallback, which fabricated a REAL
+            # session's name ("main") for a row the operator clicks to
+            # choose which session to rewind.
+            owner = seq_owner.get(s)
+            owner_name, owner_sid = owner if owner is not None else (None, None)
             rows.append({
                 "seq": s,
                 "ts": entry.get("ts", ""),
@@ -2436,12 +2488,8 @@ class AgentRegistry:
                 "anchor": anchors.get(s) if anchors is not None else "",
                 # #1533 2a→2b: the branch this checkpoint belongs to (group by this).
                 "branch_id": branch_of.get(s, 0),
-                # #5769 stage 3 ③: the (name, sid) pair that actually cut
-                # this generation — see the method's own docstring for why
-                # this lookup never collides. Presentation (grouping, a
-                # column, a filter) is a later, owner-gated decision — not
-                # this stage's own scope.
-                "sid": seq_sid.get(s, _DEFAULT_SID),
+                "name": owner_name,
+                "sid": owner_sid,
             })
         return rows
 

--- a/tests/core/test_registry_list_rewind_points_1f.py
+++ b/tests/core/test_registry_list_rewind_points_1f.py
@@ -50,6 +50,18 @@ def _record_gen(reg: AgentRegistry, name: str, seq: int) -> None:
     reg._store_for(name).record(snap)
 
 
+def _record_gen_for_sid(reg: AgentRegistry, name: str, sid: str, seq: int) -> None:
+    """#5769 stage 3: persist a generation for a NON-default ``sid`` — the
+    same on-disk shape a spawned subagent session's own generation store
+    would produce (``state/sessions/<sid>/generations/``, created via
+    ``AgentSnapshot.write_durable``'s own ``mkdir(parents=True)``), so
+    ``_discover_session_ids``'s disk scan finds it exactly the way it
+    would find a real spawned session."""
+    snap = AgentSnapshot.empty(name)
+    snap.applied_seq = seq
+    reg._store_for(name, sid).record(snap)
+
+
 # ── unit: kind mapping ────────────────────────────────────────────────────────
 
 
@@ -235,3 +247,51 @@ async def test_list_rewind_points_scopes_abandonment_per_agent(tmp_path) -> None
     listed_seqs = [r["seq"] for r in rows]
     assert a1 not in listed_seqs, "alpha's own boundary must be abandoned by its own scoped rewind"
     assert b1 in listed_seqs, "beta's boundary must be untouched by a rewind scoped to a different agent"
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_default_sid_is_main(tmp_path) -> None:
+    """Tier 2: #5769 stage 3 (③) -- backward compatibility. A generation
+    recorded via the pre-existing helper (the implicit _DEFAULT_SID store,
+    unchanged since before this stage) must still be listed, now carrying
+    ``"sid": "main"`` explicitly rather than the field being absent."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_gen(reg, "alpha", s1)
+
+    rows = reg.list_rewind_points()
+    assert [r["seq"] for r in rows] == [s1]
+    assert rows[0]["sid"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_includes_non_default_sid(tmp_path) -> None:
+    """Tier 2: #5769 stage 3 (③, architect scope) -- a generation cut by a
+    NON-default session id (the on-disk shape a spawned subagent session's
+    own generation store produces) must now be enumerated at all. Before
+    this stage the loop only consulted ``_store_for(name)``'s implicit
+    _DEFAULT_SID store, so a boundary owned by any other sid was silently
+    absent from the output -- not merely unlabeled. The returned row's
+    "sid" must equal the real sid that owns the boundary, and the agent's
+    own default-sid boundary (still present) must keep its own "main" tag,
+    proving the two are enumerated and labelled independently, not
+    conflated into one."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    s_main = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_gen(reg, "alpha", s_main)
+    s_sub = await log.append("inbox_consume", target="alpha", msg_id="m2")
+    _record_gen_for_sid(reg, "alpha", "sub-42", s_sub)
+
+    rows = reg.list_rewind_points()
+    by_seq = {r["seq"]: r for r in rows}
+    assert s_main in by_seq and s_sub in by_seq, (
+        f"both the default-sid and the non-default-sid boundary must be listed; got {sorted(by_seq)}"
+    )
+    assert by_seq[s_main]["sid"] == "main"
+    assert by_seq[s_sub]["sid"] == "sub-42"

--- a/tests/core/test_registry_list_rewind_points_1f.py
+++ b/tests/core/test_registry_list_rewind_points_1f.py
@@ -254,7 +254,7 @@ async def test_list_rewind_points_default_sid_is_main(tmp_path) -> None:
     """Tier 2: #5769 stage 3 (③) -- backward compatibility. A generation
     recorded via the pre-existing helper (the implicit _DEFAULT_SID store,
     unchanged since before this stage) must still be listed, now carrying
-    ``"sid": "main"`` explicitly rather than the field being absent."""
+    ``"name"``/``"sid"`` explicitly rather than the fields being absent."""
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
     log = reg.state_log
@@ -264,6 +264,7 @@ async def test_list_rewind_points_default_sid_is_main(tmp_path) -> None:
 
     rows = reg.list_rewind_points()
     assert [r["seq"] for r in rows] == [s1]
+    assert rows[0]["name"] == "alpha"
     assert rows[0]["sid"] == "main"
 
 
@@ -275,10 +276,10 @@ async def test_list_rewind_points_includes_non_default_sid(tmp_path) -> None:
     this stage the loop only consulted ``_store_for(name)``'s implicit
     _DEFAULT_SID store, so a boundary owned by any other sid was silently
     absent from the output -- not merely unlabeled. The returned row's
-    "sid" must equal the real sid that owns the boundary, and the agent's
-    own default-sid boundary (still present) must keep its own "main" tag,
-    proving the two are enumerated and labelled independently, not
-    conflated into one."""
+    ``name``/``sid`` pair must equal the real owner of the boundary, and
+    the agent's own default-sid boundary (still present) must keep its own
+    ``"main"`` tag, proving the two are enumerated and labelled
+    independently, not conflated into one."""
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
     log = reg.state_log
@@ -293,5 +294,39 @@ async def test_list_rewind_points_includes_non_default_sid(tmp_path) -> None:
     assert s_main in by_seq and s_sub in by_seq, (
         f"both the default-sid and the non-default-sid boundary must be listed; got {sorted(by_seq)}"
     )
-    assert by_seq[s_main]["sid"] == "main"
-    assert by_seq[s_sub]["sid"] == "sub-42"
+    assert (by_seq[s_main]["name"], by_seq[s_main]["sid"]) == ("alpha", "main")
+    assert (by_seq[s_sub]["name"], by_seq[s_sub]["sid"]) == ("alpha", "sub-42")
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_reports_no_owner_on_conflicting_claims(tmp_path) -> None:
+    """Tier 2: #5769 stage 3 (④, architect BLOCKING on #5782's own review) --
+    a seq claimed by two DIFFERING (name, sid) pairs must come back with
+    ``name`` AND ``sid`` both ``None``, never a fabricated guess (not even a
+    first-seen-wins one). This is architecturally impossible in production
+    (a WAL entry routes to exactly one session), so the setup forces the
+    conflict directly at the store layer -- the same shape a real defect
+    would take, without needing one.
+
+    Before this fix the lookup was ``seq_sid.get(s, _DEFAULT_SID)``: had the
+    invariant ever broken, it would have silently reported the row as
+    belonging to ``"main"`` -- a REAL session's own name wired into the very
+    row the operator clicks to choose which session to rewind."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    shared_seq = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_gen(reg, "alpha", shared_seq)
+    _record_gen(reg, "beta", shared_seq)  # same seq, a DIFFERENT (name, sid)
+
+    rows = reg.list_rewind_points()
+    by_seq = {r["seq"]: r for r in rows}
+    assert shared_seq in by_seq, "the seq itself is still listed -- only its owner is unresolved"
+    row = by_seq[shared_seq]
+    assert row["name"] is None, f"a conflicting claim must not fabricate an owner name; got {row}"
+    assert row["sid"] is None, f"a conflicting claim must not fabricate an owner sid; got {row}"
+    # Exactly one row for the seq -- a conflict collapses to one "unknown
+    # owner" row, it does not fan out into two.
+    assert [r["seq"] for r in rows].count(shared_seq) == 1


### PR DESCRIPTION
**[tui-coder]** — part of #5769

## What

Stage 3 item ③ (architect scope, verbatim): `list_rewind_points` previously
enumerated only each agent's DEFAULT ("main") session store via
`_store_for(name)`. Now runs `_discover_session_ids(name)` — the same
disk + in-memory discovery the rewind materialiser already depends on for
crash recovery — and attaches the owning `(name, sid)` pair to every
returned row.

Before this stage, a checkpoint cut by any non-default session (e.g. a
spawned subagent's own generation store) was **invisible in the output
entirely**, not merely unlabeled.

## Fixed after architect BLOCKING (head `d98cb335f`)

🔴 The row's owner lookup used `.get(s, _DEFAULT_SID)` — a seq without a
recorded owner would have silently reported `"main"`, a REAL session's own
name, not a placeholder, wired straight into the row an operator clicks to
choose which session to rewind. Same shape ADR-0047 decision 7 already
forbids, reappearing inside this row.

⚪ The row also carried `sid` alone, not the `(name, sid)` pair — a
consumer sourcing `name` elsewhere could present a pair that never
actually owned the seq.

Fixed: `seq_owner: dict[int, tuple[str, str] | None]` — a second,
DIFFERING claim on the same seq flips the entry to `None` (logged) rather
than any first/last-write-wins guess. Rows now carry `"name"` alongside
`"sid"`, both from the SAME lookup, and both come back `None` — never a
fabricated value — when the seq's owner isn't exactly one.

## Scope boundary (explicit, per dispatch)

This stage only makes the `(name, sid)` **data** available on each row.
Whether or how a caller surfaces it (grouping, a column, a filter) is a
presentation decision left to item ④ — owner-gated, not decided here.
No display/UI code was touched or designed in this PR.

## Why a plain seq→owner map is otherwise safe

A boundary seq is *architecturally* the origin of exactly one `(name,
sid)` pair — the same "seq is globally unique per event" property the
pre-existing per-agent seq union already relies on. `SnapshotGenerationStore`
is also a strictly separate on-disk directory per `(name, sid)`. The fix
above is the "architecturally guaranteed is not the same as checked"
correction — the invariant is now verified, not assumed, and its failure
mode is an admitted `None`, never a guess.

## Test plan

- [x] New driven tests in `tests/core/test_registry_list_rewind_points_1f.py`:
  - `test_list_rewind_points_default_sid_is_main` — a generation recorded via
    the existing default-sid helper still yields `"name": "alpha", "sid":
    "main"` (backward compatibility for the common no-subagent case).
  - `test_list_rewind_points_includes_non_default_sid` — a generation
    recorded under a non-default sid (via a new `_record_gen_for_sid`
    helper, same on-disk shape a spawned subagent session produces) is now
    listed at all, with the correct `(name, sid)` pair, while the agent's
    own default-sid boundary keeps its own independent `"main"` tag.
  - `test_list_rewind_points_reports_no_owner_on_conflicting_claims` — two
    agents forced to record a generation at the same seq (the
    architecturally-"impossible" conflict, forced directly at the store
    layer): asserts the row reports `name=None, sid=None` and collapses to
    exactly one row, not two.
- [x] Falsify-verified in-file (Edit-only, no `git checkout`/`stash`), twice:
  - reverted the sid loop to `_DEFAULT_SID`-only, confirmed
    `test_list_rewind_points_includes_non_default_sid` fails as expected
    (`sub-42`'s boundary silently absent), then restored and reconfirmed green.
  - reverted the owner lookup to a fabricated fallback, confirmed
    `test_list_rewind_points_reports_no_owner_on_conflicting_claims` fails
    (reports a fabricated owner instead of `None`), then restored and
    reconfirmed green.
- [x] Full pre-existing surface re-run together, no regressions: the 11
  tests in this file + the other 9 files referencing `list_rewind_points`
  (`test_5759_history_jsonl_gc.py`, `test_5769_stage2_scoped_derivation.py`,
  `test_anchor_text_1547.py`, `test_branch_registry_2a.py`,
  `test_slash_rewind_1f.py`,
  `test_3987_rewind_picker_shows_branch_tree.py`,
  `test_5648_rewind_row_anchor_column.py`,
  `test_slash_rewind_copy_cmds.py`,
  `test_slash_rewind_self_cancel_3362.py`) plus a `-k "rewind or checkout"`
  sweep of `tests/runtime/` — 81 passed, 0 failed.
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (this file),
  `verify_module_docstrings.py` (registry.py), `mypy_ratchet.py`,
  `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`,
  and the `tests/`-conditional gates
  (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`,
  `check_subprocess_reyn_pin.py`) — all green.
- [ ] Visual は owner 確認 — this stage is read-side data enumeration only
  (no rendering code touched), but whether any existing timeline view's
  behavior visibly shifts once these rows exist is left to the owner/④
  stage to confirm, not asserted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
