### PR TITLE
test(#5787): real AgentRegistry/Session replace hand-rolled fakes in slash-rewind tests

### DIFF
--- a/tests/interfaces/test_slash_rewind_copy_cmds.py
+++ b/tests/interfaces/test_slash_rewind_copy_cmds.py
@@ -385,8 +385,23 @@ async def test_rewind_direct_unknown_identity_without_global_is_an_error(tmp_pat
     what's under test."""
     reg = _make_registry(tmp_path)
     identityless = SimpleNamespace(agent_name=None, session_id=None, _registry=reg)
+
+    calls: list = []
+    real_checkout = reg.checkout
+
+    async def _spy_checkout(seq, *, scope):
+        calls.append(seq)
+        return await real_checkout(seq, scope=scope)
+
+    reg.checkout = _spy_checkout
+
     ctx = _ctx(identityless)
     await rewind_cmd(ctx, "5")
+    assert calls == [], (
+        "checkout must not run without a resolvable scope -- a regression "
+        "that both names the workaround AND silently runs a global checkout "
+        "anyway must not pass this test"
+    )
     err = ctx.transport.error_text()
     assert err, "expected a non-empty error reply"
     assert "global" in err, f"the error must name the workaround ('global'); got {err!r}"

--- a/tests/interfaces/test_slash_rewind_copy_cmds.py
+++ b/tests/interfaces/test_slash_rewind_copy_cmds.py
@@ -4,285 +4,363 @@
 non-int arg error, no-registry error, checkout-raises error, checkout-success
 summary.  /copy is a thin sentinel emitter; its contract is that the sentinel
 kind and verbatim args land in the outbox.
+
+#5787: real ``AgentRegistry``/``Session``/``StateLog`` throughout (no
+mocks) — replaces the earlier hand-rolled ``_FakeRegistry``/``_FakeSession``
+(CLAUDE.md: "never fake a collaborator when a real instance is cheaply
+constructible"; a real ``AgentRegistry`` is #5769/#5786/#5789's own
+established test pattern, see ``tests/core/test_5769_stage3_checkout_
+scope.py``'s own ``_make_registry``). Real collaborators are what caught a
+genuine premise defect in the ORIGINAL fake-based test (see
+``test_rewind_direct_global_success_mentions_agent_count``'s own docstring
+below): a scoped (non-``global``) checkout can only ever reset the ONE
+session named in its scope — "session-local rewind resets 3 agents" was
+never a reachable production shape, only something the fake happened to
+allow.
+
+One genuinely undrivable case remains hand-rolled, disclosed inline where
+it's used: ``test_rewind_direct_unknown_identity_without_global_is_an_
+error`` needs a session that cannot report its own ``agent_name``/
+``session_id`` — impossible with a real ``Session`` (its identity comes
+from ``Agent``, which requires a real name at construction; the defensive
+``getattr(..., None)`` branch this test exercises is documented, in
+``rewind.py``'s own module docstring, as "always true in production" —
+i.e. a shape a real Session cannot produce at all).
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.snapshot_generations import GLOBAL_SCOPE
+from reyn.core.events.state_log import StateLog
 from reyn.interfaces.slash.copy import copy_cmd
 from reyn.interfaces.slash.rewind import rewind_cmd
-from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session_params import PresentationWiring
+from tests._support.agent_session import make_session
 from tests._support.slash import slash_ctx
 
-# ── stubs ──────────────────────────────────────────────────────────────────
+# ── real-collaborator construction helpers ──────────────────────────────
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """Real ``AgentRegistry`` + real ``Session`` factory — same shape as
+    ``tests/core/test_pipeline_is2_driver_session.py``'s own
+    ``_agent_registry`` (no LLM ever runs in these tests, so no scripted
+    reply is wired)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            ),
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    return reg
+
+
+def _spawn(reg: AgentRegistry, name: str, sid: str):
+    """A real, attached ``Session`` for ``(name, sid)`` — what ``rewind_cmd``
+    actually receives as ``ctx.session`` in production."""
+    if not reg.exists(name):
+        reg.create(name)
+    reg.spawn_session(name, sid=sid, presentation_consumer=None, intervention_bridge=None)
+    return reg.get_session(name, sid)
+
+
+def _record_checkpoint(reg: AgentRegistry, name: str, seq: int) -> None:
+    """Persist a rewind-point generation for ``name`` at WAL boundary
+    ``seq`` — same helper shape as ``test_registry_list_rewind_points_1f.
+    py``'s own ``_record_gen``."""
+    snap = AgentSnapshot.empty(name)
+    snap.applied_seq = seq
+    reg._store_for(name).record(snap)
 
 
 def _ctx(session):
-    """The context the production dispatch hands a slash handler.
-
-    The transport IS this test's display recorder — ``reply()`` writes
-    through the client seam now, so the list the assertions read is the
-    one the transport fills.
-    """
-    return slash_ctx(session, recorder=session._outbox)
-
-
-class _FakeSession:
-    def __init__(
-        self, *, registry=None,
-        agent_name: "str | None" = "agent", session_id: "str | None" = "main",
-    ) -> None:
-        if registry is not None:
-            self._registry = registry
-        self._outbox: list[OutboxMessage] = []
-        self.pending_ui_calls: list[dict] = []  # public — records set_pending_command_ui calls
-        # #5769 stage 3 ④: the same PUBLIC identity a real Session exposes
-        # (``Session.agent_name`` / ``Session.session_id``) — ``rewind_cmd``
-        # now reads these to build its default session-local scope.
-        self.agent_name = agent_name
-        self.session_id = session_id
-
-    async def _put_outbox(self, msg: OutboxMessage) -> None:
-        self._outbox.append(msg)
-
-    def set_pending_command_ui(self, payload: dict) -> None:
-        self.pending_ui_calls.append(payload)
-
-    def system_text(self) -> str:
-        return " ".join(m.text for m in self._outbox if m.kind == "system")
-
-    def error_text(self) -> str:
-        return " ".join(m.text for m in self._outbox if m.kind == "error")
-
-    def outbox_kinds(self) -> list[str]:
-        return [m.kind for m in self._outbox]
-
-
-@dataclass
-class _Branch:
-    """#3987 ②: the shape ``AgentRegistry.list_branches`` returns — a real
-    ``Branch`` dataclass in production. Mirrored here rather than imported so
-    this file keeps its no-heavy-import property."""
-
-    branch_id: int
-    fork_point_seq: int
-    head_seq: int
-    parent_branch_id: "int | None"
-    is_active: bool
-
-
-class _FakeRegistry:
-    def __init__(
-        self,
-        *,
-        points: list[dict] | None = None,
-        branches: list | None = None,
-        checkout_result: dict | None = None,
-        checkout_raises: Exception | None = None,
-    ) -> None:
-        self._points = points or []
-        # #3987 ②: the real registry has always taken ``include_abandoned`` and
-        # has always had ``list_branches``; this fake models both now that the
-        # bare-/rewind path reads them. Default = one active branch, which is
-        # the single-branch shape these tests were written for.
-        self._branches = branches if branches is not None else [
-            _Branch(branch_id=0, fork_point_seq=0, head_seq=99,
-                    parent_branch_id=None, is_active=True),
-        ]
-        self._checkout_result = checkout_result
-        self._checkout_raises = checkout_raises
-        self.checkout_calls: list[int] = []
-        # #5769/#5784: the real AgentRegistry.checkout takes `scope` as a
-        # required keyword-only argument (no default) -- recorded here too
-        # so a test can assert on it, matching the real signature this fake
-        # stands in for.
-        self.checkout_scopes: "list[tuple[str, str] | None]" = []
-
-    def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
-        return self._points
-
-    def list_branches(self, *, scope: "tuple[str, str] | None") -> list:
-        # #5789: the real AgentRegistry.list_branches takes `scope` as a
-        # required keyword-only argument (no default) too now, matching
-        # `checkout`'s own contract -- accepted here so this fake stays a
-        # drop-in stand-in for the real signature.
-        return self._branches
-
-    async def checkout(self, target: int, *, scope: "tuple[str, str] | None") -> dict:
-        self.checkout_calls.append(target)
-        self.checkout_scopes.append(scope)
-        if self._checkout_raises is not None:
-            raise self._checkout_raises
-        return self._checkout_result or {"agents": [], "target_n": target}
+    """The context the production dispatch hands a slash handler."""
+    return slash_ctx(session)
 
 
 # ── /rewind bare (no arg) paths ────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_rewind_bare_no_registry_no_crash() -> None:
+async def test_rewind_bare_no_registry_no_crash(tmp_path: Path) -> None:
     """Tier 2: bare /rewind with no registry attached replies a graceful no-checkpoints message."""
-    session = _FakeSession()  # no _registry attr
-    await rewind_cmd(_ctx(session), "")
-    assert session.system_text(), "expected a system reply"
-    assert not session.error_text()
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    session._registry = None  # #5787: the one production-real shape this path covers -- a
+    # session genuinely not yet attached to any registry (early construction window).
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "")
+    assert ctx.transport.system_text(), "expected a system reply"
+    assert not ctx.transport.error_text()
 
 
 @pytest.mark.asyncio
-async def test_rewind_bare_empty_points_replies_no_checkpoints() -> None:
+async def test_rewind_bare_empty_points_replies_no_checkpoints(tmp_path: Path) -> None:
     """Tier 2: bare /rewind with registry that has no points → 'no earlier checkpoints' reply."""
-    registry = _FakeRegistry(points=[])
-    session = _FakeSession(registry=registry)
-    await rewind_cmd(_ctx(session), "")
-    assert "no earlier checkpoints" in session.system_text()
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "")
+    assert "no earlier checkpoints" in ctx.transport.system_text()
 
 
 @pytest.mark.asyncio
-async def test_rewind_bare_with_points_emits_rewind_list_sentinel() -> None:
+async def test_rewind_bare_with_points_emits_rewind_list_sentinel(tmp_path: Path) -> None:
     """Tier 2: bare /rewind with checkpoint points emits __rewind_list__ OutboxMessage."""
-    points = [{"seq": 1, "kind": "phase_start"}, {"seq": 2, "kind": "phase_end"}]
-    registry = _FakeRegistry(points=points)
-    session = _FakeSession(registry=registry)
-    await rewind_cmd(_ctx(session), "")
-    assert "__rewind_list__" in session.outbox_kinds()
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    log = reg.state_log
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    s2 = await log.append("inbox_consume", target="alpha", msg_id="m2")
+    _record_checkpoint(reg, "alpha", s1)
+    _record_checkpoint(reg, "alpha", s2)
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "")
+    assert "__rewind_list__" in ctx.transport.kinds()
 
 
 @pytest.mark.asyncio
-async def test_rewind_bare_with_points_calls_set_pending_command_ui() -> None:
+async def test_rewind_bare_with_points_calls_set_pending_command_ui(tmp_path: Path) -> None:
     """Tier 2: bare /rewind with points calls set_pending_command_ui with kind='rewind'."""
-    points = [{"seq": 5, "kind": "phase_start"}]
-    registry = _FakeRegistry(points=points)
-    session = _FakeSession(registry=registry)
-    await rewind_cmd(_ctx(session), "")
-    assert session.pending_ui_calls, "set_pending_command_ui was not called"
-    assert session.pending_ui_calls[0].get("kind") == "rewind"
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    log = reg.state_log
+    s1 = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_checkpoint(reg, "alpha", s1)
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "")
+    assert session.pending_command_ui is not None, "set_pending_command_ui was not called"
+    assert session.pending_command_ui.get("kind") == "rewind"
 
 
 # ── /rewind <N> (direct) paths ─────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_rewind_non_integer_arg_is_an_error() -> None:
+async def test_rewind_non_integer_arg_is_an_error(tmp_path: Path) -> None:
     """Tier 2: /rewind with a non-integer arg replies an error, not a crash."""
-    session = _FakeSession()
-    await rewind_cmd(_ctx(session), "notanumber")
-    assert session.error_text(), "expected error on non-integer arg"
-    assert not session.system_text()
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "notanumber")
+    assert ctx.transport.error_text(), "expected error on non-integer arg"
+    assert not ctx.transport.system_text()
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_no_registry_is_an_error() -> None:
+async def test_rewind_direct_no_registry_is_an_error(tmp_path: Path) -> None:
     """Tier 2: /rewind <N> with no registry attached replies an error."""
-    session = _FakeSession()  # no _registry
-    await rewind_cmd(_ctx(session), "3")
-    assert session.error_text(), "expected error when no registry"
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    session._registry = None
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "3")
+    assert ctx.transport.error_text(), "expected error when no registry"
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_checkout_raises_surfaces_error() -> None:
-    """Tier 2: /rewind <N> when checkout raises → error with the exception text."""
-    exc = RuntimeError("seq 99 not found in WAL")
-    registry = _FakeRegistry(checkout_raises=exc)
-    session = _FakeSession(registry=registry)
-    await rewind_cmd(_ctx(session), "99")
-    err = session.error_text()
-    assert "seq 99 not found" in err
+async def test_rewind_direct_checkout_raises_surfaces_error(tmp_path: Path) -> None:
+    """Tier 2: /rewind <N> when checkout raises → error with the exception text.
+
+    Real ``RewindBeyondRetentionError`` from a genuinely truncated WAL
+    (same shape as ``test_5769_stage3_checkout_scope.py``'s own retention
+    test) -- not a synthetic, hand-typed exception message."""
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    log = reg.state_log
+    await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    await log.append("inbox_put", target="alpha", msg_id="a2", msg_kind="user", payload={"text": "a2"})
+    await log.append("inbox_put", target="alpha", msg_id="a3", msg_kind="user", payload={"text": "a3"})
+    await log.truncate_below(3)  # drop seq 1, 2 -- oldest kept = 3
+    await log.flush()
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, "2")  # seq 2 was truncated away
+    err = ctx.transport.error_text()
+    assert "2" in err and "retained" in err, f"expected a retention error naming seq 2, got {err!r}"
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_success_mentions_agent_count() -> None:
-    """Tier 2: /rewind <N> success reply surfaces the number of agents reset."""
-    result = {"agents": ["a1", "a2", "a3"], "target_n": 7}
-    registry = _FakeRegistry(checkout_result=result)
-    session = _FakeSession(registry=registry)
-    await rewind_cmd(_ctx(session), "7")
-    text = session.system_text()
-    assert "3" in text, f"agent count not in reply: {text!r}"
-    assert not session.error_text()
+async def test_rewind_direct_global_success_mentions_agent_count(tmp_path: Path) -> None:
+    """Tier 2: /rewind <N> global success reply surfaces the number of agents reset.
+
+    #5787: real checkout — and real checkout only resets the ONE session
+    named in a session-local scope (#5769/ADR-0047 decision 3/4), never
+    several. The original fake-based test drove this assertion through
+    the session-LOCAL (bare, non-'global') path with a hand-typed
+    ``{"agents": ["a1","a2","a3"]}`` result -- a combination that is not
+    reachable in real production (a session-scoped checkout resetting 3
+    OTHER agents). Real collaborators surfaced this: to genuinely reach
+    "N agent(s) reset" with N > 1, the command must be the explicit
+    'global' form, which resets every known agent. Rewritten accordingly
+    -- same production code path (`rewind_cmd`'s own reply-formatting
+    line), a reachable scenario driving it."""
+    reg = _make_registry(tmp_path)
+    for name in ("alpha", "beta", "gamma"):
+        reg.create(name)
+    log = reg.state_log
+    s = await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    _record_checkpoint(reg, "alpha", s)
+    _record_checkpoint(reg, "beta", s)
+    _record_checkpoint(reg, "gamma", s)
+
+    session = _spawn(reg, "alpha", "sess-1")
+    results: list = []
+    real_checkout = reg.checkout
+
+    async def _spy_checkout(seq, *, scope):
+        result = await real_checkout(seq, scope=scope)
+        results.append(result)
+        return result
+
+    reg.checkout = _spy_checkout
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, f"{s} global")
+    text = ctx.transport.system_text()
+    (result,) = results
+    expected_count = len(result["agents"])
+    assert expected_count > 1, "sanity: this test's whole point is N > 1 agents reset"
+    assert str(expected_count) in text, f"agent count {expected_count} not in reply: {text!r}"
+    assert not ctx.transport.error_text()
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_success_calls_checkout_with_parsed_int() -> None:
+async def test_rewind_direct_success_calls_checkout_with_parsed_int(tmp_path: Path) -> None:
     """Tier 2: /rewind <N> parses arg to int and passes it to registry.checkout."""
-    result = {"agents": [], "target_n": 42}
-    registry = _FakeRegistry(checkout_result=result)
-    session = _FakeSession(registry=registry)
-    await rewind_cmd(_ctx(session), "42")
-    assert registry.checkout_calls == [42]
-    # #5769 stage 3 ④: the default is session-local, to the INVOKING
-    # session's own identity (`_FakeSession`'s own default here:
-    # agent_name="agent", session_id="main") -- not GLOBAL_SCOPE. This
-    # assertion is the witness that the UI default actually changed
-    # (previously every bare `/rewind <N>` named GLOBAL_SCOPE, #5784's own
-    # call site before this PR); the explicit-`global` and explicit-
-    # session-local paths are covered separately below.
-    assert registry.checkout_scopes == [("agent", "main")]
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    log = reg.state_log
+    s = await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    _record_checkpoint(reg, "alpha", s)
+
+    calls: list = []
+    real_checkout = reg.checkout
+
+    async def _spy_checkout(seq, *, scope):
+        calls.append(seq)
+        return await real_checkout(seq, scope=scope)
+
+    reg.checkout = _spy_checkout  # #5787: spies on the REAL checkout, doesn't replace it
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, str(s))
+    assert calls == [s]
 
 
 # ── /rewind <N> [global] scope (#5769 stage 3 ④, ADR-0047 decision 3) ──────
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_defaults_to_session_local_scope() -> None:
+async def test_rewind_direct_defaults_to_session_local_scope(tmp_path: Path) -> None:
     """Tier 2: bare '/rewind <N>' (no 'global') passes the INVOKING session's
     own (agent_name, session_id) as checkout's scope -- the UI default
-    (ADR-0047 decision 3), never a bare/unscoped call. The API keeps no
-    default of its own (checkout's ``scope`` is required-keyword); this
-    command layer is the one place that decides and always states it."""
-    registry = _FakeRegistry(checkout_result={"agents": [], "target_n": 5})
-    session = _FakeSession(registry=registry, agent_name="alpha", session_id="sess-9")
-    await rewind_cmd(_ctx(session), "5")
-    assert registry.checkout_scopes == [("alpha", "sess-9")]
+    (ADR-0047 decision 3), never a bare/unscoped call."""
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-9")
+    log = reg.state_log
+    s = await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    _record_checkpoint(reg, "alpha", s)
+
+    scopes: list = []
+    real_checkout = reg.checkout
+
+    async def _spy_checkout(seq, *, scope):
+        scopes.append(scope)
+        return await real_checkout(seq, scope=scope)
+
+    reg.checkout = _spy_checkout
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, str(s))
+    assert scopes == [("alpha", "sess-9")]
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_global_keyword_passes_global_scope() -> None:
+async def test_rewind_direct_global_keyword_passes_global_scope(tmp_path: Path) -> None:
     """Tier 2: '/rewind <N> global' explicitly requests the whole-substrate
-    cut -- GLOBAL_SCOPE, the architecture-enforced global shape unchanged
-    since before ADR-0047 (named explicitly per #5784, not a bare `None`
-    literal a forgetful caller could produce by accident)."""
-    registry = _FakeRegistry(checkout_result={"agents": [], "target_n": 5})
-    session = _FakeSession(registry=registry, agent_name="alpha", session_id="sess-9")
-    await rewind_cmd(_ctx(session), "5 global")
-    assert registry.checkout_scopes == [GLOBAL_SCOPE]
+    cut -- GLOBAL_SCOPE."""
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-9")
+    log = reg.state_log
+    s = await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    _record_checkpoint(reg, "alpha", s)
+
+    scopes: list = []
+    real_checkout = reg.checkout
+
+    async def _spy_checkout(seq, *, scope):
+        scopes.append(scope)
+        return await real_checkout(seq, scope=scope)
+
+    reg.checkout = _spy_checkout
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, f"{s} global")
+    assert scopes == [GLOBAL_SCOPE]
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_states_scope_before_the_operation() -> None:
+async def test_rewind_direct_states_scope_before_the_operation(tmp_path: Path) -> None:
     """Tier 2: #5769 stage 3 ④ (architect scope) -- which of the two shapes
     a '/rewind <N>' is must be visible BEFORE checkout runs, not only in
     the after-the-fact summary. A reply naming the scope must already be
     in the outbox at the moment checkout() is invoked."""
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-9")
+    log = reg.state_log
+    s = await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    _record_checkpoint(reg, "alpha", s)
+
     seen_before_checkout: list[str] = []
+    ctx = _ctx(session)
+    real_checkout = reg.checkout
 
-    class _WitnessRegistry(_FakeRegistry):
-        async def checkout(self, target: int, *, scope=None) -> dict:
-            # Captured INSIDE checkout(), so this proves order, not just
-            # eventual presence in the transcript.
-            seen_before_checkout.extend(session.system_text().split())
-            return await super().checkout(target, scope=scope)
+    async def _witness_checkout(seq, *, scope):
+        # Captured INSIDE checkout(), so this proves order, not just
+        # eventual presence in the transcript.
+        seen_before_checkout.extend(ctx.transport.system_text().split())
+        return await real_checkout(seq, scope=scope)
 
-    session = _FakeSession(agent_name="alpha", session_id="sess-9")
-    registry = _WitnessRegistry(checkout_result={"agents": [], "target_n": 5})
-    session._registry = registry
-    await rewind_cmd(_ctx(session), "5")
+    reg.checkout = _witness_checkout
+
+    await rewind_cmd(ctx, str(s))
     assert "session-local" in " ".join(seen_before_checkout), (
         f"scope must be visible in the reply BEFORE checkout runs; saw {seen_before_checkout!r}"
     )
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_scope_reply_never_says_gone() -> None:
+async def test_rewind_direct_scope_reply_never_says_gone(tmp_path: Path) -> None:
     """Tier 2: the pre-flight scope reply must never describe the rewound
     future as lost/gone (lead-coder/architect correction: it survives as
     an inactive, re-selectable branch)."""
-    registry = _FakeRegistry(checkout_result={"agents": [], "target_n": 5})
-    session = _FakeSession(registry=registry, agent_name="alpha", session_id="sess-9")
-    await rewind_cmd(_ctx(session), "5")
-    text = session.system_text().lower()
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-9")
+    log = reg.state_log
+    s = await log.append("inbox_put", target="alpha", msg_id="a1", msg_kind="user", payload={"text": "a1"})
+    _record_checkpoint(reg, "alpha", s)
+
+    ctx = _ctx(session)
+    await rewind_cmd(ctx, str(s))
+    text = ctx.transport.system_text().lower()
     # #5785 review (lead-coder BLOCKING ①): an EMPTY reply also passes every
     # "forbidden word absent" check below -- assert the reply actually
     # happened first, so the forbidden-word checks bite on real content.
@@ -292,21 +370,24 @@ async def test_rewind_direct_scope_reply_never_says_gone() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rewind_direct_unknown_identity_without_global_is_an_error() -> None:
+async def test_rewind_direct_unknown_identity_without_global_is_an_error(tmp_path: Path) -> None:
     """Tier 2: a session that cannot report its own agent_name/session_id
     (defensive -- always true in production) cannot default to
     session-local; the honest failure names the workaround rather than
-    silently falling back to a scope that was never asked for."""
-    registry = _FakeRegistry(checkout_result={"agents": [], "target_n": 5})
-    session = _FakeSession(registry=registry, agent_name=None, session_id=None)
-    await rewind_cmd(_ctx(session), "5")
-    assert registry.checkout_calls == [], "checkout must not run without a resolvable scope"
-    # #5785 review (lead-coder BLOCKING ②): the docstring's own claim is
-    # "the honest failure NAMES the workaround" -- assert an error reply
-    # actually happened (an empty checkout_calls list is also true if
-    # rewind_cmd crashed on its first line, so that assert alone is a
-    # green-on-empty witness) before checking what it names.
-    err = session.error_text()
+    silently falling back to a scope that was never asked for.
+
+    #5787: genuinely undrivable with a real ``Session`` -- ``Agent``
+    requires a real ``agent_name`` at construction, so a real Session can
+    never report ``None`` for its own identity. Minimal duck-typed stub
+    (disclosed here, not a general-purpose fake) carrying only the 2
+    attributes ``rewind_cmd``'s defensive ``getattr`` reads, plus a REAL
+    registry so the ``registry is None`` branch above this one is not
+    what's under test."""
+    reg = _make_registry(tmp_path)
+    identityless = SimpleNamespace(agent_name=None, session_id=None, _registry=reg)
+    ctx = _ctx(identityless)
+    await rewind_cmd(ctx, "5")
+    err = ctx.transport.error_text()
     assert err, "expected a non-empty error reply"
     assert "global" in err, f"the error must name the workaround ('global'); got {err!r}"
 
@@ -315,26 +396,30 @@ async def test_rewind_direct_unknown_identity_without_global_is_an_error() -> No
 
 
 @pytest.mark.asyncio
-async def test_copy_emits_copy_sentinel_kind() -> None:
+async def test_copy_emits_copy_sentinel_kind(tmp_path: Path) -> None:
     """Tier 2: /copy always emits the __copy_last_reply__ sentinel kind."""
-    session = _FakeSession()
-    await copy_cmd(_ctx(session), "")
-    assert "__copy_last_reply__" in session.outbox_kinds()
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    ctx = _ctx(session)
+    await copy_cmd(ctx, "")
+    assert "__copy_last_reply__" in ctx.transport.kinds()
 
 
 @pytest.mark.asyncio
-async def test_copy_passes_args_verbatim_as_text() -> None:
+async def test_copy_passes_args_verbatim_as_text(tmp_path: Path) -> None:
     """Tier 2: /copy <N> puts the raw arg string in the sentinel's text field."""
-    session = _FakeSession()
-    await copy_cmd(_ctx(session), "2")
-    msgs = [m for m in session._outbox if m.kind == "__copy_last_reply__"]
-    assert msgs and msgs[0].text == "2"
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    ctx = _ctx(session)
+    await copy_cmd(ctx, "2")
+    assert ctx.transport.texts("__copy_last_reply__") == ["2"]
 
 
 @pytest.mark.asyncio
-async def test_copy_list_arg_passes_through() -> None:
+async def test_copy_list_arg_passes_through(tmp_path: Path) -> None:
     """Tier 2: /copy list passes the 'list' token verbatim (the output loop validates)."""
-    session = _FakeSession()
-    await copy_cmd(_ctx(session), "list")
-    msgs = [m for m in session._outbox if m.kind == "__copy_last_reply__"]
-    assert msgs and msgs[0].text == "list"
+    reg = _make_registry(tmp_path)
+    session = _spawn(reg, "alpha", "sess-1")
+    ctx = _ctx(session)
+    await copy_cmd(ctx, "list")
+    assert ctx.transport.texts("__copy_last_reply__") == ["list"]


### PR DESCRIPTION
**[e2e-coder]**

Closes #5787

Real incident this class of defect caused: #5784 (checkout's default removal, 26 call sites / 16 files) had ONE call site slip through the sweep — `_FakeRegistry.checkout` kept accepting the OLD signature silently, so CI went red only once the actual test suite ran, not at the sweep itself. A real `AgentRegistry.checkout` would have surfaced the moment its signature changed.

Replaces `_FakeSession`/`_FakeRegistry` with real `AgentRegistry` + real `Session` (via `make_session`, `tests/core/test_pipeline_is2_driver_session.py`'s own established helper) + real `StateLog` — same pattern `test_5769_stage3_checkout_scope.py`/`test_registry_list_rewind_points_1f.py` already use for this exact API. Display output read through `ctx.transport` (real `RecordingTransport`, an existing shared convention). `set_pending_command_ui`'s payload read via the real public `Session.pending_command_ui` property.

### Findings from real collaborators (as invited: report, don't force)
- **One premise defect fixed**: `test_rewind_direct_success_mentions_agent_count`'s original fake drove "3 agents reset" through the session-LOCAL path — not reachable in real production (a scoped checkout only ever resets its ONE named session, ADR-0047 decision 3/4). Renamed + rewritten to the `global` keyword path, which genuinely resets multiple agents; expected count captured from the real `checkout()` return via a spy, not hardcoded.
- **One genuinely undrivable case, disclosed inline**: the "session cannot report its own identity" test needs `agent_name=None`/`session_id=None`, which a real `Session` can never produce (`Agent` requires a real name) — `rewind.py`'s own docstring calls this branch "always true in production." Kept as a minimal, explicitly-commented `SimpleNamespace` stub, backed by a real registry.

### Test plan
- [x] Strip-falsified: flipped `global_requested`'s branch off in `rewind.py` — exactly the 2 tests depending on the `global` path go RED, the other 15 stay green; restored, reconfirmed all 17 green
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] Regression sweep: this file + real checkout/rewind-points/reconstruct family + 4 sibling slash-command files using the same `ctx.transport` convention — 84 passed, 0 failed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51