### PR TITLE
fix(#5797): record litellm's own retry count + elapsed_s on llm_request_error

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import sys
+import time
 import uuid
 import weakref
 from dataclasses import dataclass
@@ -1950,24 +1951,58 @@ def _redact_llm_request_params(base_kwargs: dict, response_format: dict | None) 
     return out
 
 
+_LITELLM_RETRIED_RE = re.compile(r"LiteLLM Retried:\s*(\d+)\s*times?", re.IGNORECASE)
+
+
+def _parse_litellm_retry_count(error_message: str) -> "int | None":
+    """#5797: litellm appends ``"LiteLLM Retried: N times"`` to an exception's
+    own message when its internal retry mechanism ran and was exhausted
+    (owner's own real proxy incident, #5793: ``"... LiteLLM Retried: 3
+    times"``) — reyn's own retry loop never sees those attempts (they
+    happen entirely inside ``litellm.acompletion`` before it ever raises),
+    so this is the ONLY place that count is available: parsed from what
+    litellm itself already reported, not re-counted by reyn (#5797,
+    lead-coder's own ruling: "数えるのは litellm、記録するのが reyn").
+    ``None`` when the substring is absent — a call that failed WITHOUT any
+    litellm-internal retry (e.g. a straight 4xx) has nothing to report
+    here, distinct from "0" (which would falsely claim litellm tried and
+    gave up immediately)."""
+    m = _LITELLM_RETRIED_RE.search(error_message)
+    return int(m.group(1)) if m else None
+
+
 def _emit_llm_request_error(
     model: str, purpose: str, exc: BaseException, base_kwargs: dict, messages: list,
+    *, elapsed_s: "float | None" = None,
 ) -> None:
     """#1676: emit a P6 ``llm_request_error`` with the FULL provider error detail
     (status_code + whole message/body, NOT truncated — the owner's 405 root-cause
     signal) so an LLM-call failure is visible in the event tab. Same ambient
     EventLog (ContextVar) + ``model``/``purpose`` context as ``llm_request``
     (#1669). Wrapped so the audit emit can never mask the real exception (the
-    caller re-raises regardless)."""
+    caller re-raises regardless).
+
+    #5797: this is the terminal-failure chokepoint the owner's proxy-log
+    reading (#5793: "200 OK x3", reconstructed by hand) exists to replace.
+    ``litellm_retries`` (parsed from the caught exception's own text via
+    ``_parse_litellm_retry_count``) and ``elapsed_s`` (measured by the
+    caller, spanning the full ``_once``/response-format-fallback attempt
+    that ultimately failed) turn what used to require reading a THIRD
+    party's proxy log by hand into fields on reyn's own audit-event —
+    model, why (``error_type``/``error_message``), how many times litellm
+    itself retried, and how long it took, all in one place."""
     try:
         from reyn.core.events.events import get_llm_request_event_log
         log = get_llm_request_event_log()
         if log is None:
             return
+        error_message = str(exc)
         detail: dict = {
             "error_type": type(exc).__name__,
-            "error_message": str(exc),
+            "error_message": error_message,
             "status_code": getattr(exc, "status_code", None),
+            "litellm_retries": _parse_litellm_retry_count(error_message),
+            "elapsed_s": elapsed_s,
         }
         # litellm exceptions carry the provider body on ``.body`` (often the parsed
         # error dict) and/or ``.response`` (an httpx.Response). Capture BOTH, whole
@@ -3066,6 +3101,11 @@ async def recorded_acompletion(
     # provider detail incl status_code + whole body) at this single chokepoint,
     # then RE-RAISE (never swallow). Wraps the response_format-fallback retry so a
     # final failure (no fallback, or the fallback also failed) emits exactly once.
+    # #5797: ``_call_start`` spans the WHOLE attempt (including the
+    # response_format-fallback retry, if it runs) — "how long reyn waited
+    # before finally giving up" from the caller's own perspective, matching
+    # what the owner read off the proxy log by hand (#5793's own incident).
+    _call_start = time.monotonic()
     try:
         try:
             response = await _once(response_format)
@@ -3079,7 +3119,10 @@ async def recorded_acompletion(
         # api_key to litellm since #4348, so there was nothing of reyn's
         # left for this boundary to scrub — litellm's own error text is
         # already provider-scrubbed (#4343).
-        _emit_llm_request_error(effective_model, purpose, exc, base_kwargs, messages)
+        _emit_llm_request_error(
+            effective_model, purpose, exc, base_kwargs, messages,
+            elapsed_s=time.monotonic() - _call_start,
+        )
         # #1678, delegated to litellm at #3288-follow-up: this call shape
         # (reasoning_effort + tools, resolved to the openai/azure provider —
         # see the comment above ``_needs_responses_endpoint`` and

--- a/tests/core/test_llm_request_error_1676.py
+++ b/tests/core/test_llm_request_error_1676.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import litellm
 import pytest
 
+import reyn.llm.llm
 from reyn.core.events.events import EventLog, set_llm_request_event_log
 from reyn.llm.llm import recorded_acompletion
 from tests._support.events import collect_events, settle
@@ -27,7 +28,7 @@ from tests._support.events import collect_events, settle
 class _FakeProviderError(Exception):
     """Real fake mirroring a litellm provider exception (no Mock)."""
 
-    def __init__(self, message: str, status_code: int, body, response_text: str):
+    def __init__(self, message: str, status_code: "int | None", body, response_text: str):
         super().__init__(message)
         self.status_code = status_code
         self.body = body
@@ -40,7 +41,9 @@ def _reset_ambient_event_log():
     set_llm_request_event_log(None)
 
 
-def _raising_acompletion(message="Boom", status_code=405, body=None, response_text=""):
+def _raising_acompletion(
+    message="Boom", status_code: "int | None" = 405, body=None, response_text="",
+):
     async def _fn(**_kwargs):
         raise _FakeProviderError(message, status_code, body, response_text)
     return _fn
@@ -51,6 +54,29 @@ async def _run_and_settle(coro, log):
         return await coro
     finally:
         await settle(log)
+
+
+class _FakeClock:
+    """#5797: a real, deterministic stand-in for the ``time`` module's own
+    ``monotonic()`` -- not a Mock, a plain object with the one method
+    ``llm.py`` actually calls. Rebinds ``reyn.llm.llm``'s own ``time`` NAME
+    (not the shared ``time`` module's ``monotonic`` attribute in place,
+    which would also break asyncio's own event-loop clock -- confirmed the
+    hard way: a global monkeypatch of ``time.monotonic`` hangs the test
+    runner)."""
+
+    def __init__(self, *values: float) -> None:
+        self._it = iter(values)
+
+    def monotonic(self) -> float:
+        return next(self._it)
+
+
+def _inject_monotonic_clock(monkeypatch, *values: float) -> None:
+    """#5797: per CLAUDE.md's testing policy, a duration-carrying test
+    supplies the clock as an input rather than waiting out a real
+    ``sleep()`` the assertion would then depend on as a floor."""
+    monkeypatch.setattr(reyn.llm.llm, "time", _FakeClock(*values))
 
 
 def _call(monkeypatch, log=None, **extra_kwargs):
@@ -145,3 +171,75 @@ def test_no_event_when_ambient_log_unset_but_still_raises(monkeypatch) -> None:
 
     with pytest.raises(_FakeProviderError):
         _call(monkeypatch)
+
+
+# ── #5797: litellm_retries + elapsed_s ──────────────────────────────────────
+
+
+def test_error_event_parses_litellm_retry_count_from_exception_text(monkeypatch) -> None:
+    """Tier 2: #5797 — litellm appends "LiteLLM Retried: N times" to an
+    exception's own message once ITS internal retry mechanism (invisible
+    to reyn) is exhausted. The owner's own real incident (#5793) carried
+    this exact substring; `llm_request_error` now surfaces it as a
+    structured `litellm_retries` field instead of leaving it buried in
+    free text."""
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _raising_acompletion(
+            message=(
+                "litellm.Timeout: APITimeoutError - Request timed out. "
+                "timeout value=60.0, time taken=245.2 seconds  "
+                "LiteLLM Retried: 3 times"
+            ),
+            status_code=None,
+        ),
+    )
+    log = EventLog()
+    collected = collect_events(log)
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch, log=log)
+
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
+    assert err.data["litellm_retries"] == 3
+
+
+def test_error_event_litellm_retries_none_when_litellm_never_retried(monkeypatch) -> None:
+    """Tier 2: #5797 — a straight failure (e.g. a 4xx litellm never retries)
+    must NOT claim "0 retries" (a false "litellm tried and gave up
+    immediately" claim); the field is `None` -- genuinely absent, not a
+    fabricated zero."""
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _raising_acompletion(message="Method Not Allowed", status_code=405),
+    )
+    log = EventLog()
+    collected = collect_events(log)
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch, log=log)
+
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
+    assert err.data["litellm_retries"] is None
+
+
+def test_error_event_carries_real_elapsed_time(monkeypatch) -> None:
+    """Tier 2: #5797 — `elapsed_s` reflects a genuine measurement, not a
+    hardcoded stand-in. A real (injected, not slept-out per CLAUDE.md's
+    testing policy) clock advancing by exactly 5.5s between the call's
+    start and its failure must show up as exactly 5.5 on the event —
+    proving the field is wired to a REAL timer read at both ends, not a
+    constant."""
+    monkeypatch.setattr(litellm, "acompletion", _raising_acompletion())
+    _inject_monotonic_clock(monkeypatch, 100.0, 105.5)
+    log = EventLog()
+    collected = collect_events(log)
+    set_llm_request_event_log(log)
+
+    with pytest.raises(_FakeProviderError):
+        _call(monkeypatch, log=log)
+
+    (err,) = [e for e in collected if e.type == "llm_request_error"]
+    assert err.data["elapsed_s"] == pytest.approx(5.5)

--- a/tests/core/test_llm_request_error_1676.py
+++ b/tests/core/test_llm_request_error_1676.py
@@ -179,26 +179,25 @@ def test_no_event_when_ambient_log_unset_but_still_raises(monkeypatch) -> None:
 def test_error_event_parses_litellm_retry_count_from_exception_text(monkeypatch) -> None:
     """Tier 2: #5797 — litellm appends "LiteLLM Retried: N times" to an
     exception's own message once ITS internal retry mechanism (invisible
-    to reyn) is exhausted. The owner's own real incident (#5793) carried
-    this exact substring; `llm_request_error` now surfaces it as a
-    structured `litellm_retries` field instead of leaving it buried in
-    free text."""
-    monkeypatch.setattr(
-        litellm, "acompletion",
-        _raising_acompletion(
-            message=(
-                "litellm.Timeout: APITimeoutError - Request timed out. "
-                "timeout value=60.0, time taken=245.2 seconds  "
-                "LiteLLM Retried: 3 times"
-            ),
-            status_code=None,
-        ),
+    to reyn) is exhausted (real litellm behaviour, not a hand-mirrored
+    string -- litellm owns that format; a copy of it would stay green if
+    litellm ever changed it, silently losing the observability #5797
+    exists to add). `llm_request_error` now surfaces it as a structured
+    `litellm_retries` field instead of leaving it buried in free text."""
+    real_exc = litellm.Timeout(
+        message="Request timed out.", model="gpt-5.4", llm_provider="openai",
+        num_retries=3,
     )
+
+    async def _raise_real_litellm_timeout(**_kwargs):
+        raise real_exc
+
+    monkeypatch.setattr(litellm, "acompletion", _raise_real_litellm_timeout)
     log = EventLog()
     collected = collect_events(log)
     set_llm_request_event_log(log)
 
-    with pytest.raises(_FakeProviderError):
+    with pytest.raises(litellm.Timeout):
         _call(monkeypatch, log=log)
 
     (err,) = [e for e in collected if e.type == "llm_request_error"]


### PR DESCRIPTION
**[e2e-coder]**

Closes #5797

Implements lead-coder-30's ruling on the issue: **do not subscribe to `failure_callback`; record at reyn's existing terminal-failure chokepoint instead** (数えるのは litellm、記録するのが reyn).

`_emit_llm_request_error` (`recorded_acompletion`'s existing `#1676` chokepoint) already fires unconditionally on every failed `litellm.acompletion` call, already carrying `model`/`purpose`/`error_type`/`error_message` (full, untruncated). This PR adds the two remaining fields the owner had to read off a proxy log by hand (#5793):

- `litellm_retries` — parsed from the caught exception's own text (litellm appends `"LiteLLM Retried: N times"` once its internal retry mechanism, invisible to reyn, is exhausted). `None` (never a fabricated `0`) when litellm never retried.
- `elapsed_s` — measured by the caller across the whole attempt (including the response_format-fallback retry, if it runs).

No new audit-event kind, no schema-registry change — both fields are optional additions to the existing `llm_request_error` kind.

**Closing condition (lead-coder-30's own wording)**: today's owner incident's 3 proxy-log-derived facts (model / why / litellm's reported retry count) plus elapsed time are now all reconstructable from reyn's own audit-event alone.

Two adjacent findings from the same investigation, already resolved, NOT part of this diff:
- `failure_callback` fires once per outer call, not per retry — ruled out as the seam.
- An earlier "tenacity silently no-ops" report was corrected by lead-coder-30: that deprecated path `raise`s, and reyn's own `acompletion` call chain never reaches it (0 call sites) — unrelated to #5796.

### Test plan
- [x] `pytest tests/core/test_llm_request_error_1676.py` — 6/6 pass (3 pre-existing unchanged + 3 new)
- [x] Strip-falsify: forced `litellm_retries`/`elapsed_s` to constants in-file via `Edit`, confirmed each corresponding new test goes RED, restored, reconfirmed green
- [x] Scoped regression sweep: `tests/core/ tests/llm/` + directly related files — 3731 passed, 3 skipped, 0 failed
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51