### PR TITLE
fix(#5781): resume() takes an already-looked-up snapshot, not a scope

### DIFF
--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -188,17 +188,24 @@ def latest_pipeline_state(
 
     #5769 stage 3 (ADR-0047 decision 7, architect's (c) ruling on the PR
     #5778 review, replacing an earlier, disclosed (a)/(b)-shaped deviation
-    this docstring used to carry): ``scope`` is now the CALLER's own
+    this docstring used to carry): ``scope`` is the CALLER's own
     responsibility, not something this function discovers by re-reading
-    ``invocation.json``. Both real call sites already hold the run's own
-    ``PipelineWorkOrder`` when they call this — ``PipelineExecutorDriver.
-    run_turn`` (direct call) and ``PipelineExecutor.resume`` (which now
-    forwards its own ``scope`` parameter here) — so passing ``scope`` is
-    "hand over a fact you already have", not a new derivation. This
-    removes the whole class of problem the earlier version had: no
-    ``invocation.json`` re-read, no warning log, no ``GLOBAL_SCOPE``
-    fallback, no decision-7 exception to disclose — the caller's own
-    scope is simply the truth, always, with no cases to reconcile.
+    ``invocation.json``. The one real caller (``PipelineExecutorDriver.
+    run_turn``) already holds the run's own ``PipelineWorkOrder`` when it
+    calls this, so passing ``scope`` is "hand over a fact you already
+    have", not a new derivation. This removes the whole class of problem
+    the earlier version had: no ``invocation.json`` re-read, no warning
+    log, no ``GLOBAL_SCOPE`` fallback, no decision-7 exception to
+    disclose — the caller's own scope is simply the truth, always, with
+    no cases to reconcile.
+
+    #5781: ``PipelineExecutor.resume`` no longer calls this function at
+    all — it used to (forwarding its own ``scope`` parameter straight
+    through), making ``run_turn``'s one real call site read this SAME
+    generation twice per resume (once directly, once again inside
+    ``resume``, which then discarded the first read). ``resume`` now
+    takes the already-looked-up ``snapshot`` as a parameter instead, so
+    this function has exactly one caller.
     """
     store = _store(state_log, run_id)
     if store is None:

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -117,7 +117,7 @@ import re
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
-from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
+from reyn.core.events.pipeline_recovery import record_pipeline_state
 from reyn.core.offload.canonical import (
     CANONICAL_DEGRADED_EVENT,
     CANONICAL_FALLBACK_EVENT,
@@ -1905,7 +1905,7 @@ class PipelineExecutor:
         pipeline: Pipeline,
         tool_dispatch: ToolDispatch,
         state_log: "StateLog",
-        scope: "tuple[str, str] | None",
+        snapshot: "dict[str, Any] | None",
         schema_registry: "SchemaRegistry | None" = None,
         registry: "AgentRegistry | None" = None,
         default_identity: "str | None" = None,
@@ -1916,38 +1916,31 @@ class PipelineExecutor:
         max_pipeline_spawns: "int | None" = None,
         invoker_session: "Any | None" = None,
     ) -> PipelineResult:
-        """Resume `run_id`: load the latest recorded generation (R4) and replay every
-        step already in ``completed_step_results`` (no re-execution — exactly-once).
-        For a mid-``call`` crash this means resuming at the ``call`` step's index and
+        """Resume `run_id` from `snapshot` — the caller's own `latest_pipeline_state(
+        run_id, state_log, scope=...)` lookup, handed over. Replays every step already
+        in `snapshot["completed_step_results"]` (no re-execution — exactly-once). For a
+        mid-``call`` crash this means resuming at the ``call`` step's index and
         replaying the finished callee sub-steps from their dotted keys (the callee's
-        side effects do not re-fire), executing only the remainder. With no snapshot
-        at all, resume == run from scratch.
+        side effects do not re-fire), executing only the remainder. `snapshot=None`
+        (no generation was ever recorded for this run) == run from scratch.
 
         `pipeline_registry` (R7) is required only if the resumed run re-enters a
         `CallStep` — the callee is re-resolved by name and re-walked to reconstruct
         its local state from the dotted keys. `events` / `cancel_check` behave as in
         :meth:`run`.
 
-        #5769 stage 3 (ADR-0047 decision 7, architect's (c) ruling): `scope`
-        is forwarded straight to `latest_pipeline_state` — this run's own
-        (agent, sid) is a FACT, not a caller decision, so the one real
-        production caller (`PipelineExecutorDriver.run_turn`, which always
-        holds its own `PipelineWorkOrder`) always passes its real
-        `(wo.driver_agent, wo.driver_sid)`.
-
-        No default (required keyword-only), matching `latest_pipeline_state`'s
-        own required-kwarg contract one layer down — a first cut of this PR
-        gave `scope` a `GLOBAL_SCOPE` default here, but that quietly re-opened
-        the exact hole decision 7 exists to close one layer OUT: a NEW test
-        call site that simply forgets `scope` would silently get GLOBAL_SCOPE
-        with no red, rather than a `TypeError` at the call (ADR-0047's own
-        Alternatives wording: "one forgotten call site silently behaves
-        globally ... with no red"). The many pre-existing R3/R4 executor
-        tests with no owning-driver concept at all now pass `scope=GLOBAL_SCOPE`
-        EXPLICITLY — an honest spelling of "no scoped-rewind concern applies
-        here", not a silently-inferred one. The one real production caller is
-        unaffected: it already passes its real `(wo.driver_agent, wo.driver_sid)`."""
-        snapshot = latest_pipeline_state(run_id, state_log, scope=scope)
+        #5781: takes `snapshot` directly rather than a `scope` it would use to
+        look the snapshot up itself. #5769 stage 3 first had this function call
+        `latest_pipeline_state(run_id, state_log, scope=scope)` here — but the
+        one real caller (`PipelineExecutorDriver.run_turn`) ALREADY calls that
+        same function first, to decide run-vs-resume, then discarded the
+        result and let `resume` read it again: one resume, two identical
+        reads. Taking `snapshot` instead removes the second read AND the
+        `scope` parameter this function never otherwise needed (`scope` only
+        ever existed to make that internal lookup) — no `scope`-forgotten
+        default to get wrong (the #5778 review history this function's
+        docstring used to carry no longer applies: there is no lookup left
+        inside `resume` for a forgotten `scope` to silently misdirect)."""
         if snapshot is None:
             return await self.run(
                 pipeline,

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -244,12 +244,15 @@ class PipelineExecutorDriver:
         pipeline_registry = self._pipeline_registry()
         # #5769 stage 3 (ADR-0047 decision 7, architect's (c) ruling): this
         # run's own owner is a fact already in hand (`wo`), not something
-        # to re-derive from invocation.json — passed straight through to
-        # both latest_pipeline_state (direct call, below) and
-        # executor.resume (which forwards it to the same function).
+        # to re-derive from invocation.json.
+        # #5781: read ONCE and hand the result to resume() below (rather than
+        # re-deriving inside resume() a second time, which was the earlier
+        # #5769-stage-3 shape) — this is also why resume() no longer takes a
+        # `scope` parameter at all: the caller already did the lookup.
         scope = (wo.driver_agent, wo.driver_sid)
+        snapshot = latest_pipeline_state(wo.run_id, self._state_log, scope=scope)
         try:
-            if latest_pipeline_state(wo.run_id, self._state_log, scope=scope) is None:
+            if snapshot is None:
                 # Fresh run (or crashed before the first R4 snapshot): seed the
                 # ORIGINAL work-order input — resume()'s fallback would lose it.
                 result = await executor.run(
@@ -281,7 +284,7 @@ class PipelineExecutorDriver:
                     pipeline=pipeline,
                     tool_dispatch=await self._make_dispatch(),
                     state_log=self._state_log,
-                    scope=scope,
+                    snapshot=snapshot,
                     registry=self._registry,
                     default_identity=wo.reply_to_agent,
                     pipeline_registry=pipeline_registry,

--- a/tests/core/test_5769_stage3_pipeline_resume_scope.py
+++ b/tests/core/test_5769_stage3_pipeline_resume_scope.py
@@ -1,29 +1,30 @@
-"""Tier 2: OS invariant -- #5769 stage 3, ADR-0047 decision 7, architect's
-(c) ruling on PR #5778's review (superseding an earlier, disclosed
-(a)/(b)-shaped deviation).
+"""Tier 2: OS invariant -- #5769 stage 3 (ADR-0047 decision 7) + #5781.
 
 `latest_pipeline_state(run_id, state_log, *, scope)` no longer discovers
-its own owner by re-reading `invocation.json` -- both real callers
-(`PipelineExecutorDriver.run_turn`'s direct call, and
-`PipelineExecutor.resume`, which now forwards its own `scope` parameter)
-already hold the run's own `PipelineWorkOrder` when they call this, so
-`scope` is simply handed over as a fact, never re-derived. This closes
-the whole class of problem the earlier version had (an `invocation.json`
-read, a warning log, a `GLOBAL_SCOPE` fallback, and a disclosed decision-7
-exception) -- there is now exactly one path, no cases to reconcile.
+its own owner by re-reading `invocation.json` (architect's (c) ruling on
+PR #5778's review, superseding an earlier, disclosed (a)/(b)-shaped
+deviation): its one real caller (`PipelineExecutorDriver.run_turn`)
+already holds the run's own `PipelineWorkOrder`, so `scope` is simply
+handed over as a fact, never re-derived.
 
-Real `StateLog` + real `PipelineStateStore` (no mocks). Covers: `scope`
-is a required keyword-only argument on BOTH `latest_pipeline_state` and
-`resume()` (no default, no silent fallback, at either layer -- a round-1
-draft of this PR gave `resume()`'s own `scope` a `GLOBAL_SCOPE` default,
-which silently reopened decision 7's hole one layer OUT; lead-coder-30's
-review caught it, architect confirmed no default is justified here since
-every real caller already knows its own answer). `resume()` forwards its
-own `scope` straight through to `latest_pipeline_state`; every owner-less
-R3/R4/primitive-mechanics test call site now passes `scope=GLOBAL_SCOPE`
-explicitly (honest, not silently-forgotten -- nothing in this codebase
-can yet write a scoped pipeline-state record without going through the
-one real production caller, which always passes its real scope).
+#5781: `PipelineExecutor.resume` no longer calls `latest_pipeline_state`
+at all -- it used to (forwarding its own `scope` parameter through), so
+`run_turn`'s one real call site read the SAME generation twice per
+resume (once directly to decide run-vs-resume, once again inside
+`resume`, discarding the first read). `resume` now takes the
+already-looked-up `snapshot` directly, removing both the second read and
+the `scope` parameter (which existed only to make that internal lookup).
+
+Real `StateLog` + real `PipelineStateStore` (no mocks). Covers:
+`latest_pipeline_state`'s `scope` remains a required keyword-only
+argument (no default, no silent fallback -- unaffected by #5781, since
+`scope` only ever existed to make `resume`'s now-removed internal lookup,
+never `latest_pipeline_state`'s own contract); `resume`'s new `snapshot`
+parameter is ALSO required, no default (matching decision 2/7's own
+no-silent-default precedent -- a `None` default would be indistinguishable
+from an intentional "always run from scratch"), and `resume` uses
+EXACTLY the `snapshot` its caller passes, never re-deriving one from
+`state_log` itself (the #5781 witness below).
 """
 from __future__ import annotations
 
@@ -54,15 +55,15 @@ async def test_latest_pipeline_state_requires_scope_kwarg(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_resume_requires_scope_kwarg(tmp_path):
-    """Tier 2: no default -- same shape as
-    `test_latest_pipeline_state_requires_scope_kwarg` above, one layer OUT.
-    Pins OUR signature decision (decision 2/7: no silent GLOBAL_SCOPE
-    default), not a language behaviour -- a round-1 draft of this PR gave
-    `resume()`'s own `scope` a `GLOBAL_SCOPE` default, silently reopening
-    the same hole `latest_pipeline_state`'s required kwarg already closed
-    one layer in (lead-coder-30 review, PR #5778). A call site that forgets
-    `scope` must fail at the call, not silently resume as GLOBAL_SCOPE."""
+async def test_resume_requires_snapshot_kwarg(tmp_path):
+    """Tier 2: no default -- #5781 replaced `resume()`'s `scope` parameter
+    with `snapshot` (the caller's own already-looked-up
+    `latest_pipeline_state` result); this pins the same no-silent-default
+    contract onto the new parameter (decision 2/7's own precedent: two real
+    meanings -- "here is the run's state" vs "this is a fresh run" -- and
+    the one real caller always knows which one applies, so a default would
+    only ever paper over a forgotten call, not serve a caller with nothing
+    to say). A call site that forgets `snapshot` must fail at the call."""
     log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
     pipeline = Pipeline(steps=[TransformStep(value="1 + 1", output="x")])
 
@@ -167,24 +168,24 @@ def _bare_ctx():
 
 
 @pytest.mark.asyncio
-async def test_resume_forwards_its_scope_real_witness(tmp_path, monkeypatch):
-    """Tier 2: `PipelineExecutor.resume`'s own `scope` parameter really
-    reaches `latest_pipeline_state` -- proven by a REAL, observable
-    behavioral difference (no patch of any collaborator this test itself
-    depends on -- the only monkeypatch here registers a genuine tool
-    handler, the same idiom test_pipeline_is6_attached.py's own sibling
-    helper uses, not a stand-in for the thing under test).
+async def test_resume_uses_exactly_the_snapshot_the_caller_passes(tmp_path, monkeypatch):
+    """Tier 2: #5781's own witness -- `resume()` uses EXACTLY the `snapshot`
+    its caller hands it, and never re-derives one from `state_log` itself
+    (the double-read #5781 removed). Proven by a REAL, observable behavioral
+    difference (no patch of any collaborator this test itself depends on --
+    the only monkeypatch here registers a genuine tool handler, the same
+    idiom test_pipeline_is6_attached.py's own sibling helper uses, not a
+    stand-in for the thing under test).
 
-    A recorded generation carries an impossible `step_index` (5, for a
-    1-step pipeline where only 0/1 are ever real) and is then hidden by a
-    rewind scoped to EXACTLY the scope this test passes to `resume()`. If
-    `resume()` genuinely forwarded that scope to `latest_pipeline_state`,
-    the impossible generation is invisible -> resume() falls through to a
-    fresh run -> the one real step executes for real (the counting file
-    gets exactly one line) -> `step_index == 1`. If scope were silently
-    dropped (always seeing the record), resume() would instead try to
-    replay from the impossible snapshot -- observably NOT "one real
-    execution, step_index == 1"."""
+    A real generation carrying an impossible `step_index` (5, for a 1-step
+    pipeline where only 0/1 are ever real) is recorded and durably on disk.
+    `resume()` is then called with `snapshot=None` anyway -- if `resume`
+    still consulted `state_log` on its own (the pre-#5781 shape), it would
+    find that impossible generation and try to replay from it. Because it
+    now trusts ONLY the `snapshot` argument, it falls through to a genuine
+    fresh run instead: the one real step executes for real (the counting
+    file gets exactly one line) and `step_index == 1` -- not the impossible
+    on-disk 5, and not a second read of it."""
     out_file = tmp_path / "out.txt"
     _install_counting_tool(monkeypatch, out_file)
     log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
@@ -192,22 +193,54 @@ async def test_resume_forwards_its_scope_real_witness(tmp_path, monkeypatch):
     dispatch = _make_tool_dispatch(_bare_ctx())
 
     await _put(log, "worker")
-    await record_pipeline_state(log, "run-scope-check", {"step_index": 5}, durable=True)
-
-    # Scoped to hide the impossible generation FOR EXACTLY (worker, sidA).
-    await log.append(
-        REWIND_KIND, target_n=0, supersedes=None, scope=["worker", "sidA"],
-    )
+    await record_pipeline_state(log, "run-snapshot-check", {"step_index": 5}, durable=True)
 
     result = await PipelineExecutor().resume(
-        "run-scope-check",
+        "run-snapshot-check",
         pipeline=pipeline,
         tool_dispatch=dispatch,
         state_log=log,
-        scope=("worker", "sidA"),
+        snapshot=None,
     )
 
-    # Hidden for (worker, sidA) -> resume() fell through to a genuine
-    # fresh run -> the one real step executed once -> step_index == 1.
+    # A real (step_index=5) generation sits on disk for this run_id, but
+    # `resume` was told `snapshot=None` -- it must honor THAT, not go look.
     assert result.step_index == 1
     assert out_file.read_text(encoding="utf-8").splitlines() == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_from_the_snapshot_the_caller_passes(tmp_path, monkeypatch):
+    """Tier 2: the complementary half of the witness above -- when the
+    caller DOES pass a real snapshot (its own `latest_pipeline_state`
+    lookup, exactly as `PipelineExecutorDriver.run_turn` does), `resume`
+    replays from it (exactly-once: the completed step is NOT re-executed;
+    only `step_index` advances)."""
+    out_file = tmp_path / "out.txt"
+    _install_counting_tool(monkeypatch, out_file)
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    pipeline = _one_step_pipeline()
+    dispatch = _make_tool_dispatch(_bare_ctx())
+
+    await _put(log, "worker")
+    await record_pipeline_state(
+        log, "run-replay-check",
+        {"step_index": 1, "pipe_data": None, "named_stores": {}, "completed_step_results": {"0": {}}},
+        durable=True,
+    )
+    snapshot = latest_pipeline_state("run-replay-check", log, scope=GLOBAL_SCOPE)
+    assert snapshot is not None  # the fixture above; a real lookup, not asserted-as-given
+
+    result = await PipelineExecutor().resume(
+        "run-replay-check",
+        pipeline=pipeline,
+        tool_dispatch=dispatch,
+        state_log=log,
+        snapshot=snapshot,
+    )
+
+    # Already at step_index 1 (the pipeline's only step) -> resume is a
+    # replay-to-completion with ZERO new tool executions -- the counting
+    # tool's own side effect (creating out_file) never fires.
+    assert result.step_index == 1
+    assert not out_file.exists()

--- a/tests/core/test_pipeline_call_primitive.py
+++ b/tests/core/test_pipeline_call_primitive.py
@@ -267,11 +267,13 @@ async def test_truncate_falsify_call_resumes_callee_substeps_exactly_once(tmp_pa
     # RESUME with the crash DISARMED: the finished sub-step replays from the gen
     # FILE (no re-write of A), only sub-step 1 executes (writes B once).
     crash.clear()
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-tf", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-tf", pipeline=outer,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
 
     # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
@@ -305,11 +307,13 @@ async def test_call_resume_after_full_run_replays_with_zero_new_side_effects(tmp
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
 
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-done", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-done", pipeline=outer,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
     # No new lines — a fully-completed run replays with zero side effects.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]

--- a/tests/core/test_pipeline_executor_r3_r4.py
+++ b/tests/core/test_pipeline_executor_r3_r4.py
@@ -216,10 +216,12 @@ async def test_truncate_falsify_generation_survives_wal_truncation_below_its_seq
     )
 
     full_pipeline = Pipeline(steps=[step0, step1, step2, step3])
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-truncate", state_log, scope=GLOBAL_SCOPE)
     resumed = await executor.resume(
         "run-truncate", pipeline=full_pipeline,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
 
     assert call_counts["count"] == 3, (
@@ -256,10 +258,12 @@ async def test_exactly_once_resume_does_not_replay_completed_tool_side_effect(tm
     assert crashed_result.step_index == 1
     assert call_counts["count"] == 1
 
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-exactly-once", state_log, scope=GLOBAL_SCOPE)
     resumed = await executor.resume(
         "run-exactly-once", pipeline=Pipeline(steps=[step0, step1]),
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
 
     assert call_counts["count"] == 2, "step0 must not be re-run; only step1 is new"
@@ -276,10 +280,12 @@ async def test_resume_with_no_snapshot_runs_from_scratch(tmp_path):
     executor = PipelineExecutor()
     pipeline = Pipeline(steps=[TransformStep(value="1 + 1", output="two")])
 
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("never-run-before", state_log, scope=GLOBAL_SCOPE)
     result = await executor.resume(
         "never-run-before", pipeline=pipeline,
-        tool_dispatch=lambda *_a, **_k: None, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=lambda *_a, **_k: None, state_log=state_log, snapshot=snapshot,
     )
 
     assert result.pipe_data == 2

--- a/tests/core/test_pipeline_fold_primitive.py
+++ b/tests/core/test_pipeline_fold_primitive.py
@@ -233,9 +233,10 @@ async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(t
     # RESUME with the crash DISARMED: iteration 0 replays from the gen FILE
     # (no re-write of A), only iteration 1 executes (writes B once).
     crash.clear()
+    snapshot = latest_pipeline_state("run-fold-tf", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-fold-tf", pipeline=outer,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
 
     # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
@@ -278,10 +279,12 @@ async def test_fold_resume_after_full_run_replays_with_zero_new_side_effects(tmp
     await state_log.flush()
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
 
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-fold-done", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-fold-done", pipeline=outer,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
     assert resumed.named_stores["joined"] == {"text": "AB"}

--- a/tests/core/test_pipeline_for_each_primitive.py
+++ b/tests/core/test_pipeline_for_each_primitive.py
@@ -393,9 +393,10 @@ async def test_truncate_falsify_mid_fan_out_replays_items_exactly_once(tmp_path:
 
     # RESUME with COLLECT disarmed (C stays armed — it must NOT be re-run anyway).
     crash.discard("COLLECT")
+    snapshot = latest_pipeline_state("run-fe-tf", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-fe-tf", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
@@ -427,10 +428,12 @@ async def test_resume_after_full_fan_out_replays_with_zero_new_side_effects(tmp_
     before = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert before == ["A", "B", "C", "COLLECT", "D"]
 
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-fe-done", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-fe-done", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
     after = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert after == before, "a fully-completed fan-out must replay with zero side effects"
@@ -508,10 +511,11 @@ async def test_truncate_falsify_compositional_do_sub_step_survives_mid_item_cras
     # RESUME with the crash disarmed: sub-step 0 REPLAYS (does not re-fire) —
     # only sub-step 1 (X-b) executes.
     crash.clear()
+    snapshot = latest_pipeline_state("run-fe-comp-tf", state_log, scope=GLOBAL_SCOPE)
     await PipelineExecutor().resume(
         "run-fe-comp-tf", pipeline=pipeline,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines == ["X-a", "X-b"], (

--- a/tests/core/test_pipeline_is6_attached.py
+++ b/tests/core/test_pipeline_is6_attached.py
@@ -396,9 +396,10 @@ async def test_executor_cancel_at_boundary_leaves_resumable_journal(
     assert snap is not None and snap["step_index"] == 1
 
     # Explicit resume (no cancel): completes exactly-once — step 0 NOT re-run.
+    snapshot = latest_pipeline_state("run-cancel", state_log, scope=GLOBAL_SCOPE)
     result = await PipelineExecutor().resume(
         "run-cancel", pipeline=pipeline, tool_dispatch=dispatch, state_log=state_log,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
     assert result.step_index == 3
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]
@@ -454,10 +455,11 @@ async def test_driver_cancel_writes_terminal_marker_recovery_skips(
     assert read_resume_attempts(run_dir) == 0
 
     # The preserved journal still supports an EXPLICIT resume, exactly-once.
+    snapshot = latest_pipeline_state("run-dcancel", state_log, scope=GLOBAL_SCOPE)
     result = await PipelineExecutor().resume(
         "run-dcancel", pipeline=pipeline,
         tool_dispatch=_make_tool_dispatch(_bare_ctx(state_log)), state_log=state_log,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
     assert result.step_index == 3
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]

--- a/tests/core/test_pipeline_match_primitive.py
+++ b/tests/core/test_pipeline_match_primitive.py
@@ -306,11 +306,13 @@ async def test_truncate_falsify_match_resumes_case_substeps_exactly_once(tmp_pat
     assert all(s >= 40 for s in surviving), "the case sub-step's WAL entry is truncated away"
 
     crash.clear()
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-match-tf", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-match-tf", pipeline=outer,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
 
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]

--- a/tests/core/test_pipeline_parallel_primitive.py
+++ b/tests/core/test_pipeline_parallel_primitive.py
@@ -455,9 +455,10 @@ async def test_truncate_falsify_mid_parallel_replays_branches_exactly_once(tmp_p
 
     # RESUME with COLLECT disarmed (C stays armed — it must NOT be re-run anyway).
     crash.discard("COLLECT")
+    snapshot = latest_pipeline_state("run-par-tf", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-par-tf", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
 
     lines = out_file.read_text(encoding="utf-8").splitlines()
@@ -489,10 +490,12 @@ async def test_resume_after_full_parallel_replays_with_zero_new_side_effects(tmp
     before = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert before == ["A", "B", "C", "COLLECT", "D"]
 
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-par-done", state_log, scope=GLOBAL_SCOPE)
     resumed = await PipelineExecutor().resume(
         "run-par-done", pipeline=pipeline,
-        tool_dispatch=dispatch, state_log=state_log, scope=GLOBAL_SCOPE,
+        tool_dispatch=dispatch, state_log=state_log, snapshot=snapshot,
     )
     after = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert after == before, "a fully-completed fan-out must replay with zero side effects"
@@ -741,10 +744,11 @@ async def test_truncate_falsify_compositional_branch_sub_step_survives_mid_branc
     # RESUME with the crash disarmed: sub-step 0 REPLAYS (does not re-fire) —
     # only sub-step 1 (X-b) executes.
     crash.clear()
+    snapshot = latest_pipeline_state("run-par-comp-tf", state_log, scope=GLOBAL_SCOPE)
     await PipelineExecutor().resume(
         "run-par-comp-tf", pipeline=pipeline,
         tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
-        scope=GLOBAL_SCOPE,
+        snapshot=snapshot,
     )
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines == ["X-a", "X-b"], (

--- a/tests/core/test_pipeline_r5_agent_step_executor.py
+++ b/tests/core/test_pipeline_r5_agent_step_executor.py
@@ -294,11 +294,13 @@ async def test_resume_replays_completed_agent_step_without_rerunning_llm_turn(
     )
 
     full_pipeline = Pipeline(steps=[step0, step1, step2])
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
     from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+    snapshot = latest_pipeline_state("run-agent-truncate", state_log, scope=GLOBAL_SCOPE)
     resumed = await executor.resume(
         "run-agent-truncate", pipeline=full_pipeline,
         tool_dispatch=lambda *_a, **_k: None,
-        state_log=state_log, registry=reg, scope=GLOBAL_SCOPE,
+        state_log=state_log, registry=reg, snapshot=snapshot,
     )
 
     assert scripted.calls == 1, (


### PR DESCRIPTION
**[e2e-coder]** — #5781: `resume()` takes an already-looked-up `snapshot`, not a `scope`.

Closes #5781

## Why

Architect's finding on PR #5778's own review: `PipelineExecutorDriver.run_turn` (the one real production caller) calls `latest_pipeline_state(wo.run_id, self._state_log, scope=scope)` at `:246` to decide run-vs-resume, then — on the resume path — discards that result and lets `executor.resume` call the SAME function again internally with the SAME scope. One resume, two identical reads. Passing the already-read `snapshot` instead removes the second read AND the `scope` parameter itself — `scope` only ever existed to make that internal lookup, and is the exact parameter #5778 spent two review rounds getting a safe (no-default) signature for. This is not a further hardening of that parameter; it removes it — per architect's own framing this is a simplification, not a hole to close (the #5778 required-kwarg fix already closed the class of bug on its own).

## Changes

- `PipelineExecutor.resume(..., snapshot: dict | None, ...)` replaces the `scope` parameter. `snapshot=None` means "no generation was ever recorded" (run from scratch) — the exact same meaning the internal `latest_pipeline_state(...) is None` check used to produce, now handed in directly. No default (same no-silent-default precedent #5778 established for `scope`).
- `pipeline_executor_driver.py`'s `run_turn`: reads `latest_pipeline_state` ONCE, branches run-vs-resume on that same value, and passes it straight into `resume(snapshot=snapshot, ...)` on the resume path — no second read.
- `latest_pipeline_state` itself is unchanged (still takes `scope`, still required) — #5781 only removes its SECOND call site (inside `resume`); its own contract and the driver's direct call are untouched.
- Updated docstrings in `executor.py` and `pipeline_recovery.py` that described the now-removed internal lookup and its `scope` forwarding (same-PR fix — they went stale the moment this change landed).
- Updated all 19 test call sites (1 real-caller-shaped + 18 test) that passed `scope=GLOBAL_SCOPE` to `resume()`: each now calls `latest_pipeline_state(run_id, state_log, scope=GLOBAL_SCOPE)` itself first (mirroring the real driver's own pattern) and passes the result as `snapshot=`.
- `test_5769_stage3_pipeline_resume_scope.py`: replaced `test_resume_requires_scope_kwarg` with `test_resume_requires_snapshot_kwarg` (same required-kwarg shape, new parameter), and replaced `test_resume_forwards_its_scope_real_witness` with two tests proving the actual #5781 property:
  - `resume(snapshot=None)` ignores a real (impossible `step_index=5`) generation sitting on disk for the same `run_id` — proving `resume` no longer consults `state_log` itself.
  - a complementary test that `resume` correctly replays from a real caller-supplied `snapshot`.

## Tests

Strip-falsified: temporarily reintroduced the old double-read shape (`snapshot = snapshot or latest_pipeline_state(run_id, state_log, scope=GLOBAL_SCOPE)`) via in-file `Edit` inside `resume`, confirmed `test_resume_uses_exactly_the_snapshot_the_caller_passes` goes genuinely RED (`KeyError: 'named_stores'` — the impossible on-disk generation is found and used), restored, confirmed `git diff --stat` clean on `executor.py` and green again.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on touched/new test files (100/100 OK)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py` (200/208, unchanged, all pre-baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`, `check_file_depth_reference.py` (tests/ touched)
- [x] `pytest` scoped to the diff + the full rewind/pipeline-recovery/config-generation/spawn-routing/pipeline-primitives/is2-is6/r3-r4 test surface: 190 tests, all green
- [ ] (skipped — Visual, standing waiver 2026-08-08)

TESTS-READ / merge: lead-coder-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
