### PR TITLE
docs(#5794): TimeoutConfig.mcp_probe_seconds -- why reyn holds this bound

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -101,6 +101,20 @@ class TimeoutConfig:
             repeating the literal, so raising this one number is the only
             operator action needed to widen the budget under co-located
             CPU load; it does not itself change the default.
+
+            #5794: why reyn holds this bound instead of delegating to the
+            MCP SDK's own `read_timeout_seconds`. That parameter exists,
+            but carries no default of its own (`ClientSession`/`call_tool`
+            both default it to `None`); an omitted value reaches
+            `JSONRPCDispatcher.send_raw_request`'s `anyio.fail_after(opts.
+            get("timeout"))` as `None`, which `anyio.fail_after` treats as
+            "disable the timeout" (`deadline = math.inf`,
+            `jsonrpc_dispatcher.py:401`) — measured, not assumed: the SDK
+            genuinely never bounds this wait on its own. Delegating would
+            trade the #3475/#3520 stale-empty-tools-cache regression this
+            field's own docstring describes above for an UNBOUNDED hang —
+            worse, not merely different. The delegate having a parameter
+            is not a witness that omitting it is safe.
     """
 
     llm_call_seconds: float = field(default=60.0, metadata={"axis": Axis.BOUNDING})


### PR DESCRIPTION
**[e2e-coder]** — `TimeoutConfig.mcp_probe_seconds`: why reyn holds this bound.

part of #5794

## Why

#5794 measured, then closed without a code change ("measured, not built" — the MCP SDK's own `read_timeout_seconds` parameter carries no default, so delegating to it would trade the #3475/#3520 stale-cache regression for an unbounded hang). The measurement lived only in the issue thread, which closes and stops being visible — the existing 12-line docstring already answers "why 5 seconds" but never answered "why does reyn hold this at all instead of the SDK." Both together are what closes the reasoning; leaving only the first invites the next reader to re-derive the second from scratch.

## Change

Added the measurement's conclusion directly into the docstring (not a reference to the closed issue): `anyio.fail_after(None)` — what an omitted `read_timeout_seconds` reaches at `JSONRPCDispatcher.send_raw_request` — sets `deadline = math.inf`, disabling the timeout outright. No default to delegate to.

## Test plan

- [x] `ruff check src/reyn/config/chat.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/config/chat.py`
- [x] `python scripts/mypy_ratchet.py` (200/208, unchanged, all pre-baselined)
- [x] `TimeoutConfig().mcp_probe_seconds` still `5.0` — docstring-only change, behavior byte-for-byte unchanged
- [ ] (skipped — Visual, standing waiver 2026-08-08)

TESTS-READ / merge: lead-coder-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
