### PR TITLE
fix(#5793): stop reyn from inventing its own timeout/retry defaults on litellm surfaces

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -78,9 +78,16 @@ class TimeoutConfig:
 
     Fields:
         llm_call_seconds:
-            Per-call timeout passed to ``litellm.acompletion``.
+            #5793: per-call timeout passed to ``litellm.acompletion``.
+            ``None`` (the default) means NOT PASSED at all — litellm has
+            its own default (an operator-tunable knob on litellm's own
+            surface); reyn does not invent a second one. Set this only to
+            OVERRIDE litellm's default with a reyn-specific bound.
         llm_max_retries:
-            Transient-error retry budget per call.
+            #5793: transient-error retry budget per call, forwarded to
+            litellm's ``num_retries``. ``None`` (the default) means NOT
+            PASSED — litellm's own retry default applies. Set this only
+            to override it.
         chain_seconds:
             How long a multi-agent pending chain waits for a delegate
             reply before the runtime synthesises an upstream error.
@@ -103,8 +110,12 @@ class TimeoutConfig:
             CPU load; it does not itself change the default.
     """
 
-    llm_call_seconds: float = field(default=60.0, metadata={"axis": Axis.BOUNDING})
-    llm_max_retries: int = field(default=3, metadata={"axis": Axis.BOUNDING})
+    # #5793 (owner decision, "わざわざ reyn が別に規定を持つ理由がわからん — 未指定な
+    # ら litellm 規定にして"): NOT PASSED when unset, not "0/None passed as a
+    # value" — see ``_resolve_llm_call_bounds`` in ``llm.py``, the one place
+    # that turns this into an actual litellm kwarg (or omits it).
+    llm_call_seconds: "float | None" = field(default=None, metadata={"axis": Axis.BOUNDING})
+    llm_max_retries: "int | None" = field(default=None, metadata={"axis": Axis.BOUNDING})
     chain_seconds: float = field(default=60.0, metadata={"axis": Axis.BOUNDING})
     mcp_probe_seconds: float = field(default=5.0, metadata={"axis": Axis.BOUNDING})
 
@@ -833,7 +844,8 @@ class CompactionConfig:
     # main-loop call already has `safety.timeout.llm_call_seconds`; this
     # one had nothing). `recorded_acompletion` (the #1190 single funnel)
     # now resolves an unset timeout for EVERY caller from that SAME
-    # `safety.timeout.llm_call_seconds` value (default 60s) — compaction
+    # `safety.timeout.llm_call_seconds` value (#5793: `None` unless the
+    # operator sets it — no longer a reyn-owned 60s) — compaction
     # already inherits it with NO config change (architect ruling: "新し
     # い数を作らない。routerの値をそのまま使う" — the output compaction
     # produces is `section_token_caps`-bounded, structurally SHORTER than
@@ -1336,12 +1348,20 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         )),
     )
     timeout = TimeoutConfig(
-        llm_call_seconds=float(timeout_raw.get(
-            "llm_call_seconds", timeout_defaults.llm_call_seconds,
-        )),
-        llm_max_retries=int(timeout_raw.get(
-            "llm_max_retries", timeout_defaults.llm_max_retries,
-        )),
+        # #5793: unlike the other TimeoutConfig fields, these two defaults
+        # are ``None`` (not passed to litellm) — mirrors the compaction
+        # config's own ``llm_call_seconds`` loader just above, which
+        # already had this "None means None, not `float(None)`" shape.
+        llm_call_seconds=(
+            float(timeout_raw["llm_call_seconds"])
+            if timeout_raw.get("llm_call_seconds") is not None
+            else timeout_defaults.llm_call_seconds
+        ),
+        llm_max_retries=(
+            int(timeout_raw["llm_max_retries"])
+            if timeout_raw.get("llm_max_retries") is not None
+            else timeout_defaults.llm_max_retries
+        ),
         chain_seconds=float(timeout_raw.get(
             "chain_seconds", timeout_defaults.chain_seconds,
         )),

--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -142,23 +142,28 @@ class EmbeddingConfig:
         max_retries:   Transient-error retries (0–10).
         retry_backoff: Backoff strategy: ``'exponential'`` or ``'linear'``.
         timeout:       Per-attempt deadline in seconds — how long reyn WAITS for
-                       one embedding attempt (#3043). ``<= 0`` opts out (= no
-                       bound), mirroring the MCP gateway's
-                       ``call_timeout_seconds`` contract.
+                       one embedding attempt (#3043). ``None`` (the default,
+                       #5793) means NOT PASSED at all — litellm/the OpenAI SDK's
+                       own timeout default applies (owner decision: reyn does
+                       not invent a default duplicating litellm's own — this
+                       field used to default to 60.0, mirroring
+                       ``chat.timeout.llm_call_seconds``, which got the same
+                       fix in the same PR). ``<= 0`` is a SEPARATE, explicit
+                       operator setting (not the same fact as "unset" —
+                       mirrors the MCP gateway's ``call_timeout_seconds``
+                       contract) that resolves to the identical ``None`` at
+                       the one call site that consumes it, since litellm's
+                       own default is the ceiling either way — see
+                       ``resolve_embed_timeout``'s own docstring. Set this
+                       only to override litellm's default with a
+                       reyn-specific bound.
                        Bounds waiting, NOT spending: the OpenAI SDK client
                        retries beneath this knob, so one attempt can deliver up
                        to 3 requests and ``max_retries: 3`` up to 9 (measured:
-                       all 9 delivered in 7.6s under the 60.0s default, which
-                       never engages). Lowering it does not lower that count —
-                       reducing REQUESTS is a separate lever, open in #3047.
-                       Default 60.0 == ``chat.timeout.llm_call_seconds``: an
-                       embedding call is the same KIND of thing as a chat LLM
-                       call (one HTTP round-trip to a model provider), so it
-                       carries the same bound — unlike an MCP call (120.0),
-                       which also pays a subprocess spawn. Without this the
-                       effective bound was litellm's own ``request_timeout``
-                       default of 6000s (= 100 min/attempt, ~5h across
-                       ``max_retries``) — indistinguishable from a hang.
+                       all 9 delivered in 7.6s under the former 60.0s default,
+                       which never engaged). Lowering it does not lower that
+                       count — reducing REQUESTS is a separate lever, open in
+                       #3047.
         tokenizer:     tiktoken encoding used for chunk-size estimation.
         cost_warn_threshold:
                        Ask-user gate fires when estimated chunk count
@@ -176,7 +181,7 @@ class EmbeddingConfig:
     max_concurrent_batches: int = field(default=1, metadata={"axis": Axis.PROJECT})
     max_retries: int = field(default=3, metadata={"axis": Axis.PROJECT})
     retry_backoff: Literal["exponential", "linear"] = field(default="exponential", metadata={"axis": Axis.PROJECT})
-    timeout: float = field(default=60.0, metadata={"axis": Axis.PROJECT})
+    timeout: "float | None" = field(default=None, metadata={"axis": Axis.PROJECT})
     tokenizer: str = field(default="cl100k_base", metadata={"axis": Axis.PROJECT})
     cost_warn_threshold: int = field(default=10000, metadata={"axis": Axis.PROJECT})
 
@@ -316,13 +321,23 @@ def _build_embedding_config(raw: object) -> EmbeddingConfig:
     max_concurrent_batches = int(raw.get("max_concurrent_batches", defaults.max_concurrent_batches))
     max_retries = int(raw.get("max_retries", defaults.max_retries))
     retry_backoff = str(raw.get("retry_backoff", defaults.retry_backoff))
-    raw_timeout = raw.get("timeout", defaults.timeout)
-    try:
-        timeout = float(raw_timeout)
-    except (TypeError, ValueError):
-        raise ValueError(
-            f"embedding.timeout must be a number of seconds, got {raw_timeout!r}"
-        ) from None
+    # #5793: `timeout` unset in reyn.yaml means the OPERATOR never set it —
+    # `defaults.timeout` is None by design, and stays None, never coerced
+    # through `float(None)`. A genuinely-present-but-malformed value (the
+    # operator DID write something, just not a number) still raises —
+    # unlike `resolve_embed_timeout`'s own fail-open ("effectively
+    # unspecified") contract, THIS parser is reyn.yaml's own validation
+    # gate, where a malformed value is an operator TYPO to surface, not a
+    # silent no-op.
+    if "timeout" not in raw or raw.get("timeout") is None:
+        timeout: "float | None" = defaults.timeout
+    else:
+        try:
+            timeout = float(raw["timeout"])
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"embedding.timeout must be a number of seconds, got {raw['timeout']!r}"
+            ) from None
     tokenizer = str(raw.get("tokenizer", defaults.tokenizer))
     cost_warn_threshold = int(raw.get("cost_warn_threshold", defaults.cost_warn_threshold))
     default_class = str(raw.get("default_class", defaults.default_class))
@@ -346,7 +361,9 @@ def _build_embedding_config(raw: object) -> EmbeddingConfig:
         raise ValueError(
             f"embedding.max_retries must be 0–10, got {max_retries}"
         )
-    if timeout <= 0:
+    # #5793: `timeout is None` (unset — the new default) is NOT the same
+    # fact as an explicit `<= 0` opt-out; only warn on the latter.
+    if timeout is not None and timeout <= 0:
         logging.getLogger(__name__).warning(
             "embedding.timeout=%s opts OUT of the per-attempt bound: an embedding "
             "API call that stalls will run to litellm's own request_timeout "

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -127,7 +127,12 @@ class RouterConfig:
     """
 
     use: bool = field(default=False, metadata={"axis": Axis.PROJECT})
-    num_retries: int = field(default=3, metadata={"axis": Axis.PROJECT})
+    # #5793 (owner decision): None by default — NOT PASSED to litellm.Router
+    # unless the operator sets it, matching the ``cooldown_time``/
+    # ``allowed_fails`` fields just below (both already ``None → litellm
+    # default``). Reyn does not invent a retry-count default duplicating
+    # litellm's own.
+    num_retries: "int | None" = field(default=None, metadata={"axis": Axis.PROJECT})
     # model_name → [fallback model_names]. Converted to litellm's
     # ``[{primary: [fallbacks]}]`` form when the Router is built. Empty → no
     # chain (single-deployment Router).
@@ -320,7 +325,13 @@ def _build_router_config(raw: object) -> RouterConfig:
         )
     return RouterConfig(
         use=bool(raw.get("use", d.use)),
-        num_retries=int(raw.get("num_retries", d.num_retries)),
+        # #5793: mirrors cooldown_time/allowed_fails just below — None
+        # unless the operator set it (raw.get returns None either way when
+        # the key is absent from reyn.yaml, so this collapses to the same
+        # ternary those two already use).
+        num_retries=(
+            int(raw["num_retries"]) if raw.get("num_retries") is not None else d.num_retries
+        ),
         fallbacks={
             str(k): [str(x) for x in (v or [])] for k, v in (fb or {}).items()
         },

--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -41,22 +41,30 @@ logger = logging.getLogger(__name__)
 # Per-attempt bound (#3043)
 # ---------------------------------------------------------------------------
 
-#: Per-attempt deadline for ONE ``litellm.aembedding`` call, in seconds.
-#: Matches ``chat.timeout.llm_call_seconds`` (``reyn.config.chat``): an embedding
-#: call is the same KIND of external call as a chat LLM call — one HTTP round-trip
-#: to a model provider — so it carries the same bound. (The MCP gateway's 120.0 is
-#: deliberately NOT the mirror target for the VALUE: an MCP call also pays a
-#: subprocess spawn, which an embedding call does not. It IS the mirror target for
-#: the SHAPE — see ``_bounded_timeout`` and the op-level cancel race.)
-#: Without a bound, litellm's own ``request_timeout`` default (6000.0 = 100 min per
-#: attempt, ~5h across ``max_retries``) is the only ceiling — a hang, to an operator.
-_DEFAULT_EMBED_TIMEOUT_SECONDS: float = 60.0
+#: #5793 (owner decision): NOT a default any more — reyn does not invent a
+#: per-attempt embedding timeout duplicating litellm/the OpenAI SDK's own.
+#: Kept only as the historical value this used to default to, referenced by
+#: this module's own docstring; no code reads it.
+#:
+#: Without ANY bound, litellm's own ``request_timeout`` default (6000.0 =
+#: 100 min per attempt, ~5h across ``max_retries``) is the ceiling unless
+#: the operator sets ``embedding.timeout`` explicitly.
+_FORMER_DEFAULT_EMBED_TIMEOUT_SECONDS: float = 60.0
 
 
 def resolve_embed_timeout(config: "dict[str, Any] | Any") -> "float | None":
-    """Per-attempt embedding timeout: the finite default, overridden by ``timeout``
-    (``embedding.timeout`` in reyn.yaml); ``<= 0`` opts out (no bound). A malformed
-    value falls back to the default — fail-safe, i.e. keep a finite bound.
+    """Per-attempt embedding timeout: ``None`` — whether the operator never
+    set ``embedding.timeout`` (#5793: NOT PASSED at all, litellm/the OpenAI
+    SDK's own timeout default applies — reyn does not invent a duplicate),
+    entered a malformed value (effectively unspecified, not a reason to
+    inject a reyn-chosen number either), or explicitly opted all the way
+    out with ``<= 0`` — means the same thing at the one call site that
+    consumes this (:meth:`LiteLLMEmbeddingProvider._aembedding_bounded`):
+    no ``timeout=`` kwarg, no ``asyncio.timeout`` wrap. All three cases
+    already resolved to identical behaviour before #5793 too (the ``<= 0``
+    branch never actually produced a MORE unbounded call than omitting the
+    kwarg does) — #5793 only changes what happens when the operator set
+    nothing at all.
 
     Mirrors :func:`reyn.mcp.gateway.resolve_call_timeout` (the same contract, so an
     operator who knows one knob knows the other), reading from either the
@@ -67,13 +75,13 @@ def resolve_embed_timeout(config: "dict[str, Any] | Any") -> "float | None":
         if isinstance(config, dict)
         else getattr(config, "timeout", None)
     )
-    timeout: "float | None" = _DEFAULT_EMBED_TIMEOUT_SECONDS
-    if raw is not None:
-        try:
-            timeout = float(raw)
-        except (TypeError, ValueError):
-            timeout = _DEFAULT_EMBED_TIMEOUT_SECONDS
-    if timeout is not None and timeout <= 0:
+    if raw is None:
+        return None
+    try:
+        timeout = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if timeout <= 0:
         return None
     return timeout
 
@@ -214,9 +222,11 @@ class LiteLLMEmbeddingProvider:
             self._max_retries: int = int(config.get("max_retries", 3))
             self._retry_backoff: float = float(config.get("retry_backoff", 2.0))
             self.tokenizer: str = config.get("tokenizer", "cl100k_base")
-        # #3043: resolved from EITHER config form by the same function, so the
-        # dict (legacy / test) path and the dataclass (production) path cannot
-        # disagree about the bound. None = operator opted out (`timeout <= 0`).
+        # #3043/#5793: resolved from EITHER config form by the same function,
+        # so the dict (legacy / test) path and the dataclass (production)
+        # path cannot disagree about the bound. None = unset, malformed, or
+        # explicit `timeout <= 0` opt-out — all three defer to litellm's own
+        # default (see resolve_embed_timeout's own docstring).
         self._timeout: "float | None" = resolve_embed_timeout(config)
 
     # ── Config read-only accessors ────────────────────────────────────────
@@ -243,7 +253,8 @@ class LiteLLMEmbeddingProvider:
 
     @property
     def timeout(self) -> "float | None":
-        """Per-attempt bound in seconds; ``None`` = operator opted out (#3043)."""
+        """Per-attempt bound in seconds; ``None`` = unset, malformed, or an
+        explicit opt-out (#3043/#5793 — see resolve_embed_timeout)."""
         return self._timeout
 
     # ── Model resolution ───────────────────────────────────────────────────
@@ -474,8 +485,10 @@ class LiteLLMEmbeddingProvider:
 
         The single place the bound is applied, so a future call site cannot reach
         ``aembedding`` unbounded by forgetting to wrap it (the swept-missed shape
-        that produced this bug). ``self._timeout is None`` = operator opted out
-        (``embedding.timeout <= 0``) → the historical unbounded call, unchanged.
+        that produced this bug). ``self._timeout is None`` (unset, malformed,
+        or an explicit ``embedding.timeout <= 0`` opt-out — #5793) → no
+        ``timeout=`` kwarg, no ``asyncio.timeout`` wrap; litellm's own
+        default applies.
 
         ``max_retries=0`` (#3047, measured): without it, litellm's
         ``llms/openai/openai.py::OpenAIChatCompletion.embedding``'s

--- a/src/reyn/interfaces/cli/common_args.py
+++ b/src/reyn/interfaces/cli/common_args.py
@@ -36,15 +36,17 @@ def add_limits_args(parser: argparse.ArgumentParser) -> None:
         default=None, metavar="SECONDS",
         help=(
             "Per-call LLM HTTP timeout (seconds). "
-            "Default: from reyn.yaml `safety.timeout.llm_call_seconds` or 60."
+            "Default: from reyn.yaml `safety.timeout.llm_call_seconds`, "
+            "or unset (litellm's own default) if that is also unset (#5793)."
         ),
     )
     parser.add_argument(
         "--llm-max-retries", dest="llm_max_retries", type=int,
         default=None, metavar="N",
         help=(
-            "Transient-error retries per LLM call (LiteLLM exponential backoff). "
-            "Default: from reyn.yaml `safety.timeout.llm_max_retries` or 3."
+            "Transient-error retries per LLM call (litellm's own retry, not reyn's). "
+            "Default: from reyn.yaml `safety.timeout.llm_max_retries`, "
+            "or unset (litellm's own default) if that is also unset (#5793)."
         ),
     )
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -727,11 +727,12 @@ class LLMToolCallResult:
     reasoning: dict | None = None
 
 # ---------------------------------------------------------------------------
-# Infrastructure retry — exponential backoff on transient LLM API errors
+# Empty-choices retry — exponential backoff on the ONE case litellm can't
+# retry itself (#5793: every infra-exception kind reyn used to also retry
+# here is litellm's own job now — see ``_is_retryable_exc``'s own docstring).
 # ---------------------------------------------------------------------------
 
-# Retryable: infrastructure / transient errors where the same call may succeed.
-# Non-retryable: semantic / auth / quota errors (4xx) where retry won't help.
+# Retryable: EmptyLLMResponseError only (see ``_is_retryable_exc``, #5793).
 # Resolved lazily so importing this module does not trigger `import litellm`.
 # #3671 P1: single check-then-set on ONE global holding the complete tuple —
 # already the correct shape (see ``_get_retryable_litellm_exceptions``'s own
@@ -788,6 +789,24 @@ def _env_num(name: str, default: "int | float", lo: "int | float", hi: "int | fl
         return default
 
 
+def _env_int_or_none(name: str, lo: int, hi: int) -> "int | None":
+    """#5793: like ``_env_num``, but the unset/invalid case is ``None`` (don't
+    pass a value at all — litellm's own default applies), not a reyn-chosen
+    literal. A separate helper rather than widening ``_env_num`` itself: that
+    function's callers with a REAL numeric default (``_LLM_RETRY_MAX_ATTEMPTS``/
+    ``_LLM_RETRY_BASE_S`` — the one retry loop #5793 keeps, see llm.py:1320's
+    empty-choices case) must stay non-Optional; mixing the two contracts into
+    one signature would make every caller's return type ``T | None`` whether
+    it wanted that or not."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    try:
+        return max(lo, min(hi, int(raw)))
+    except (TypeError, ValueError):
+        return None
+
+
 # Defaults preserve today's behaviour (3 attempts / 2s base); the env overrides let an
 # operator absorb a transient empty-generation / 5xx storm without editing code.
 _LLM_RETRY_MAX_ATTEMPTS: int = _env_num("REYN_LLM_RETRY_MAX_ATTEMPTS", 3, 1, 10, int)
@@ -822,7 +841,9 @@ def _env_router_config():
     return RouterConfig(
         use=os.environ.get("REYN_LLM_USE_ROUTER", "").strip().lower()
         in ("1", "true", "yes"),
-        num_retries=_env_num("REYN_LLM_ROUTER_NUM_RETRIES", 3, 0, 10, int),
+        # #5793: None unless the env var is set — the back-compat tail
+        # mirrors RouterConfig's own default now, not a reyn-invented "3".
+        num_retries=_env_int_or_none("REYN_LLM_ROUTER_NUM_RETRIES", 0, 10),
     )
 
 
@@ -1059,20 +1080,24 @@ def _is_llm_timeout_exc(exc: BaseException) -> bool:
 
 
 def _resolve_llm_call_bounds(
-    timeout: "float | None", max_retries: int, *, purpose: "str | None" = None,
-) -> "tuple[float | None, int]":
-    """#2210/#5597: resolve the per-call HTTP bounds for a ``recorded_acompletion``
-    call. An EXPLICIT ``timeout`` (the kernel path threads it via the
-    LLMCallRecorder; ``call_llm_tools`` resolves + passes its own before
-    this is ever reached) WINS — returned as-is, so kernel/router
-    behaviour is unchanged (regression-impossible by construction). Only
-    a ``None`` timeout (a caller that never resolved one itself — #5597's
-    own gap: ``CompactionEngine._acompletion`` passed neither ``timeout``
-    nor ``num_retries`` at all, so an upstream hang blocked forever) falls
-    back to the ambient per-LLM-call policy context (same
-    ``safety.timeout.*`` source `call_llm_tools` already uses). No
-    context → stays ``None`` (litellm default — the pre-#2210 behaviour,
-    no worse).
+    timeout: "float | None", max_retries: "int | None", *, purpose: "str | None" = None,
+) -> "tuple[float | None, int | None]":
+    """#2210/#5597/#5793: resolve the per-call HTTP bounds for a
+    ``recorded_acompletion`` call. An EXPLICIT ``timeout`` (the kernel path
+    threads it via the LLMCallRecorder; ``call_llm_tools`` resolves + passes
+    its own before this is ever reached) WINS — returned as-is, so
+    kernel/router behaviour is unchanged (regression-impossible by
+    construction). Only a ``None`` timeout (a caller that never resolved
+    one itself — #5597's own gap: ``CompactionEngine._acompletion`` passed
+    neither ``timeout`` nor ``num_retries`` at all, so an upstream hang
+    blocked forever) falls back to the ambient per-LLM-call policy context
+    (same ``safety.timeout.*`` source `call_llm_tools` already uses). No
+    context, or a context whose field is itself ``None`` (#5793: the
+    operator never set ``safety.timeout.llm_call_seconds``/
+    ``llm_max_retries``) → stays ``None``, meaning the caller must NOT pass
+    the corresponding litellm kwarg at all — litellm's own default applies
+    (owner decision, #5793: reyn does not invent a default duplicating
+    litellm's own).
 
     ``purpose`` (#5597): when the resolved ambient context carries a
     NON-``None`` ``compaction_llm_call_timeout`` (``chat.compaction.
@@ -1131,7 +1156,21 @@ class EmptyLLMResponseError(Exception):
     same backoff machinery retries it (the condition is transient), and on
     exhaustion the caller sees this named error instead of a cryptic
     IndexError.
+
+    ``response`` (#5793, optional, defaults to ``None``, unused by the
+    production raise site above — a 200-with-empty-choices condition has
+    no HTTP-level Retry-After to carry): a genuine constructor field, not
+    a post-hoc test attribute, so ``_extract_retry_after``'s generic
+    ``getattr(exc, "response", None)`` reads a REAL declared attribute
+    when a caller (a test, or a future producer) does supply one — #5793
+    narrowed retryable exceptions to this class alone, so it is now the
+    only kind whose Retry-After-handling path in ``_llm_call_with_retry``
+    is reachable at all.
     """
+
+    def __init__(self, message: str, *, response: object = None) -> None:
+        super().__init__(message)
+        self.response = response
 
 
 def _empty_response_diag(response: object) -> str:
@@ -1196,20 +1235,21 @@ def _get_retryable_litellm_exceptions() -> tuple:
 
 
 def _is_retryable_exc(exc: BaseException) -> bool:
-    """Return True for infrastructure errors that justify a retry attempt.
-
-    Catches litellm's typed exceptions for 5xx / timeout / connection failures.
-    Also catches httpx transport-level errors that LiteLLM may not wrap when
-    the request fails before reaching the provider's HTTP response logic.
+    """#5793 (owner decision, "自前の...汎用再試行は litellm に委ねる"): return True
+    ONLY for :class:`EmptyLLMResponseError` — a 200 response with an empty
+    ``choices`` list is a transient provider condition that is NOT an API
+    error, so litellm neither raises nor retries it. This is the one case
+    litellm structurally cannot handle (the sole exception #5793 keeps,
+    llm.py's own retry loop below). Every infra-exception kind this used to
+    also catch (litellm's typed 5xx/timeout/connection exceptions, raw
+    httpx transport errors) is now litellm's own job — passing
+    ``num_retries`` (chat) lets litellm/its Router retry those; reyn no
+    longer re-retries what litellm already retries (the pre-#5793 shape,
+    only ever a no-op savings on the Router path via the ``_use_llm_router``
+    guard below, was a genuine double-retry on the direct-``acompletion``
+    path when the Router was off).
     """
-    if isinstance(exc, EmptyLLMResponseError):
-        # #187 B1: 200 + choices=[] is a transient provider condition — retry.
-        return True
-    if isinstance(exc, _get_retryable_litellm_exceptions()):
-        return True
-    if isinstance(exc, _get_httpx_exc_types()):
-        return True
-    return False
+    return isinstance(exc, EmptyLLMResponseError)
 
 
 def _backoff_s(attempt: int) -> float:
@@ -1291,7 +1331,13 @@ async def _llm_call_with_retry(
     *,
     sleep_fn=None,
 ) -> object:
-    """Execute ``coro_fn()`` with infrastructure-error retry + backoff.
+    """Execute ``coro_fn()`` with retry + backoff — #5793: NARROWED to the one
+    case litellm structurally cannot handle (a 200 response with an empty
+    ``choices`` list, ``EmptyLLMResponseError``, not an API error so litellm
+    neither raises nor retries it). Every infra-exception kind (5xx/timeout/
+    connection) this used to also retry is litellm's own job now — reyn
+    passes ``num_retries`` and lets litellm/its Router retry those, instead
+    of duplicating the decision (owner decision, #5793: "車輪の再発明やめてよ").
 
     ``coro_fn`` must be a zero-arg async callable that returns the litellm
     response object.  It is called once per attempt.
@@ -1345,15 +1391,12 @@ async def _llm_call_with_retry(
         except BaseException as exc:
             if not _is_retryable_exc(exc):
                 raise
-            # #1829 S3a (#1835 fold): on the router path the litellm.Router has
-            # ALREADY retried infra exceptions (5xx / timeout / connect) with
-            # native Retry-After respect, so re-retrying them here would double
-            # (Router N × Reyn N). Only EmptyLLMResponseError (200 + empty choices,
-            # #187 B1) stays Reyn-owned — the Router does not retry a non-exception
-            # 200. Router OFF → unchanged (full exponential-backoff retry of all
-            # _is_retryable_exc kinds; byte-identical to pre-#1829).
-            if _use_llm_router() and not isinstance(exc, EmptyLLMResponseError):
-                raise
+            # #5793: the router-vs-direct guard that used to live here is
+            # gone — ``_is_retryable_exc`` now only ever returns True for
+            # ``EmptyLLMResponseError`` (every infra-exception kind is
+            # litellm's own retry job, chat's ``num_retries``), so there is
+            # no other kind left to double-retry against the Router's own
+            # native retry, on OR off.
             last_exc = exc
             retries_remaining = _LLM_RETRY_MAX_ATTEMPTS - attempt - 1
             if retries_remaining == 0:
@@ -1817,7 +1860,12 @@ def _single_deployment_router(model: str, *, original_model: "str | None" = None
         model_list: list = []
         for m in [model, *fb_targets]:
             model_list.extend(_deployments_for_model(m, rcfg))
-        kwargs: dict = {"model_list": model_list, "num_retries": rcfg.num_retries}
+        kwargs: dict = {"model_list": model_list}
+        # #5793: only set when the operator configured it — matches
+        # cooldown_time/allowed_fails just below (both already
+        # None → omitted → litellm.Router's own default).
+        if rcfg.num_retries is not None:
+            kwargs["num_retries"] = rcfg.num_retries
         if fb_targets:
             kwargs["fallbacks"] = [{model: fb_targets}]
         if rcfg.cooldown_time is not None:
@@ -2455,11 +2503,14 @@ async def recorded_acompletion(
     # forgets to set its own bound, by construction.
     if "timeout" not in base_kwargs:
         _resolved_timeout, _resolved_num_retries = _resolve_llm_call_bounds(
-            None, base_kwargs.get("num_retries", 1), purpose=purpose,
+            None, base_kwargs.get("num_retries"), purpose=purpose,
         )
         if _resolved_timeout is not None:
             base_kwargs["timeout"] = _resolved_timeout
-        if "num_retries" not in base_kwargs:
+        # #5793: an unresolved (None) num_retries must NOT become a
+        # reyn-chosen literal here either — omit the kwarg, litellm's own
+        # default applies (the same rule as ``call_llm_tools`` above).
+        if "num_retries" not in base_kwargs and _resolved_num_retries is not None:
             base_kwargs["num_retries"] = _resolved_num_retries
 
     # #1650: when an operator sets ``reasoning_effort`` on a model, the proxy
@@ -3126,7 +3177,11 @@ async def call_llm_tools(
     tools: list[dict],               # OpenAI-format tools array
     tool_choice: str = "auto",       # "auto" | "required" | "none" (note: "none" not Gemini-safe)
     timeout: float | None = None,
-    max_retries: int = 1,
+    # #5793: None (not 1) — an unset caller must not force a reyn-invented
+    # retry count onto litellm; ``_resolve_llm_call_bounds`` only overrides
+    # this with a real number when the operator set
+    # ``safety.timeout.llm_max_retries``.
+    max_retries: "int | None" = None,
     prompt_cache_enabled: bool = True,
     budget: "BudgetTracker | None" = None,
     budget_agent: str | None = None,
@@ -3316,7 +3371,11 @@ async def call_llm_tools(
     timeout, max_retries = _resolve_llm_call_bounds(timeout, max_retries)
     if timeout is not None:
         call_kwargs["timeout"] = timeout
-    call_kwargs["num_retries"] = max_retries
+    # #5793: only set when resolved to a real value — an unset operator
+    # config must not force ANY num_retries onto litellm (its own default
+    # applies), not even a reyn-chosen "safe-looking" one.
+    if max_retries is not None:
+        call_kwargs["num_retries"] = max_retries
 
     # Payload trace dump (request)
     _trace_rid = _dump_llm_request({

--- a/src/reyn/runtime/process_registry.py
+++ b/src/reyn/runtime/process_registry.py
@@ -593,12 +593,15 @@ def read_process_markers() -> "list[dict]":
 
 #: The beat's own polling resolution — derivation, not a guess: the
 #: longest "normal silence" a healthy turn can produce is one LLM call's
-#: own bound (``chat.py``'s ``llm_call_seconds = 60.0``,
-#: ``src/reyn/interfaces/cli/commands/chat.py``). 10s keeps the death
-#: window well inside that bound without being so fine-grained the writes
-#: themselves become a cost. Not a config key (architect ruling, #5709
-#: R4): no operator has a reason to change it today — the day one does,
-#: that need is the re-open trigger, not a guess made now.
+#: own bound. #5793: ``chat.py``'s ``llm_call_seconds`` no longer has a
+#: reyn-owned default (``None`` unless the operator sets
+#: ``safety.timeout.llm_call_seconds``, in which case litellm's own
+#: default bound applies — commonly minutes, not this comment's former
+#: 60s) — 10s is still well inside ANY of those, so the derivation's
+#: CONCLUSION is unaffected, only its former single-number premise. Not a
+#: config key (architect ruling, #5709 R4): no operator has a reason to
+#: change it today — the day one does, that need is the re-open trigger,
+#: not a guess made now.
 _LOOP_BEAT_INTERVAL_S: Final[float] = 10.0
 
 

--- a/tests/core/test_embed_bound_cancel_3043.py
+++ b/tests/core/test_embed_bound_cancel_3043.py
@@ -193,15 +193,20 @@ async def test_batches_are_bounded_independently_of_batch_count(
 # The operator knob
 # ---------------------------------------------------------------------------
 
-def test_default_bound_is_finite_and_matches_the_chat_llm_call_bound() -> None:
-    """Tier 2: with no operator config the bound is finite (the invariant) and is
-    the same number a chat LLM call carries — an embed is the same kind of call.
+def test_default_bound_is_unset_and_matches_the_chat_llm_call_bound() -> None:
+    """Tier 2: #5793 — with no operator config the bound is ``None`` (NOT
+    PASSED to litellm at all; litellm/the OpenAI SDK's own default applies),
+    the same as a chat LLM call's own default — an embed is the same kind
+    of call, and the two surfaces got the SAME fix in the same PR.
 
     Reads `chat.timeout.llm_call_seconds`'s own default rather than restating
-    60.0, so the two cannot silently drift apart.
+    None, so the two cannot silently drift apart. Deliberately NOT "finite"
+    any more — reyn no longer invents a per-attempt number duplicating
+    litellm's own (owner decision, #5793).
     """
     from reyn.config.chat import TimeoutConfig
 
+    assert resolve_embed_timeout({}) is None
     assert resolve_embed_timeout({}) == TimeoutConfig().llm_call_seconds
 
 
@@ -227,9 +232,13 @@ def test_non_positive_timeout_opts_out_of_the_bound() -> None:
     assert LiteLLMEmbeddingProvider({"timeout": 0}).timeout is None
 
 
-def test_malformed_timeout_falls_back_to_the_bound_not_to_no_bound() -> None:
-    """Tier 2: a malformed value fails SAFE — it keeps a finite bound rather than
-    silently restoring the unbounded call (mirrors `resolve_call_timeout`)."""
+def test_malformed_timeout_is_treated_as_unspecified() -> None:
+    """Tier 2: #5793 — a malformed value collapses to the SAME state as no
+    config at all: ``None``, litellm's own default. (Pre-#5793 this used to
+    fail SAFE to a reyn-owned finite bound instead; #5793 removed that
+    reyn-owned number, so "malformed" and "unspecified" are now the same
+    fact, not two that happen to produce equal numbers.)"""
+    assert resolve_embed_timeout({"timeout": "not-a-number"}) is None
     assert resolve_embed_timeout({"timeout": "not-a-number"}) == resolve_embed_timeout({})
     assert resolve_embed_timeout({"timeout": None}) == resolve_embed_timeout({})
 
@@ -252,9 +261,12 @@ async def test_cancel_event_interrupts_a_stalled_embed_op_immediately(
     """Tier 2: Ctrl-C mid-embed cancels the in-flight call at once and surfaces the
     cancelled outcome + audit-event — it does not wait out the bound.
 
-    The bound here is the 60s default and the cancel fires at 0.3s, so the bound
-    CANNOT be what ends this call: only the cancel seam can. Pre-#3043 the op had
-    no seam at all and this would run the full 60s (past the 20s ceiling).
+    No explicit ``timeout`` is configured here — #5793: the default is no
+    longer a reyn-owned 60s, so whatever bound applies (litellm's own,
+    commonly far longer) is CERTAINLY not what ends this call at 0.3s: only
+    the cancel seam can. Pre-#3043 the op had no seam at all and this would
+    have run out whatever bound (or lack of one) applied (past the 20s
+    ceiling either way).
     """
     cancel_event = asyncio.Event()
     ctx, events = _make_ctx(cancel_event=cancel_event)

--- a/tests/llm/test_2210_llm_call_timeout.py
+++ b/tests/llm/test_2210_llm_call_timeout.py
@@ -82,6 +82,40 @@ def test_none_timeout_no_context_stays_none():
     assert timeout is None and retries == 1
 
 
+# ── #5793: unset config must resolve to None, not a reyn-chosen literal ────────
+
+
+def test_unset_ambient_context_stays_none_not_a_reyn_default():
+    """Tier 2: #5793 (owner decision, "わざわざ reyn が別に規定を持つ理由がわからん") —
+    an ambient context whose OWN `llm_call_timeout`/`llm_max_retries` are
+    `None` (the operator never set `safety.timeout.llm_call_seconds`/
+    `llm_max_retries` in reyn.yaml — TimeoutConfig's own new default) must
+    resolve BOTH bounds to `None`, not silently substitute a reyn-invented
+    number. This is the exact call shape `call_llm_tools`'s own now-`None`
+    default produces (see test_llm_call_bounds_omission_5793.py) — RED if a
+    future change reintroduces a fallback literal here."""
+    set_llm_call_limit_context(
+        _Bus(None), OnLimitConfig(), "run", False,
+        llm_call_timeout=None, llm_max_retries=None)
+    timeout, retries = _resolve_llm_call_bounds(None, None)
+    assert timeout is None, "an unset ambient timeout must stay None, never a reyn default"
+    assert retries is None, "an unset ambient max_retries must stay None, never a reyn default"
+
+
+def test_explicit_ambient_context_still_overrides_when_set():
+    """Tier 2: #5793 deny — the operator's own EXPLICIT
+    safety.timeout.llm_call_seconds/llm_max_retries (a real, non-None
+    ambient context) still wins over an unset per-call default, proving
+    #5793 only removed the INVENTED fallback, not the override path
+    itself."""
+    set_llm_call_limit_context(
+        _Bus(None), OnLimitConfig(), "run", False,
+        llm_call_timeout=17.0, llm_max_retries=6)
+    timeout, retries = _resolve_llm_call_bounds(None, None)
+    assert timeout == 17.0
+    assert retries == 6
+
+
 # ── HIGH: persistent-timeout → on_limit (framework integration) ───────────────
 
 

--- a/tests/llm/test_5793_litellm_default_omission.py
+++ b/tests/llm/test_5793_litellm_default_omission.py
@@ -1,0 +1,166 @@
+"""Tier 2: #5793 — "operator explicit only, else NOT PASSED at all" across the
+3 litellm-touching surfaces (owner decision, verbatim: "わざわざ reyn が別に規定
+を持つ理由がわからん...未指定なら litellm 規定にして").
+
+Each surface has its OWN litellm entry point (`acompletion` / `aembedding` /
+`Router`) and is verified SEPARATELY here — a pass on one entry point does not
+generalize to the others (lead-coder's own explicit instruction on this issue).
+Every test below inspects the REAL kwargs/attributes litellm actually received
+(a spy on the real litellm boundary, or the real litellm.Router's own resolved
+attribute), not a declaration that the code "should" omit the key.
+
+"Not passed" and "None/0 passed as a value" are different facts (owner's own
+distinction) — every assertion below checks the KEY IS ABSENT (or, for the
+Router, that litellm's OWN default numeral appears, not reyn's former one),
+never merely that a variable equals ``None`` in reyn's own code.
+"""
+from __future__ import annotations
+
+import litellm
+import pytest
+
+from reyn.config.embedding import EmbeddingConfig
+from reyn.config.infra import RouterConfig
+from reyn.data.embedding.litellm_provider import LiteLLMEmbeddingProvider
+from reyn.llm.llm import _single_deployment_router, call_llm_tools
+
+
+@pytest.fixture(autouse=True)
+def _isolate_litellm_model_cost():
+    """Same #1762 global-state-isolation discipline as test_llm_router_s1_1829.py —
+    Router build registers a model_cost placeholder; restore in place."""
+    before = dict(litellm.model_cost)
+    yield
+    litellm.model_cost.clear()
+    litellm.model_cost.update(before)
+
+
+# ── config defaults themselves (the data-layer half of the fix) ────────────
+
+
+def test_config_defaults_are_none_not_reyn_numbers() -> None:
+    """Tier 2: the 3 config surfaces' own defaults are None — the OTHER half
+    of "not passed", proven at the config layer (the kwargs-omission tests
+    below prove the consuming half)."""
+    from reyn.config.chat import TimeoutConfig
+    assert TimeoutConfig().llm_call_seconds is None
+    assert TimeoutConfig().llm_max_retries is None
+    assert EmbeddingConfig().timeout is None
+    assert RouterConfig().num_retries is None
+
+
+def test_call_llm_tools_own_default_is_none_not_1() -> None:
+    """Tier 2: #5793 — call_llm_tools's OWN function-signature default for
+    max_retries used to be the literal 1 (a reyn-invented number, independent
+    of any config), forced onto every caller that omits the kwarg (the main
+    chat router path always does — see router_loop.py's own call sites,
+    none of which pass max_retries). Now None, so an unset caller reaches
+    litellm with no forced retry count at all."""
+    import inspect
+    sig = inspect.signature(call_llm_tools)
+    assert sig.parameters["max_retries"].default is None
+
+
+# ── Router surface: litellm.Router's own entry point ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_num_retries_is_litellms_own_default_not_reyns_former_3() -> None:
+    """Tier 2: #5793 — a Router built from an UNCONFIGURED RouterConfig (the
+    single-deployment path `_single_deployment_router` uses when no
+    reyn.yaml `llm.router.*` and no legacy env var are set) must carry
+    litellm's OWN num_retries default, not reyn's former hardcoded 3.
+
+    Verified against a REAL bare litellm.Router built the same way, with
+    num_retries genuinely omitted from its own kwargs — the reference value
+    is read live, never hardcoded, so this stays correct even if litellm's
+    own default itself changes in a future litellm release.
+
+    ``async def`` (#5793 fix): `_single_deployment_router` is per-running-
+    loop-cached (`asyncio.get_running_loop()`), so it needs a real running
+    loop — a bare `def` test raised "no running event loop"."""
+    reference = litellm.Router(
+        model_list=[{"model_name": "t5793-ref", "litellm_params": {"model": "openai/gpt-4o-mini"}}],
+    )
+    assert reference.num_retries != 3, (
+        "sanity: litellm's own default must differ from reyn's former 3, "
+        "else this test cannot distinguish the two"
+    )
+
+    router = _single_deployment_router("openai/t5793-probe-model")
+    assert router.num_retries == reference.num_retries, (
+        f"an unconfigured Router must resolve to litellm's OWN default "
+        f"({reference.num_retries!r}), not reyn's former hardcoded 3 — "
+        f"got {router.num_retries!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_router_num_retries_still_honours_an_explicit_operator_value() -> None:
+    """Tier 2: #5793 deny — an operator who DOES set llm.router.num_retries
+    still reaches litellm with that exact value; #5793 only removed the
+    unset-case fallback, not the override path."""
+    from reyn.llm.llm import set_router_config
+
+    token = set_router_config(RouterConfig(use=True, num_retries=9))
+    try:
+        router = _single_deployment_router("openai/t5793-probe-model-explicit")
+    finally:
+        from reyn.llm.llm import _router_config_var
+        _router_config_var.reset(token)
+    assert router.num_retries == 9
+
+
+# ── Embedding surface: litellm.aembedding's own entry point ────────────────
+
+
+@pytest.mark.asyncio
+async def test_embedding_omits_timeout_kwarg_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: #5793 — an unconfigured EmbeddingConfig (`timeout` unset)
+    reaches ``litellm.aembedding`` with NO ``timeout=`` kwarg at all — a real
+    spy on litellm's own boundary (the LLMReplay monkeypatch point), not a
+    declaration. ``max_retries=0`` is EXPECTED to still be present — that is
+    #3047's own deliberate, documented exception (reyn's retry loop stays
+    the sole retry layer for embeddings), unrelated to #5793."""
+    captured: dict = {}
+
+    async def _spy(**kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("spy-short-circuit")  # no real network call
+
+    monkeypatch.setattr(litellm, "aembedding", _spy)
+    provider = LiteLLMEmbeddingProvider({"classes": {"standard": "openai/probe-embed-model"}})
+    with pytest.raises(RuntimeError, match="Embedding failed"):
+        await provider.embed(["hello"], "standard")
+
+    assert "timeout" not in captured, (
+        f"an unset embedding.timeout must not reach litellm.aembedding at "
+        f"all; got kwargs={sorted(captured)}"
+    )
+    assert captured.get("max_retries") == 0, (
+        "the #3047 max_retries=0 kwarg (a SEPARATE, deliberate exception — "
+        "reyn's own retry loop, not litellm's, stays the retry layer for "
+        "embeddings) must be unaffected by #5793"
+    )
+
+
+@pytest.mark.asyncio
+async def test_embedding_passes_timeout_kwarg_when_operator_sets_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5793 deny — an operator-set embedding.timeout still reaches
+    litellm.aembedding as an explicit kwarg."""
+    captured: dict = {}
+
+    async def _spy(**kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("spy-short-circuit")
+
+    monkeypatch.setattr(litellm, "aembedding", _spy)
+    provider = LiteLLMEmbeddingProvider({
+        "timeout": 5.0, "classes": {"standard": "openai/probe-embed-model"},
+    })
+    with pytest.raises(RuntimeError, match="Embedding failed"):
+        await provider.embed(["hello"], "standard")
+
+    assert captured.get("timeout") == 5.0

--- a/tests/llm/test_llm_call_retry.py
+++ b/tests/llm/test_llm_call_retry.py
@@ -1,38 +1,58 @@
-"""Tier 2: OS invariant — LLM call infrastructure retry + event observability.
+"""Tier 2: OS invariant — LLM call retry + event observability.
 
 Guards the retry wrapper around the LiteLLM call boundary introduced in
-FP-0008 PR-Q v8:
+FP-0008 PR-Q v8. #5793 (owner decision, "自前の...汎用再試行は litellm に委ねる")
+NARROWED this wrapper to retry ONLY EmptyLLMResponseError (the one case
+litellm structurally cannot handle — a 200 with empty ``choices`` is not an
+API error, so litellm neither raises nor retries it). Every infra-exception
+kind (timeout / 5xx / httpx transport) this wrapper used to ALSO retry is
+litellm's own job now (reyn passes ``num_retries``, letting litellm/its
+Router retry those) — items 2/3/6/7 below were rewritten from "retried by
+reyn" (accept) to "NOT retried by reyn, propagates immediately" (deny), the
+new true contract.
 
 1. test_no_retry_on_success
    Successful call on first attempt → no retry, no retry events emitted.
 
-2. test_retry_and_succeed
-   Timeout on attempt 1 → retry fires, succeeds on attempt 2.
-   llm_call_retry event emitted with correct fields.
+2. test_infra_exception_not_retried_by_reyn_any_more (#5793 deny, was
+   test_retry_and_succeed)
+   A Timeout on attempt 1 propagates immediately — no reyn-owned retry;
+   litellm's own num_retries is the retry layer for this kind now.
 
-3. test_all_retries_exhausted
-   Timeout on all 3 attempts → llm_call_retry_exhausted event emitted,
-   exception propagates.
+3. test_infra_exception_exhausted_by_reyn_removed (#5793 deny, was
+   test_all_retries_exhausted)
+   A ServiceUnavailableError propagates on the FIRST attempt — no
+   llm_call_retry_exhausted event, because there was never a reyn retry
+   to exhaust.
 
 4. test_4xx_no_retry
-   BadRequestError (4xx semantic) → immediate failure, no retry, no events.
+   BadRequestError (4xx semantic) → immediate failure, no retry, no events
+   (unchanged — was never retried, by either reyn or litellm).
 
 5. test_backoff_shape
    Backoff values follow the exponential curve: _backoff_s(0)=2s,
-   _backoff_s(1)=4s, _backoff_s(2)=8s — capped at 16s.
+   _backoff_s(1)=4s, _backoff_s(2)=8s — capped at 16s. Unaffected by
+   #5793 — still exercised by the one retry kind that remains.
 
-6. test_httpx_errors_retried
-   Raw httpx.ConnectError and httpx.ReadTimeout are retried (= transport-level
-   errors LiteLLM may not wrap).
+6. test_httpx_errors_not_retried_by_reyn_any_more (#5793 deny, was
+   test_httpx_errors_retried)
+   Raw httpx.ConnectError / httpx.ReadTimeout propagate immediately — no
+   longer a reyn-owned retry kind.
+
+7. test_is_retryable_exc_classification (#5793 rewritten)
+   ONLY EmptyLLMResponseError classifies as retryable now; every litellm
+   infra-exception kind this used to also classify as retryable no longer
+   does — litellm's own retry handles those, not this function.
 
 9. test_empty_choices_retried_then_succeed   (#187 B1)
    A 200 response with choices=[] on attempt 1 → retried as a transient
-   condition, succeeds on attempt 2. No IndexError, no crash.
+   condition, succeeds on attempt 2. No IndexError, no crash. Unaffected
+   by #5793 — this is the ONE case litellm can't handle, kept explicitly.
 
 10. test_empty_choices_exhausted_raises_named_error   (#187 B1)
    choices=[] on every attempt → raises the named EmptyLLMResponseError
    (NOT a cryptic IndexError from response.choices[0]); exhausted event
-   emitted. Pins the real proxy failure-mode shape.
+   emitted. Pins the real proxy failure-mode shape. Unaffected by #5793.
 
 No real network calls — tests use a counter-based async callable stub that
 fails K times then succeeds (real instance, no unittest.mock).
@@ -220,12 +240,12 @@ async def _no_op_coro():
 
 
 @pytest.mark.asyncio
-async def test_retry_and_succeed(monkeypatch):
-    """Tier 2: retry wrapper — timeout on attempt 1, success on attempt 2.
-
-    Invariant: one llm_call_retry event emitted, no exhausted event, correct
-    error_kind and attempt_n fields.
-    """
+async def test_infra_exception_not_retried_by_reyn_any_more(monkeypatch):
+    """Tier 2: #5793 deny — a Timeout on attempt 1 propagates IMMEDIATELY, no
+    reyn-owned retry. litellm's own num_retries is the retry layer for this
+    kind now (owner decision: reyn does not duplicate litellm's own retry
+    decision). Was test_retry_and_succeed (accept-side, pre-#5793); rewritten
+    rather than deleted — the deny form is the live contract now."""
     import reyn.llm.llm as llm_mod
     slept: list[float] = []
     async def _fake_sleep(s: float) -> None:
@@ -241,33 +261,17 @@ async def test_retry_and_succeed(monkeypatch):
         success_response=resp,
     )
 
-    result = await _llm_call_with_retry(stub, "test-model", log)
-    assert result is resp
-    assert stub.call_count == 2
+    with pytest.raises(litellm.exceptions.Timeout):
+        await _llm_call_with_retry(stub, "test-model", log)
+    assert stub.call_count == 1, "a Timeout must not be retried by reyn's own loop any more"
+    assert slept == [], "no backoff sleep — there is no reyn-owned retry to back off before"
 
     await settle(log)
-    # Exactly one retry event (present) and no exhausted event (absent)
-    retry_events = [e for e in collected if e.type == "llm_call_retry"]
-    assert retry_events, "at least one llm_call_retry event must be emitted after a timeout"
-    assert not any(e.type == "llm_call_retry_exhausted" for e in collected), (
-        "llm_call_retry_exhausted must NOT be emitted when retry succeeds"
+    types = [e.type for e in collected]
+    assert "llm_call_retry" not in types, (
+        "no llm_call_retry event — reyn no longer retries this exception kind"
     )
-
-    ev = retry_events[0]
-    assert ev.data["model"] == "test-model"
-    assert ev.data["error_kind"] == "Timeout"
-    assert ev.data["attempt_n"] == 1
-    # #1835: jitter is default-ON — the emitted backoff_s and the sleep duration are
-    # independently drawn from [base/2, base] = [1.0, 2.0] for attempt 0 (base=2.0),
-    # so exact-value equality would be non-deterministic. Assert the range instead.
-    assert 1.0 <= ev.data["backoff_s"] <= 2.0, (
-        f"backoff_s for attempt 0 must be in [1.0, 2.0] (jitter range), got {ev.data['backoff_s']}"
-    )
-
-    # Sleep called exactly once (one retry); with jitter the value is in [1.0, 2.0].
-    # Use unpack to assert exactly-one-element rather than len() (pin behavior not size).
-    (sleep_val,) = slept
-    assert 1.0 <= sleep_val <= 2.0, f"sleep duration must be in [1.0, 2.0], got {sleep_val}"
+    assert "llm_call_retry_exhausted" not in types
 
 
 # ---------------------------------------------------------------------------
@@ -276,12 +280,12 @@ async def test_retry_and_succeed(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_all_retries_exhausted(monkeypatch):
-    """Tier 2: retry wrapper — all 3 attempts fail → exhausted event + exception.
-
-    Invariant: llm_call_retry_exhausted emitted on terminal failure; the
-    original exception propagates; call_count == _LLM_RETRY_MAX_ATTEMPTS.
-    """
+async def test_infra_exception_exhausted_by_reyn_removed(monkeypatch):
+    """Tier 2: #5793 deny — a ServiceUnavailableError propagates on the FIRST
+    attempt, no llm_call_retry_exhausted event, since there is no reyn-owned
+    retry to exhaust any more (litellm's own num_retries governs this kind).
+    Was test_all_retries_exhausted (accept-side, pre-#5793); rewritten rather
+    than deleted."""
     import reyn.llm.llm as llm_mod
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
 
@@ -293,13 +297,14 @@ async def test_all_retries_exhausted(monkeypatch):
     with pytest.raises(litellm.exceptions.ServiceUnavailableError):
         await _llm_call_with_retry(stub, "model-503", log)
 
-    assert stub.call_count == _LLM_RETRY_MAX_ATTEMPTS
+    assert stub.call_count == 1, "a ServiceUnavailableError must not be retried by reyn any more"
 
     await settle(log)
-    exhausted = [e for e in collected if e.type == "llm_call_retry_exhausted"]
-    assert exhausted, "llm_call_retry_exhausted must be emitted when all retries fail"
-    assert exhausted[0].data["model"] == "model-503"
-    assert exhausted[0].data["error_kind"] == "ServiceUnavailableError"
+    types = [e.type for e in collected]
+    assert "llm_call_retry_exhausted" not in types, (
+        "no exhausted event — there is no reyn-owned retry loop to exhaust for this kind"
+    )
+    assert "llm_call_retry" not in types
 
 
 async def _fake_sleep_noop(_: float) -> None:
@@ -352,21 +357,20 @@ async def test_4xx_no_retry(monkeypatch):
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Test 6: httpx transport errors retried
+# Test 6: httpx transport errors — #5793 deny, no longer retried by reyn
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_httpx_errors_retried(monkeypatch):
-    """Tier 2: retry wrapper — httpx.ConnectError and httpx.ReadTimeout are retried.
-
-    LiteLLM may not wrap transport-level errors that occur before the HTTP
-    response is received. The retry wrapper must catch them directly.
-    """
+async def test_httpx_errors_not_retried_by_reyn_any_more(monkeypatch):
+    """Tier 2: #5793 deny — httpx.ConnectError and httpx.ReadTimeout propagate
+    IMMEDIATELY now; reyn no longer catches raw transport-level errors as a
+    retry trigger (litellm's own num_retries governs transport failures now,
+    same as every other infra-exception kind #5793 moved). Was
+    test_httpx_errors_retried (accept-side, pre-#5793); rewritten rather
+    than deleted."""
     import reyn.llm.llm as llm_mod
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
-
-    resp = _fake_response()
 
     for exc_cls in (httpx.ConnectError, httpx.ReadTimeout):
         log = _make_event_log()
@@ -380,16 +384,17 @@ async def test_httpx_errors_retried(monkeypatch):
         stub = _FailThenSucceedCallable(
             fail_count=1,
             exc=raw_exc,
-            success_response=resp,
+            success_response=_fake_response(),
         )
 
-        result = await _llm_call_with_retry(stub, "model-net", log)
-        assert result is resp, f"{exc_cls.__name__} should be retried"
-        assert stub.call_count == 2
+        with pytest.raises(exc_cls):
+            await _llm_call_with_retry(stub, "model-net", log)
+        assert stub.call_count == 1, f"{exc_cls.__name__} must not be retried by reyn any more"
 
         await settle(log)
-        retry_events = [e for e in collected if e.type == "llm_call_retry"]
-        assert retry_events, f"{exc_cls.__name__}: expected at least one llm_call_retry event"
+        assert "llm_call_retry" not in [e.type for e in collected], (
+            f"{exc_cls.__name__}: no llm_call_retry event any more"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -398,25 +403,32 @@ async def test_httpx_errors_retried(monkeypatch):
 
 
 def test_is_retryable_exc_classification():
-    """Tier 2: _is_retryable_exc — correct classification of retryable vs non-retryable.
-
-    Checks the classification function directly against concrete exception
-    instances without exercising the full retry loop.
+    """Tier 2: #5793 rewritten — _is_retryable_exc now classifies ONLY
+    EmptyLLMResponseError as retryable. Every litellm infra-exception kind
+    this used to also classify as retryable (Timeout/APIConnectionError/
+    5xx/BadGateway) no longer does — litellm's own retry (reyn's
+    ``num_retries`` kwarg) is that decision now, not this function.
+    Was an accept-list for those kinds; now a deny list, the live contract.
     """
-    # Retryable
-    assert _is_retryable_exc(litellm.exceptions.Timeout("t", model="m", llm_provider="p"))
-    assert _is_retryable_exc(litellm.exceptions.APIConnectionError("c", llm_provider="p", model="m"))
-    assert _is_retryable_exc(
+    empty = EmptyLLMResponseError("empty choices")
+    assert _is_retryable_exc(empty), "EmptyLLMResponseError is the ONE case litellm can't handle"
+
+    # #5793: none of these are reyn-retryable any more.
+    assert not _is_retryable_exc(litellm.exceptions.Timeout("t", model="m", llm_provider="p"))
+    assert not _is_retryable_exc(
+        litellm.exceptions.APIConnectionError("c", llm_provider="p", model="m")
+    )
+    assert not _is_retryable_exc(
         litellm.exceptions.InternalServerError("500", response=None, llm_provider="p", model="m")
     )
-    assert _is_retryable_exc(
+    assert not _is_retryable_exc(
         litellm.exceptions.ServiceUnavailableError("503", response=None, llm_provider="p", model="m")
     )
-    assert _is_retryable_exc(
+    assert not _is_retryable_exc(
         litellm.exceptions.BadGatewayError("502", response=None, llm_provider="p", model="m")
     )
 
-    # Non-retryable
+    # Never retryable, unaffected by #5793 — semantic/validation errors.
     assert not _is_retryable_exc(
         litellm.exceptions.BadRequestError("400", response=None, llm_provider="p", model="m")
     )
@@ -439,20 +451,19 @@ async def test_event_log_none_no_crash(monkeypatch):
     """Tier 2: retry wrapper — event_log=None suppresses observability events without crashing.
 
     Callers that don't pass an EventLog must still benefit from retry behavior.
-    """
+    #5793: switched from a Timeout-retry scenario (no longer retried by reyn
+    at all) to the empty-choices scenario (#187 B1) — the one retry kind
+    #5793 keeps, so this test still exercises a REAL reyn-owned retry with
+    event_log=None, not a scenario that no longer retries at all."""
     import reyn.llm.llm as llm_mod
     monkeypatch.setattr(llm_mod.asyncio, "sleep", _fake_sleep_noop)
 
-    resp = _fake_response()
-    stub = _FailThenSucceedCallable(
-        fail_count=1,
-        exc=litellm.exceptions.Timeout("timed out", model="m", llm_provider="p"),
-        success_response=resp,
-    )
+    valid = _fake_response()
+    stub = _ReturnEmptyThenValidCallable(empty_count=1, valid_response=valid)
 
     # No event_log — must not raise
     result = await _llm_call_with_retry(stub, "model-y", None)
-    assert result is resp
+    assert result is valid
     assert stub.call_count == 2
 
 

--- a/tests/llm/test_llm_retry_jitter_retry_after_1835.py
+++ b/tests/llm/test_llm_retry_jitter_retry_after_1835.py
@@ -41,6 +41,7 @@ import pytest
 from reyn.config.infra import RetryConfig
 from reyn.llm.llm import (
     _LLM_RETRY_MAX_BACKOFF_S,
+    EmptyLLMResponseError,
     _backoff_s,
     _extract_retry_after,
     _llm_call_with_retry,
@@ -94,6 +95,38 @@ def _make_exc_no_retry_after(status: int = 503):
         llm_provider="openai",
         model="openai/gpt-4o-mini",
     )
+
+
+def _make_empty_response_exc_with_retry_after(header_value: str, status: int = 503):
+    """#5793: the litellm ServiceUnavailableError-carrying tests below used to
+    exercise ``_llm_call_with_retry``'s backoff/Retry-After wiring via a
+    litellm infra exception — #5793 narrowed retryability to
+    EmptyLLMResponseError only (litellm's own num_retries now retries
+    ServiceUnavailableError, so it is no longer a real reyn-retried
+    exception, and using one here would no longer exercise the retry loop
+    at all). The backoff/Retry-After MECHANISM itself is unchanged — it is
+    generic over any exception `_is_retryable_exc` accepts — so this
+    carries the SAME real ``httpx.Response`` (Retry-After header included)
+    on a real EmptyLLMResponseError instance instead, the one kind #5793
+    keeps retried — via its own genuine ``response=`` constructor kwarg
+    (#5793 also added, precisely so a test never has to attach a fake
+    attribute to a real object; see that class's own docstring).
+    ``_extract_retry_after`` reads ``exc.response.headers`` via a
+    defensive ``getattr`` — it does not care which exception TYPE
+    carries the attribute, only that it does."""
+    response = httpx.Response(
+        status_code=status,
+        headers={"retry-after": header_value},
+        text="service unavailable",
+    )
+    return EmptyLLMResponseError("empty choices (test)", response=response)
+
+
+def _make_empty_response_exc_no_retry_after(status: int = 503):
+    """See :func:`_make_empty_response_exc_with_retry_after` — same switch,
+    no Retry-After header."""
+    response = httpx.Response(status_code=status, text="service unavailable")
+    return EmptyLLMResponseError("empty choices (test)", response=response)
 
 
 # ---------------------------------------------------------------------------
@@ -220,13 +253,16 @@ def test_extract_retry_after_unparseable_returns_none():
 async def test_retry_uses_retry_after_when_header_present():
     """Tier 2: retry loop honours Retry-After header when respect_retry_after=true.
 
-    Constructs a real ServiceUnavailableError with Retry-After: 7 on a real
-    httpx.Response. The first call raises it; the second succeeds (simulates a
-    transient 503). The recorded sleep must be ~7 (within float tolerance) and
-    NOT the jittered exponential (which for attempt=0 would be in [1.0, 2.0]).
+    #5793: uses EmptyLLMResponseError (the one exception kind reyn's retry
+    loop still retries — a ServiceUnavailableError would no longer be
+    retried by reyn at all, see test_llm_call_retry.py's own #5793
+    rewrites) carrying a real httpx.Response with Retry-After: 7. The first
+    call raises it; the second succeeds. The recorded sleep must be ~7
+    (within float tolerance) and NOT the jittered exponential (which for
+    attempt=0 would be in [1.0, 2.0]).
     """
     set_retry_config(RetryConfig(jitter=True, respect_retry_after=True))
-    exc = _make_exc_with_retry_after("7")
+    exc = _make_empty_response_exc_with_retry_after("7")
 
     # A real mock-free callable sequence: first call raises, second returns.
     class _FakeResponse:
@@ -255,12 +291,14 @@ async def test_retry_uses_retry_after_when_header_present():
 async def test_retry_uses_jittered_backoff_when_no_header():
     """Tier 2: retry loop uses jittered backoff when no Retry-After header.
 
-    The first call raises a real ServiceUnavailableError with no header.
-    The recorded sleep must fall in [1.0, 2.0] (= [base/2, base] for attempt=0,
-    base=2.0) — NOT the exact pure-exponential 2.0.
+    #5793: uses EmptyLLMResponseError, see
+    test_retry_uses_retry_after_when_header_present's own docstring for why.
+    The first call raises it, carrying no header. The recorded sleep must
+    fall in [1.0, 2.0] (= [base/2, base] for attempt=0, base=2.0) — NOT the
+    exact pure-exponential 2.0.
     """
     set_retry_config(RetryConfig(jitter=True, respect_retry_after=True))
-    exc = _make_exc_no_retry_after()
+    exc = _make_empty_response_exc_no_retry_after()
 
     class _FakeResponse:
         choices = [object()]
@@ -288,12 +326,14 @@ async def test_retry_uses_jittered_backoff_when_no_header():
 async def test_retry_ignores_retry_after_when_disabled():
     """Tier 2: retry loop ignores Retry-After header when respect_retry_after=false.
 
+    #5793: uses EmptyLLMResponseError, see
+    test_retry_uses_retry_after_when_header_present's own docstring for why.
     The exception carries Retry-After: 99. With respect_retry_after=false and
     jitter=false, the sleep must be the pure-exponential 2.0 (attempt=0),
     NOT 99.
     """
     set_retry_config(RetryConfig(jitter=False, respect_retry_after=False))
-    exc = _make_exc_with_retry_after("99")
+    exc = _make_empty_response_exc_with_retry_after("99")
 
     class _FakeResponse:
         choices = [object()]

--- a/tests/llm/test_llm_router_s3a_1829.py
+++ b/tests/llm/test_llm_router_s3a_1829.py
@@ -1,11 +1,21 @@
-"""Tier 2: OS-invariant tests for #1829 S3a — the #1835 retry-layering fold.
+"""Tier 2: OS-invariant tests for #1829 S3a — the #1835 retry-layering fold,
+NARROWED further by #5793.
 
-S3a makes the litellm.Router own infra-exception retry (with native Retry-After
+S3a made the litellm.Router own infra-exception retry (with native Retry-After
 respect) on the router path, so Reyn's ``_llm_call_with_retry`` no longer
-re-retries infra exceptions when the router is ON — it drops to
-EmptyLLMResponseError-only (200 + empty choices, #187 B1; the Router never retries
-a non-exception 200). Router OFF is byte-identical to pre-#1829 (full
-exponential-backoff retry of every ``_is_retryable_exc`` kind).
+re-retried infra exceptions when the router was ON — dropping to
+EmptyLLMResponseError-only there, while Router OFF stayed byte-identical to
+pre-#1829 (full exponential-backoff retry of every infra-exception kind).
+
+#5793 (owner decision, "自前の...汎用再試行は litellm に委ねる") removed the OFF-path
+half of that split: ``_is_retryable_exc`` now classifies ONLY
+EmptyLLMResponseError as retryable, on EVERY path — litellm's own
+``num_retries`` (passed to ``acompletion``/the Router alike) is the infra-retry
+layer now, not a router-state-conditional reyn one. The router-ON/OFF
+DISTINCTION this file used to test is gone: an infra exception is never
+re-retried by reyn any more, regardless of ``REYN_LLM_USE_ROUTER``.
+EmptyLLMResponseError stays Reyn-owned on both paths, unaffected by #5793 (the
+Router never retries a non-exception 200 either way).
 
 Policy: no mocks of collaborators — the real ``_llm_call_with_retry`` is driven by
 a real async callable and the real env gate (``REYN_LLM_USE_ROUTER``); only the
@@ -43,32 +53,20 @@ def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_router_off_infra_exception_still_retried(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("router_env", ["", "1"])
+async def test_infra_exception_never_retried_by_reyn_regardless_of_router(
+    monkeypatch: pytest.MonkeyPatch, router_env: str,
 ) -> None:
-    """Tier 2: router OFF (default) — an infra exception is retried by Reyn to
-    success (the pre-#1829 behavior is preserved, byte-identical)."""
-    monkeypatch.delenv("REYN_LLM_USE_ROUTER", raising=False)
-    calls = {"n": 0}
-
-    async def coro_fn() -> object:
-        calls["n"] += 1
-        if calls["n"] <= 2:
-            raise _infra_exc()
-        return _Resp([object()])
-
-    resp = await _llm_call_with_retry(coro_fn, "openai/gpt-4o-mini", None)
-    assert resp.choices, "OFF path must retry the infra exception to success"
-    assert calls["n"] == 3, "OFF path retries infra exceptions (2 fail + 1 ok)"
-
-
-@pytest.mark.asyncio
-async def test_router_on_infra_exception_not_re_retried(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: router ON — Reyn does NOT re-retry an infra exception (the Router
-    owns that retry now); the wrapper raises after a single attempt."""
-    monkeypatch.setenv("REYN_LLM_USE_ROUTER", "1")
+    """Tier 2: #5793 — an infra exception propagates on the FIRST attempt,
+    whether ``REYN_LLM_USE_ROUTER`` is unset (OFF, the historical
+    always-retried path pre-#5793) or set (ON). The router-state
+    distinction S3a used to carry is gone: litellm's own ``num_retries``
+    is the infra-retry layer now, unconditionally — not "reyn retries
+    when OFF, Router retries when ON"."""
+    if router_env:
+        monkeypatch.setenv("REYN_LLM_USE_ROUTER", router_env)
+    else:
+        monkeypatch.delenv("REYN_LLM_USE_ROUTER", raising=False)
     calls = {"n": 0}
 
     async def coro_fn() -> object:
@@ -78,19 +76,24 @@ async def test_router_on_infra_exception_not_re_retried(
     with pytest.raises(litellm.InternalServerError):
         await _llm_call_with_retry(coro_fn, "openai/gpt-4o-mini", None)
     assert calls["n"] == 1, (
-        "router ON: the Router owns infra-exception retry — Reyn's wrapper must "
-        "not re-retry it (would double Router N × Reyn N)"
+        f"an infra exception must not be re-retried by reyn (router_env={router_env!r}) "
+        "— litellm's own num_retries is the retry layer now, on every path"
     )
 
 
 @pytest.mark.asyncio
-async def test_router_on_empty_choices_still_retried_by_reyn(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("router_env", ["", "1"])
+async def test_empty_choices_still_retried_by_reyn_regardless_of_router(
+    monkeypatch: pytest.MonkeyPatch, router_env: str,
 ) -> None:
-    """Tier 2: router ON — EmptyLLMResponseError (200 + empty choices, #187 B1)
-    stays Reyn-owned and is STILL retried (the Router never retries a
-    non-exception 200)."""
-    monkeypatch.setenv("REYN_LLM_USE_ROUTER", "1")
+    """Tier 2: EmptyLLMResponseError (200 + empty choices, #187 B1) stays
+    Reyn-owned and is STILL retried on EVERY path (unaffected by #5793 —
+    litellm structurally cannot retry a non-exception 200, on OR off the
+    router)."""
+    if router_env:
+        monkeypatch.setenv("REYN_LLM_USE_ROUTER", router_env)
+    else:
+        monkeypatch.delenv("REYN_LLM_USE_ROUTER", raising=False)
     calls = {"n": 0}
 
     async def coro_fn() -> object:
@@ -100,8 +103,8 @@ async def test_router_on_empty_choices_still_retried_by_reyn(
         return _Resp([object()])
 
     resp = await _llm_call_with_retry(coro_fn, "openai/gpt-4o-mini", None)
-    assert resp.choices, "router ON must still retry the empty-choices condition"
+    assert resp.choices, f"router_env={router_env!r} must still retry the empty-choices condition"
     assert calls["n"] == 3, (
-        "EmptyLLMResponseError (#187 B1) is Reyn-owned even on the router path "
-        "(2 empty + 1 ok)"
+        f"EmptyLLMResponseError (#187 B1) is Reyn-owned regardless of router "
+        f"state (router_env={router_env!r}; 2 empty + 1 ok)"
     )

--- a/tests/runtime/test_5597_compaction_llm_call_timeout.py
+++ b/tests/runtime/test_5597_compaction_llm_call_timeout.py
@@ -2,8 +2,12 @@
 no per-request timeout at all, so an upstream provider that stopped
 responding hung the call for 11+ minutes with zero reyn-side events —
 `main`'s own router path already carries `safety.timeout.llm_call_seconds`
-(60s default) + `num_retries`; compaction's call site
-(`CompactionEngine._acompletion`, engine.py) passed neither.
++ `num_retries`; compaction's call site (`CompactionEngine._acompletion`,
+engine.py) passed neither. (#5793: `safety.timeout.llm_call_seconds` no
+longer defaults to 60s — it defaults to `None`, meaning NOT PASSED to
+litellm at all; this file's own assertions read the value dynamically
+off the real `SafetyConfig`, never a hardcoded `60`, so they are
+unaffected either way — see each test's own docstring.)
 
 Architect's own final ruling (issue #5597, verbatim): "新しい数を作らない。
 routerの値をそのまま使う" — no new number, compaction inherits `main`'s


### PR DESCRIPTION
**[tui-coder]** — Closes #5793

🔴 **Priority (owner-declared, real-machine incident)**: a proxy took 245s and returned 200 while reyn discarded the call at 60s × 3 retries, stalling an agent. **Owner decision, verbatim**:
> litellm の規定を流用すべきだと思うんだけど。わざわざ reyn が別に規定を持つ理由がわからん。即刻修正して。ユーザ指定がないなら litellm 規定にして。retry も litellm の仕組みがあるんじゃないの？規定も litellm のを流用すべきでしょ。車輪の再発明やめてよ。

## ⚠️ Behavior change

A call with no explicit operator config used to be bounded by reyn's own 60s / 3-retries. It is now bounded by **litellm's own default** (commonly much longer) unless the operator sets it explicitly in reyn.yaml. This is intentional — the whole point of the fix.

## What changed, per litellm-touching surface (operator-explicit only; unset → NOT PASSED, never `None`/`0` passed as a value)

- **Chat** (`config/chat.py` `TimeoutConfig.llm_call_seconds`/`llm_max_retries` → `None` default). `llm.py`'s `_resolve_llm_call_bounds` and every kwargs-building call site (`recorded_acompletion`'s #5597 funnel, `call_llm_tools`'s own `max_retries` — was a reyn-hardcoded `1` on the function signature itself, independent of any config, forced onto the main chat router path since none of its 3 call sites in `router_loop.py` pass it) now omit `timeout`/`num_retries` entirely when unresolved.
- **Embedding** (`config/embedding.py` `EmbeddingConfig.timeout` → `None`, `litellm_provider.py`'s `resolve_embed_timeout`). `max_retries` is a genuinely **different** case — reyn's own retry loop (#3047) deliberately replaces litellm's own SDK-level retry to avoid a measured request-multiplication bug, and is never forwarded to litellm as `num_retries` (which stays explicitly `0`). **Left unchanged** — flagged below for review, not silently decided.
- **Router** (`config/infra.py` `RouterConfig.num_retries` → `None`, `llm.py`'s `_single_deployment_router`/`_env_router_config`). Empirically verified: a real, unconfigured `litellm.Router` resolves `num_retries` to litellm's own default (**2**), not reyn's former hardcoded 3.
- **Reyn's own general infra-retry loop** (`llm.py` `_is_retryable_exc`) narrowed to **only** `EmptyLLMResponseError` — a 200 + empty `choices` list, not an API error, so litellm neither raises nor retries it (the ONE case litellm structurally cannot handle, per lead-coder's own dispatch). Every infra-exception kind (timeout/5xx/httpx transport) this used to also retry is litellm's job now — reyn passing `num_retries` is enough.

## ⚪ Flagging for review, not silently decided

`embedding.max_retries` (reyn's own retry-loop bound, #3047) was **not** changed — it doesn't correspond to a litellm kwarg being duplicated (litellm's own retry is deliberately zeroed there for a measured, documented reason). If this should also move, please say so explicitly rather than me guessing either way under time pressure.

## Verified empirically (per lead-coder's explicit instruction — not accepted as a declaration, and each surface checked via its OWN litellm entry point, not generalized from one)

- **Router**: a real `litellm.Router(model_list=...)` with `num_retries` genuinely omitted resolves to litellm's own default, read live against a reference Router built the same way (never hardcoded).
- **Embedding**: a real spy on `litellm.aembedding` shows the `timeout` key genuinely **absent** from the kwargs dict when unset — `max_retries=0` (#3047's own unrelated, unaffected exception) still present.
- **Chat**: `call_llm_tools`'s own default for `max_retries` is now `None`; `_resolve_llm_call_bounds` returns `(None, None)` for a fully-unset ambient context.

## Test suite: adapted, not deleted, where #5793 falsified the premise

`test_llm_call_retry.py`, `test_llm_retry_jitter_retry_after_1835.py`, `test_llm_router_s3a_1829.py` had accept-side tests pinning the OLD "reyn retries litellm infra exceptions" behavior — rewritten to their deny-side counterparts (propagates immediately now), not deleted, since the file's own coverage intent (retry-wrapper observability, jitter/Retry-After wiring) is still real, just narrower. `EmptyLLMResponseError` gained a genuine (`None`-default, unused by the production raise site) `response=` constructor kwarg so these tests exercise the Retry-After machinery without attaching a fake attribute to a real object (testing.ja.md #3037 — caught by `test_tier_audit.py --strict`, fixed).

Also found and fixed 2 real bugs in embedding's own reyn.yaml **parser** (not just the resolver) that `float(None)` / `None <= 0` would have crashed on with the new default — found by running `tests/config/`, not by inspection.

**Relationship to this PR's own change (per lead-coder's request)**: both were **exposed by this PR's own signature change**, not drive-by fixes — `EmbeddingConfig.timeout`'s default moving from `60.0` to `None` is exactly what makes `float(raw.get("timeout", defaults.timeout))` and the later `timeout <= 0` check crash on the new `None`; neither line was buggy before this PR touched that default. Same-PR was correct.

## Out of scope (explicit, per dispatch — confirmed NOT touched)

- `safety.timeout.chain_seconds` — a reyn-only concept (multi-agent pending chain), no litellm equivalent.
- `mcp_probe_seconds` — MCP does not use litellm at all (owner corrected an earlier over-broad scope pass on this issue).
- `ask_timeout_seconds` — default `0` = disabled, asserts no number.

## Test plan

- [x] New `tests/llm/test_5793_litellm_default_omission.py` — 6 tests, one per surface's own real litellm entry point (see "Verified empirically" above).
- [x] Rewrote 3 pre-existing test files whose accept-side tests pinned now-removed behavior (`test_llm_call_retry.py`, `test_llm_retry_jitter_retry_after_1835.py`, `test_llm_router_s3a_1829.py`) — see their own diffs for the accept→deny rewrite reasoning per test.
- [x] Fixed 2 stale test docstrings/premises that coincidentally still passed structurally after the change but asserted a now-false claim (`test_embed_bound_cancel_3043.py`'s "finite bound" / "falls back to the bound" tests, `test_5597_compaction_llm_call_timeout.py`'s module docstring).
- [x] Full regression: `tests/llm/` (777), `tests/config/` (271), `tests/core/test_embed_bound_cancel_3043.py` + `tests/runtime/test_5597_compaction_llm_call_timeout.py` (26), plus `tests/dev/test_missing_fixture_fails_loud_3662.py` / `test_network_gate_3451.py` / `test_llm_request_event_1669.py` / `test_embed_max_retries_wire_count_3047.py` (21) — all green. (`tests/llm/test_llm_router_s1_1829.py`'s own `is_litellm_ready()` async-warmup race is a confirmed pre-existing environmental flake in isolated runs — reproduces identically on an unmodified `origin/main` checkout; green when run as part of the full `tests/llm/` suite.)
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (7 changed/new test files — caught and fixed the #3037 fake-attribute violation above), `verify_module_docstrings.py` (7 changed src files), `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-conditional gates — all green.
- [x] Falsify-verified in-file (Edit-only, no `git checkout`/`stash`), twice: reverted `_is_retryable_exc` to always-True (5 tests caught it), reverted `TimeoutConfig.llm_call_seconds`'s default to `60.0` (4 tests caught it, 2 unrelated pre-existing-flake failures excluded) — both restored and reconfirmed green.
- [ ] Visual は owner 確認 — no UI surface touched; this is a config-default and retry-logic change with no rendering component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

