### PR TITLE
fix(#5786): reconstruct() takes scope instead of treating scoped rewinds as global

### DIFF
--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -636,6 +636,8 @@ def reconstruct(
     state_log: StateLog,
     target_seq: int,
     session_id: str = "main",
+    *,
+    scope: "tuple[str, str] | None",
 ) -> AgentSnapshot:
     """Reconstruct ``agent_name``'s state as-of WAL ``target_seq`` (PITR), on the
     **active branch**.
@@ -652,9 +654,26 @@ def reconstruct(
     durable state, so the un-durable tail is cleanly dropped = recover-to-last-durable)
     — which, after a rewind, yields the current active-branch state (and collapses to
     as-of-N when the rewind reset-record is itself head).
-    """
-    abandoned = _abandoned_intervals(_rewind_records(state_log))
-    is_active = _make_is_active(abandoned)
+
+    #5769 ADR-0047 acceptance-3 gap (real bug, found while building that
+    acceptance witness, not a design decision): this function used to
+    derive ``is_active`` from scope-BLIND ``_abandoned_intervals(
+    _rewind_records(state_log))`` — treating EVERY reset-record as global
+    regardless of its own ``scope`` field. Both real callers
+    (``AgentRegistry._materialize_rewind``'s scoped branch AND its GLOBAL
+    per-session loop) already build a correctly-scoped
+    ``build_active_predicate(state_log, scope=...)`` for their own
+    spawn/vanish gate checks one line above their call here — but the
+    computed predicate was discarded, and this function recomputed (and
+    used) the wrong, unscoped one instead. Effect: a session-scoped
+    checkout's reset-record was silently treated as a GLOBAL abandonment
+    when a DIFFERENT, unrelated agent/session was later reconstructed,
+    hiding that session's own real WAL entries — exactly the cross-session
+    corruption decision 5 exists to rule out. ``scope`` is now required,
+    no default, matching every other #5769 seam's own contract (`GLOBAL_
+    SCOPE` for the GLOBAL per-session loop's own per-`(name, sid)` call,
+    a real `(agent, sid)` for the scoped branch)."""
+    is_active = build_active_predicate(state_log, scope=scope)
 
     # Base = nearest ACTIVE generation <= target_seq (never an abandoned-branch
     # generation); empty if none.

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3176,7 +3176,7 @@ class AgentRegistry:
             store = self._store_for(name, sid)
             snap = reconstruct(
                 name, store, self._state_log,
-                target_seq=reconstruct_seq, session_id=sid,
+                target_seq=reconstruct_seq, session_id=sid, scope=scope,
             )
             snap.applied_seq = reconstruct_seq
             snap.save(self._session_snapshot_path(name, sid))
@@ -3294,7 +3294,7 @@ class AgentRegistry:
                 store = self._store_for(name, sid)
                 snap = reconstruct(
                     name, store, self._state_log,
-                    target_seq=reconstruct_seq, session_id=sid,
+                    target_seq=reconstruct_seq, session_id=sid, scope=(name, sid),
                 )
                 # Self-contained: the reset-record carries no agent target, so
                 # reconstruct leaves applied_seq at the last active entry. Pin it to

--- a/tests/core/test_2259_pr2b_crash_recovery_falsify.py
+++ b/tests/core/test_2259_pr2b_crash_recovery_falsify.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import SnapshotGenerationStore, reconstruct
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, SnapshotGenerationStore, reconstruct
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
 
@@ -59,7 +59,7 @@ async def test_crash_between_wal_and_snapshot_replays_to_state_n(tmp_path):
     await journal.flush()  # WAL_2 becomes durable; the snapshot/generation are still at seq 1
 
     # recovery: reconstruct from the durable gen (seq 1) + replay the durable WAL in (1, head].
-    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq)
+    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq, scope=GLOBAL_SCOPE)
     texts = [m["payload"].get("text") for m in rebuilt.inbox]
     assert texts == ["a", "b"], (
         "crash mid-pair: WAL_2 (durable) must replay onto snap_1 → state 2 (consistent prefix); "
@@ -80,7 +80,7 @@ async def test_crash_before_wal_durable_loses_the_undurable_tail(tmp_path):
     # NO flush — the WAL_2 job never drains (the crash). The durable WAL stays at seq 1. There is
     # no await between the submit and the reconstruct, so the drainer cannot sneak the write in.
 
-    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq)
+    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq, scope=GLOBAL_SCOPE)
     texts = [m["payload"].get("text") for m in rebuilt.inbox]
     assert texts == ["a"], (
         "crash before durable: the un-durable mutation 2 must be LOST = state 1 (consistent "

--- a/tests/core/test_5786_reconstruct_scope_aware.py
+++ b/tests/core/test_5786_reconstruct_scope_aware.py
@@ -1,0 +1,193 @@
+"""Tier 2: OS invariant -- #5786, a real, reachable correctness bug found
+while building ADR-0047 (#5769) acceptance item 3's own witness (not a
+missing-witness gap -- the bug pre-dates this PR, on `origin/main` since
+#5778 introduced the scoped-checkout writer).
+
+`snapshot_generations.reconstruct()` used to derive `is_active` from
+scope-BLIND `_abandoned_intervals(_rewind_records(state_log))` --
+stripping every reset-record's own `scope` field and treating it as
+GLOBAL regardless. Both real callers (`AgentRegistry._materialize_
+rewind`'s scoped branch AND its GLOBAL per-session loop) already build a
+correctly-scoped `build_active_predicate(state_log, scope=...)` for
+their own spawn/vanish gate checks one line above their call into
+`reconstruct` -- but the computed predicate was discarded, and
+`reconstruct` recomputed (and used) the wrong, unscoped one instead.
+
+Effect: a session-scoped checkout's reset-record was silently treated as
+a GLOBAL abandonment when a DIFFERENT, unrelated agent/session was later
+reconstructed, hiding that session's own real WAL entries -- exactly the
+cross-session corruption ADR-0047 decision 5 exists to rule out.
+
+`reconstruct` now takes `scope` as a required keyword-only argument (no
+default -- matching every other #5769 seam's own contract): `GLOBAL_
+SCOPE` for the GLOBAL per-session loop's own per-`(name, sid)` call, a
+real `(agent, sid)` for the scoped branch.
+
+`test_scoped_rewind_of_a_leaves_bs_own_received_message_untouched` is
+simultaneously the bug's own regression test AND ADR-0047 acceptance
+item 3's witness ("An A->B message is B's WAL entry (routed by target).
+Rewinding A alone leaves B holding a message A no longer remembers
+sending.") -- driven end to end via `AgentRegistry.checkout`
+(`event_route_key` routes an event by `target` first, falling back to
+`agent`; a real `chain_register` event, routed via `agent` per
+`SnapshotJournal`'s own production append, is A's own "I registered
+this delegation" record, distinct from B's own `inbox_put`, routed by
+`target=B`, for the delivered task). Confirmed genuinely RED before the
+fix (strip-falsified: temporarily reverted `reconstruct`'s own
+`is_active` line back to the scope-blind form via in-file `Edit` --
+B's reconstructed inbox came back empty instead of holding its own
+message -- restored, green again).
+
+Acceptance item 10 (decision 6, agent existence/`.archived` untouched)
+is a SEPARATE, independent witness -- already correctly implemented,
+unaffected by this bug, and deliberately left out of this PR's scope
+(lead-coder-30's explicit call: keep this PR to the one fix + its one
+directly-dependent witness) -- tracked as a quick follow-up.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.snapshot_generations import reconstruct
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+def _snap_path(tmp_path: Path, name: str) -> Path:
+    return tmp_path / ".reyn" / "agents" / name / "state" / "snapshot.json"
+
+
+def _inbox_ids(snap: AgentSnapshot) -> "list[str]":
+    return [m["id"] for m in snap.inbox]
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- same shape as every other #5769 seam's own
+    required-kwarg contract. Pins OUR signature decision (a forgotten
+    scope here silently treats a scoped reset-record as global,
+    corrupting an unrelated session's reconstruction -- the #5786 bug),
+    not a language behaviour."""
+    from reyn.core.events.snapshot_generations import SnapshotGenerationStore
+
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    store = SnapshotGenerationStore("alpha", tmp_path / "generations")
+
+    with pytest.raises(TypeError):
+        reconstruct("alpha", store, log, 0)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_scoped_rewind_of_a_leaves_bs_own_received_message_untouched(tmp_path):
+    """Tier 2: #5786's own regression test AND ADR-0047 acceptance item 3's
+    witness, driven end to end. See module docstring."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    # A's own memory BEFORE the delegation -- kept (the rewind target below
+    # is exactly this seq).
+    kept_seq = await _put(log, "alpha", "a-earlier")  # seq 1
+
+    # A registers a pending chain waiting on B -- A's own "I sent this"
+    # record (chain_register routes via `agent`, matching
+    # SnapshotJournal's real production append: `agent=self._agent_name`).
+    await log.append(
+        "chain_register", agent="alpha", session_id="main",
+        chain_id="c1", origin_depth=0, original_request="do X",
+        waiting_on=["beta-task-1"], task_kind="prompt",
+    )
+
+    # B receives the delegated task -- B's OWN WAL entry (routed by target).
+    await _put(log, "beta", "beta-task-1")
+
+    # Scoped checkout: rewind ALPHA alone back to BEFORE the chain_register.
+    await reg.checkout(kept_seq, scope=("alpha", "main"))
+
+    alpha_snap = AgentSnapshot.load("alpha", _snap_path(tmp_path, "alpha"))
+    assert _inbox_ids(alpha_snap) == ["a-earlier"]
+    assert alpha_snap.pending_chains == {}  # A forgot registering the delegation
+
+    # B, reconstructed under ITS OWN real scope -- untouched by A's scoped
+    # rewind (the reset-record above carries scope=["alpha", "main"], which
+    # `build_active_predicate`'s own contract makes invisible to a (beta,
+    # main) query): still holds the delegated task.
+    head = log.current_seq
+    await reg.checkout(head, scope=("beta", "main"))
+    beta_snap = AgentSnapshot.load("beta", _snap_path(tmp_path, "beta"))
+    assert _inbox_ids(beta_snap) == ["beta-task-1"]
+
+
+@pytest.mark.asyncio
+async def test_bs_message_survives_wal_truncation_past_the_scoped_rewind(tmp_path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate -- a recovery-feature PR
+    needs a truncate-falsify test: set X, truncate the WAL past X's
+    events, reconstruct, assert X survives. X here is the #5786 fix's own
+    property: B's message stays correctly visible after A's scoped
+    rewind, EVEN ONCE the WAL entries that made the bug possible (A's own
+    chain_register and its scoped reset-record) are truncated away --
+    proving the fix's correctness rides the self-contained snapshot +
+    surviving records, not a happenstance of an untruncated WAL."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    kept_seq = await _put(log, "alpha", "a-earlier")  # seq 1
+    await log.append(
+        "chain_register", agent="alpha", session_id="main",
+        chain_id="c1", origin_depth=0, original_request="do X",
+        waiting_on=["beta-task-1"], task_kind="prompt",
+    )  # seq 2
+    await _put(log, "beta", "beta-task-1")  # seq 3
+
+    await reg.checkout(kept_seq, scope=("alpha", "main"))  # seq 4 (alpha's reset-record)
+
+    beta_head = log.current_seq
+    beta_result = await reg.checkout(beta_head, scope=("beta", "main"))
+    beta_reset_seq = beta_result["reset_seq"]
+
+    # More activity on the active branch, then truncate the WAL below beta's
+    # OWN reset-record's seq -- dropping seq 1-4 entirely (alpha's earlier
+    # message, its chain_register, its scoped reset-record, AND beta's own
+    # original inbox_put) from the raw WAL. Only beta's self-contained
+    # snapshot (pinned at beta_reset_seq) and whatever survives above it
+    # remain.
+    await log.truncate_below(beta_reset_seq)
+    await log.flush()
+    surviving = {e["seq"] for e in log.iter_from(0)}
+    assert all(s >= beta_reset_seq for s in surviving), (
+        "the WAL entries this fix depends on must be genuinely truncated away"
+    )
+
+    beta_snap = AgentSnapshot.load("beta", _snap_path(tmp_path, "beta"))
+    assert beta_snap.applied_seq == beta_reset_seq
+    beta_snap.apply_events(list(log.iter_from(beta_snap.applied_seq + 1)))
+    assert _inbox_ids(beta_snap) == ["beta-task-1"]  # survives truncation

--- a/tests/core/test_retention_floor.py
+++ b/tests/core/test_retention_floor.py
@@ -14,6 +14,7 @@ import pytest
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.retention import RetentionPolicy, compute_retention_floor
 from reyn.core.events.snapshot_generations import (
+    GLOBAL_SCOPE,
     SnapshotGenerationStore,
     reconstruct,
     rewind,
@@ -102,11 +103,11 @@ async def test_retained_checkpoints_reconstructable_after_clamped_truncate(tmp_p
     store = SnapshotGenerationStore(AGENT, tmp_path / "gens")
 
     await _put(log, "a")                                   # seq 1
-    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @1
+    store.record(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE))  # gen @1
     await _put(log, "b")                                   # seq 2
-    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @2
+    store.record(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE))  # gen @2
     await _put(log, "c")                                   # seq 3
-    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @3
+    store.record(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE))  # gen @3
 
     floor = compute_retention_floor(
         RetentionPolicy(keep_generations=2), live_floor=log.current_seq + 1,
@@ -116,8 +117,8 @@ async def test_retained_checkpoints_reconstructable_after_clamped_truncate(tmp_p
     await log.truncate_below(floor)                         # drops seq 1
 
     # retained checkpoints still reconstruct correctly (gen base bakes truncated history)
-    assert _ids(reconstruct(AGENT, store, log, 2)) == ["a", "b"]
-    assert _ids(reconstruct(AGENT, store, log, 3)) == ["a", "b", "c"]
+    assert _ids(reconstruct(AGENT, store, log, 2, scope=GLOBAL_SCOPE)) == ["a", "b"]
+    assert _ids(reconstruct(AGENT, store, log, 3, scope=GLOBAL_SCOPE)) == ["a", "b", "c"]
 
 
 @pytest.mark.asyncio
@@ -133,12 +134,12 @@ async def test_retained_checkpoints_reconstructable_across_rewind(tmp_path):
     store = SnapshotGenerationStore(AGENT, tmp_path / "gens")
 
     await _put(log, "a")                                   # seq 1
-    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @1
+    store.record(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE))  # gen @1
     await _put(log, "b")                                   # seq 2 (will be abandoned)
-    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @2
+    store.record(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE))  # gen @2
     await rewind(log, target_n=1)                          # seq 3 — abandons (1,3) incl b
     await _put(log, "d")                                   # seq 4 (active, new branch)
-    store.record(reconstruct(AGENT, store, log, log.current_seq))  # gen @4
+    store.record(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE))  # gen @4
 
     floor = compute_retention_floor(
         RetentionPolicy(keep_generations=2), live_floor=log.current_seq + 1,
@@ -150,4 +151,4 @@ async def test_retained_checkpoints_reconstructable_across_rewind(tmp_path):
     await log.flush()
 
     # active-branch reconstruct at head: a (kept) + d (post-rewind), b abandoned.
-    assert _ids(reconstruct(AGENT, store, log, log.current_seq)) == ["a", "d"]
+    assert _ids(reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE)) == ["a", "d"]

--- a/tests/core/test_rewind_reset_record.py
+++ b/tests/core/test_rewind_reset_record.py
@@ -15,6 +15,7 @@ import pytest
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.snapshot_generations import (
+    GLOBAL_SCOPE,
     RewindIntoAbandonedError,
     SnapshotGenerationStore,
     is_active_seq,
@@ -51,7 +52,7 @@ async def test_reconstruct_skips_abandoned_after_rewind(tmp_path):
     await _put(log, "c")          # seq 3
     await rewind(log, target_n=1)  # seq 4 — undo back to 1 (abandons 2,3)
     assert is_active_seq(log, 1) and not is_active_seq(log, 2) and not is_active_seq(log, 3)
-    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a"]   # b, c undone
 
 
@@ -67,7 +68,7 @@ async def test_post_rewind_work_yields_current_state(tmp_path):
     await _put(log, "b")          # seq 2
     await rewind(log, target_n=1)  # seq 3 — abandons 2
     await _put(log, "d")          # seq 4 — new work on the active branch
-    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a", "d"]   # b undone, d kept
 
 
@@ -83,8 +84,8 @@ async def test_crash_mid_rewind_idempotent(tmp_path):
     await _put(log, "a")          # seq 1
     await _put(log, "b")          # seq 2
     await rewind(log, target_n=1)  # seq 3 = head; crash here, no new work
-    first = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
-    second = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    first = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
+    second = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(first) == ["a"]          # b (abandoned future) not resurrected
     assert first == second                     # idempotent
 
@@ -98,7 +99,7 @@ async def test_nested_rewind_subsuming(tmp_path):
     await rewind(log, target_n=1)  # seq 3 — abandons 2
     await _put(log, "c")           # seq 4
     await rewind(log, target_n=1)  # seq 5 — back to 1 again, subsumes the 1st rewind
-    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a"]   # b and c both undone
 
 
@@ -116,7 +117,7 @@ async def test_nested_rewind_partial(tmp_path):
     await _put(log, "c")           # seq 4 (active, new branch)
     await _put(log, "d")           # seq 5 (active, new branch)
     await rewind(log, target_n=4)  # seq 6 — undo back to 4 (abandons 5), keeps c
-    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a", "c"]   # b abandoned (1st), d abandoned (2nd)
 
 
@@ -138,7 +139,7 @@ async def test_no_rewind_is_backward_compatible(tmp_path):
     await _put(log, "a")
     await _put(log, "b")
     assert is_active_seq(log, 1) and is_active_seq(log, 2)
-    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq)
+    snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a", "b"]
 
 
@@ -155,8 +156,8 @@ async def test_abandoned_branch_generation_not_used_as_base(tmp_path):
     await _put(log, "a")           # seq 1
     await _put(log, "b")           # seq 2
     # Cut a generation on what will become the abandoned branch (applied_seq 2).
-    store.record(reconstruct(AGENT, store, log, 2))
+    store.record(reconstruct(AGENT, store, log, 2, scope=GLOBAL_SCOPE))
     assert store.seqs() == [2]
     await rewind(log, target_n=1)  # seq 3 — abandons 2 (incl. the gen at seq 2)
-    snap = reconstruct(AGENT, store, log, log.current_seq)
+    snap = reconstruct(AGENT, store, log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a"]   # the abandoned gen@2 (with 'b') is not the base

--- a/tests/core/test_snapshot_generation_recording.py
+++ b/tests/core/test_snapshot_generation_recording.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from reyn.core.events.snapshot_generations import SnapshotGenerationStore, reconstruct
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, SnapshotGenerationStore, reconstruct
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.services.snapshot_journal import SnapshotJournal
 
@@ -66,7 +66,7 @@ async def test_reconstruct_head_equals_live_snapshot(tmp_path):
     # durable head == live (the consistent-prefix parity; "reconstruct(current_seq) == live"
     # was the synchronous-durability assumption, correctly retired).
     await journal.flush()
-    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq)
+    rebuilt = reconstruct(AGENT, store, log, log.last_durable_seq, scope=GLOBAL_SCOPE)
     assert rebuilt == journal.snapshot
 
 

--- a/tests/core/test_snapshot_generations.py
+++ b/tests/core/test_snapshot_generations.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
-from reyn.core.events.snapshot_generations import SnapshotGenerationStore, reconstruct
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, SnapshotGenerationStore, reconstruct
 from reyn.core.events.state_log import StateLog
 
 AGENT = "alpha"
@@ -59,7 +59,7 @@ async def test_reconstruct_matches_full_replay_at_every_seq(tmp_path):
     store.record(_full_replay(log, 4))
 
     for n in range(0, 7):
-        got = reconstruct(AGENT, store, log, n)
+        got = reconstruct(AGENT, store, log, n, scope=GLOBAL_SCOPE)
         expected = _full_replay(log, n)
         assert got == expected, f"reconstruct({n}) diverged from full replay"
 
@@ -71,7 +71,7 @@ async def test_reconstruct_head_is_crash_recovery(tmp_path):
     store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
     store.record(_full_replay(log, 4))
     head = log.current_seq
-    assert reconstruct(AGENT, store, log, head) == _full_replay(log, head)
+    assert reconstruct(AGENT, store, log, head, scope=GLOBAL_SCOPE) == _full_replay(log, head)
 
 
 @pytest.mark.asyncio
@@ -81,7 +81,7 @@ async def test_reconstruct_with_no_generations_uses_empty_base(tmp_path):
     store = SnapshotGenerationStore(AGENT, tmp_path / AGENT / "generations")
     assert store.seqs() == []
     head = log.current_seq
-    assert reconstruct(AGENT, store, log, head) == _full_replay(log, head)
+    assert reconstruct(AGENT, store, log, head, scope=GLOBAL_SCOPE) == _full_replay(log, head)
 
 
 @pytest.mark.asyncio
@@ -98,7 +98,7 @@ async def test_generation_base_is_used_not_just_empty(tmp_path):
     assert store.nearest_at_or_below(5) == 4
     assert store.nearest_at_or_below(3) == 1
     assert store.nearest_at_or_below(0) is None
-    assert reconstruct(AGENT, store, log, 5) == _full_replay(log, 5)
+    assert reconstruct(AGENT, store, log, 5, scope=GLOBAL_SCOPE) == _full_replay(log, 5)
 
 
 @pytest.mark.asyncio
@@ -114,4 +114,4 @@ async def test_prune_below_drops_old_generations(tmp_path):
     assert dropped == 1
     assert store.seqs() == [4, 6]
     # Surviving generations still reconstruct correctly.
-    assert reconstruct(AGENT, store, log, 6) == _full_replay(log, 6)
+    assert reconstruct(AGENT, store, log, 6, scope=GLOBAL_SCOPE) == _full_replay(log, 6)


### PR DESCRIPTION
**[e2e-coder]** — `reconstruct()` takes `scope`, no longer treats scoped rewinds as global.

Closes #5786
part of #5769

## Why

Found while building ADR-0047 (#5769) acceptance item 3's own witness — a real, reachable bug on `origin/main` since #5778 introduced the scoped-checkout writer, not a missing-witness gap.

`snapshot_generations.reconstruct()` derived `is_active` from scope-BLIND `_abandoned_intervals(_rewind_records(state_log))` — stripping every reset-record's own `scope` field and treating it as GLOBAL regardless. Both real callers (`AgentRegistry._materialize_rewind`'s scoped branch AND its GLOBAL per-session loop) already build a correctly-scoped `build_active_predicate(state_log, scope=...)` for their own spawn/vanish gate checks one line above their call into `reconstruct` — but the computed predicate was discarded, and `reconstruct` recomputed (and used) the wrong, unscoped one instead.

Effect: a session-scoped checkout's reset-record was silently treated as a GLOBAL abandonment when a DIFFERENT, unrelated agent/session was later reconstructed, hiding that session's own real WAL entries — exactly the cross-session corruption ADR-0047 decision 5 exists to rule out.

Architect co-vetted this fix (per lead-coder-30 on #5786).

## Changes

- `reconstruct` now takes `scope` as a required keyword-only argument (no default, matching every other #5769 seam's own contract). Both real call sites in `registry.py` pass their own already-built scope (the scoped branch's real `(agent, sid)`, the GLOBAL loop's own per-`(name, sid)` value).
- Updated 26 test call sites across 6 files that relied on the removed implicit global behavior, all with `scope=GLOBAL_SCOPE`.

## Tests (`test_5786_reconstruct_scope_aware.py`, all real, driven, no mocks)

- `test_reconstruct_requires_scope_kwarg` — the committed guard (learned from tonight's own `resume`/`checkout` review cycles: an uncommitted strip-falsify witness doesn't survive to catch the next regression).
- `test_scoped_rewind_of_a_leaves_bs_own_received_message_untouched` — the bug's own regression test AND ADR-0047 acceptance item 3's witness simultaneously ("An A->B message is B's WAL entry (routed by target). Rewinding A alone leaves B holding a message A no longer remembers sending."). Driven end to end via `AgentRegistry.checkout`: a real `chain_register` event (routed via `agent`, matching `SnapshotJournal`'s own production append) is A's own "I registered this delegation" record; a real `inbox_put` (routed via `target=B`) is B's own received message. **Confirmed genuinely RED before the fix** (strip-falsified: temporarily reverted `reconstruct`'s own `is_active` line to the scope-blind form via in-file `Edit` — B's reconstructed inbox came back empty instead of holding its own message — restored, green again).
- `test_bs_message_survives_wal_truncation_past_the_scoped_rewind` — the CLAUDE.md-mandated truncate-falsify test for a recovery-feature PR: the WAL entries that made the bug possible (A's earlier message, its chain_register, its own scoped reset-record, and B's original inbox_put) are truncated away entirely; B's message still reconstructs correctly from the surviving self-contained snapshot + WAL tail.

**ADR-0047 acceptance item 10** (decision 6, agent existence/`.archived` untouched by a session-scoped rewind) is a separate, independent witness — already correctly implemented, unaffected by this bug, and deliberately kept OUT of this PR's scope (lead-coder-30's explicit call: keep this PR to the one fix + its one directly-dependent witness) — filed as a quick, separate follow-up.

**Also decided, for a later separate PR** (not this one): remove `_rewind_records` (the scope-discarding helper) entirely so every consumer must pass scope explicitly — "unable to omit" is stronger than "remembered not to forget," the same shape `latest_pipeline_state` took tonight.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on the new test file (3/3 OK)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py` (200/208, unchanged, all pre-baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`, `check_file_depth_reference.py` (tests/ touched)
- [x] `pytest` scoped to the diff + the full rewind/branch-tree/checkout/pipeline-recovery/retention/agent-lifecycle test surface: 164 tests, all green
- [ ] (skipped — Visual, standing waiver 2026-08-08)

TESTS-READ / merge: lead-coder-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
