### PR TITLE
fix(#5769): checkout takes scope as a required keyword instead of a silent global default

### DIFF
--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -550,7 +550,7 @@ def lineage_predecessor(
 
 async def checkout(
     state_log: StateLog, *, target_seq: int,
-    scope: "tuple[str, str] | None" = None,
+    scope: "tuple[str, str] | None",
     supersedes: int | None = None,
 ) -> int:
     """Append a reset-record to ``target_seq`` UNCONDITIONALLY (Phase-2 D8 fork).
@@ -569,21 +569,30 @@ async def checkout(
     ``supersedes`` is **audit-only** (records the prior active pointer for the
     branch-tree audit trail); ``is_active`` derivation does not depend on it.
 
-    #5769 stage 3 (ADR-0047 decision 3): ``scope=None`` (the default) writes
-    the SAME record shape as before this parameter existed — no ``scope``
-    key at all in the WAL entry, byte-identical to every pre-#5769 call —
-    so every existing caller (``rewind()`` below, and the ~20 direct test
-    call sites across the suite) is completely unaffected. ``scope=(agent,
-    sid)`` writes that pair into the entry's own ``scope`` field, read back
-    by ``build_active_predicate``'s own scope filter (stage 1). Unlike
-    ``build_active_predicate``'s ``scope`` (required, no default — stage 1
-    made that required because a forgotten scope there silently reasons
-    about the WRONG branch for a real, already-known (agent, sid)), a
-    default here is safe: a caller that omits ``scope`` gets EXACTLY
-    today's well-understood global-rewind behavior, not a silent
-    misbehavior — there is no "wrong branch" to accidentally read on the
-    WRITE side, only "write global" (unchanged) vs. "write scoped" (new,
-    opt-in)."""
+    #5769 (ADR-0047 decision 3): ``scope=GLOBAL_SCOPE`` writes the SAME record
+    shape as before this parameter existed — no ``scope`` key at all in the
+    WAL entry, byte-identical to every pre-#5769 call. ``scope=(agent, sid)``
+    writes that pair into the entry's own ``scope`` field, read back by
+    ``build_active_predicate``'s own scope filter (stage 1).
+
+    No default (required keyword-only) — a stage-3 draft of this function
+    gave ``scope`` a ``None`` default, reasoning that "write global" is a
+    safe, well-understood fallback (unlike a forgotten READ-side scope,
+    which silently reasons about the wrong branch). Architect's follow-up
+    review overruled that: a forgotten ``scope`` here does not merely widen
+    a read, it WRITES a real, effectful reset-record that rewinds every
+    session atomically — the exact function ADR-0047 decision 3 names as
+    the session-scoped-rewind boundary. All three of the architect's
+    standing "does this default matter" lines land here: (1) is it visible
+    under the shipped config — no, an omitted ``scope`` produces a
+    successful, ordinary-looking global rewind; (2) is it the safe
+    direction — no, "forgot to scope it" silently becomes "rewound
+    everyone," the more dangerous of the two outcomes; (3) does the caller
+    already know its answer — yes, every real caller either has a real
+    ``(agent, sid)`` in hand or is an intentionally-global primitive
+    (``rewind``/``rewind_to``/the ``/rewind`` slash command) that can name
+    ``GLOBAL_SCOPE`` explicitly. A default here would only ever paper over
+    a forgotten call, never serve a caller with nothing to say."""
     fields: "dict[str, object]" = {
         "target_n": int(target_seq), "supersedes": supersedes,
     }
@@ -602,6 +611,12 @@ async def rewind(
     rewinds along the live timeline; Phase-2 ``checkout`` lifts it.
 
     Raises ``RewindIntoAbandonedError`` when ``target_n`` is on an abandoned branch.
+
+    No ``scope`` parameter of its own: ``rewind`` is the pre-#5769,
+    genuinely global Phase-1 undo primitive (no per-session concept
+    anywhere in its own contract), so it passes ``GLOBAL_SCOPE`` to
+    ``checkout`` explicitly — an honest spelling of "this caller has no
+    owner to name," not an inferred or forgotten one.
     """
     is_active = _make_is_active(_abandoned_intervals(_rewind_records(state_log)))
     if not is_active(target_n):
@@ -610,7 +625,9 @@ async def rewind(
             "to an abandoned branch is a Phase-2 fork, not supported by Phase-1 "
             "undo (use checkout). Rewind only to a seq on the active timeline."
         )
-    return await checkout(state_log, target_seq=target_n, supersedes=supersedes)
+    return await checkout(
+        state_log, target_seq=target_n, scope=GLOBAL_SCOPE, supersedes=supersedes,
+    )
 
 
 def reconstruct(

--- a/src/reyn/interfaces/slash/rewind.py
+++ b/src/reyn/interfaces/slash/rewind.py
@@ -104,7 +104,10 @@ async def rewind_cmd(ctx: "SlashContext", args: str) -> None:
         # undo for a live-branch seq, fork-switch for a dead-branch seq. Keeps
         # the two "go to seq N" entries (slash + picker) behaviourally identical
         # (no sibling-gap); checkout subsumes rewind_to for active seqs.
-        result = await registry.checkout(target)
+        # #5769: this command has no per-session concept yet (the session-scoped
+        # rewind UI is a later, separate arc) — GLOBAL_SCOPE names that honestly.
+        from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+        result = await registry.checkout(target, scope=GLOBAL_SCOPE)
     except Exception as exc:  # noqa: BLE001 — surface the reason to the user
         await reply_error(ctx, f"/rewind: {exc}")
         return

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2162,7 +2162,7 @@ class AgentRegistry:
                     )
 
     async def checkout(
-        self, seq: int, *, scope: "tuple[str, str] | None" = None,
+        self, seq: int, *, scope: "tuple[str, str] | None",
     ) -> dict:
         """Consistent-cut checkout to ANY WAL ``seq`` (ADR-0038 D8 Phase-2 /
         ADR-0047 decision 3, session-scoped rewind).
@@ -2182,7 +2182,7 @@ class AgentRegistry:
         ``is_active`` from the full chain, the runtime substrate follows the
         *target's* lineage automatically.
 
-        ``scope=None`` (default) is the **architecture-enforced global cut**
+        ``scope=GLOBAL_SCOPE`` is the **architecture-enforced global cut**
         (D2), byte-identical to before this parameter existed: one global
         single-seq WAL ⇒ one reset-record moves *every* agent atomically:
 
@@ -2207,6 +2207,19 @@ class AgentRegistry:
         exact same physical floor a global one is.
 
         ``_rewind_in_progress`` gates compaction for the whole window.
+
+        No default (required keyword-only): a forgotten ``scope`` here does
+        not merely widen a read, it WRITES a real, effectful reset-record
+        that rewinds every session atomically — the exact function ADR-0047
+        decision 3 names as the session-scoped-rewind boundary. Architect's
+        ruling (following the parallel finding on the module-level
+        ``checkout`` this method delegates the reset-record write to,
+        via ``_append_reset_record``): a default here would be unsafe in
+        the dangerous direction (an omitted ``scope`` silently becomes a
+        full global rewind, not an error) and every real caller already
+        knows its own answer (``rewind_to`` below, and the ``/rewind``
+        slash command, are both intentionally-global callers that name
+        ``GLOBAL_SCOPE`` explicitly).
         """
         if self._state_log is None:
             raise RuntimeError("checkout requires a state log")
@@ -2274,7 +2287,7 @@ class AgentRegistry:
             # 4. single global reset-record; supersedes = prior active head (audit).
             prior_head = self._state_log.last_durable_seq
             reset_seq = await _append_reset_record(
-                self._state_log, target_seq=seq, supersedes=prior_head,
+                self._state_log, target_seq=seq, scope=GLOBAL_SCOPE, supersedes=prior_head,
             )
             # 5. materialise both substrates along the target lineage.
             agents = await self._materialize_rewind(
@@ -2306,6 +2319,10 @@ class AgentRegistry:
         Raises ``RewindIntoAbandonedError`` if ``target_n`` is on an abandoned
         branch (switching branches is a Phase-2 fork, not Phase-1 undo — use
         ``checkout``).
+
+        No ``scope`` parameter of its own: like the module-level ``rewind``,
+        this is the pre-#5769, genuinely global Phase-1 undo primitive — it
+        passes ``GLOBAL_SCOPE`` to ``checkout`` explicitly.
         """
         if self._state_log is None:
             raise RuntimeError("rewind_to requires a state log")
@@ -2315,7 +2332,7 @@ class AgentRegistry:
                 "Phase-1 undo only rewinds to a seq on the active timeline "
                 "(use checkout for a Phase-2 branch-switch)."
             )
-        return await self.checkout(target_n)
+        return await self.checkout(target_n, scope=GLOBAL_SCOPE)
 
     def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
         """Enumerate rewind targets for the time-travel UI (1f / Phase-2 fork).

--- a/tests/core/test_2103_Btool_lineage_rewind_1953.py
+++ b/tests/core/test_2103_Btool_lineage_rewind_1953.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import checkout, rewind
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, checkout, rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -72,7 +72,7 @@ async def test_lineage_survives_rewind_round_trip_child_stays_capped(tmp_path):
 
     # forward-checkout PAST C's create: Phase-2 checkout since cseq is now abandoned.
     # checkout subsumes R1 (R1 falls in (cseq, R2)), leaving C's seq active again.
-    R2 = await checkout(log, target_seq=cseq)    # new active target; R1 subsumed
+    R2 = await checkout(log, target_seq=cseq, scope=GLOBAL_SCOPE)    # new active target; R1 subsumed
     await reg._materialize_rewind(reconstruct_seq=R2, workspace_at_or_below=cseq)
     assert _agent_dir(tmp_path, "C").is_dir()  # re-materialised
     contextual, _ = reg.resolved_profile_for("C")

--- a/tests/core/test_4387_active_branch_history_extend_on_demand.py
+++ b/tests/core/test_4387_active_branch_history_extend_on_demand.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import REWIND_KIND, checkout
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session
@@ -78,7 +78,7 @@ async def test_rewind_past_a_bounded_prefix_extends_backward(tmp_path, monkeypat
     assert [m.content for m in s.history] == ["turn 8", "turn 9", "turn 10"]
 
     # Rewind to after turn 3 — entirely OLDER than what's currently loaded.
-    await checkout(state_log, target_seq=anchors[2])
+    await checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE)
 
     assert _visible_texts(s) == ["turn 1", "turn 2", "turn 3"], (
         "the active branch (turns 1-3) must be visible even though none of "
@@ -143,7 +143,7 @@ async def test_extend_backward_survives_wal_truncation_below_the_rewind_record(
     anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 11)]
     s.history = s.history[-3:]  # bounded load: only turns 8-10 in memory
 
-    await checkout(state_log, target_seq=anchors[2])  # hide turns 4-10
+    await checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE)  # hide turns 4-10
     # Grow the WAL further so there's real content past the rewind to
     # truncate BELOW (truncate_below's min_keep_seq must be > the rewind
     # record's own seq for this to be a meaningful drop, not a no-op).

--- a/tests/core/test_4768_ephemeral_vanish_during_global_rewind.py
+++ b/tests/core/test_4768_ephemeral_vanish_during_global_rewind.py
@@ -50,6 +50,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -115,7 +116,7 @@ async def test_ephemeral_vanish_racing_a_global_rewind_no_straggler_and_terminat
     # TrackedTaskSet.aclose's reentrancy exclusion (or anything else in the
     # #4759/#4765 chain) has a real cycle, THIS is where it hangs, and CI's
     # own --timeout=120 is the only thing that catches it.
-    result = await reg.checkout(put_seq)
+    result = await reg.checkout(put_seq, scope=GLOBAL_SCOPE)
     R = result["reset_seq"]
 
     # The vanish task must have actually run to completion by now (checkout's

--- a/tests/core/test_5769_stage3_checkout_scope.py
+++ b/tests/core/test_5769_stage3_checkout_scope.py
@@ -1,20 +1,33 @@
 """Tier 2: OS invariant -- #5769 stage 3, checkout gains a session scope
 (ADR-0047 decision 3/5, the writer + recovery half).
 
-Real `AgentRegistry` + `StateLog` + on-disk agents (no mocks). `scope=None`
-(default) is byte-identical to the pre-#5769 global cut; `scope=(name, sid)`
-cancels/quiesces, appends a reset-record for, and materialises ONLY that
-session -- never touching another agent/session, the workspace, or config
-generations (decision 4/6).
+Real `AgentRegistry` + `StateLog` + on-disk agents (no mocks). `scope=
+GLOBAL_SCOPE` is byte-identical to the pre-#5769 global cut; `scope=(name,
+sid)` cancels/quiesces, appends a reset-record for, and materialises ONLY
+that session -- never touching another agent/session, the workspace, or
+config generations (decision 4/6).
 
 Covers: the retention guard staying global regardless of scope (architect's
 explicit ruling), a scoped checkout leaving an unrelated agent's session
 completely untouched (decision 5's own "sessions can diverge" witness),
 crash recovery reading `(target_n, scope)` off the latest reset-record and
-materialising only that pair, and the CLAUDE.md hard-rule truncate-falsify
+materialising only that pair, the CLAUDE.md hard-rule truncate-falsify
 test for a recovery-feature PR: write a scoped rewind, truncate the WAL past
 its own supporting events, reconstruct from the surviving self-contained
 snapshot alone, and confirm the scoped rewind's effect survives.
+
+`scope` is a required keyword-only argument on BOTH `checkout` functions
+(module-level `snapshot_generations.checkout` and
+`AgentRegistry.checkout`) -- no default. An earlier draft of this PR gave
+`scope` a `None` default, reasoning (by analogy with the READ-side/WRITE-side
+split #5769 stage 1 drew) that "write global" is a safe fallback. Architect's
+follow-up review overruled that: unlike a merely-too-broad READ, a forgotten
+`scope` here WRITES a real, effectful reset-record that rewinds every session
+atomically -- the exact function ADR-0047 decision 3 names as the
+session-scoped-rewind boundary -- so the omission is invisible under the
+shipped config, lands in the dangerous direction (silently global, not an
+error), and every real caller already knows its own answer (`rewind`/
+`rewind_to`/the `/rewind` slash command all name `GLOBAL_SCOPE` explicitly).
 """
 from __future__ import annotations
 
@@ -23,7 +36,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
-from reyn.core.events.snapshot_generations import RewindBeyondRetentionError
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, RewindBeyondRetentionError
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -61,14 +74,14 @@ def _inbox_ids(snap: AgentSnapshot) -> list[str]:
 
 @pytest.mark.asyncio
 async def test_checkout_scope_none_writes_the_same_record_shape_as_before(tmp_path):
-    """Tier 2: acceptance -- scope=None (default) leaves the existing WAL
+    """Tier 2: acceptance -- scope=GLOBAL_SCOPE leaves the existing WAL
     entry shape untouched: no `scope` key at all in the reset-record."""
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
     log = reg.state_log
     await _put(log, "alpha", "a1")
 
-    result = await reg.checkout(1)
+    result = await reg.checkout(1, scope=GLOBAL_SCOPE)
 
     entry = next(e for e in log.iter_from(0) if e.get("kind") == "rewind")
     assert "scope" not in entry
@@ -177,8 +190,8 @@ async def test_recover_rewind_if_needed_materialises_only_the_scoped_session(tmp
 @pytest.mark.asyncio
 async def test_recover_rewind_if_needed_stays_global_for_a_legacy_unscoped_record(tmp_path):
     """Tier 2: non-regression -- a crash mid-GLOBAL-rewind (no scope field
-    at all, exactly what checkout()'s scope=None path still writes) is
-    still recovered via the full, unchanged materialise-everything path."""
+    at all, exactly what checkout()'s scope=GLOBAL_SCOPE path still writes)
+    is still recovered via the full, unchanged materialise-everything path."""
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
     _seed_agent(tmp_path, "beta")
@@ -188,7 +201,9 @@ async def test_recover_rewind_if_needed_stays_global_for_a_legacy_unscoped_recor
     await _put(log, "beta", "b1")
 
     from reyn.core.events.snapshot_generations import checkout as append_reset_record
-    await append_reset_record(log, target_seq=1, supersedes=log.current_seq)  # no scope
+    await append_reset_record(
+        log, target_seq=1, scope=GLOBAL_SCOPE, supersedes=log.current_seq,
+    )  # GLOBAL_SCOPE writes no scope field -- byte-identical to legacy
 
     result = await reg.recover_rewind_if_needed()
 
@@ -243,3 +258,34 @@ async def test_scoped_rewind_survives_wal_truncation_past_its_own_events(tmp_pat
     saved.apply_events(list(log.iter_from(saved.applied_seq + 1)))
 
     assert _inbox_ids(saved) == ["a1", "a3"]  # a2 stays gone -- the scope survived truncation
+
+
+@pytest.mark.asyncio
+async def test_module_level_checkout_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- a call site that forgets scope fails at the
+    call, matching every other #5769/#5781 (agent, sid)-carrying seam's
+    own required-kwarg contract. Pins OUR signature decision (a forgotten
+    scope here WRITES a real, effectful global rewind -- the dangerous
+    direction -- rather than silently reading the wrong branch), not a
+    language behaviour."""
+    from reyn.core.events.snapshot_generations import checkout
+
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    with pytest.raises(TypeError):
+        await checkout(log, target_seq=0)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_registry_checkout_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- same shape as
+    `test_module_level_checkout_requires_scope_kwarg`, one layer OUT, on
+    `AgentRegistry.checkout` itself (the function ADR-0047 decision 3
+    names as the session-scoped-rewind boundary)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    await _put(log, "alpha", "a1")
+
+    with pytest.raises(TypeError):
+        await reg.checkout(1)  # type: ignore[call-arg]

--- a/tests/core/test_5769_stage3_pipeline_resume_scope.py
+++ b/tests/core/test_5769_stage3_pipeline_resume_scope.py
@@ -244,3 +244,12 @@ async def test_resume_replays_from_the_snapshot_the_caller_passes(tmp_path, monk
     # tool's own side effect (creating out_file) never fires.
     assert result.step_index == 1
     assert not out_file.exists()
+
+    # Population witness (lead-coder-30 review, PR #5784): the negative
+    # assertion above is only meaningful if the counting tool actually
+    # WORKS -- fire it directly, once, and confirm it creates the file.
+    # Distinguishes "resume chose not to execute it" from "it could never
+    # have executed regardless" (a broken _install_counting_tool would
+    # pass the assertion above for the wrong reason).
+    await dispatch("stage3_step", {})
+    assert out_file.exists()

--- a/tests/core/test_active_branch_history_scan_bound_2941.py
+++ b/tests/core/test_active_branch_history_scan_bound_2941.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session
@@ -77,7 +77,7 @@ async def test_active_branch_history_scans_wal_o1_per_build_not_per_message(tmp_
         anchors.append(s.history[-1].meta["wal_seq"])
     # A rewind exists so the abandoned-interval predicate is non-trivial (not the
     # degenerate empty-list fast path).
-    await checkout(state_log, target_seq=anchors[5])
+    await checkout(state_log, target_seq=anchors[5], scope=GLOBAL_SCOPE)
 
     state_log.iter_from_calls = 0  # measure only the build_history() call under test
     wire = s._history_buffer.build_history()
@@ -106,7 +106,7 @@ async def test_active_branch_history_scan_count_independent_of_message_count(tmp
 
     for i in range(5):
         await _turn(i)
-    await checkout(state_log, target_seq=(await _turn(5)))
+    await checkout(state_log, target_seq=(await _turn(5)), scope=GLOBAL_SCOPE)
 
     state_log.iter_from_calls = 0
     s._history_buffer.build_history()

--- a/tests/core/test_build_active_predicate_equivalence_2941.py
+++ b/tests/core/test_build_active_predicate_equivalence_2941.py
@@ -46,7 +46,7 @@ async def test_single_rewind_abandons_interval(tmp_path: Path) -> None:
     """Tier 2: one rewind — the abandoned (target, R) interval hidden under both."""
     state_log = StateLog(tmp_path / "state.wal")
     seqs = [await state_log.append("step_completed") for _ in range(10)]
-    await checkout(state_log, target_seq=seqs[2])
+    await checkout(state_log, target_seq=seqs[2], scope=GLOBAL_SCOPE)
     _assert_equivalent(state_log, range(1, state_log.current_seq + 1))
 
 
@@ -56,9 +56,9 @@ async def test_nested_subsuming_rewinds(tmp_path: Path) -> None:
     (nested abandonment) — equivalence holds through the composition."""
     state_log = StateLog(tmp_path / "state.wal")
     seqs = [await state_log.append("step_completed") for _ in range(6)]
-    await checkout(state_log, target_seq=seqs[4])  # abandon a small tail first
+    await checkout(state_log, target_seq=seqs[4], scope=GLOBAL_SCOPE)  # abandon a small tail first
     more = [await state_log.append("step_completed") for _ in range(4)]
-    await checkout(state_log, target_seq=seqs[1])  # subsumes the first rewind entirely
+    await checkout(state_log, target_seq=seqs[1], scope=GLOBAL_SCOPE)  # subsumes the first rewind entirely
     _assert_equivalent(state_log, range(1, state_log.current_seq + 1))
     assert more  # sanity: the intervening turns exist in the WAL
 
@@ -69,10 +69,10 @@ async def test_checkout_back_resurrection(tmp_path: Path) -> None:
     tip — resurrects it. Equivalence holds across the resurrection."""
     state_log = StateLog(tmp_path / "state.wal")
     seqs = [await state_log.append("step_completed") for _ in range(6)]
-    await checkout(state_log, target_seq=seqs[2])       # rewind: abandons seqs[3:6]
+    await checkout(state_log, target_seq=seqs[2], scope=GLOBAL_SCOPE)       # rewind: abandons seqs[3:6]
     for _ in range(3):
         await state_log.append("step_completed")         # new branch forward
-    await checkout(state_log, target_seq=seqs[5])       # checkout back: resurrects seqs[3:6]
+    await checkout(state_log, target_seq=seqs[5], scope=GLOBAL_SCOPE)       # checkout back: resurrects seqs[3:6]
     _assert_equivalent(state_log, range(1, state_log.current_seq + 1))
 
 
@@ -83,7 +83,7 @@ async def test_predicate_is_reusable_across_many_seqs(tmp_path: Path) -> None:
     on (build once per turn, apply per message)."""
     state_log = StateLog(tmp_path / "state.wal")
     seqs = [await state_log.append("step_completed") for _ in range(20)]
-    await checkout(state_log, target_seq=seqs[9])
+    await checkout(state_log, target_seq=seqs[9], scope=GLOBAL_SCOPE)
     predicate = build_active_predicate(state_log, scope=GLOBAL_SCOPE)
     expected = [is_active_seq(state_log, s) for s in range(1, state_log.current_seq + 1)]
     actual = [predicate(s) for s in range(1, state_log.current_seq + 1)]

--- a/tests/core/test_conversation_rewind_2360.py
+++ b/tests/core/test_conversation_rewind_2360.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session
@@ -91,7 +91,7 @@ async def test_rewind_hides_post_cut_turns_exactly(tmp_path, monkeypatch):
 
     assert _visible(s) == [f"turn {i}" for i in range(1, 6)]  # all visible pre-rewind
 
-    await checkout(state_log, target_seq=anchors[2])  # keep through turn 3
+    await checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE)  # keep through turn 3
 
     assert _visible(s) == ["turn 1", "turn 2", "turn 3"], "exact prefix, 4/5 hidden"
 
@@ -104,7 +104,7 @@ async def test_history_file_stays_append_only(tmp_path, monkeypatch):
     state_log = StateLog(tmp_path / "state.wal")
     s = _session(tmp_path, "alice", state_log)
     anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 6)]
-    await checkout(state_log, target_seq=anchors[2])
+    await checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE)
 
     raw = s.history_path.read_text()
     assert "turn 4" in raw and "turn 5" in raw, "append-only: hidden turns still on disk"
@@ -120,12 +120,12 @@ async def test_fork_switch_and_no_discard(tmp_path, monkeypatch):
     s = _session(tmp_path, "alice", state_log)
     anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 6)]
 
-    await checkout(state_log, target_seq=anchors[2])  # rewind to after turn 3
+    await checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE)  # rewind to after turn 3
     await _turn(s, state_log, "turn 6")
     await _turn(s, state_log, "turn 7")
     assert _visible(s) == ["turn 1", "turn 2", "turn 3", "turn 6", "turn 7"]
 
-    await checkout(state_log, target_seq=anchors[4])  # switch back to the old tip (turn 5)
+    await checkout(state_log, target_seq=anchors[4], scope=GLOBAL_SCOPE)  # switch back to the old tip (turn 5)
     assert _visible(s) == [f"turn {i}" for i in range(1, 6)], "old future revived"
     raw = s.history_path.read_text()
     assert "turn 6" in raw and "turn 7" in raw, "no discard: the alternate branch survives in the file"
@@ -147,7 +147,7 @@ async def test_global_cut_filters_each_session_own_view(tmp_path, monkeypatch):
     await _turn(a, state_log, "A2")
     await _turn(b, state_log, "B2")
 
-    await checkout(state_log, target_seq=b1)  # world-cut just after B1 (A1 < B1 < A2 < B2)
+    await checkout(state_log, target_seq=b1, scope=GLOBAL_SCOPE)  # world-cut just after B1 (A1 < B1 < A2 < B2)
 
     assert _visible(a) == ["A1"], "alice: only her ≤-cut turn"
     assert _visible(b) == ["B1"], "bob: only his ≤-cut turn"
@@ -164,7 +164,7 @@ async def test_unanchored_turns_always_visible(tmp_path, monkeypatch):
     s.history.append(ChatMessage(role="user", content="legacy-no-anchor"))  # no wal_seq in meta
     await _turn(s, state_log, "anchored-2")
 
-    await checkout(state_log, target_seq=a1)  # hides anchored-2
+    await checkout(state_log, target_seq=a1, scope=GLOBAL_SCOPE)  # hides anchored-2
 
     visible = _visible(s)
     assert "legacy-no-anchor" in visible, "unanchored turns stay visible (no migration)"
@@ -186,7 +186,7 @@ async def test_mid_tool_cycle_cut_leaves_no_dangling(tmp_path, monkeypatch):
     assert result_anchor > call_anchor  # the cut can fall strictly between call and result
 
     # cut lands mid-cycle (at the call anchor; the result's anchor is beyond it)
-    await checkout(state_log, target_seq=call_anchor)
+    await checkout(state_log, target_seq=call_anchor, scope=GLOBAL_SCOPE)
     wire = s._history_buffer.build_history()
     assert _dangling(wire) == set(), "mid-cycle cut must leave a well-formed (dangling-free) payload"
     assert any(m.get("role") == "tool" and m.get("tool_call_id") == "tc1" for m in wire), \
@@ -211,7 +211,7 @@ async def test_rewind_record_survives_wal_truncation(tmp_path, monkeypatch):
 
     # Three turns; rewind to after turn 1 (abandons turns 2 and 3).
     anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 4)]
-    reset_seq = await checkout(state_log, target_seq=anchors[0])
+    reset_seq = await checkout(state_log, target_seq=anchors[0], scope=GLOBAL_SCOPE)
 
     # New turns on the active branch — these advance applied_seq past the reset record.
     for i in range(4, 10):
@@ -249,7 +249,7 @@ async def test_cut_before_tool_cycle_hides_whole_cycle_no_dangling(tmp_path, mon
     u1 = await _turn(s, state_log, "hello")
     await _tool_cycle(s, state_log, "tc1")
 
-    await checkout(state_log, target_seq=u1)  # cut before the cycle
+    await checkout(state_log, target_seq=u1, scope=GLOBAL_SCOPE)  # cut before the cycle
     wire = s._history_buffer.build_history()
     assert _dangling(wire) == set(), "cut before the cycle must leave no dangling tool result"
     assert not any(m.get("role") == "tool" for m in wire), "the whole cycle is hidden (call+result)"

--- a/tests/core/test_registry_checkout_2a2.py
+++ b/tests/core/test_registry_checkout_2a2.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
-from reyn.core.events.snapshot_generations import RewindIntoAbandonedError, rewind
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, RewindIntoAbandonedError, rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -80,14 +80,14 @@ async def test_checkout_back_revives_lineage_runtime(tmp_path):
     assert _inbox_ids(tmp_path, "alpha") == ["a1"]   # post-rewind active = [a1] (a3 not yet materialised on disk)
 
     # checkout to seq 2 (ABANDONED — a2's dead branch): revives a2, abandons a3.
-    res2 = await reg.checkout(2)
+    res2 = await reg.checkout(2, scope=GLOBAL_SCOPE)
     assert res2["target_n"] == 2
     assert _inbox_ids(tmp_path, "alpha") == ["a1", "a2"]   # target lineage, NOT [a1,a3]
     # self-contained snapshot pinned to the new reset-record (same invariant as rewind).
     assert AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha")).applied_seq == res2["reset_seq"]
 
     # checkout BACK to seq 4 (now abandoned — a3's lineage): revives a3, re-abandons a2.
-    res4 = await reg.checkout(4)
+    res4 = await reg.checkout(4, scope=GLOBAL_SCOPE)
     assert res4["target_n"] == 4
     assert _inbox_ids(tmp_path, "alpha") == ["a1", "a3"]   # lineage swapped back, no a2 leakage
 
@@ -108,7 +108,7 @@ async def test_checkout_to_active_seq_equals_rewind_to(tmp_path):
     await _put(log, "alpha", "a1")          # seq 1
     await _put(log, "alpha", "a2")          # seq 2
 
-    res = await reg.checkout(1)               # active target → undo semantics
+    res = await reg.checkout(1, scope=GLOBAL_SCOPE)  # active target → undo semantics
     assert res["target_n"] == 1
     assert _inbox_ids(tmp_path, "alpha") == ["a1"]   # a2 abandoned, as rewind_to(1) would
     assert AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha")).applied_seq == res["reset_seq"]
@@ -133,6 +133,6 @@ async def test_rewind_to_still_rejects_abandoned_after_refactor(tmp_path):
         await reg.rewind_to(2)               # abandoned target — undo still rejects
 
     # but checkout to the same abandoned seq is ALLOWED (the lifted guard).
-    res = await reg.checkout(2)
+    res = await reg.checkout(2, scope=GLOBAL_SCOPE)
     assert res["target_n"] == 2
     assert _inbox_ids(tmp_path, "alpha") == ["a", "b"]   # a2 lineage revived

--- a/tests/core/test_restore_all_subscription_scan_bound_2944.py
+++ b/tests/core/test_restore_all_subscription_scan_bound_2944.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 
@@ -76,7 +76,7 @@ async def test_restore_all_scan_count_independent_of_wal_size(tmp_path, monkeypa
 
     small_log = _CountingStateLog(tmp_path / "small" / ".reyn" / "wal.jsonl")
     seqs = await _seed_wal(small_log, 30)
-    await checkout(small_log, target_seq=seqs[5])
+    await checkout(small_log, target_seq=seqs[5], scope=GLOBAL_SCOPE)
     small_reg = _make_registry(tmp_path / "small", small_log)
     small_log.iter_from_calls = 0
     await small_reg.restore_all()
@@ -84,7 +84,7 @@ async def test_restore_all_scan_count_independent_of_wal_size(tmp_path, monkeypa
 
     large_log = _CountingStateLog(tmp_path / "large" / ".reyn" / "wal.jsonl")
     seqs = await _seed_wal(large_log, 600)
-    await checkout(large_log, target_seq=seqs[5])
+    await checkout(large_log, target_seq=seqs[5], scope=GLOBAL_SCOPE)
     large_reg = _make_registry(tmp_path / "large", large_log)
     large_log.iter_from_calls = 0
     await large_reg.restore_all()
@@ -109,7 +109,7 @@ async def test_restore_all_scan_count_bounded_not_proportional_to_wal_entries(
     state_log = _CountingStateLog(tmp_path / ".reyn" / "wal.jsonl")
     n = 200
     seqs = await _seed_wal(state_log, n)
-    await checkout(state_log, target_seq=seqs[10])  # non-trivial abandoned interval
+    await checkout(state_log, target_seq=seqs[10], scope=GLOBAL_SCOPE)  # non-trivial abandoned interval
     reg = _make_registry(tmp_path, state_log)
 
     state_log.iter_from_calls = 0

--- a/tests/core/test_rewind_index_incremental_2939.py
+++ b/tests/core/test_rewind_index_incremental_2939.py
@@ -68,7 +68,7 @@ async def test_active_branch_derivation_decodes_do_not_grow_with_wal_size(tmp_pa
     with the WAL; the incremental index keeps it flat."""
     state_log = StateLog(tmp_path / "state.wal")
     anchor = await _grow_wal(state_log, 50)
-    await checkout(state_log, target_seq=anchor // 2)
+    await checkout(state_log, target_seq=anchor // 2, scope=GLOBAL_SCOPE)
     build_active_predicate(state_log, scope=GLOBAL_SCOPE)  # warm
 
     counter = _count_decodes(monkeypatch)
@@ -99,7 +99,7 @@ async def test_repeated_derivation_over_unchanged_wal_decodes_nothing(tmp_path, 
     — the dropdown-open / per-turn path pays for change, not for history size."""
     state_log = StateLog(tmp_path / "state.wal")
     anchor = await _grow_wal(state_log, 200)
-    await checkout(state_log, target_seq=anchor // 2)
+    await checkout(state_log, target_seq=anchor // 2, scope=GLOBAL_SCOPE)
     build_active_predicate(state_log, scope=GLOBAL_SCOPE)  # warm
 
     counter = _count_decodes(monkeypatch)
@@ -123,7 +123,7 @@ async def test_rewind_appended_after_warm_index_takes_effect(tmp_path):
 
     assert is_active_seq(state_log, abandoned_seq), "sanity: active before any rewind"
 
-    await checkout(state_log, target_seq=anchor)
+    await checkout(state_log, target_seq=anchor, scope=GLOBAL_SCOPE)
 
     assert not is_active_seq(state_log, abandoned_seq), (
         "a rewind appended after the derivation was first built must abandon the "
@@ -146,7 +146,7 @@ async def test_truncation_dropping_a_rewind_record_does_not_serve_a_stale_interv
     state_log = StateLog(tmp_path / "state.wal")
     anchor = await _grow_wal(state_log, 10)
     abandoned_seq = await _grow_wal(state_log, 5)
-    await checkout(state_log, target_seq=anchor)
+    await checkout(state_log, target_seq=anchor, scope=GLOBAL_SCOPE)
     head = await _grow_wal(state_log, 5)
 
     # Warm the derivation while the reset-record is present.
@@ -178,7 +178,7 @@ async def test_truncation_preserving_rewind_records_keeps_them_active(tmp_path):
     state_log = StateLog(tmp_path / "state.wal")
     anchor = await _grow_wal(state_log, 10)
     abandoned_seq = await _grow_wal(state_log, 5)
-    await checkout(state_log, target_seq=anchor)
+    await checkout(state_log, target_seq=anchor, scope=GLOBAL_SCOPE)
     head = await _grow_wal(state_log, 5)
 
     assert not is_active_seq(state_log, abandoned_seq), "sanity: abandoned pre-truncation"

--- a/tests/interfaces/test_slash_rewind_copy_cmds.py
+++ b/tests/interfaces/test_slash_rewind_copy_cmds.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.interfaces.slash.copy import copy_cmd
 from reyn.interfaces.slash.rewind import rewind_cmd
 from reyn.runtime.outbox import OutboxMessage
@@ -86,6 +87,11 @@ class _FakeRegistry:
         self._checkout_result = checkout_result
         self._checkout_raises = checkout_raises
         self.checkout_calls: list[int] = []
+        # #5769/#5784: the real AgentRegistry.checkout takes `scope` as a
+        # required keyword-only argument (no default) -- recorded here too
+        # so a test can assert on it, matching the real signature this fake
+        # stands in for.
+        self.checkout_scopes: "list[tuple[str, str] | None]" = []
 
     def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
         return self._points
@@ -93,8 +99,9 @@ class _FakeRegistry:
     def list_branches(self) -> list:
         return self._branches
 
-    async def checkout(self, target: int) -> dict:
+    async def checkout(self, target: int, *, scope: "tuple[str, str] | None") -> dict:
         self.checkout_calls.append(target)
+        self.checkout_scopes.append(scope)
         if self._checkout_raises is not None:
             raise self._checkout_raises
         return self._checkout_result or {"agents": [], "target_n": target}
@@ -193,6 +200,9 @@ async def test_rewind_direct_success_calls_checkout_with_parsed_int() -> None:
     session = _FakeSession(registry=registry)
     await rewind_cmd(_ctx(session), "42")
     assert registry.checkout_calls == [42]
+    # #5769: /rewind has no per-session UI yet (a separate, owner-gated arc
+    # per #5778's own explicit split) -- it names GLOBAL_SCOPE explicitly.
+    assert registry.checkout_scopes == [GLOBAL_SCOPE]
 
 
 # ── /copy sentinel emitter ─────────────────────────────────────────────────

--- a/tests/runtime/test_4387_history_resident_eviction.py
+++ b/tests/runtime/test_4387_history_resident_eviction.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import pytest
 
 from reyn.config.chat import HistoryResidentConfig
-from reyn.core.events.snapshot_generations import REWIND_KIND, checkout
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.mcp.server import _history_baseline_seq, _new_agent_history_entries
 from reyn.runtime.chat_message import ChatMessage
@@ -272,7 +272,7 @@ async def test_active_branch_history_survives_wal_truncation_after_real_eviction
         "earliest turn for this test to actually exercise eviction"
     )
 
-    await checkout(state_log, target_seq=anchors[2])  # hide turns 4-10
+    await checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE)  # hide turns 4-10
 
     for i in range(11, 14):
         await _turn(s, state_log, f"turn {i}")

--- a/tests/runtime/test_4472_compaction_reads_durable_store.py
+++ b/tests/runtime/test_4472_compaction_reads_durable_store.py
@@ -38,7 +38,7 @@ from types import SimpleNamespace
 import litellm
 
 from reyn.config import CompactionConfig
-from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.chat_message import ChatMessage
@@ -148,7 +148,7 @@ def test_compaction_never_folds_an_abandoned_branch_turn_into_the_summary(
             asyncio.run(_turn(s, state_log, f"ABANDONED-MARKER-turn-{i} {pad}"))
         )
 
-    asyncio.run(checkout(state_log, target_seq=anchors[2]))  # hide turns 4-10
+    asyncio.run(checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE))  # hide turns 4-10
 
     for i in range(11, 15):
         asyncio.run(_turn(s, state_log, f"active-turn-{i} {pad}"))
@@ -189,7 +189,7 @@ def test_active_branch_history_still_agrees_with_compaction_after_a_rewind(
     for i in range(1, 8):
         anchors.append(asyncio.run(_turn(s, state_log, f"turn-{i}")))
 
-    asyncio.run(checkout(state_log, target_seq=anchors[2]))  # hide turns 4-7
+    asyncio.run(checkout(state_log, target_seq=anchors[2], scope=GLOBAL_SCOPE))  # hide turns 4-7
 
     visible_resident = [m.content for m in s._active_branch_history()]
     durable_turns, _truncated = s._durable_active_history_after(0)

--- a/tests/runtime/test_4771_rewind_quiesce_bound.py
+++ b/tests/runtime/test_4771_rewind_quiesce_bound.py
@@ -46,6 +46,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.core.events.state_log import StateLog
 from reyn.runtime import registry as registry_module
 from reyn.runtime.profile import AgentProfile
@@ -103,7 +104,7 @@ async def test_a_session_that_never_quiesces_fails_the_rewind_not_hangs(
 
     seq_before = reg.state_log.current_seq
     with pytest.raises(RewindQuiesceTimeoutError):
-        await asyncio.wait_for(reg.checkout(put_seq), timeout=5.0)
+        await asyncio.wait_for(reg.checkout(put_seq, scope=GLOBAL_SCOPE), timeout=5.0)
 
     # No reset-record was ever appended — the failure happened BEFORE step 4.
     assert reg.state_log.current_seq == seq_before, (

--- a/tests/runtime/test_live_fork_gate.py
+++ b/tests/runtime/test_live_fork_gate.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -109,11 +110,11 @@ async def test_live_fork_checkout_back_follows_lineage_runtime(tmp_path):
     assert _turn_markers(session.current_snapshot) == ["turn A", "turn C"]
 
     # ── checkout(seqB): branch-switch — revive the abandoned B lineage ──
-    await reg.checkout(seq_b)
+    await reg.checkout(seq_b, scope=GLOBAL_SCOPE)
     assert _turn_markers(AgentSnapshot.load("alpha", snap_path)) == ["turn A", "turn B"]  # disk
     assert _turn_markers(session.current_snapshot) == ["turn A", "turn B"]    # live in-memory
 
     # ── checkout(seqC): switch back to the C lineage ──
-    await reg.checkout(seq_c)
+    await reg.checkout(seq_c, scope=GLOBAL_SCOPE)
     assert _turn_markers(AgentSnapshot.load("alpha", snap_path)) == ["turn A", "turn C"]  # disk
     assert _turn_markers(session.current_snapshot) == ["turn A", "turn C"]    # live in-memory

--- a/tests/runtime/test_web_rewind_attach_seam_2d.py
+++ b/tests/runtime/test_web_rewind_attach_seam_2d.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -72,7 +73,7 @@ async def test_web_path_session_checkout_restores_runtime(tmp_path) -> None:
 
     # Web checkout (the unified primitive) to seq A → the runtime substrate reverts.
     await session._journal.flush()  # #2259 PR-2b: drain before durable read
-    await reg.checkout(seq_a)
+    await reg.checkout(seq_a, scope=GLOBAL_SCOPE)
     markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
     assert markers == ["A"]                                            # runtime reverted
 

--- a/tests/runtime/test_workspace_capture_optout_1582.py
+++ b/tests/runtime/test_workspace_capture_optout_1582.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import is_active_seq
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, is_active_seq
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -80,7 +80,7 @@ async def test_rewind_reverts_runtime_not_workspace(tmp_path) -> None:
 
     # Runtime checkout works (consistent-cut on the runtime substrate alone).
     await session._journal.flush()  # #2259 PR-2b: drain before durable read
-    await reg.checkout(seq_a)
+    await reg.checkout(seq_a, scope=GLOBAL_SCOPE)
     markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
     assert markers == ["A"]                                  # runtime reverted
     assert is_active_seq(reg.state_log, seq_a)               # cut landed on the runtime substrate


### PR DESCRIPTION
**[e2e-coder]** — `checkout` takes `scope` as a required keyword, no silent global default.

part of #5769

## Why

Follow-up to #5778's own review history: `PipelineExecutor.resume()`'s `scope` parameter went through two rounds getting a safe (no-default) signature, but the SAME `scope=None` default was still sitting on the two `checkout` functions decision 3 itself names as the session-scoped-rewind boundary — `snapshot_generations.checkout` and `AgentRegistry.checkout` — both missed in that earlier sweep because each session only checked the one call chain it happened to be tracing at the time.

Architect's discriminator (restated for this case): a default is justified only when it is the right answer for a caller with nothing to say — when two real choices exist and the caller always knows which applies, a default is not. This case is structurally MORE dangerous than `resume()`'s own: a forgotten `scope` there merely widened a READ; here it WRITES a real, effectful reset-record that rewinds every loaded session atomically. All three lines land against the default: (1) not visible under the shipped config — an omitted `scope` produces an ordinary-looking, successful global rewind, not an error; (2) not the safe direction — "forgot to scope it" silently becomes "rewound everyone," not the reverse; (3) every real caller already knows its answer — `rewind`/`rewind_to`/the `/rewind` slash command are intentionally-global primitives that can name `GLOBAL_SCOPE` explicitly, and every scoped caller already holds a real `(agent, sid)`.

## Changes

- `snapshot_generations.checkout(state_log, *, target_seq, scope, ...)`: `scope` is now required, no default. Docstring rewritten to explain the no-default rationale (replacing the earlier "a default here is safe" reasoning it carried, which is exactly what this PR overturns).
- `AgentRegistry.checkout(seq, *, scope)`: same change, same rationale. Its own internal GLOBAL branch (the unscoped 5-step path) now passes `scope=GLOBAL_SCOPE` explicitly to `_append_reset_record`. NOT a bug fix — `_append_reset_record` is `checkout` under an alias, and its old default (`scope=None`) was global, so this branch always wrote a correct, unscoped reset-record; nothing was broken. What this removes is the invisible COUPLING itself: the branch's correctness depended on two separate functions' defaults silently agreeing, a dependency a required keyword makes visible and unbreakable rather than one that happened to hold. Found only because removing one of the two defaults is what made the coupling visible at all — a real instance of a required keyword doing more than "fail loudly when forgotten": it also surfaces a place two callers were silently relying on the same implicit answer.
- `rewind()` (module-level, pre-#5769 pure Phase-1 undo) and `AgentRegistry.rewind_to()`: neither gained a new parameter of its own — they are the genuinely-global, no-owner-concept primitives, so each now passes `scope=GLOBAL_SCOPE` to `checkout` explicitly, an honest spelling of "this caller has no owner to name."
- `/rewind` slash command (`interfaces/slash/rewind.py`): same — explicitly names `GLOBAL_SCOPE` (this command has no per-session UI yet; that is a separate, owner-gated arc per #5778's own explicit split).
- Added `test_module_level_checkout_requires_scope_kwarg` and `test_registry_checkout_requires_scope_kwarg` (committed guards, mirroring `latest_pipeline_state`'s and `resume`'s own required-kwarg tests) to `test_5769_stage3_checkout_scope.py` — the lesson from #5778's own 3rd review round: a strip-falsified-but-uncommitted witness doesn't survive to catch the next regression.
- Updated 26 test call sites across 16 files that relied on the removed default (module-level `checkout(...)` and `AgentRegistry.checkout(...)` direct calls) to pass `scope=GLOBAL_SCOPE` explicitly — all genuinely global-rewind tests with no per-session scoping concern.

## Tests

Strip-falsified: temporarily reintroduced `scope: ... = None` on both `checkout` functions via in-file `Edit`, confirmed both new guard tests go genuinely RED (`DID NOT RAISE TypeError`), restored, confirmed `git diff` shows only the intended docstring/call-site changes (no stray default) and green again.

Rebased cleanly onto `origin/main` (no conflicts) after #5782 and #5783 merged underneath this branch; re-ran the full gate + test sweep on the rebased tree.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on the touched test file (9/9 OK)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py` (200/208, unchanged, all pre-baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`, `check_file_depth_reference.py` (tests/ touched)
- [x] `pytest` scoped to the diff + the full rewind/branch-tree/checkout/pipeline-recovery test surface: 179 tests, all green
- [ ] (skipped — Visual, standing waiver 2026-08-08)

TESTS-READ / merge: lead-coder-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

