### PR TITLE
fix(#5789): delete _rewind_records -- every remaining consumer names its own scope

### DIFF
--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -359,23 +359,31 @@ def earliest_relevant_wal_seq(
     construction, off every interval it could possibly be inside, so
     nothing OLDER than the lowest ``lo`` changes the answer for it.
 
-    #5789: ``scope`` is required, no default. GLOBAL_SCOPE at the one real
-    call site (``Session._active_branch_history``) — safe, but only
-    because this function's OWN role is a conservative LOAD-EXTENSION
-    bound, not the correctness filter itself (the sibling `is_active`
-    check right after it in that same method is properly scoped to
-    ``(self.agent_name, self.session_id)``). Disclosed, not silently
-    inherited: `GLOBAL_SCOPE` here sees strictly FEWER abandoned intervals
-    than a query scoped to this session's own `(agent, sid)` would (global
-    records only, excluding this session's own scoped ones per decision
-    7's "GLOBAL_SCOPE means apply only the unscoped ones") — meaning it is
-    a **lower**, not higher, threshold whenever this session has its own
-    scoped rewind records. `GLOBAL_SCOPE` was safe here before ANY scoped
-    writer existed (stage 1-2); #5778 made scoped `checkout()` real. This
-    is exactly the "safe but accidental" case #5789 exists to convert into
-    a stated decision, not the closed-out consequence of one: if a
-    session's own scoped rewind is ever observed under-loading history
-    here, this comment is where that regression should be chased first."""
+    #5789/#5795 correction (architect-caught): ``scope`` is required, no
+    default, and the one real call site (``Session._active_branch_
+    history``) must pass ``(self.agent_name, self.session_id)`` — the
+    SAME scope its sibling `is_active` check already uses — NOT
+    `GLOBAL_SCOPE`. A round-1 draft of this fix passed `GLOBAL_SCOPE`
+    here, reasoning it was merely a "safe but accidental" conservative
+    bound; that reasoning had the DIRECTION backwards. Trace the math:
+    `threshold = min(lo for lo, _hi in abandoned)` over a query's own
+    `abandoned` set — a query that sees FEWER abandoned intervals (as
+    `GLOBAL_SCOPE` does whenever a session has its own scoped rewinds,
+    which excludes them) produces a **higher** `min`, not lower (removing
+    candidates from a min can only raise or hold it, never lower it). The
+    caller's loop is `if earliest_loaded <= threshold: break` — a HIGHER
+    threshold satisfies that sooner, extending history LESS far backward,
+    not more. Worse: `if not abandoned: return None` — a session using
+    ONLY session-local scoped rewinds (the common case since #5785 made
+    `/rewind` default to session-local) has ZERO global-scope records, so
+    `GLOBAL_SCOPE` returns `None` and the caller's entire backward-load
+    loop never runs AT ALL, even though that session's own scoped rewind
+    genuinely needs history extended to be classified correctly by the
+    properly-scoped `is_active` filter run afterward. Passing the SAME
+    scope as that filter makes "this bound is conservative for what the
+    filter will need" true BY CONSTRUCTION (same set, same or looser
+    interval boundaries), not an accident resting on no scoped writer
+    existing yet."""
     abandoned = _abandoned_intervals(_rewind_records_for_scope(state_log, scope=scope))
     if not abandoned:
         return None

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -266,19 +266,33 @@ def _rewind_records_with_scope(
     return index.records()
 
 
-def _rewind_records(state_log: StateLog) -> list[tuple[int, int]]:
-    """All rewind reset-records as ``(R, target_n)`` (R = the record's own seq).
+def _rewind_records_for_scope(
+    state_log: StateLog, *, scope: "tuple[str, str] | None",
+) -> list[tuple[int, int]]:
+    """Rewind reset-records visible to ``scope`` (global + exactly matching),
+    scope stripped, as ``(R, target_n)``.
 
-    #5769 stage 1: every OTHER consumer of the branch model
-    (``is_active_seq``, ``active_rewind_target``, ``branch_ids_for``,
-    ``list_branches``, ``rewind()`` itself) stays scope-blind on purpose —
-    stage 1's only scope-aware consumer is ``build_active_predicate``
-    (see :func:`_rewind_records_with_scope`); narrowing these too is a
-    later stage's own decision, not made here. Strips ``scope`` off the
-    same underlying records, so this remains byte-identical to its own
-    pre-#5769 behavior regardless of what any record's ``scope`` holds.
-    """
-    return [(r, n) for (r, n, _scope) in _rewind_records_with_scope(state_log)]
+    #5789: the scope-application step every consumer of the abandoned-
+    interval model now uses explicitly, replacing the removed
+    ``_rewind_records`` (which stripped ``scope`` off EVERY record and
+    fed it to every consumer as if it were global-only — stage 1's own
+    docstring for that function admitted this was "a later stage's own
+    decision, not made here"; #5786 found the exact cost of that stage
+    never being named: `reconstruct` silently treated a scoped checkout's
+    reset-record as global abandonment for an unrelated session it
+    reconstructed afterward). ``_rewind_records`` is deleted rather than
+    kept: with it gone, no consumer can omit ``scope`` by continuing to
+    call the old, unscoped accessor — the same "delete the function that
+    lets you skip the decision" shape ``latest_pipeline_state`` and
+    `reconstruct` already took (#5786/#5788).
+
+    Same filter :func:`build_active_predicate` applies inline: a record is
+    visible when its own ``scope`` is ``None`` (global) or equals the
+    query's ``scope`` exactly."""
+    return [
+        (r, n) for (r, n, record_scope) in _rewind_records_with_scope(state_log)
+        if record_scope is None or record_scope == scope
+    ]
 
 
 def _abandoned_intervals(rewinds: list[tuple[int, int]]) -> list[tuple[int, int]]:
@@ -314,12 +328,20 @@ def _make_is_active(abandoned: list[tuple[int, int]]):
     return is_active
 
 
-def is_active_seq(state_log: StateLog, seq: int) -> bool:
-    """True if ``seq`` is on the current active branch (not in any abandoned segment)."""
-    return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))(seq)
+def is_active_seq(state_log: StateLog, seq: int, *, scope: "tuple[str, str] | None") -> bool:
+    """True if ``seq`` is on the current active branch (not in any abandoned segment).
+
+    #5789: ``scope`` is required, no default. GLOBAL-BY-DESIGN at both real
+    call sites (``AgentRegistry.rewind_to``'s own active-target guard, and
+    every test call over a plain-global fixture) — neither has a per-
+    session concept in play, so ``GLOBAL_SCOPE`` is the honest, explicit
+    answer rather than an inferred one."""
+    return _make_is_active(_abandoned_intervals(_rewind_records_for_scope(state_log, scope=scope)))(seq)
 
 
-def earliest_relevant_wal_seq(state_log: StateLog) -> "int | None":
+def earliest_relevant_wal_seq(
+    state_log: StateLog, *, scope: "tuple[str, str] | None",
+) -> "int | None":
     """The lowest ``wal_seq`` any abandoned interval's active-check could
     possibly need to compare against, or ``None`` if the session has never
     rewound. #4387 Phase B ②: a consumer holding only a BOUNDED in-memory
@@ -336,8 +358,25 @@ def earliest_relevant_wal_seq(state_log: StateLog) -> "int | None":
     is ``lo < seq < hi`` — a seq at or below every ``lo`` is active by
     construction, off every interval it could possibly be inside, so
     nothing OLDER than the lowest ``lo`` changes the answer for it.
-    """
-    abandoned = _abandoned_intervals(_rewind_records(state_log))
+
+    #5789: ``scope`` is required, no default. GLOBAL_SCOPE at the one real
+    call site (``Session._active_branch_history``) — safe, but only
+    because this function's OWN role is a conservative LOAD-EXTENSION
+    bound, not the correctness filter itself (the sibling `is_active`
+    check right after it in that same method is properly scoped to
+    ``(self.agent_name, self.session_id)``). Disclosed, not silently
+    inherited: `GLOBAL_SCOPE` here sees strictly FEWER abandoned intervals
+    than a query scoped to this session's own `(agent, sid)` would (global
+    records only, excluding this session's own scoped ones per decision
+    7's "GLOBAL_SCOPE means apply only the unscoped ones") — meaning it is
+    a **lower**, not higher, threshold whenever this session has its own
+    scoped rewind records. `GLOBAL_SCOPE` was safe here before ANY scoped
+    writer existed (stage 1-2); #5778 made scoped `checkout()` real. This
+    is exactly the "safe but accidental" case #5789 exists to convert into
+    a stated decision, not the closed-out consequence of one: if a
+    session's own scoped rewind is ever observed under-loading history
+    here, this comment is where that regression should be chased first."""
+    abandoned = _abandoned_intervals(_rewind_records_for_scope(state_log, scope=scope))
     if not abandoned:
         return None
     return min(lo for lo, _hi in abandoned)
@@ -349,8 +388,9 @@ def build_active_predicate(
     """Build a reusable ``is_active(seq)`` predicate — ONE derivation for MANY seqs.
 
     #2941 (owner-reported ``reyn chat`` freeze, growing with session length):
-    ``_abandoned_intervals(_rewind_records(state_log))`` depends only on the
-    state_log's rewind records, NOT on ``seq`` — so calling ``is_active_seq``
+    ``_abandoned_intervals(_rewind_records_for_scope(state_log, scope=...))``
+    depends only on the state_log's rewind records (for a given scope), NOT
+    on ``seq`` — so calling ``is_active_seq``
     once per history message (``Session._active_branch_history``, the
     LLM-facing hot path run every turn) re-derived the whole branch model once
     per message: O(N messages x M WAL entries) per turn. This factors the
@@ -394,34 +434,22 @@ def build_active_predicate(
     return _make_is_active(_abandoned_intervals(relevant))
 
 
-def active_rewind_target(state_log: StateLog) -> int | None:
-    """``target_n`` of the active reset-record, or ``None`` when no rewind exists.
-
-    The active reset-record is the **highest-seq** rewind (latest wins — a later
-    rewind can never be abandoned by an earlier one, so the max-R record is always
-    the active pointer). Crash recovery uses this to re-materialise the active
-    branch as-of-N idempotently (ADR-0038 Stage 1d two-substrate crash-safety).
-    """
-    records = _rewind_records(state_log)
-    if not records:
-        return None
-    return max(records, key=lambda t: t[0])[1]
-
-
 def active_rewind_target_with_scope(
     state_log: StateLog,
 ) -> "tuple[int, tuple[str, str] | None] | None":
     """``(target_n, scope)`` of the active reset-record, or ``None`` when no
-    rewind exists — #5769 stage 3's scope-aware sibling of
-    :func:`active_rewind_target` above.
+    rewind exists.
 
     Crash recovery needs not just WHERE the active rewind points but WHOSE
     scope it was written under, to materialise only that ``(name, sid)`` on
-    a scoped crash-recovery (ADR-0047 decision 3's own recovery half) —
-    ``active_rewind_target`` itself stays unchanged (it still has its own
-    caller-independent contract; this is a genuinely new question, not a
-    replacement). Same latest-wins rule: the active reset-record is the
-    highest-seq one."""
+    a scoped crash-recovery (ADR-0047 decision 3's own recovery half).
+
+    #5789: the scope-blind ``active_rewind_target`` this was originally
+    written as a sibling of is deleted — it had zero real callers left in
+    ``src/`` (this function fully subsumed its own crash-recovery caller
+    when #5769 stage 3 landed the recovery half; the plain-target answer
+    is `result[0]` for any caller that only needs `target_n`). Same
+    latest-wins rule: the active reset-record is the highest-seq one."""
     records = _rewind_records_with_scope(state_log)
     if not records:
         return None
@@ -466,7 +494,9 @@ def _branch_of_seq(seq: int, abandoned: list[tuple[int, int]]) -> int:
     return ACTIVE_BRANCH_ID if best is None else best[1]
 
 
-def branch_ids_for(state_log: StateLog, seqs: "list[int]") -> dict[int, int]:
+def branch_ids_for(
+    state_log: StateLog, seqs: "list[int]", *, scope: "tuple[str, str] | None",
+) -> dict[int, int]:
     """Map each seq → its owning branch_id (lineage-correct membership, #1533 2a→2b).
 
     ``is_active`` seqs → the active branch (0); a rewound-past seq → the dead branch
@@ -475,23 +505,39 @@ def branch_ids_for(state_log: StateLog, seqs: "list[int]") -> dict[int, int]:
     so a naive intersect over-includes — e2e's repro). Grounded in the proven
     ``_abandoned_intervals`` (inherits 1b-1e correctness). ``list_rewind_points``
     tags each row with this so the UX groups by branch_id.
-    """
-    abandoned = _abandoned_intervals(_rewind_records(state_log))
+
+    #5789: ``scope`` is required, no default -- SCOPED, a real behavior
+    change from the prior scope-blind form (#5786 review, decision table):
+    since #5782 every ``list_rewind_points`` row already carries its own
+    real ``(name, sid)`` owner, ``branch_id`` must be that SAME owner's
+    value, not one global tree blindly applied to every owner's seqs (a
+    session-scoped reset-record would otherwise misclassify an unrelated
+    owner's seqs, the same class of bug #5786 fixed for ``reconstruct``).
+    Callers with seqs spanning more than one owner must call this once per
+    owner group and merge results -- see ``list_rewind_points``'s own
+    per-``(name, sid)`` loop."""
+    abandoned = _abandoned_intervals(_rewind_records_for_scope(state_log, scope=scope))
     return {s: _branch_of_seq(s, abandoned) for s in seqs}
 
 
-def list_branches(state_log: StateLog) -> list[Branch]:
+def list_branches(state_log: StateLog, *, scope: "tuple[str, str] | None") -> list[Branch]:
     """Derive the branch tree (#1533 Phase-2 2a / D8).
 
     The active branch (id 0) = the live lineage (all is_active seqs). Each abandoned
     interval ``(N, R)`` = a dead branch (id R) forked at N, with ``parent`` = the
     branch owning N (active or an enclosing dead branch → nesting). Returns the
     active branch first, then dead branches ascending by id. Empty WAL → [].
-    """
+
+    #5789: ``scope`` is required, no default -- SCOPED: "the fork UX's
+    branches are the OWNER's own branches" (decision table, #5786 review).
+    ``scope=GLOBAL_SCOPE`` sees only unscoped/global forks -- the same
+    tree this function always derived before any scoped writer existed.
+    ``scope=(name, sid)`` additionally includes that session's own scoped
+    forks, invisible to every other session (ADR-0047 decision 5)."""
     head = state_log.last_durable_seq  # #2259 PR-2b: durable head (operates on durable state)
     if head <= 0:
         return []
-    abandoned = _abandoned_intervals(_rewind_records(state_log))
+    abandoned = _abandoned_intervals(_rewind_records_for_scope(state_log, scope=scope))
     out: list[Branch] = [Branch(
         branch_id=ACTIVE_BRANCH_ID, fork_point_seq=0, head_seq=head,
         parent_branch_id=None, is_active=True,
@@ -509,6 +555,7 @@ def list_branches(state_log: StateLog) -> list[Branch]:
 
 def lineage_predecessor(
     state_log: StateLog, candidates: "list[int]", target: int,
+    *, scope: "tuple[str, str] | None",
 ) -> int | None:
     """The greatest candidate seq strictly below ``target`` on ``target``'s lineage.
 
@@ -522,12 +569,17 @@ def lineage_predecessor(
 
     ``candidates`` is the caller-filtered set (e.g. turn-kind checkpoint seqs);
     this function only resolves lineage ordering, staying kind-agnostic (P7).
-    """
+
+    #5789: ``scope`` is required, no default -- SCOPED, same family as
+    ``list_branches`` (decision table, #5786 review): ``target``'s own
+    lineage is its OWNER's lineage, so both the abandoned-interval model
+    and the branch tree this walks must be derived under that same owner's
+    scope, not a scope-blind global-only view."""
     cand = [int(c) for c in candidates]
     if not cand:
         return None
-    abandoned = _abandoned_intervals(_rewind_records(state_log))
-    by_id = {b.branch_id: b for b in list_branches(state_log)}
+    abandoned = _abandoned_intervals(_rewind_records_for_scope(state_log, scope=scope))
+    by_id = {b.branch_id: b for b in list_branches(state_log, scope=scope)}
     cur: int | None = _branch_of_seq(int(target), abandoned)
     cutoff = int(target)            # collect candidates strictly below this on `cur`
     best: int | None = None
@@ -616,9 +668,15 @@ async def rewind(
     genuinely global Phase-1 undo primitive (no per-session concept
     anywhere in its own contract), so it passes ``GLOBAL_SCOPE`` to
     ``checkout`` explicitly — an honest spelling of "this caller has no
-    owner to name," not an inferred or forgotten one.
+    owner to name," not an inferred or forgotten one. #5789: its own
+    active-target guard now names ``GLOBAL_SCOPE`` explicitly too, for
+    the same reason — checking "is `target_n` on MY active branch" for a
+    caller with no owner concept at all is a GLOBAL question by
+    definition, matching the ``checkout`` call it guards.
     """
-    is_active = _make_is_active(_abandoned_intervals(_rewind_records(state_log)))
+    is_active = _make_is_active(
+        _abandoned_intervals(_rewind_records_for_scope(state_log, scope=GLOBAL_SCOPE)),
+    )
     if not is_active(target_n):
         raise RewindIntoAbandonedError(
             f"rewind target seq {target_n} is on an abandoned branch — switching "

--- a/src/reyn/interfaces/slash/rewind.py
+++ b/src/reyn/interfaces/slash/rewind.py
@@ -99,7 +99,21 @@ async def rewind_cmd(ctx: "SlashContext", args: str) -> None:
             # ``list_branches`` returns ``Branch`` dataclasses; the tree builder
             # and the command-UI payload both speak plain dicts (the payload
             # crosses a transport boundary). Converted here, at the one seam.
-            for b in (registry.list_branches() if registry is not None else [])
+            # #5789: `list_branches` is now SCOPED (decision table, #5786
+            # review). `GLOBAL_SCOPE` here is a DELIBERATE, disclosed choice
+            # preserving today's picker behavior byte-for-byte, not the
+            # session-local default #5785 gave the actual rewind operation:
+            # `points` above already aggregates EVERY session's own
+            # checkpoints (each correctly tagged with its own owner, #5782),
+            # so the tree must cover every branch those rows can reference —
+            # a session-scoped tree would omit branches other sessions' rows
+            # point at. Narrowing the PICKER itself to session-local-by-
+            # default is a real UX decision (which forks a user sees without
+            # asking) that needs the owner's own screen, not an inference
+            # made here.
+            for b in (
+                registry.list_branches(scope=GLOBAL_SCOPE) if registry is not None else []
+            )
         ]
         if not points:
             await reply(ctx, "/rewind: no earlier checkpoints to rewind to")

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2326,7 +2326,7 @@ class AgentRegistry:
         """
         if self._state_log is None:
             raise RuntimeError("rewind_to requires a state log")
-        if not is_active_seq(self._state_log, target_n):
+        if not is_active_seq(self._state_log, target_n, scope=GLOBAL_SCOPE):
             raise RewindIntoAbandonedError(
                 f"rewind target seq {target_n} is on an abandoned branch — "
                 "Phase-1 undo only rewinds to a seq on the active timeline "
@@ -2478,7 +2478,28 @@ class AgentRegistry:
 
         anchors = self.anchor_store
         # #1533 2a→2b: lineage-correct branch membership per checkpoint seq.
-        branch_of = branch_ids_for(self._state_log, sorted(seqs))
+        # #5789: `branch_ids_for` is now SCOPED (decision table, #5786
+        # review) -- a seq's branch_id must be derived under its OWN
+        # owner's abandoned-interval view (global + that owner's own
+        # scoped records), never one global tree blindly applied to every
+        # owner's seqs (the same class of bug #5786 fixed for
+        # `reconstruct`). `seq_owner` already has each seq's real owner
+        # (or `None` for the structurally-impossible ambiguous case, see
+        # above) -- grouped here and called once per owner, merged into
+        # one dict. An unresolved (`None`) owner gets `GLOBAL_SCOPE`: with
+        # no nameable owner to ask for, the global-only view is the
+        # honest "don't know" answer, not a guess (ADR-0047 decision 7).
+        by_owner: "dict[tuple[str, str] | None, list[int]]" = {}
+        for s in seqs:
+            by_owner.setdefault(seq_owner.get(s), []).append(s)
+        branch_of: dict[int, int] = {}
+        for owner, owner_seqs in by_owner.items():
+            branch_of.update(
+                branch_ids_for(
+                    self._state_log, sorted(owner_seqs),
+                    scope=owner if owner is not None else GLOBAL_SCOPE,
+                ),
+            )
         rows: list[dict] = []
         for s in sorted(seqs):
             entry = wal_at.get(s, {})
@@ -2510,7 +2531,7 @@ class AgentRegistry:
             })
         return rows
 
-    def list_branches(self) -> "list[Branch]":
+    def list_branches(self, *, scope: "tuple[str, str] | None") -> "list[Branch]":
         """The derived branch tree for the fork UX (#1533 Phase-2 2a / D8).
 
         ``[Branch(branch_id, fork_point_seq, head_seq, parent_branch_id,
@@ -2518,12 +2539,23 @@ class AgentRegistry:
         Tree topology (nesting/active); per-branch checkpoint *membership* comes
         from ``list_rewind_points(include_abandoned=True)`` rows' ``branch_id``.
         Empty when there is no WAL.
+
+        #5789: ``scope`` is required, no default -- SCOPED (decision table,
+        #5786 review): "the fork UX's branches are the OWNER's own
+        branches." Callers wiring a cross-session picker alongside
+        ``list_rewind_points``'s own multi-owner rows should pass
+        ``GLOBAL_SCOPE`` to keep every row's branch_id resolvable in the
+        returned tree (a session-scoped tree would omit branches other
+        sessions' rows reference) -- see ``interfaces/slash/rewind.py``'s
+        own call for the disclosed reasoning.
         """
         if self._state_log is None:
             return []
-        return list_branches(self._state_log)
+        return list_branches(self._state_log, scope=scope)
 
-    def predecessor_turn_checkpoint(self, seq: int) -> int | None:
+    def predecessor_turn_checkpoint(
+        self, seq: int, *, scope: "tuple[str, str] | None",
+    ) -> int | None:
         """The lineage-correct prior **turn** checkpoint of ``seq`` (#1533 2c edit).
 
         The 2c edit flow re-runs an edited turn from the state before it: checkout
@@ -2538,14 +2570,30 @@ class AgentRegistry:
         the UX disables first-turn edit. Genesis-checkout is intentionally NOT
         offered — there is no captured pre-turn-1 workspace version, so it would be
         workspace-incoherent (coherent genesis = a future session-start capture).
+
+        #5789: ``scope`` is required, no default -- SCOPED, same family as
+        ``list_branches``/``branch_ids_for`` (decision table, #5786
+        review): an edit's own lineage is its OWNER's lineage. No real
+        caller exists yet (the 2c edit-flow wiring this serves has not
+        landed) -- ``scope=GLOBAL_SCOPE`` preserves this method's own
+        pre-#5789 behavior byte-for-byte (checkpoints across every known
+        agent's default session); ``scope=(name, sid)`` narrows to that
+        one session's own checkpoints only, for whenever the edit flow
+        lands and needs it.
         """
         if self._state_log is None:
             return None
         # Checkpoint seqs = generation boundaries across every known agent (all
         # branches — the lineage walk may cross to a parent/ancestor branch).
+        # #5789: `scope=GLOBAL_SCOPE` keeps this exact cross-agent collection
+        # (byte-identical to pre-#5789); a real `(name, sid)` narrows to
+        # just that owner's own store.
         cps: set[int] = set()
-        for name in self.list_names():
-            cps.update(self._store_for(name).seqs())
+        if scope is None:
+            for name in self.list_names():
+                cps.update(self._store_for(name).seqs())
+        else:
+            cps.update(self._store_for(*scope).seqs())
         if not cps:
             return None
         # Turn-kind filter via the WAL entry kind at each boundary (one pass;
@@ -2556,7 +2604,7 @@ class AgentRegistry:
             s = entry.get("seq")
             if isinstance(s, int) and s in cps and _rewind_point_kind(entry.get("kind", "")) == "turn":
                 turn_cps.append(s)
-        return lineage_predecessor(self._state_log, turn_cps, seq)
+        return lineage_predecessor(self._state_log, turn_cps, seq, scope=scope)
 
     @property
     def anchor_store(self) -> AnchorStore | None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4388,11 +4388,19 @@ class Session:
         if self._state_log is None:
             return self.history
         from reyn.core.events.snapshot_generations import (
+            GLOBAL_SCOPE,
             build_active_predicate,
             earliest_relevant_wal_seq,
         )
 
-        threshold = earliest_relevant_wal_seq(self._state_log)
+        # #5789: `earliest_relevant_wal_seq` is GLOBAL-BY-DESIGN, not
+        # scoped to (self.agent_name, self.session_id) -- see its own
+        # docstring for the disclosed, measured caveat this default
+        # carries now that a scoped writer (checkout()) exists: this
+        # function is a conservative LOAD-EXTENSION bound only, the
+        # actual correctness filter is the properly-scoped `is_active`
+        # built below.
+        threshold = earliest_relevant_wal_seq(self._state_log, scope=GLOBAL_SCOPE)
         if threshold is not None:
             while True:
                 loaded_wal_seqs: "list[int]" = [

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4388,19 +4388,30 @@ class Session:
         if self._state_log is None:
             return self.history
         from reyn.core.events.snapshot_generations import (
-            GLOBAL_SCOPE,
             build_active_predicate,
             earliest_relevant_wal_seq,
         )
 
-        # #5789: `earliest_relevant_wal_seq` is GLOBAL-BY-DESIGN, not
-        # scoped to (self.agent_name, self.session_id) -- see its own
-        # docstring for the disclosed, measured caveat this default
-        # carries now that a scoped writer (checkout()) exists: this
-        # function is a conservative LOAD-EXTENSION bound only, the
-        # actual correctness filter is the properly-scoped `is_active`
-        # built below.
-        threshold = earliest_relevant_wal_seq(self._state_log, scope=GLOBAL_SCOPE)
+        # #5789 correction (architect-caught, PR #5795): `GLOBAL_SCOPE` here
+        # was WRONG, not merely "safe but accidental" -- self-corrected
+        # direction: `earliest_relevant_wal_seq` returns
+        # `min(lo for lo, _hi in abandoned)` -- FEWER abandoned intervals
+        # means a HIGHER (not lower) threshold, and `if not abandoned:
+        # return None` means a session with ZERO global-scope rewind
+        # records (the common case now that #5785 made `/rewind` default
+        # to session-local) gets `threshold=None` -> the backward-load
+        # loop below NEVER RUNS AT ALL for that session's own scoped
+        # rewinds -- exactly the #5786 class of bug (a scope mismatch
+        # silently produces a wrong-but-plausible answer), reached via the
+        # now-common session-local path, not an edge case. Scoped to
+        # `(self.agent_name, self.session_id)` -- the SAME scope the
+        # sibling `is_active` check below already uses -- so the
+        # abandoned-interval SET this bound is derived from is the same
+        # set that check filters against: "conservative" becomes true by
+        # construction, not accidental.
+        threshold = earliest_relevant_wal_seq(
+            self._state_log, scope=(self.agent_name, self.session_id),
+        )
         if threshold is not None:
             while True:
                 loaded_wal_seqs: "list[int]" = [

--- a/tests/core/test_4387_active_branch_history_extend_on_demand.py
+++ b/tests/core/test_4387_active_branch_history_extend_on_demand.py
@@ -183,3 +183,43 @@ async def test_extend_backward_survives_wal_truncation_below_the_rewind_record(
         "STILL correctly recovered by extend-backward, using the "
         "truncated-but-REWIND_KIND-protected WAL"
     )
+
+
+@pytest.mark.asyncio
+async def test_rewind_scoped_to_this_session_alone_still_extends_backward(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: #5789/#5795 regression -- architect caught this direction
+    error in review (the fix's own round-1 draft passed `GLOBAL_SCOPE` to
+    `earliest_relevant_wal_seq`, reasoning it was a safe, merely-accidental
+    conservative bound; the reasoning had the direction backwards). A
+    session using ONLY its own session-scoped rewind (the common case
+    since #5785 made `/rewind` default to session-local) has ZERO
+    global-scope reset-records -- `earliest_relevant_wal_seq(scope=
+    GLOBAL_SCOPE)` would see an EMPTY `abandoned` set and return `None`,
+    skipping the backward-load-extension loop ENTIRELY, even though this
+    session's own scoped rewind genuinely hid older turns that the
+    properly-scoped `is_active` filter (run right after) needs the
+    extended prefix to correctly classify. Scoping the bound to THIS
+    session's own `(agent_name, session_id)` -- the same scope the
+    sibling `is_active` filter already uses -- fixes it: same interval
+    set, so the bound is conservative by construction."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log)
+    anchors = [await _turn(s, state_log, f"turn {i}") for i in range(1, 11)]
+    s.history = s.history[-3:]  # bounded load: only turns 8-10 in memory
+
+    # SESSION-SCOPED rewind only -- zero global-scope reset-records exist.
+    await checkout(
+        state_log, target_seq=anchors[2], scope=(s.agent_name, s.session_id),
+    )  # hide turns 4-10, scoped to this session alone
+
+    assert _visible_texts(s) == ["turn 1", "turn 2", "turn 3"], (
+        "the active branch (turns 1-3) must be visible even though none of "
+        "them were in the bounded self.history before the rewind, AND the "
+        "rewind was scoped (not global) -- a regression here would show "
+        "['turn 8', 'turn 9', 'turn 10'] (the stale bounded prefix, "
+        "backward extension never triggered)"
+    )
+    assert [m.content for m in s.history[:3]] == ["turn 1", "turn 2", "turn 3"]

--- a/tests/core/test_5769_rewind_scope_stage1.py
+++ b/tests/core/test_5769_rewind_scope_stage1.py
@@ -67,11 +67,11 @@ async def test_scope_none_reproduces_identical_behavior_to_pre_5769(tmp_path):
     # Positive control: the reset-record was genuinely appended, and it
     # genuinely abandoned something.
     assert log.current_seq == 4
-    assert is_active_seq(log, 2) is False
+    assert is_active_seq(log, 2, scope=GLOBAL_SCOPE) is False
 
     is_active = build_active_predicate(log, scope=GLOBAL_SCOPE)
     for seq in (1, 2, 3, 4):
-        assert is_active(seq) == is_active_seq(log, seq), seq
+        assert is_active(seq) == is_active_seq(log, seq, scope=GLOBAL_SCOPE), seq
 
 
 def test_build_active_predicate_requires_scope_kwarg(tmp_path):

--- a/tests/core/test_5789_rewind_records_removed.py
+++ b/tests/core/test_5789_rewind_records_removed.py
@@ -1,0 +1,178 @@
+"""Tier 2: OS invariant -- #5789: `_rewind_records` (the scope-discarding
+helper) is deleted; every remaining consumer of the abandoned-interval
+model now takes `scope` as a required keyword-only argument, no default.
+
+Decision table (architect co-vetted, https://github.com/tya5/reyn/issues/5789):
+`is_active_seq`, `earliest_relevant_wal_seq`, `rewind()`'s own active-target
+guard -- GLOBAL-BY-DESIGN, now naming `GLOBAL_SCOPE` explicitly at every real
+call site. `branch_ids_for`, `list_branches`, `lineage_predecessor` (and their
+`AgentRegistry` wrappers `list_branches`/`predecessor_turn_checkpoint`) --
+SCOPED: a real behavior change, since #5782 already gave every
+`list_rewind_points` row its own real `(name, sid)` owner, so `branch_id`
+must be that SAME owner's value, not one global tree blindly applied to
+every owner's seqs (the exact class of bug #5786 fixed for `reconstruct`).
+`active_rewind_target` (0 real callers in `src/`) is deleted outright.
+
+With `_rewind_records` gone, no consumer can omit `scope` by continuing to
+call the old, unscoped accessor -- "unable to omit" rather than "remembered
+not to forget," the same shape #5786/`latest_pipeline_state` already took.
+
+Real `StateLog` (no mocks). Covers: the required-kwarg guard on all 7
+remaining consumers + their 2 `AgentRegistry` wrappers, `active_rewind_target`
+and `_rewind_records` both genuinely gone (import fails), and a real,
+driven witness that `branch_ids_for` is now scope-correct: a session-scoped
+checkout's reset-record must NOT be treated as a global abandonment when
+classifying an UNRELATED session's own seq.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import (
+    ACTIVE_BRANCH_ID,
+    branch_ids_for,
+    earliest_relevant_wal_seq,
+    is_active_seq,
+    lineage_predecessor,
+    list_branches,
+)
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _put(log: StateLog, agent: str, text: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=text, msg_kind="user",
+        payload={"text": text},
+    )
+
+
+def test_rewind_records_is_gone():
+    """Tier 2: the scope-discarding helper #5789 exists to remove is
+    genuinely gone -- pins the deletion itself, not merely "unused"."""
+    import reyn.core.events.snapshot_generations as sg
+    assert not hasattr(sg, "_rewind_records")
+
+
+def test_active_rewind_target_is_gone():
+    """Tier 2: 0 real callers in src/ (decision table item 8) -- deleted,
+    not merely deprecated."""
+    import reyn.core.events.snapshot_generations as sg
+    assert not hasattr(sg, "active_rewind_target")
+
+
+@pytest.mark.asyncio
+async def test_is_active_seq_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- decision table item 5 (GLOBAL-BY-DESIGN, but
+    still required, no silent fallback)."""
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    with pytest.raises(TypeError):
+        is_active_seq(log, 1)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_earliest_relevant_wal_seq_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- decision table item 7 (GLOBAL-BY-DESIGN, the
+    "safe but accidental" case #5789 converts into a stated decision)."""
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    with pytest.raises(TypeError):
+        earliest_relevant_wal_seq(log)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_branch_ids_for_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- decision table item 2 (SCOPED, a real behavior
+    change per #5786's own review)."""
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    with pytest.raises(TypeError):
+        branch_ids_for(log, [1])  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_list_branches_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- decision table item 3 (SCOPED: "the fork UX's
+    branches are the owner's own branches")."""
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    with pytest.raises(TypeError):
+        list_branches(log)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_lineage_predecessor_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- decision table item 4 (SCOPED, same family as
+    item 3)."""
+    log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    with pytest.raises(TypeError):
+        lineage_predecessor(log, [1], 2)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_registry_list_branches_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- `AgentRegistry.list_branches`'s own public
+    wrapper around item 3, same required-kwarg contract."""
+    reg = _make_registry(tmp_path)
+    with pytest.raises(TypeError):
+        reg.list_branches()  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_registry_predecessor_turn_checkpoint_requires_scope_kwarg(tmp_path):
+    """Tier 2: no default -- `AgentRegistry.predecessor_turn_checkpoint`'s
+    own public wrapper around item 4, same required-kwarg contract."""
+    reg = _make_registry(tmp_path)
+    with pytest.raises(TypeError):
+        reg.predecessor_turn_checkpoint(1)  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
+async def test_branch_ids_for_scoped_to_b_ignores_as_reset_record(tmp_path):
+    """Tier 2: the real behavior fix -- `branch_ids_for` scoped to B must
+    NOT treat A's own scoped reset-record as a global abandonment when
+    classifying B's own seq, even though B's seq falls inside the numeric
+    interval A's scoped record would abandon under the OLD, scope-blind
+    form. Structurally identical to the #5786 `reconstruct` bug, one layer
+    over in the branch/fork-UX surface rather than snapshot reconstruction."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    kept_seq = await _put(log, "alpha", "a1")   # seq 1
+    b_seq = await _put(log, "beta", "b1")       # seq 2 -- falls inside (1, R) below
+
+    # Scope A's own checkout back to seq 1 -- abandons (1, R) where R is the
+    # new reset-record's own seq. b_seq (2) sits inside that interval.
+    await reg.checkout(kept_seq, scope=("alpha", "main"))
+
+    # Scoped to B: b_seq must read as ACTIVE (0) -- A's own scoped record
+    # (scope=["alpha", "main"]) is invisible to a (beta, main) query, per
+    # `build_active_predicate`'s own contract.
+    ids = branch_ids_for(log, [b_seq], scope=("beta", "main"))
+    assert ids[b_seq] == ACTIVE_BRANCH_ID
+
+    # Population witness: the OLD, scope-blind shape genuinely WOULD have
+    # misclassified b_seq (proving the interval really is non-trivial, not
+    # a no-op the fix happens to pass vacuously) -- GLOBAL_SCOPE sees only
+    # unscoped records, so it also reads b_seq as active (A's record is
+    # scoped, invisible to GLOBAL_SCOPE too); the discriminating case is
+    # querying under (alpha, main) itself, where the abandonment DOES apply.
+    ids_for_alpha = branch_ids_for(log, [b_seq], scope=("alpha", "main"))
+    assert ids_for_alpha[b_seq] != ACTIVE_BRANCH_ID

--- a/tests/core/test_branch_registry_2a.py
+++ b/tests/core/test_branch_registry_2a.py
@@ -13,6 +13,7 @@ import pytest
 
 from reyn.core.events.snapshot_generations import (
     ACTIVE_BRANCH_ID,
+    GLOBAL_SCOPE,
     branch_ids_for,
     list_branches,
     rewind,
@@ -46,7 +47,7 @@ async def test_branch_membership_over_include_repro(tmp_path):
     await _put(log, "m12")                      # seq 12
     await _put(log, "m13")                      # seq 13
 
-    ids = branch_ids_for(log, [3, 6, 9, 12])
+    ids = branch_ids_for(log, [3, 6, 9, 12], scope=GLOBAL_SCOPE)
     assert ids[3] == ACTIVE_BRANCH_ID           # active (<=6, on the live line)
     assert ids[6] == ACTIVE_BRANCH_ID           # the rewind target is active
     assert ids[12] == ACTIVE_BRANCH_ID          # post-rewind continuation = active
@@ -67,7 +68,7 @@ async def test_no_rewind_all_active(tmp_path):
     log = StateLog(tmp_path / "wal")
     for i in range(1, 4):
         await _put(log, f"m{i}")
-    assert branch_ids_for(log, [1, 2, 3]) == {1: 0, 2: 0, 3: 0}
+    assert branch_ids_for(log, [1, 2, 3], scope=GLOBAL_SCOPE) == {1: 0, 2: 0, 3: 0}
 
 
 # ── list_branches: tree topology ───────────────────────────────────────────────
@@ -83,7 +84,7 @@ async def test_list_branches_single_undo(tmp_path):
     await _put(log, "m12")
     head = log.current_seq
 
-    branches = list_branches(log)
+    branches = list_branches(log, scope=GLOBAL_SCOPE)
     active = next(b for b in branches if b.is_active)
     dead = [b for b in branches if not b.is_active]
     assert active.branch_id == ACTIVE_BRANCH_ID and active.fork_point_seq == 0
@@ -112,7 +113,7 @@ async def test_list_branches_nested_dead_branches_parent_edges(tmp_path):
     await _put(log, "d")                    # seq 5
     r2 = await rewind(log, target_n=4)      # seq 6 — abandons (4,6) = {5}
 
-    branches = list_branches(log)
+    branches = list_branches(log, scope=GLOBAL_SCOPE)
     by_id = {b.branch_id: b for b in branches}
     assert by_id[ACTIVE_BRANCH_ID].is_active
     assert by_id[r1].fork_point_seq == 1 and by_id[r1].head_seq == r1 - 1
@@ -127,7 +128,7 @@ async def test_list_branches_nested_dead_branches_parent_edges(tmp_path):
 async def test_empty_wal_no_branches(tmp_path):
     """Tier 2: empty WAL → no branches."""
     log = StateLog(tmp_path / "wal")
-    assert list_branches(log) == []
+    assert list_branches(log, scope=GLOBAL_SCOPE) == []
 
 
 @pytest.mark.asyncio
@@ -141,7 +142,7 @@ async def test_derivation_robust_without_supersedes(tmp_path):
     for i in range(1, 6):
         await _put(log, f"m{i}")
     r = await rewind(log, target_n=2)       # supersedes NOT passed
-    branches = list_branches(log)
+    branches = list_branches(log, scope=GLOBAL_SCOPE)
     dead = [b for b in branches if not b.is_active]
     assert {b.branch_id for b in dead} == {r}   # exactly the orphaning record
     assert dead[0].fork_point_seq == 2
@@ -205,6 +206,6 @@ async def test_list_rewind_points_branch_id_and_include_abandoned(tmp_path):
     assert by_seq[12]["branch_id"] == ACTIVE_BRANCH_ID
 
     # reg.list_branches(): active + the dead branch.
-    branches = reg.list_branches()
+    branches = reg.list_branches(scope=GLOBAL_SCOPE)
     assert any(b.is_active and b.branch_id == ACTIVE_BRANCH_ID for b in branches)
     assert any(b.branch_id == r and not b.is_active and b.fork_point_seq == 6 for b in branches)

--- a/tests/core/test_build_active_predicate_equivalence_2941.py
+++ b/tests/core/test_build_active_predicate_equivalence_2941.py
@@ -27,7 +27,7 @@ from reyn.core.events.state_log import StateLog
 def _assert_equivalent(state_log: StateLog, seqs: range) -> None:
     predicate = build_active_predicate(state_log, scope=GLOBAL_SCOPE)
     for seq in seqs:
-        assert predicate(seq) == is_active_seq(state_log, seq), (
+        assert predicate(seq) == is_active_seq(state_log, seq, scope=GLOBAL_SCOPE), (
             f"build_active_predicate diverges from is_active_seq at seq={seq}"
         )
 
@@ -85,6 +85,6 @@ async def test_predicate_is_reusable_across_many_seqs(tmp_path: Path) -> None:
     seqs = [await state_log.append("step_completed") for _ in range(20)]
     await checkout(state_log, target_seq=seqs[9], scope=GLOBAL_SCOPE)
     predicate = build_active_predicate(state_log, scope=GLOBAL_SCOPE)
-    expected = [is_active_seq(state_log, s) for s in range(1, state_log.current_seq + 1)]
+    expected = [is_active_seq(state_log, s, scope=GLOBAL_SCOPE) for s in range(1, state_log.current_seq + 1)]
     actual = [predicate(s) for s in range(1, state_log.current_seq + 1)]
     assert actual == expected

--- a/tests/core/test_predecessor_turn_checkpoint_2c.py
+++ b/tests/core/test_predecessor_turn_checkpoint_2c.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import pytest
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
-from reyn.core.events.snapshot_generations import rewind
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, rewind
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -78,7 +78,7 @@ async def test_predecessor_skips_plan_step_to_prior_turn(tmp_path):
     await _plan_step_cp(reg)                 # intra-turn plan-step (must be skipped)
     t2 = await _turn_cp(reg, "turn2")
 
-    assert reg.predecessor_turn_checkpoint(t2) == t1   # NOT the plan-step between them
+    assert reg.predecessor_turn_checkpoint(t2, scope=GLOBAL_SCOPE) == t1   # NOT the plan-step between them
 
 
 @pytest.mark.asyncio
@@ -89,8 +89,8 @@ async def test_predecessor_linear_prior_turn(tmp_path):
     t2 = await _turn_cp(reg, "t2")
     t3 = await _turn_cp(reg, "t3")
 
-    assert reg.predecessor_turn_checkpoint(t3) == t2
-    assert reg.predecessor_turn_checkpoint(t2) == t1
+    assert reg.predecessor_turn_checkpoint(t3, scope=GLOBAL_SCOPE) == t2
+    assert reg.predecessor_turn_checkpoint(t2, scope=GLOBAL_SCOPE) == t1
 
 
 # ── first turn → None (genesis = (b)) ─────────────────────────────────────────
@@ -101,7 +101,7 @@ async def test_first_turn_has_no_predecessor(tmp_path):
     """Tier 2: the first turn has no prior turn → None (UX disables first-turn edit)."""
     reg = _make_registry(tmp_path)
     t1 = await _turn_cp(reg, "only")
-    assert reg.predecessor_turn_checkpoint(t1) is None
+    assert reg.predecessor_turn_checkpoint(t1, scope=GLOBAL_SCOPE) is None
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_first_turn_none_even_with_leading_plan_step(tmp_path):
     reg = _make_registry(tmp_path)
     await _plan_step_cp(reg)                  # not a turn
     t1 = await _turn_cp(reg, "first-turn")
-    assert reg.predecessor_turn_checkpoint(t1) is None
+    assert reg.predecessor_turn_checkpoint(t1, scope=GLOBAL_SCOPE) is None
 
 
 # ── lineage: cross-fork-point ─────────────────────────────────────────────────
@@ -131,13 +131,13 @@ async def test_cross_fork_point_predecessor_is_parent_fork_point_turn(tmp_path):
     await rewind(reg.state_log, target_n=t2)  # t3 now on a dead branch forked at t2
 
     # t3 is the first (only) turn on the dead branch → predecessor = parent fork-point turn t2.
-    assert reg.predecessor_turn_checkpoint(t3) == t2
+    assert reg.predecessor_turn_checkpoint(t3, scope=GLOBAL_SCOPE) == t2
     # sanity: t2's own predecessor is still t1 (active lineage).
-    assert reg.predecessor_turn_checkpoint(t2) == t1
+    assert reg.predecessor_turn_checkpoint(t2, scope=GLOBAL_SCOPE) == t1
 
 
 @pytest.mark.asyncio
 async def test_empty_or_no_state_log_returns_none(tmp_path):
     """Tier 2: no checkpoints → None (slot-in-unconditionally for the UX gate)."""
     reg = _make_registry(tmp_path)
-    assert reg.predecessor_turn_checkpoint(5) is None
+    assert reg.predecessor_turn_checkpoint(5, scope=GLOBAL_SCOPE) is None

--- a/tests/core/test_registry_rewind_to.py
+++ b/tests/core/test_registry_rewind_to.py
@@ -456,8 +456,8 @@ async def test_restore_all_triggers_crash_recovery(tmp_path):
     R = await rewind(log, target_n=1)       # seq 3 — abandons (1,3); crash before materialise
 
     # pre-recovery: the active-branch rewind target is outstanding.
-    from reyn.core.events.snapshot_generations import active_rewind_target
-    assert active_rewind_target(log) == 1
+    from reyn.core.events.snapshot_generations import active_rewind_target_with_scope
+    assert active_rewind_target_with_scope(log) == (1, None)
 
     await reg.restore_all()                 # production seam — must trigger recovery
 

--- a/tests/core/test_rewind_index_incremental_2939.py
+++ b/tests/core/test_rewind_index_incremental_2939.py
@@ -121,11 +121,11 @@ async def test_rewind_appended_after_warm_index_takes_effect(tmp_path):
     anchor = await _grow_wal(state_log, 10)
     abandoned_seq = await _grow_wal(state_log, 5)
 
-    assert is_active_seq(state_log, abandoned_seq), "sanity: active before any rewind"
+    assert is_active_seq(state_log, abandoned_seq, scope=GLOBAL_SCOPE), "sanity: active before any rewind"
 
     await checkout(state_log, target_seq=anchor, scope=GLOBAL_SCOPE)
 
-    assert not is_active_seq(state_log, abandoned_seq), (
+    assert not is_active_seq(state_log, abandoned_seq, scope=GLOBAL_SCOPE), (
         "a rewind appended after the derivation was first built must abandon the "
         "seqs it rewound past — a frozen index would still call them active"
     )
@@ -150,7 +150,7 @@ async def test_truncation_dropping_a_rewind_record_does_not_serve_a_stale_interv
     head = await _grow_wal(state_log, 5)
 
     # Warm the derivation while the reset-record is present.
-    assert not is_active_seq(state_log, abandoned_seq), "sanity: abandoned pre-truncation"
+    assert not is_active_seq(state_log, abandoned_seq, scope=GLOBAL_SCOPE), "sanity: abandoned pre-truncation"
 
     # Retention rewrite WITHOUT always_keep_kinds → the reset-record is dropped.
     await state_log.truncate_below(head)
@@ -161,7 +161,7 @@ async def test_truncation_dropping_a_rewind_record_does_not_serve_a_stale_interv
         "otherwise it cannot witness staleness"
     )
 
-    assert is_active_seq(state_log, abandoned_seq), (
+    assert is_active_seq(state_log, abandoned_seq, scope=GLOBAL_SCOPE), (
         "after the reset-record was truncated away, the branch model must reflect "
         "the WAL that now exists (nothing abandoned) — still reporting the seq as "
         "abandoned means a stale interval was served from a cache the truncation "
@@ -181,12 +181,12 @@ async def test_truncation_preserving_rewind_records_keeps_them_active(tmp_path):
     await checkout(state_log, target_seq=anchor, scope=GLOBAL_SCOPE)
     head = await _grow_wal(state_log, 5)
 
-    assert not is_active_seq(state_log, abandoned_seq), "sanity: abandoned pre-truncation"
+    assert not is_active_seq(state_log, abandoned_seq, scope=GLOBAL_SCOPE), "sanity: abandoned pre-truncation"
 
     await state_log.truncate_below(head, always_keep_kinds=frozenset({REWIND_KIND}))
     await state_log.flush()
 
-    assert not is_active_seq(state_log, abandoned_seq), (
+    assert not is_active_seq(state_log, abandoned_seq, scope=GLOBAL_SCOPE), (
         "a truncation that keeps the reset-record must keep its abandoned interval "
         "— dropping it here would resurrect rewound-past turns into the LLM context"
     )

--- a/tests/core/test_rewind_reset_record.py
+++ b/tests/core/test_rewind_reset_record.py
@@ -51,7 +51,7 @@ async def test_reconstruct_skips_abandoned_after_rewind(tmp_path):
     await _put(log, "b")          # seq 2
     await _put(log, "c")          # seq 3
     await rewind(log, target_n=1)  # seq 4 — undo back to 1 (abandons 2,3)
-    assert is_active_seq(log, 1) and not is_active_seq(log, 2) and not is_active_seq(log, 3)
+    assert is_active_seq(log, 1, scope=GLOBAL_SCOPE) and not is_active_seq(log, 2, scope=GLOBAL_SCOPE) and not is_active_seq(log, 3, scope=GLOBAL_SCOPE)
     snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a"]   # b, c undone
 
@@ -138,7 +138,7 @@ async def test_no_rewind_is_backward_compatible(tmp_path):
     log = StateLog(tmp_path / "wal")
     await _put(log, "a")
     await _put(log, "b")
-    assert is_active_seq(log, 1) and is_active_seq(log, 2)
+    assert is_active_seq(log, 1, scope=GLOBAL_SCOPE) and is_active_seq(log, 2, scope=GLOBAL_SCOPE)
     snap = reconstruct(AGENT, _empty_store(tmp_path), log, log.current_seq, scope=GLOBAL_SCOPE)
     assert _inbox_ids(snap) == ["a", "b"]
 

--- a/tests/interfaces/test_slash_rewind_copy_cmds.py
+++ b/tests/interfaces/test_slash_rewind_copy_cmds.py
@@ -104,7 +104,11 @@ class _FakeRegistry:
     def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
         return self._points
 
-    def list_branches(self) -> list:
+    def list_branches(self, *, scope: "tuple[str, str] | None") -> list:
+        # #5789: the real AgentRegistry.list_branches takes `scope` as a
+        # required keyword-only argument (no default) too now, matching
+        # `checkout`'s own contract -- accepted here so this fake stays a
+        # drop-in stand-in for the real signature.
         return self._branches
 
     async def checkout(self, target: int, *, scope: "tuple[str, str] | None") -> dict:

--- a/tests/runtime/test_workspace_capture_optout_1582.py
+++ b/tests/runtime/test_workspace_capture_optout_1582.py
@@ -83,6 +83,6 @@ async def test_rewind_reverts_runtime_not_workspace(tmp_path) -> None:
     await reg.checkout(seq_a, scope=GLOBAL_SCOPE)
     markers = [m["payload"]["turn"] for m in session.current_snapshot.inbox]
     assert markers == ["A"]                                  # runtime reverted
-    assert is_active_seq(reg.state_log, seq_a)               # cut landed on the runtime substrate
+    assert is_active_seq(reg.state_log, seq_a, scope=GLOBAL_SCOPE)  # cut landed on the runtime substrate
     # Workspace NOT reverted — repo files are the user's work product, not rewound.
     assert (tmp_path / _WS_FILE).read_text(encoding="utf-8") == "vB"


### PR DESCRIPTION
**[e2e-coder]** — delete `_rewind_records`, every remaining consumer names its own scope.

Closes #5789
part of #5769

## Why

Applies the decision table #5786's review recorded (https://github.com/tya5/reyn/issues/5786#issuecomment-5551218860, architect co-vetted): `_rewind_records` (the helper that stripped every reset-record's own `scope` field and fed every consumer as if it were global-only) is deleted, and its 7 remaining consumers (an 8th, `active_rewind_target`, had zero real callers and is deleted outright) each take `scope` as a required keyword-only argument, no default.

With `_rewind_records` gone, no consumer can omit `scope` by continuing to call the old, unscoped accessor — the same "delete the function that lets you skip the decision" shape `latest_pipeline_state` and `reconstruct` already took (#5786/#5788). `_rewind_records`'s own stage-1 docstring had disclosed this gap honestly ("narrowing these too is a later stage's own decision, not made here") but nothing ever signaled that the later stage (#5778's scoped-checkout writer) had arrived — #5786 found the one real cost (`reconstruct` silently treating a scoped checkout's reset-record as global); this closes the other 7 before any of them cost the same way.

## Changes, per the decision table

**GLOBAL-BY-DESIGN, `GLOBAL_SCOPE` named explicitly** (items 5-6): `is_active_seq` (used by `AgentRegistry.rewind_to`'s own active-target guard — genuinely global, no per-session concept), `rewind()`'s own active-target guard (mirrors the `checkout` call it guards, which already named `GLOBAL_SCOPE`).

**CORRECTED post-review** (item 7, architect-caught): `earliest_relevant_wal_seq` is NOT global-by-design — its one real call site (`Session._active_branch_history`) now passes `(self.agent_name, self.session_id)`, the SAME scope the sibling `is_active` filter already uses. A round-1 draft passed `GLOBAL_SCOPE` here, reasoning it was a safe, merely-accidental conservative bound; the direction was backwards (`threshold = min(lo for lo, _hi in abandoned)` — FEWER intervals raises the min, which makes the caller's `break` condition fire with LESS history loaded, and `if not abandoned: return None` means a session using only session-local scoped rewinds — the common case since #5785 — got ZERO backward extension at all). A real, driven witness (`test_rewind_scoped_to_this_session_alone_still_extends_backward`) confirmed the observed failure was complete data loss (an EMPTY visible history), not merely a stale prefix. Fixed and re-verified; see the PR's own review thread for the full disclosure/correction history.

**SCOPED, a real behavior change** (items 2-4): `branch_ids_for`, `list_branches`, `lineage_predecessor` (and their `AgentRegistry` wrappers `list_branches`/`predecessor_turn_checkpoint`) — since #5782 already gave every `list_rewind_points` row its own real `(name, sid)` owner, a seq's `branch_id` must be that SAME owner's value, not one global tree blindly applied to every owner's seqs (the exact class of bug #5786 fixed for `reconstruct`, one layer over in the branch/fork-UX surface). `list_rewind_points`'s `branch_ids_for` call now groups seqs by their already-known real owner and calls once per owner group, merging results. `AgentRegistry.list_branches`'s one real caller (`/rewind`'s bare picker) passes `GLOBAL_SCOPE` explicitly — a disclosed, deliberate choice preserving today's picker behavior byte-for-byte (the picker's `points` already aggregate every session, so its branch tree must cover every branch those rows can reference); narrowing the picker itself to session-local-by-default is a real UX decision needing the owner's own screen, not made here. `AgentRegistry.predecessor_turn_checkpoint` has zero real callers yet (the 2c edit-flow wiring it serves has not landed) — `scope=GLOBAL_SCOPE` preserves its pre-#5789 behavior byte-for-byte; `scope=(name, sid)` is ready for whenever that flow lands.

**Deleted outright** (item 8): `active_rewind_target` — 0 real callers in `src/`, fully subsumed by `active_rewind_target_with_scope` since #5769 stage 3 landed the recovery half. Its one test caller now uses the scope-aware sibling.

Test/fake updates: 26 test call sites across 9 files updated with `scope=GLOBAL_SCOPE`/`scope=(name, sid)`; `_FakeRegistry` (`test_slash_rewind_copy_cmds.py`) gained `scope` on `list_branches` too, matching the real signature it stands in for.

## Tests

New `test_5789_rewind_records_removed.py`: required-kwarg guards on all 7 remaining consumers + their 2 `AgentRegistry` wrappers, `active_rewind_target`/`_rewind_records` both pinned genuinely gone (`hasattr` checks), and a real, driven behavioral witness that `branch_ids_for` is now scope-correct — a session-scoped checkout's reset-record must NOT be treated as a global abandonment when classifying an UNRELATED session's own seq (structurally identical to the #5786 `reconstruct` bug).

Strip-falsified: temporarily reverted `branch_ids_for`'s own scope application back to the scope-blind form via in-file `Edit`, confirmed the new behavioral witness goes genuinely RED (`3 == 0` instead of `0 == 0` — the wrong branch_id), restored, confirmed `git diff --stat` clean and green again.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on the new test file (10/10 OK)
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] `python scripts/mypy_ratchet.py` (200/208, unchanged, all pre-baselined)
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`, `check_file_depth_reference.py` (tests/ touched)
- [x] `pytest` scoped to the diff + the full rewind/branch-tree/checkout/pipeline-recovery/retention/agent-lifecycle/history-loading test surface: 193 tests, all green
- [ ] (unticked, honest reason) **Visual**: items 2-4's behavior change (branch_id now derived per-owner rather than from one global tree) can affect what the fork UX visually shows when scoped rewinds and multi-session forks coexist — the owner's own screen is needed to confirm the picker's visual grouping still reads correctly; this PR cannot make that claim from here.

TESTS-READ / merge: lead-coder-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

