### PR TITLE
fix(#5801): structural, one-rule token expansion for every reyn-token-aware yaml face

### DIFF
--- a/scripts/check_load_yaml_vocabulary.py
+++ b/scripts/check_load_yaml_vocabulary.py
@@ -46,7 +46,20 @@ This gate parses the real `src/` tree and reports the real line/file of
 any offending call — nothing here is a fixture; a strip (deleting a
 `vocabulary=` kwarg from any current call site) turns this RED against
 the actual codebase.
-"""
+
+## #5801: ``token_map`` gets the SAME treatment, as a second axis
+
+``_load_yaml`` grew a second required keyword, ``token_map`` (#5801 —
+reyn's own ``${REYN_*}`` token expansion, previously applied by hand
+after the fact to the merged config only, never to ``profile.yaml``
+at all — the real incident this closes). Same reasoning, same "AST
+call-site gate outlives a signature regression" argument, kept as a
+SEPARATE visitor/function (:func:`find_token_map_violations`) rather
+than folded into :func:`find_violations` above so the two axes stay
+independently testable — a fixture exercising only the `vocabulary=`
+axis (the tests below) does not also have to supply a real
+`token_map=` to stay a valid accept-case, and vice versa. `main()`
+below reports both."""
 from __future__ import annotations
 
 import ast
@@ -99,32 +112,95 @@ def find_violations(src_dir: Path = _SRC) -> "list[tuple[Path, int]]":
     return violations
 
 
+class _TokenMapCallVisitor(ast.NodeVisitor):
+    """#5801: the ``token_map=`` twin of :class:`_CallVisitor` above —
+    same shape, a DIFFERENT required keyword. A bare ``None`` is flagged
+    too (an omitted-expansion face would otherwise read exactly like a
+    genuinely-empty ``{}`` map, and nothing downstream could tell "this
+    face has no reyn tokens" from "nobody decided")."""
+
+    def __init__(self) -> None:
+        self.violations: "list[tuple[int, str]]" = []
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 (ast API name)
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else (
+            func.attr if isinstance(func, ast.Attribute) else None
+        )
+        if name == "_load_yaml":
+            kw = next((kw for kw in node.keywords if kw.arg == "token_map"), None)
+            if kw is None:
+                self.violations.append((node.lineno, ast.dump(node)[:120]))
+            elif isinstance(kw.value, ast.Constant) and kw.value.value is None:
+                self.violations.append((node.lineno, ast.dump(node)[:120]))
+        self.generic_visit(node)
+
+
+def find_token_map_violations(src_dir: Path = _SRC) -> "list[tuple[Path, int]]":
+    """#5801: every ``_load_yaml(...)`` call under *src_dir* missing a
+    ``token_map=`` keyword argument, or passing a bare ``None`` — the
+    structural gate that makes "a new reyn-token-aware yaml face reads
+    a file but never expands it" (the real #5801 defect: profile.yaml's
+    ``context_path``) impossible to write for any face going through
+    this function, not just impossible to remember to check."""
+    violations: "list[tuple[Path, int]]" = []
+    for path in sorted(src_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        visitor = _TokenMapCallVisitor()
+        visitor.visit(tree)
+        for lineno, _ in visitor.violations:
+            violations.append((path, lineno))
+    return violations
+
+
 def main() -> int:
-    violations = find_violations()
-    if not violations:
+    vocab_violations = find_violations()
+    token_map_violations = find_token_map_violations()
+    if not vocab_violations and not token_map_violations:
         print(
-            "OK: every _load_yaml(...) call passes vocabulary= with a "
-            "real reason (never a bare None)."
+            "OK: every _load_yaml(...) call passes vocabulary= and "
+            "token_map= with a real value (never a bare None)."
         )
         return 0
-    print("load-yaml-vocabulary gate FAILED:\n")
-    print(
-        f"{len(violations)} call(s) to _load_yaml(...) either omit the "
-        f"required vocabulary= keyword argument, or pass a bare None "
-        f"(no longer valid — see below):\n"
-    )
-    for path, lineno in violations:
-        print(f"  {path.relative_to(_REPO_ROOT)}:{lineno}")
-    print(
-        "\nPass vocabulary=<unknown_config_keys-shaped callable> to WARN on "
-        "this file's own unknown keys at read time, or one of "
-        "_CheckedElsewhere's named members (CHECKED_BY_CONFIG_VALIDATE / "
-        "CHECKED_AT_LOAD_POINT / CHECKED_BY_CALLER) if this file's content "
-        "is validated elsewhere — never a bare None, which collapses all "
-        "three of those distinct reasons into one value nothing can tell "
-        "apart. See _load_yaml's and _CheckedElsewhere's own docstrings "
-        "(src/reyn/config/loader.py)."
-    )
+    if vocab_violations:
+        print("load-yaml-vocabulary gate FAILED:\n")
+        print(
+            f"{len(vocab_violations)} call(s) to _load_yaml(...) either omit the "
+            f"required vocabulary= keyword argument, or pass a bare None "
+            f"(no longer valid — see below):\n"
+        )
+        for path, lineno in vocab_violations:
+            print(f"  {path.relative_to(_REPO_ROOT)}:{lineno}")
+        print(
+            "\nPass vocabulary=<unknown_config_keys-shaped callable> to WARN on "
+            "this file's own unknown keys at read time, or one of "
+            "_CheckedElsewhere's named members (CHECKED_BY_CONFIG_VALIDATE / "
+            "CHECKED_AT_LOAD_POINT / CHECKED_BY_CALLER) if this file's content "
+            "is validated elsewhere — never a bare None, which collapses all "
+            "three of those distinct reasons into one value nothing can tell "
+            "apart. See _load_yaml's and _CheckedElsewhere's own docstrings "
+            "(src/reyn/config/loader.py).\n"
+        )
+    if token_map_violations:
+        print("load-yaml-token-map gate FAILED:\n")
+        print(
+            f"{len(token_map_violations)} call(s) to _load_yaml(...) either omit "
+            f"the required token_map= keyword argument, or pass a bare None "
+            f"(#5801 — see below):\n"
+        )
+        for path, lineno in token_map_violations:
+            print(f"  {path.relative_to(_REPO_ROOT)}:{lineno}")
+        print(
+            "\nPass token_map={\"REYN_PROJECT_DIR\": ...} (plus REYN_AGENT_NAME "
+            "when this face has an agent identity) — an explicit {} only for a "
+            "face this issue's own scoping decided has genuinely no reyn-token "
+            "value to offer. See _load_yaml's own docstring and "
+            "reyn.plugins.tokens.expand_yaml_tokens_or_refuse "
+            "(src/reyn/config/loader.py, src/reyn/plugins/tokens.py)."
+        )
     return 1
 
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -86,9 +86,12 @@ class _CheckedElsewhere(enum.Enum):
 
 
 def _load_yaml(
-    path: Path, *, vocabulary: "Callable[[dict], dict] | _CheckedElsewhere",
+    path: Path, *,
+    vocabulary: "Callable[[dict], dict] | _CheckedElsewhere",
+    token_map: dict[str, str],
 ) -> dict:
-    """Read *path* as YAML, returning ``{}`` if absent or unparseable.
+    """Read *path* as YAML, returning ``{}`` if absent, unparseable, OR
+    refused for an unresolved reyn token (see ``token_map`` below).
 
     #5455 ②: ``vocabulary`` is REQUIRED (no default) — every call site
     must actively choose. Architect's own design for this issue: the
@@ -105,6 +108,23 @@ def _load_yaml(
     falsifiable claim a reviewer can question — the structural guarantee
     is that NO call site can decide silently, and no two DIFFERENT
     reasons can look like the same value.
+
+    #5801: ``token_map`` is REQUIRED too, same shape and same reasoning —
+    this is the ONE function every config-cascade YAML file is read
+    through, so making token expansion a required parameter here (not a
+    separate pass a caller might forget to run afterward, the #5801 gap:
+    profile.yaml was read via a totally different path with no expansion
+    call anywhere) is what makes "read but never expanded" impossible to
+    write for any file that goes through THIS function. Applied via
+    :func:`reyn.plugins.tokens.expand_yaml_tokens_or_refuse` — reyn's own
+    ``${REYN_*}``/``${CLAUDE_*}`` vocabulary left unresolved after this
+    call's own map is applied is reyn's bug (fail-closed, this file
+    contributes nothing, matching the existing malformed-file fallback);
+    an unrelated ``${VAR}`` (an MCP server's own env token, say) is left
+    untouched for ``expand_env`` (ADR-0030) to resolve later, same as
+    always. Pass ``{}`` for a file this face has genuinely no reyn-token
+    value to offer (still required — an empty map is a real, visible
+    choice; omitting the parameter is not).
     """
     if not path.exists():
         return {}
@@ -113,6 +133,10 @@ def _load_yaml(
         with path.open(encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         data = data if isinstance(data, dict) else {}
+        if data:
+            from reyn.plugins.tokens import expand_yaml_tokens_or_refuse
+            expanded = expand_yaml_tokens_or_refuse(data, token_map, source=path)
+            data = expanded if expanded is not None else {}
         if callable(vocabulary) and data:
             unknown = vocabulary(data)
             if unknown:
@@ -398,6 +422,16 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     from reyn.builtin.registry import build_builtin_config
     merged = _merge(merged, build_builtin_config(), tier_label="builtin")
 
+    # #5801: project_root is computed FIRST now (used to be after
+    # user_global's own read) so every _load_yaml call in this function,
+    # user_global included, can supply the SAME REYN_PROJECT_DIR token
+    # map -- ${REYN_PROJECT_DIR} in ~/.reyn/config.yaml is as legitimate
+    # as in reyn.yaml (a user-global agent default naming a project-
+    # relative path), and there is no reason this one file alone should
+    # be unable to use reyn's own token vocabulary.
+    project_root = _find_project_root(cwd)
+    _policy_tier_token_map = {"REYN_PROJECT_DIR": str(project_root or cwd)}
+
     # #5455 ②: CHECKED_BY_CONFIG_VALIDATE for all 3 policy-tier files
     # here — checked downstream on the MERGED view by load_config's own
     # _warn_unknown_config_keys(merged) call (see that call site's
@@ -406,19 +440,21 @@ def build_policy_tier_config(cwd: Path | None = None) -> dict:
     user_global = _load_yaml(
         Path.home() / ".reyn" / "config.yaml",
         vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
+        token_map=_policy_tier_token_map,
     )
     merged = _merge(merged, user_global, tier_label="user_global")
 
-    project_root = _find_project_root(cwd)
     if project_root:
         project = _load_yaml(
             project_root / "reyn.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
+            token_map=_policy_tier_token_map,
         )
         merged = _merge(merged, project, tier_label="project")
         project_local = _load_yaml(
             project_root / "reyn.local.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
+            token_map=_policy_tier_token_map,
         )
         merged = _merge(merged, project_local, tier_label="project_local")
 
@@ -926,6 +962,11 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # at their own load points (runtime.hot_reload.validate_in_set),
         # not duplicated here.
         unknown_config_keys_found = _warn_unknown_config_keys(merged)
+        # #5801: same map every _load_yaml call in build_policy_tier_config
+        # already uses — these 5 dynamic ``.reyn/config/*.yaml`` files are
+        # the SAME face (project-wide, no per-agent identity) as
+        # reyn.yaml/reyn.local.yaml, just a different physical file.
+        _dynamic_token_map = {"REYN_PROJECT_DIR": str(project_root)}
 
         # Issue #470: dynamic MCP registry separated from static config.
         # ``.reyn/mcp.yaml`` carries op-managed server entries; merged
@@ -938,6 +979,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_mcp = _load_yaml(
             project_root / ".reyn" / "config" / "mcp.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+            token_map=_dynamic_token_map,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_mcp)
 
@@ -953,6 +995,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_cron = _load_yaml(
             project_root / ".reyn" / "config" / "cron.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+            token_map=_dynamic_token_map,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_cron)
 
@@ -967,6 +1010,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_skills = _load_yaml(
             project_root / ".reyn" / "config" / "skills.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+            token_map=_dynamic_token_map,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_skills, tier_label="dynamic")
 
@@ -981,6 +1025,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_pipelines = _load_yaml(
             project_root / ".reyn" / "config" / "pipelines.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+            token_map=_dynamic_token_map,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_pipelines)
 
@@ -996,6 +1041,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_presentations = _load_yaml(
             project_root / ".reyn" / "config" / "presentations.yaml",
             vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+            token_map=_dynamic_token_map,
         )  # #5455 ②: checked downstream on the merged IN-set by validate_in_set
         merged = _merge(merged, dynamic_presentations)
 
@@ -1009,68 +1055,27 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         # key should not go unreported just because there's no project).
         unknown_config_keys_found = _warn_unknown_config_keys(merged)
 
-    # #5166: reyn's OWN token vocabulary (${REYN_PROJECT_DIR} — the only one
-    # this project-wide, agent-less load has a real value for;
-    # ${REYN_AGENT_NAME} has no meaning here and is deliberately NOT in this
-    # map, same as any other token this pass does not recognise) is expanded
-    # FIRST, via expand_with_map — never os.environ, the same reasoning
-    # load_per_agent_hooks/read_and_expand_hooks_yaml use. ORDER MATTERS:
-    # this must run BEFORE expand_env below. expand_with_map's own contract
-    # leaves anything absent from its map untouched (an MCP server's
-    # ${API_KEY} is not a reyn token, so this pass never touches it) — doing
-    # it in the other order would let expand_env's os.environ lookup consume
-    # ${REYN_PROJECT_DIR} first (undefined there, silently degrading to ""),
-    # exactly the #5140 failure shape one layer up. No fail-close here
-    # (unlike the per-agent/per-session hooks.yaml layers): an unresolved
-    # ${REYN_AGENT_NAME} in reyn.yaml itself has no agent context to supply
-    # it at this project-wide load — refusing the WHOLE config over one
-    # per-agent token would be a disproportionate blast radius this
-    # project-wide layer was never asked to take on (architect ruling on
-    # #5166 scopes fail-close to the 4 enumerated hooks.yaml layers only).
-    # #5351: see the check right after this expansion for why a SEPARATE
-    # reyn-token warning runs here even though expand_env (further below,
-    # ADR-0030) already warns on any undefined ${VAR} it can't resolve.
-    from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
-    merged = expand_with_map(merged, {"REYN_PROJECT_DIR": str(project_root or cwd)})
-
-    # #5351 witness 4 (lead-coder measurement, issue thread) + architect
-    # BLOCKING on the first version of this fix (PR #5503, head
-    # 0237874a0): an operator who writes ${REYN_AGENT_NAME} in the shared
-    # reyn.yaml was NOT met with silence -- expand_env (below) already
-    # warns "Config references undefined environment variable:
-    # ${REYN_AGENT_NAME}" and degrades it to "" (verified directly: the
-    # token is not left literal). The real defect is that this EXISTING
-    # signal points at the WRONG fix: it reads exactly like a genuine
-    # unset env var, so an operator who "fixes" it by `export
-    # REYN_AGENT_NAME=...` succeeds -- expand_env's warning disappears,
-    # the token resolves to whichever value happens to be in THIS
-    # process's env, and the shared, project-wide config is now silently
-    # pinned to one agent's name with zero remaining signal. This check
-    # runs BEFORE expand_env and BEFORE any os.environ lookup, so it
-    # fires on reyn's own token vocabulary regardless of whether the
-    # operator already "fixed" it via export -- catching exactly the
-    # failure mode the existing warning's own wrong fix produces. Never
-    # refuses (#5166's fail-close scoping to the 4 hooks.yaml layers only
-    # stands unchanged) -- this adds a correctly-aimed signal, it does
-    # not change what happens to the value.
-    _unresolved_policy_tokens = find_unresolved_reyn_tokens(merged)
-    if _unresolved_policy_tokens:
-        import warnings
-        warnings.warn(
-            f"reyn.yaml/reyn.local.yaml references reyn token(s) "
-            f"{sorted(set(_unresolved_policy_tokens))} that this layer "
-            "has no per-agent context to resolve (config is loaded once, "
-            "project-wide, before any agent is resolved). Do NOT "
-            "`export` it as an environment variable to silence the "
-            "'undefined environment variable' warning that follows this "
-            "one; that pins this shared config to whichever agent's name "
-            "happens to be in this process's env, with no further "
-            "signal. Move a per-agent value to that agent's own "
-            ".reyn/agents/<name>/hooks.yaml, or use ${REYN_PROJECT_DIR} "
-            "if a project-relative path was intended.",
-            UserWarning,
-            stacklevel=2,
-        )
+    # #5801: reyn's OWN token vocabulary (${REYN_PROJECT_DIR} — the only
+    # one this project-wide, agent-less load has a real value for;
+    # ${REYN_AGENT_NAME} has no meaning here, same as any other token
+    # this face's map does not carry) is now expanded PER FILE, inside
+    # every _load_yaml call above (required `token_map` parameter) —
+    # not as one extra pass over the already-merged dict. ORDER (must
+    # run before expand_env below) is preserved the same way: every
+    # _load_yaml call happens before this point. #5166's own file-level
+    # scoping question ("does an unresolved ${REYN_AGENT_NAME} here
+    # refuse the whole file, or only warn?") is answered uniformly now
+    # (owner ruling, #5801: "環境変数の展開ルールを yaml 内で統一して
+    # 構造化" — one rule, applied by every reyn-token-aware face's own
+    # _load_yaml call, not a second hand-written check here that could
+    # itself be forgotten for the NEXT face). See
+    # reyn.plugins.tokens.expand_yaml_tokens_or_refuse's own docstring
+    # for the shared expand-then-fail-closed rule + its warning text
+    # (which already names the exact unresolved token — an operator who
+    # `export`s ${REYN_AGENT_NAME} to silence expand_env's OWN separate
+    # "undefined environment variable" warning below gets no help from
+    # that; THIS warning already fired, and fires again on every load
+    # until the profile.yaml/reyn.yaml source is actually fixed).
 
     # ADR-0030: apply ${VAR} interpolation across all string fields of the
     # merged config dict.  At this point os.environ already contains values
@@ -1293,7 +1298,11 @@ def load_hot_reload_config(project_root: "Path | None" = None) -> dict:
         # _warn_unknown_hot_reload_keys call — see _load_yaml's docstring.
         merged = _merge(
             merged,
-            _load_yaml(root / ".reyn" / fname, vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT),
+            _load_yaml(
+                root / ".reyn" / fname,
+                vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+                token_map={"REYN_PROJECT_DIR": str(root)},
+            ),
         )
     from reyn.security.secrets.interpolation import expand_env
     return expand_env(merged)
@@ -1339,14 +1348,17 @@ def read_and_expand_hooks_yaml(
     unified all 4 onto one implementation.
 
     Expands reyn's OWN token vocabulary via
-    :func:`reyn.plugins.tokens.expand_with_map` with an explicit
-    ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map — never ``os.environ``
-    (``expand_env``, ADR-0030): that expander is for a SPAWNED CHILD
-    process's own config-time env-injection, and ``REYN_AGENT_NAME`` is
-    only ever set on a child's env, never on THIS process's own
-    ``os.environ`` — so it is always undefined here regardless of layer
-    (#5140's original finding). Fails closed via
-    :func:`~reyn.plugins.tokens.find_unresolved_reyn_tokens` on any
+    :func:`reyn.plugins.tokens.expand_yaml_tokens_or_refuse` (#5801 — the
+    ONE expand-then-fail-closed rule every reyn-token-aware yaml face
+    now shares; this function was that rule's ORIGINAL, hand-written
+    home before #5801 pulled it out so ``_load_yaml``/``AgentProfile.
+    load`` could reuse it verbatim instead of re-deriving it) with an
+    explicit ``{REYN_PROJECT_DIR, REYN_AGENT_NAME}`` map — never
+    ``os.environ`` (``expand_env``, ADR-0030): that expander is for a
+    SPAWNED CHILD process's own config-time env-injection, and
+    ``REYN_AGENT_NAME`` is only ever set on a child's env, never on THIS
+    process's own ``os.environ`` — so it is always undefined here
+    regardless of layer (#5140's original finding). Fails closed on any
     REMAINING ``${REYN_*}``/``${CLAUDE_*}`` token (reyn's own bug, not an
     operator's config choice) — returns ``None`` (never ``{}``, so a
     caller can tell "genuinely absent" from "refused" if it ever needs
@@ -1363,21 +1375,11 @@ def read_and_expand_hooks_yaml(
     raw = _load_hooks_yaml(path)
     if not raw:
         return None
-    from reyn.plugins.tokens import expand_with_map, find_unresolved_reyn_tokens
-    data = expand_with_map(
-        raw, {"REYN_PROJECT_DIR": str(project_root), "REYN_AGENT_NAME": agent_name}
+    from reyn.plugins.tokens import expand_yaml_tokens_or_refuse
+    data = expand_yaml_tokens_or_refuse(
+        raw, {"REYN_PROJECT_DIR": str(project_root), "REYN_AGENT_NAME": agent_name},
+        source=path,
     )
-    unresolved = find_unresolved_reyn_tokens(data)
-    if unresolved:
-        import warnings
-        warnings.warn(
-            f"{path} left reyn token(s) {sorted(set(unresolved))} "
-            "unresolved -- refusing to load this hooks.yaml layer (this "
-            "is reyn's own bug, not a config choice to honor).",
-            UserWarning,
-            stacklevel=2,
-        )
-        return None
     return data if isinstance(data, dict) else None
 
 

--- a/src/reyn/interfaces/cli/commands/config.py
+++ b/src/reyn/interfaces/cli/commands/config.py
@@ -512,8 +512,13 @@ def _validate() -> None:
     # (policy_unknown, on the merged policy-tier view); this second
     # read's own job is the mcp-placement/rename check, unrelated to the
     # key vocabulary.
+    # #5801: same map every other project-wide-tier _load_yaml call uses.
+    _mcp_diag_token_map = {"REYN_PROJECT_DIR": str(project_root)}
     for label, path in static_mcp_sources.items():
-        raw = _load_yaml(path, vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE)
+        raw = _load_yaml(
+            path, vocabulary=_CheckedElsewhere.CHECKED_BY_CONFIG_VALIDATE,
+            token_map=_mcp_diag_token_map,
+        )
         mcp_section = raw.get("mcp")
         misplaced_found = _mcp_misplaced_server_entries(mcp_section)
         if misplaced_found:
@@ -526,6 +531,7 @@ def _validate() -> None:
     dynamic_mcp_raw = _load_yaml(
         project_root / ".reyn" / "config" / "mcp.yaml",
         vocabulary=_CheckedElsewhere.CHECKED_AT_LOAD_POINT,
+        token_map=_mcp_diag_token_map,
     )
     dynamic_mcp_section = dynamic_mcp_raw.get("mcp")
     dynamic_found = _mcp_misplaced_server_entries(dynamic_mcp_section)
@@ -563,8 +569,14 @@ def _validate() -> None:
             # #5455 ②: CHECKED_BY_CALLER — the very next lines run
             # unknown_profile_keys/retired_profile_keys_present on this
             # exact return value.
+            # #5801: same per-agent map AgentProfile.load itself uses —
+            # this diagnostic reads profile.yaml through the same
+            # structural gate, not a second, unexpanded copy of it.
             raw_profile = _load_yaml(
                 profile_path, vocabulary=_CheckedElsewhere.CHECKED_BY_CALLER,
+                token_map={
+                    "REYN_PROJECT_DIR": str(project_root), "REYN_AGENT_NAME": agent_dir.name,
+                },
             )
             retired_found = retired_profile_keys_present(raw_profile)
             if retired_found:

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -271,3 +271,49 @@ def find_unresolved_reyn_tokens(obj: Any) -> list[str]:
             found.extend(find_unresolved_reyn_tokens(v))
         return found
     return []
+
+
+def expand_yaml_tokens_or_refuse(
+    obj: Any, token_map: dict[str, str], *, source: object,
+) -> Any:
+    """#5801: the ONE expand-then-fail-closed rule every reyn-token-aware
+    YAML face applies — :func:`expand_with_map` then
+    :func:`find_unresolved_reyn_tokens` on the result, WARN + refuse
+    (``None``) on any remainder, exactly the shape
+    ``config/loader.py``'s ``read_and_expand_hooks_yaml`` established for
+    hooks.yaml (#5140/#5166) before this function existed to name it
+    once. Before this, each face (config cascade, hooks.yaml,
+    profile.yaml) called ``expand_with_map``/``find_unresolved_reyn_tokens``
+    by hand or not at all — profile.yaml called neither (#5801's own
+    finding: coder-brown's ``${REYN_PROJECT_DIR}`` context_path never
+    expanded, AGENTS.md silently never read). A face's *vocabulary*
+    still varies (hooks.yaml/profile.yaml know ``REYN_AGENT_NAME``, the
+    project-wide config cascade does not) — that lives entirely in
+    *token_map*, which every caller supplies for itself (req③: one
+    entry point per face, not one map broadcast to all); this function
+    is the one thing every face shares.
+
+    ``source`` is whatever the caller wants named in the warning (a
+    ``Path``, or a string like ``"reyn.yaml/reyn.local.yaml"`` for a
+    caller that already merged several files before this check runs) —
+    only ever ``str()``-ed, never opened.
+
+    Returns the expanded structure, or ``None`` on refusal — callers
+    already treat ``None``/``{}`` as "this file/layer contributes
+    nothing" (the same fallback every face used before this existed),
+    so refusing composes without a new caller-side branch."""
+    expanded = expand_with_map(obj, token_map)
+    unresolved = find_unresolved_reyn_tokens(expanded)
+    if unresolved:
+        import warnings
+
+        warnings.warn(
+            f"{source} left reyn token(s) {sorted(set(unresolved))} "
+            "unresolved -- refusing to use this content (this is reyn's "
+            "own bug -- it could not supply a value it owns -- not a "
+            "config choice to honor).",
+            UserWarning,
+            stacklevel=2,
+        )
+        return None
+    return expanded

--- a/src/reyn/runtime/profile.py
+++ b/src/reyn/runtime/profile.py
@@ -262,6 +262,35 @@ class AgentProfile:
         if not path.is_file():
             raise FileNotFoundError(path)
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        # #5801: profile.yaml is a reyn-token-aware face too (base_dir /
+        # context_path both name project-relative locations) but was
+        # never routed through reyn's own expand-then-fail-closed rule —
+        # a real incident: coder-brown/coder-smith's own
+        # ``context_path: ${REYN_PROJECT_DIR}/AGENTS.md`` never expanded,
+        # so ``resolve_context_candidate`` looked for a literal
+        # ``${REYN_PROJECT_DIR}`` subdirectory under workspace_dir, found
+        # none, and this agent silently never read its own instructed
+        # text — every session, with no warning (the pre-#5801 gap: no
+        # expansion call existed here AT ALL, so there was nothing to
+        # warn). ``agent_dir`` is always ``<project_root>/.reyn/agents/
+        # <name>`` (AgentRegistry.load_profile/agent_workspace_dir's own
+        # ``self._dir / name`` — the SAME path every ``AgentProfile.load``
+        # caller in src/ passes, verified by grep), so project_root is
+        # available here without a caller-supplied parameter — same
+        # shared rule as every other face (:func:`reyn.plugins.tokens.
+        # expand_yaml_tokens_or_refuse`), this face's own map.
+        # ``agent_dir.name`` (not yet-unparsed ``data["name"]``) supplies
+        # ``REYN_AGENT_NAME`` — the profile's own filename IS this
+        # agent's identity, same value ``name`` below falls back to.
+        if data:
+            from reyn.plugins.tokens import expand_yaml_tokens_or_refuse
+            _project_root = agent_dir.parent.parent.parent
+            _expanded = expand_yaml_tokens_or_refuse(
+                data,
+                {"REYN_PROJECT_DIR": str(_project_root), "REYN_AGENT_NAME": agent_dir.name},
+                source=path,
+            )
+            data = _expanded if isinstance(_expanded, dict) else {}
         retired_present = retired_profile_keys_present(data)
         if retired_present:
             lines = ", ".join(

--- a/tests/config/test_5351_policy_tier_unresolved_agent_token_warns.py
+++ b/tests/config/test_5351_policy_tier_unresolved_agent_token_warns.py
@@ -1,24 +1,35 @@
-"""Tier 2: #5351 witness 4 (lead-coder measurement, issue thread) +
-architect BLOCKING on the first version of this fix (PR #5503, head
-0237874a0) — the shared ``reyn.yaml`` (policy tier) load point was NOT
-silent about an unresolved ``${REYN_AGENT_NAME}``: ``expand_env`` (ADR-0030)
-already warns "Config references undefined environment variable:
-${REYN_AGENT_NAME}" and degrades it to ``""``. The real defect is that this
-EXISTING signal points at the WRONG fix — it reads exactly like a genuine
-unset env var, so an operator who "fixes" it via ``export
-REYN_AGENT_NAME=...`` succeeds: ``expand_env``'s warning disappears, the
-token silently resolves to whichever agent's name happens to be in this
-process's env, and the shared, project-wide config is now pinned to one
-agent with ZERO remaining signal.
+"""Tier 2: #5351 witness 4 (lead-coder measurement, issue thread), UPDATED
+by #5801 (owner ruling, 2026-09-05: "環境変数の展開漏れなんてのは、環境変数の
+展開ルールを yaml ないで統一して構造化すべきだからね" — reyn's own token
+expansion rule is now ONE rule, applied the same way by every
+reyn-token-aware yaml face, not "warn but keep going" for this one face
+and "fail closed" for hooks.yaml).
 
-This test proves the actual fix: a SEPARATE, correctly-aimed ``UserWarning``
-now fires BEFORE ``expand_env`` (so before any ``os.environ`` lookup),
-catching the case the existing warning's own wrong fix produces —
-including after the operator has already exported the var. Never a
-refusal (#5166's fail-close scoping to the 4 hooks.yaml layers only is
-unchanged).
+The original #5351 finding stands unchanged: the shared ``reyn.yaml``
+(policy tier) load point was NOT silent about an unresolved
+``${REYN_AGENT_NAME}`` — ``expand_env`` (ADR-0030) already warned "Config
+references undefined environment variable: ${REYN_AGENT_NAME}" and
+degraded it to ``""``, and an operator who "fixed" that via ``export
+REYN_AGENT_NAME=...`` silently pinned the shared, project-wide config to
+one agent's name with ZERO remaining signal.
 
-Real ``load_config`` + a real ``reyn.yaml`` on disk — no mocks."""
+#5351's OWN fix (PR #5503) deliberately did not refuse the file — "no
+fail-close (#5166's ruling is unchanged)" was #5351's explicit scoping
+at the time. #5801 supersedes that scoping: this file's own
+``${REYN_AGENT_NAME}`` is now a face going through the SAME
+``_load_yaml``/``expand_yaml_tokens_or_refuse`` every other
+reyn-token-aware face does, and that shared rule fails closed
+(#5801 req②) — REFUSING the whole layer, not just warning + degrading
+one field. This is a STRICTLY LOUDER outcome for the exact failure mode
+#5351 exists to catch (an operator's `export` "fix" now doesn't even
+make the config load with a wrong value silently baked in — it refuses
+outright, both with and without the export).
+
+Real ``load_config`` + a real ``reyn.yaml`` on disk — no mocks. Witness
+is the real content (``cfg.mcp["servers"]`` genuinely absent), not just
+"a warning fired" (lead-coder's own standing correction on this exact
+family of finding, #5801: "witness は「warning が出ない」ではなく「中身が
+system prompt に入る」で")."""
 from __future__ import annotations
 
 import warnings
@@ -27,22 +38,21 @@ import pytest
 
 from reyn.config.loader import load_config
 
-# Matches ONLY the new #5351 warning, never expand_env's own pre-existing
-# "undefined environment variable" warning (both warnings legitimately
-# mention REYN_AGENT_NAME by name — the first version of this test matched
-# on that shared substring and stayed green with the #5351 fix entirely
-# deleted, architect's own strip-falsify finding on PR #5503).
-_NEW_WARNING_MATCH = r"has no per-agent context to resolve"
+# Matches the #5801 shared expand_yaml_tokens_or_refuse warning -- fires
+# on ANY unresolved reyn token this face's map doesn't cover, not just
+# REYN_AGENT_NAME specifically (the vocabulary lives in the token_map,
+# not in a second hand-written check here -- #5801 req③).
+_REFUSAL_WARNING_MATCH = r"left reyn token\(s\).*unresolved -- refusing"
 
 
-def test_unresolved_reyn_agent_name_warns_before_expand_env_and_before_export(
+def test_unresolved_reyn_agent_name_fails_closed_even_after_export(
     tmp_path, monkeypatch,
 ) -> None:
-    """Tier 2: the new warning fires even when the operator has already
+    """Tier 2: the file is refused even when the operator has already
     "fixed" the pre-existing expand_env warning by exporting
-    REYN_AGENT_NAME — the exact failure mode #5351 exists to catch (the
-    existing signal's own wrong fix silences the existing signal, but
-    must not silence THIS one)."""
+    REYN_AGENT_NAME -- #5801's fail-closed rule does not consult
+    os.environ at all (never did; that was always #5166's point), so
+    exporting the var changes nothing about this outcome."""
     monkeypatch.setenv("REYN_AGENT_NAME", "coder-brown")
     (tmp_path / "reyn.yaml").write_text(
         "mcp:\n"
@@ -55,25 +65,23 @@ def test_unresolved_reyn_agent_name_warns_before_expand_env_and_before_export(
         encoding="utf-8",
     )
 
-    with pytest.warns(UserWarning, match=_NEW_WARNING_MATCH):
+    with pytest.warns(UserWarning, match=_REFUSAL_WARNING_MATCH):
         cfg = load_config(tmp_path)
 
-    env = cfg.mcp["servers"]["myserver"]["env"]
-    assert env["AGENT_TAG"] == "coder-brown", (
-        "sanity: the exported env var IS what expand_env resolves the "
-        f"token to (this is the silent-pin failure mode itself) -- got {env!r}"
+    # Real-content witness (not just "a warning fired"): the whole
+    # reyn.yaml layer -- including the otherwise-valid `myserver` entry
+    # -- never made it into the merged config.
+    assert not cfg.mcp.get("servers"), (
+        "reyn.yaml must be refused wholesale on an unresolved reyn token "
+        f"-- got {cfg.mcp.get('servers')!r}"
     )
 
 
-def test_unresolved_reyn_agent_name_still_warns_and_degrades_without_export(
-    tmp_path,
-) -> None:
-    """Tier 2: without any export, the config still loads (no fail-close,
-    #5166's ruling is unchanged) and the token degrades exactly like any
-    other undefined ${VAR} (the SAME shape #5166's own
-    ``test_a_non_reyn_var_degrades_exactly_as_expand_env_always_has``
-    documents) -- the #5351 warning never mutates the value, only adds a
-    correctly-aimed second signal alongside expand_env's existing one."""
+def test_unresolved_reyn_agent_name_fails_closed_without_export(tmp_path) -> None:
+    """Tier 2: without any export, the same refusal fires -- #5801's rule
+    does not distinguish "operator tried to fix it" from "never tried";
+    both are reyn's own bug (it could not supply a value it owns), not
+    an operator env-var problem to work around either way."""
     (tmp_path / "reyn.yaml").write_text(
         "mcp:\n"
         "  servers:\n"
@@ -85,24 +93,19 @@ def test_unresolved_reyn_agent_name_still_warns_and_degrades_without_export(
         encoding="utf-8",
     )
 
-    with pytest.warns(UserWarning, match=_NEW_WARNING_MATCH):
+    with pytest.warns(UserWarning, match=_REFUSAL_WARNING_MATCH):
         cfg = load_config(tmp_path)
 
-    env = cfg.mcp["servers"]["myserver"]["env"]
-    assert env["AGENT_TAG"] == "", (
-        "no fail-close (#5166's ruling is unchanged) -- the config must "
-        "still load, with the unresolved token degrading via the later "
-        f"expand_env pass exactly like any other undefined ${{VAR}} -- "
-        f"got {env!r}"
+    assert not cfg.mcp.get("servers"), (
+        f"got {cfg.mcp.get('servers')!r}"
     )
 
 
-def test_a_resolvable_reyn_project_dir_does_not_warn(tmp_path) -> None:
+def test_a_resolvable_reyn_project_dir_does_not_fail_closed(tmp_path) -> None:
     """Tier 2: the accept-side witness -- a real, resolvable
-    ${REYN_PROJECT_DIR} in the same load point must NOT trip the new
-    warning (it would make the negative claim above meaningless if the
-    warning fired unconditionally on any reyn token at all, resolved or
-    not)."""
+    ${REYN_PROJECT_DIR} in the same load point must NOT trip the
+    refusal warning, and its real, expanded value must land in the
+    merged config (not just "no warning" -- the actual content)."""
     (tmp_path / "reyn.yaml").write_text(
         "mcp:\n"
         "  servers:\n"
@@ -118,14 +121,13 @@ def test_a_resolvable_reyn_project_dir_does_not_warn(tmp_path) -> None:
         warnings.simplefilter("always")
         cfg = load_config(tmp_path)
 
-    new_warnings = [
+    refusals = [
         w for w in caught
-        if issubclass(w.category, UserWarning)
-        and "has no per-agent context to resolve" in str(w.message)
+        if issubclass(w.category, UserWarning) and "unresolved -- refusing" in str(w.message)
     ]
-    assert not new_warnings, (
-        f"a fully-resolved ${{REYN_PROJECT_DIR}} must not trip the #5351 "
-        f"warning -- got {[str(w.message) for w in new_warnings]}"
+    assert not refusals, (
+        f"a fully-resolved ${{REYN_PROJECT_DIR}} must not be refused -- "
+        f"got {[str(w.message) for w in refusals]}"
     )
     env = cfg.mcp["servers"]["myserver"]["env"]
     assert env["PROJECT_TAG"] == str(tmp_path.resolve())

--- a/tests/runtime/test_5801_profile_yaml_reyn_token_expansion.py
+++ b/tests/runtime/test_5801_profile_yaml_reyn_token_expansion.py
@@ -1,0 +1,166 @@
+"""Tier 2: #5801 — profile.yaml's ``context_path``/``base_dir`` are
+reyn-token-aware fields (both name project-relative locations) but
+``AgentProfile.load`` read them via a totally separate path from every
+other reyn-yaml face (the config cascade / hooks.yaml), with NO token
+expansion call anywhere. Real incident: an operator's
+``context_path: ${REYN_PROJECT_DIR}/AGENTS.md`` never expanded --
+``resolve_context_candidate`` looked for a literal ``${REYN_PROJECT_DIR}``
+subdirectory under the agent's own workspace_dir, found none, and the
+agent silently never read its own instructed text, every session, with
+zero warning (there was nothing there to warn -- no expansion call
+existed to notice the token was unresolved).
+
+Witness discipline (lead-coder's own standing correction on this exact
+family, #5801): "witness は「warning が出ない」ではなく「中身が system
+prompt に入る」で" -- a passing test that only checks "no warning fired"
+would also pass if ``context_path`` silently resolved to nothing and the
+agent still never read anything. Every test below asserts the REAL file
+CONTENT actually lands where the agent frame reads it
+(``RouterHostAdapter.get_project_context()``, the same live surface
+#5742's own hot-reload tests use) -- not merely the absence of a warning.
+
+Real ``AgentRegistry``/``Session`` construction throughout -- no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry_bootstrap import build_agent_registry_from_project
+
+
+def _write_reyn_yaml(project_root: Path) -> None:
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "reyn.yaml").write_text(
+        yaml.dump({"llm": {"model": "standard"}}, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_path_reyn_project_dir_token_expands_and_content_is_read(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the exact real incident -- ``context_path:
+    ${REYN_PROJECT_DIR}/CODER_BROWN_INSTRUCTIONS.md`` in profile.yaml,
+    naming a file OUTSIDE the agent's own workspace_dir (at the project
+    root, shared across agents -- the real coder-brown/coder-smith
+    shape). Deliberately NOT named REYN.md/AGENTS.md (#5742's own
+    project-frame default-order search would find those independently
+    of context_path at all -- self-caught test-validity bug: an earlier
+    draft of this test used AGENTS.md and stayed green even with the
+    #5801 fix stripped out, because the project frame's OWN default
+    read supplied the content regardless of whether context_path ever
+    expanded). Real-content witness: ``get_project_context()`` returns
+    the genuine file text, not merely "no warning fired"."""
+    project_root = tmp_path / "project"
+    _write_reyn_yaml(project_root)
+    (project_root / "CODER_BROWN_INSTRUCTIONS.md").write_text(
+        "# real project instructions\nbe careful with prod.\n", encoding="utf-8",
+    )
+
+    monkeypatch.chdir(project_root)
+    from reyn.config import load_config
+
+    config = load_config()
+    registry = build_agent_registry_from_project(project_root, config, non_interactive=True)
+    try:
+        registry.create("coder-brown")
+        profile_path = registry.agent_workspace_dir("coder-brown") / "profile.yaml"
+        profile_path.write_text(
+            "name: coder-brown\n"
+            "role: brown\n"
+            "created_at: '2026-01-01T00:00:00+00:00'\n"
+            "context_path: ${REYN_PROJECT_DIR}/CODER_BROWN_INSTRUCTIONS.md\n",
+            encoding="utf-8",
+        )
+
+        session = registry.get_or_load("coder-brown")
+        composed = session.router_host.get_project_context()
+        assert "# real project instructions\nbe careful with prod." in composed, (
+            "the agent's own instructed text must actually be read, not "
+            f"silently skipped -- got {composed!r}"
+        )
+    finally:
+        await registry.shutdown()
+
+
+def test_base_dir_reyn_project_dir_token_also_expands(tmp_path: Path) -> None:
+    """Tier 2: the OTHER field lead-coder's review explicitly flagged --
+    fixing context_path alone while leaving base_dir unexpanded is a
+    known failure shape ("片方だけ直すと、もう片方が黙って残ります"). Real
+    content witness: the resolved AgentProfile.base_dir is a genuine
+    absolute path under project_root, not a literal unexpanded token."""
+    project_root = tmp_path / "project"
+    agent_dir = project_root / ".reyn" / "agents" / "coder-brown"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "profile.yaml").write_text(
+        "name: coder-brown\n"
+        "role: brown\n"
+        "created_at: '2026-01-01T00:00:00+00:00'\n"
+        "base_dir: ${REYN_PROJECT_DIR}/repos/coder-brown\n",
+        encoding="utf-8",
+    )
+
+    profile = AgentProfile.load(agent_dir)
+
+    assert profile.base_dir == str((project_root / "repos" / "coder-brown").resolve()) or (
+        profile.base_dir == str(project_root / "repos" / "coder-brown")
+    ), f"base_dir must be a real expanded path, not a literal token -- got {profile.base_dir!r}"
+    assert "${REYN_PROJECT_DIR}" not in (profile.base_dir or "")
+
+
+def test_context_path_unresolved_reyn_token_fails_closed(tmp_path: Path) -> None:
+    """Tier 2: #5801 req② -- an unresolved reyn token in profile.yaml is
+    reyn's own bug (it could not supply a value it owns), not an
+    operator config choice to silently honor as a literal path. Uses
+    ``${REYN_SKILL_DIR}`` -- a real member of reyn's own token vocabulary
+    that profile.yaml's own map does not carry (only
+    REYN_PROJECT_DIR/REYN_AGENT_NAME are this face's map, #5801 req③) --
+    so this is a genuine "reyn cannot resolve this here" case, not a
+    typo'd unrelated ${VAR}."""
+    project_root = tmp_path / "project"
+    agent_dir = project_root / ".reyn" / "agents" / "coder-brown"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "profile.yaml").write_text(
+        "name: coder-brown\n"
+        "role: brown\n"
+        "created_at: '2026-01-01T00:00:00+00:00'\n"
+        "context_path: ${REYN_SKILL_DIR}/AGENTS.md\n",
+        encoding="utf-8",
+    )
+
+    with pytest.warns(UserWarning, match=r"left reyn token\(s\).*unresolved -- refusing"):
+        profile = AgentProfile.load(agent_dir)
+
+    # Real-content witness: refusal degrades the WHOLE file's contribution
+    # (context_path falls back to its own None default), not a half-
+    # applied partial expansion that would leave a literal token behind.
+    assert profile.context_path is None, (
+        f"a refused profile.yaml must not leave a literal unresolved token "
+        f"in context_path -- got {profile.context_path!r}"
+    )
+
+
+def test_context_path_with_no_reyn_token_is_unaffected(tmp_path: Path) -> None:
+    """Tier 2: accept-side control -- the common case, a bare filename
+    with no reyn token at all, is completely unaffected by this change
+    (#5742's own default shape, still the majority of real profile.yaml
+    files)."""
+    project_root = tmp_path / "project"
+    agent_dir = project_root / ".reyn" / "agents" / "coder-brown"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "profile.yaml").write_text(
+        "name: coder-brown\n"
+        "role: brown\n"
+        "created_at: '2026-01-01T00:00:00+00:00'\n"
+        "context_path: REYN.md\n",
+        encoding="utf-8",
+    )
+
+    profile = AgentProfile.load(agent_dir)
+
+    assert profile.context_path == "REYN.md"

--- a/tests/scripts/test_check_load_yaml_token_map_5801.py
+++ b/tests/scripts/test_check_load_yaml_token_map_5801.py
@@ -1,0 +1,97 @@
+"""Tier 2: #5801 — the load-yaml-token-map gate, the ``token_map=`` twin
+of ``tests/scripts/test_check_load_yaml_vocabulary_5455.py``'s own
+``vocabulary=`` gate.
+
+Real filesystem fixtures throughout (a real `tmp_path` tree of `.py`
+files parsed as real ASTs) — same shape as its sibling (reject variant /
+accept variant / real-tree-is-clean check).
+
+The essential witness (owner ruling, #5801 req④): writing a NEW
+``_load_yaml(path, vocabulary=...)`` call with no ``token_map=`` must be
+structurally caught — a NEW reyn-token-aware yaml face that forgets to
+expand reyn's own token vocabulary (the real #5801 defect: profile.yaml
+never called any expansion at all) turns this gate RED, not "stays
+green because nobody thought to check." Python's own ``TypeError``
+already catches an omitted ``token_map`` at CALL time (the parameter has
+no default) — this gate is the SECOND line of defense, same reasoning
+as its sibling: it would also catch a hypothetical future regression on
+the SIGNATURE side (a default quietly reintroduced).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_load_yaml_vocabulary import find_token_map_violations
+
+
+def test_a_call_missing_token_map_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: the exact class this gate exists to close — a call to
+    `_load_yaml(path, vocabulary=X)` with no `token_map=` keyword at all."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(some_path, vocabulary=X)\n",
+    )
+    ((path, lineno),) = find_token_map_violations(tmp_path)
+    assert path == tmp_path / "reader.py"
+    assert lineno == 2
+
+
+def test_token_map_none_explicit_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: an EXPLICIT `token_map=None` is a violation too, not just
+    an omitted keyword — same "None collapses distinct reasons" concern
+    as the vocabulary axis (a NEW face copying a neighbor's
+    `token_map=None` would look plausible and mean nothing)."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(some_path, vocabulary=X, token_map=None)\n",
+    )
+    ((path, lineno),) = find_token_map_violations(tmp_path)
+    assert path == tmp_path / "reader.py"
+    assert lineno == 2
+
+
+def test_token_map_a_real_dict_literal_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: accept-side — a real dict literal (including an explicit
+    empty `{}` — a genuine, visible "this face has no reyn-token value
+    to offer" choice, distinct from an omitted/None keyword) passes."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(\n"
+        "        some_path, vocabulary=X,\n"
+        "        token_map={\"REYN_PROJECT_DIR\": str(project_root)},\n"
+        "    )\n",
+    )
+    assert find_token_map_violations(tmp_path) == []
+
+
+def test_token_map_an_empty_dict_literal_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: accept-side — a bare `{}` is a real, explicit choice (this
+    face genuinely has no reyn token to offer), not a violation the way
+    `None` is."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_yaml(some_path, vocabulary=X, token_map={})\n",
+    )
+    assert find_token_map_violations(tmp_path) == []
+
+
+def test_a_differently_named_function_is_not_matched(tmp_path: Path) -> None:
+    """Tier 2: noise guard — a call to a DIFFERENT function that merely
+    resembles `_load_yaml` in shape is not flagged; the gate matches on
+    the exact callee name."""
+    (tmp_path / "reader.py").write_text(
+        "def f():\n"
+        "    return _load_json(some_path)\n",
+    )
+    assert find_token_map_violations(tmp_path) == []
+
+
+def test_the_real_source_tree_is_currently_clean() -> None:
+    """Tier 2: the real repo — every ACTUAL `_load_yaml(...)` call site in
+    `src/` passes `token_map=` today. Runs against the true source tree,
+    not a fixture — the positive control the gate exists to keep green
+    (strip-verified by hand this PR: removing one real `token_map=`
+    kwarg turns this exact check RED — see this PR's own description)."""
+    from scripts.check_load_yaml_vocabulary import _SRC
+
+    assert find_token_map_violations(_SRC) == []


### PR DESCRIPTION
**[e2e-coder]**

Closes #5801

Owner decision (relayed on the issue): "環境変数の展開漏れなんてのは、環境変数の展開ルールを yaml ないで統一して構造化すべきだからね" — patching profile.yaml alone was explicitly rejected. This makes `token_map` a REQUIRED parameter on `_load_yaml` (the one function every reyn-token-aware config read already funnels through) — same "omission is a TypeError, not a silent gap" shape #5455 ② already established for `vocabulary=`.

**Real incident**: coder-brown/coder-smith's `profile.yaml` `context_path: ${REYN_PROJECT_DIR}/AGENTS.md` never expanded — the agent silently never read its own 30KB of instructions, every session, with zero warning.

### Req① — no face can forget
All 9 real `_load_yaml(...)` call sites in `src/` (6 lead-coder named + 3 more a fresh grep found) now pass an explicit `token_map`. `AgentProfile.load` (profile.yaml — never went through `_load_yaml` at all) now calls the same shared `reyn.plugins.tokens.expand_yaml_tokens_or_refuse` helper directly. Both `base_dir` and `context_path` covered (lead-coder's own explicit flag: fixing one field while leaving the other is a known failure shape).

### Req② — fail-closed, uniformly
Every face now refuses (not warns-and-degrades) on an unresolved reyn token — supersedes #5166's prior narrower scoping, an explicit behavior change per this issue's req②. `test_5351_...` (whose premise was the old scoping) is rewritten for the new outcome, not deleted.

### Req③ — per-face vocabulary
`token_map` supplied by each call site for itself — never one map broadcast everywhere.

### Req④ — a new face that forgets goes RED
Two lines of defense, mirroring #5455 ②: (a) `TypeError` at call time (required kwarg, no default), (b) `scripts/check_load_yaml_vocabulary.py` gains `find_token_map_violations`, a static AST gate — the second line in case a future default quietly reappears on the signature.

### Witness discipline
Per lead-coder's own standing correction: every new test asserts real file CONTENT lands where the agent actually reads it (`RouterHostAdapter.get_project_context()`), not just "no warning fired". One test-validity bug self-caught in the process (see commit body for detail — an early draft's fixture filename let a different code path supply the content, masking the fix's own absence).

### Test plan
- [x] Strip-falsified: profile.py's own expansion call (3 dependent tests go RED, accept-side control stays green); the new AST gate itself (missing/None/real-dict fixtures classify correctly)
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] Regression sweep: `tests/config/ tests/plugins/ tests/runtime/ tests/scripts/` + CLI config-validate suite — 3908 passed, 7 skipped (unrelated missing-extras), 0 failed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51