### PR TITLE
fix(#5802): wire pending_command_ui onto project_status for web/connect's rewind picker

### DIFF
--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -720,6 +720,22 @@ _UNWIRED_KEY_VIOLATIONS_BASELINE: "dict[str, str]" = {
     # have its own project_status twin (see the block comment above).
     "completion_source": _LOCAL,
     "intervention_head": _LOCAL,
+    # #5802 (owner-hit; corrects the #5773 baseline's own "permanently
+    # session-local; no project_status twin is ever planned" — the owner's
+    # report falsified that "ever"). Both flags stay LOCAL by the SAME
+    # DESIGN reasoning as every entry in this block (a flag NAME is never
+    # itself a project_status key) — but unlike before #5802, the
+    # UNDERLYING DATA these flags describe genuinely IS wired now, the
+    # same "flag stays LOCAL, its data gets its own real key" shape
+    # `mcp_probe_states_reported`/`hooks_config_warnings_reported` below
+    # already are: `pending_command_ui` the METHOD now reads a real
+    # `project_status` key, `pending_command_ui_request` (named
+    # differently to avoid colliding with THIS flag's own literal
+    # `"pending_command_ui": <bool>` spread entry — see `status.py`'s own
+    # comment at that key); `has_command_ui_region` is now `True` for
+    # remote (RegistryReadModel's own precedent — no wire key of its own
+    # is needed, the value is read directly off `ChatReadModel.
+    # capabilities`, never off a snapshot dict).
     "pending_command_ui": _LOCAL,
     "has_command_ui_region": _LOCAL,
     "conversation_history": _LOCAL,

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4781,10 +4781,12 @@ class TextualChatApp(App):
           (``ClientTransport.clear_pending_command_ui`` — #5045: moved off the
           read model, which must not write) so it can never be replayed onto a
           later sentinel.
-        - No structured request available — the REMOTE case, where command-UI is
-          not on the AG-UI wire and ``pending_command_ui()`` is ``None`` by
-          design (``read_model.py``) — falls back to appending the sentinel's
-          text list. Swallowing it there would trade one silent no-op for
+        - No structured request available — a read model that does not host a
+          command-UI region (``has_command_ui_region`` False; #5802 wired
+          ``pending_command_ui()`` onto the AG-UI wire for the remote case
+          too, so this is no longer "remote" specifically, only a
+          region-less client) — falls back to appending the sentinel's text
+          list. Swallowing it there would trade one silent no-op for
           another, waiting on a picker that can never arrive.
 
         A ``kind`` other than ``"rewind"`` takes the text fallback too, rather

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -437,8 +437,12 @@ LOCAL_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
 REMOTE_CHAT_READ_CAPABILITIES = ChatReadModelCapabilities(
     completion_source=False,
     intervention_head=True,
-    pending_command_ui=False,
-    has_command_ui_region=False,
+    # #5802: both were False ("permanently session-local" per the #5773
+    # baseline declaration — the owner's own report falsified that
+    # "permanently"; see RemoteReadModel.pending_command_ui/
+    # has_command_ui_region's own docstrings for the wire mechanism).
+    pending_command_ui=True,
+    has_command_ui_region=True,
     conversation_history=False,
     load_older_conversation_history=False,
     # #5774: ctx_recent_usage (this field's own sole remaining consumer
@@ -1265,11 +1269,37 @@ class RemoteReadModel(ChatReadModel):
         return (values or {}).get("pending_intervention_head")
 
     def pending_command_ui(self):
-        return None
+        # #5802: was unconditional None (a #5773 baseline declaration this
+        # falsified — "permanently session-local, no project_status twin
+        # is ever planned"). STATE_SNAPSHOT/STATE_DELTA now carry
+        # ``pending_command_ui_request`` (state.py's own
+        # ``project_status`` — NOT ``pending_command_ui``, which is a
+        # different, pre-existing literal key on the SAME snapshot dict,
+        # the ChatReadModelCapabilities flag value; see that call site's
+        # own comment), the same live-tick pattern :meth:`intervention_
+        # head` above already uses. Returns the SAME JSON-safe dict
+        # production already builds (``Session.pending_command_ui``, set
+        # by ``slash/rewind.py``'s own ``set_pending_command_ui`` —
+        # ``{"kind", "points", "branches", "default_scope"}``), so
+        # ``app.py``'s ``_handle_rewind_request`` (already
+        # read-model-agnostic) needs no changes to consume this for real.
+        values = getattr(getattr(self._transport, "status", None), "values", None)
+        return (values or {}).get("pending_command_ui_request")
 
     @property
     def has_command_ui_region(self) -> bool:
-        return False
+        # #5802: was unconditionally False. The interactive-TTY `--connect`
+        # path mounts the SAME `TextualChatApp`/`RewindPicker` the local
+        # path does (`client_driver.py`'s own renderer-selection seam is
+        # shared, D2 local ≡ remote) — this read model's own capability
+        # declaration is the only thing that made it unreachable. True,
+        # matching `RegistryReadModel`'s own unconditional True just
+        # below: the non-interactive `--cui` path never reaches the code
+        # that reads this flag at all (`run_output_loop`'s own
+        # `renderer.uses_app_input()` gate is already False there,
+        # independent of this value — see that function's own docstring),
+        # so the local precedent this mirrors is not a decoration.
+        return True
 
     @property
     def history_path(self) -> Path:

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -628,6 +628,29 @@ def _snapshot_for_session(registry, s, config=None):
         # call sites.
         **_reported_snapshot_keys(),
         "pending_intervention_head": pending_intervention_head,
+        # #5802 (owner-hit: web/connect's /rewind showed the text
+        # fallback only, no picker — `pending_command_ui`/
+        # `has_command_ui_region` were declared `_LOCAL` in the #5773
+        # baseline, "permanently session-local; no project_status twin
+        # is ever planned" — the owner's report falsified that "ever").
+        # Already a JSON-safe plain dict (`{"kind", "points", "branches",
+        # "default_scope"}` — see `slash/rewind.py`'s own
+        # `set_pending_command_ui` call), so no reshape is needed here,
+        # unlike `pending_intervention_head` above (which projects a
+        # `UserIntervention` object). `None` when nothing is pending —
+        # never a fabricated placeholder.
+        #
+        # Named `pending_command_ui_request`, NOT `pending_command_ui`
+        # (mirrors `pending_intervention_head` vs. the `intervention_
+        # head` capability flag, same reason): `**_reported_snapshot_
+        # keys()` above already spreads a LITERAL `"pending_command_ui":
+        # <bool>` key (the ChatReadModelCapabilities FLAG value, off
+        # `reported_snapshot_keys`'s own field-name-doubles-as-snapshot-
+        # key convention) — reusing that exact name here would silently
+        # overwrite the flag with this method's own real DATA in the
+        # same dict literal (later key wins), the collision this
+        # different name avoids.
+        "pending_command_ui_request": s.pending_command_ui,
         "model": s.model,
         "model_active_class": s.active_model_class(),
         "model_classes": list(s.known_model_classes()),

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -173,6 +173,28 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         # docstring). See ``status._snapshot``'s own docstring for the
         # shape.
         "pending_intervention_head": snap.get("pending_intervention_head"),
+        # #5802 (owner-hit: web/connect's /rewind showed the text list
+        # only, no picker — the #5773 baseline had declared this
+        # "permanently session-local", falsified by the owner's report).
+        # The pending command-UI request (currently only ``{"kind":
+        # "rewind", "points": [...], "branches": [...], "default_scope":
+        # {...} | None}``, #5769) — the source
+        # ``RemoteReadModel.pending_command_ui()`` reads instead of an
+        # unconditional None. None when nothing is pending — never a
+        # fabricated placeholder. Same STATE_SNAPSHOT/STATE_DELTA channel
+        # as every other field here; ``points`` can be large (one row per
+        # session checkpoint), but STATE_DELTA only carries CHANGED keys
+        # (this project_status call's own contract), so this rides the
+        # wire only when a picker opens or closes, not every frame — see
+        # the delta-not-every-frame test this field's own PR pins.
+        #
+        # Named ``pending_command_ui_request`` — NOT ``pending_command_
+        # ui`` — to avoid colliding with the LITERAL ``"pending_command_
+        # ui": <bool>`` key ``snap`` already carries (the
+        # ChatReadModelCapabilities FLAG value, spread in by ``status.py``'s
+        # own ``_reported_snapshot_keys()``); see that call site's own
+        # comment for the full reasoning.
+        "pending_command_ui_request": snap.get("pending_command_ui_request"),
         # #3300 P2a: server-authoritative sent-queue state — the
         # undispatched inbox queue (list of {msg_id, chain_id, text}) +
         # whether a turn is currently dispatched. Rides this SAME

--- a/tests/interfaces/test_5802_remote_rewind_cui_region.py
+++ b/tests/interfaces/test_5802_remote_rewind_cui_region.py
@@ -1,0 +1,133 @@
+"""Tier 2: #5802 — web/connect's ``/rewind`` gets the real picker, not just
+the text list.
+
+Owner-hit: ``web/connect`` で ``/rewind`` すると候補リストが会話画面に流れ
+るだけで、選択パネルが出てこない ("only the text list streams into the chat
+pane, the picker never appears"). Root cause (architect): ``REMOTE_CHAT_READ_
+CAPABILITIES.pending_command_ui``/``.has_command_ui_region`` were declared
+``False`` — a #5773 baseline disposition whose own comment claimed
+"permanently session-local; no ``project_status`` twin is ever planned",
+falsified by this report. ``RemoteReadModel`` now reads a real
+``pending_command_ui_request`` key off the SAME STATE_SNAPSHOT/STATE_DELTA
+channel every other remote-wired field (#5774, #5771) already rides.
+
+Real ``project_status``/``StatusModel``/``RemoteReadModel`` throughout — no
+mocks (mirrors #5774's own established pattern in this file's sibling).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.repl.read_model import REMOTE_CHAT_READ_CAPABILITIES, RemoteReadModel
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.state import StatusModel, project_status
+
+
+def _local_snapshot(*, pending_command_ui_request=None) -> dict:
+    """A LOCAL ``_snapshot()``-shaped dict carrying the one field this
+    issue's own fix wires, mirroring ``status.py``'s real producer."""
+    return {"pending_command_ui_request": pending_command_ui_request}
+
+
+_REWIND_REQUEST = {
+    "kind": "rewind",
+    "points": [{"turn": 3, "text": "abc"}],
+    "branches": [],
+    "default_scope": {"turn": 3},
+}
+
+
+def test_project_status_carries_the_real_pending_request() -> None:
+    """Tier 2: ``project_status`` emits the real dict, not a fixed None."""
+    out = project_status(_local_snapshot(pending_command_ui_request=_REWIND_REQUEST))
+    assert out["pending_command_ui_request"] == _REWIND_REQUEST
+
+
+def test_project_status_stays_none_when_nothing_pending() -> None:
+    """Tier 2: no fabricated placeholder — None stays None, never a stand-in
+    dict, when no picker request is pending."""
+    out = project_status(_local_snapshot(pending_command_ui_request=None))
+    assert out["pending_command_ui_request"] is None
+
+
+def test_delta_carries_the_field_only_on_open_and_close_not_every_frame() -> None:
+    """Tier 2: architect's explicit cost/observability requirement — STATE_
+    DELTA only carries CHANGED keys, so a picker open→same→close sequence
+    must put ``pending_command_ui_request`` on the wire exactly twice (the
+    None→dict open transition, the dict→None close transition), never on an
+    unchanged in-between tick. A regression that re-sends the field every
+    frame (e.g. a snapshot rebuilt with a fresh, `==`-equal-but-not-`is`-
+    tracked dict on each tick) must turn this red."""
+    model = StatusModel()
+
+    # Connect-time snapshot: nothing pending yet.
+    snap = model.snapshot(project_status(_local_snapshot(pending_command_ui_request=None)))
+    assert snap["pending_command_ui_request"] is None
+
+    # Open: a picker request appears — must ride this delta.
+    opened = model.delta(project_status(_local_snapshot(pending_command_ui_request=_REWIND_REQUEST)))
+    assert opened.get("pending_command_ui_request") == _REWIND_REQUEST
+
+    # Unchanged tick (some OTHER field moves, this one doesn't): must NOT
+    # reappear in the delta.
+    unchanged_snapshot = _local_snapshot(pending_command_ui_request=_REWIND_REQUEST)
+    still = model.delta(project_status(unchanged_snapshot))
+    assert "pending_command_ui_request" not in still, (
+        f"pending_command_ui_request rode an unchanged-value delta: {still}"
+    )
+
+    # A second unchanged tick, to rule out a one-tick-late suppression bug.
+    still_again = model.delta(project_status(_local_snapshot(pending_command_ui_request=_REWIND_REQUEST)))
+    assert "pending_command_ui_request" not in still_again
+
+    # Close: request cleared — must ride this delta too.
+    closed = model.delta(project_status(_local_snapshot(pending_command_ui_request=None)))
+    assert "pending_command_ui_request" in closed
+    assert closed["pending_command_ui_request"] is None
+
+
+def test_remote_read_model_capabilities_declare_true_now() -> None:
+    """Tier 2: the #5773 baseline's ``False``/``False`` disposition for
+    these 2 flags is corrected — no longer "permanently session-local"."""
+    assert REMOTE_CHAT_READ_CAPABILITIES.pending_command_ui is True
+    assert REMOTE_CHAT_READ_CAPABILITIES.has_command_ui_region is True
+
+
+def _real_transport() -> AgUiTransport:
+    """A real :class:`AgUiTransport` (never exercised for its own frame
+    stream here — only as the real collaborator :class:`RemoteReadModel` is
+    constructed with, mirroring test_5050's own established pattern in this
+    directory). ``.status`` is the real :class:`RemoteStatusView`."""
+
+    async def _empty_lines():
+        return
+        yield  # pragma: no cover
+
+    async def _send(_payload):
+        return None
+
+    return AgUiTransport(_empty_lines(), _send)
+
+
+def test_remote_read_model_returns_the_real_pending_request() -> None:
+    """Tier 2: end-to-end witness — ``RemoteReadModel.pending_command_ui()``
+    returns the real wire value now, not an unconditional None."""
+    transport = _real_transport()
+    transport.status.apply_snapshot({"pending_command_ui_request": _REWIND_REQUEST})
+    read_model = RemoteReadModel(transport)
+    assert read_model.pending_command_ui() == _REWIND_REQUEST
+    assert read_model.has_command_ui_region is True
+
+
+def test_remote_read_model_returns_none_when_nothing_pending() -> None:
+    """Tier 2: no fabricated placeholder on the read-model side either."""
+    transport = _real_transport()
+    transport.status.apply_snapshot({"pending_command_ui_request": None})
+    read_model = RemoteReadModel(transport)
+    assert read_model.pending_command_ui() is None
+
+
+def test_remote_read_model_degrades_gracefully_for_a_pre_5802_server() -> None:
+    """Tier 2: backward compat — a pre-#5802 server's STATE_SNAPSHOT never
+    populated this key at all; the client must not KeyError."""
+    transport = _real_transport()
+    read_model = RemoteReadModel(transport)
+    assert read_model.pending_command_ui() is None

--- a/tests/interfaces/test_agui_remote_inline_p3.py
+++ b/tests/interfaces/test_agui_remote_inline_p3.py
@@ -200,9 +200,16 @@ async def test_remote_read_model_intervention_head_is_none_not_unsupported() -> 
 
 @pytest.mark.asyncio
 async def test_remote_read_model_degrades_local_only_affordances() -> None:
-    """Tier 2: the remote read-model returns empty (not fabricated) for everything
-    NOT on the wire — intervention region, command-UI — and declares it
-    has no command-UI region so the /rewind text fallback engages."""
+    """Tier 2: the remote read-model returns empty (not fabricated) for
+    everything not yet ON the wire — intervention region, command-UI's own
+    pending request — before any STATE_SNAPSHOT has arrived.
+
+    ``has_command_ui_region`` is deliberately NOT one of these any more
+    (#5802 — the remote /rewind picker owner-hit): it is no longer a
+    session-local-only affordance, it is now unconditionally True for
+    remote too (the interactive `--connect` path mounts the SAME
+    TextualChatApp/RewindPicker widget stack local chat does), so it is
+    pinned in its own test below instead of this "local-only" group."""
 
     async def _noop_send(_payload):
         return None
@@ -211,10 +218,25 @@ async def test_remote_read_model_degrades_local_only_affordances() -> None:
     rm = RemoteReadModel(transport)
     assert rm.intervention_head() is None
     assert rm.pending_command_ui() is None
-    assert rm.has_command_ui_region is False
     # A pre-STATE_SNAPSHOT snapshot renders a placeholder model.
     snap = rm.snapshot()
     assert snap["model"] == "—"
+
+
+def test_remote_read_model_has_command_ui_region_true() -> None:
+    """Tier 2: (#5802) unlike this file's other local-only affordances
+    above, ``has_command_ui_region`` is unconditionally True for remote —
+    D2 (ADR-0039 P3, "local ≡ remote"): the interactive `--connect` path
+    mounts the identical widget stack local chat does, so the region
+    itself is never session-local; only the DATA it reads (``pending_
+    command_ui()``, pinned empty-before-wire-arrival above) is."""
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(""), _noop_send)
+    rm = RemoteReadModel(transport)
+    assert rm.has_command_ui_region is True
 
 
 def test_project_remote_snapshot_expansion_keys_are_empty() -> None:


### PR DESCRIPTION
**[tui-coder]** — Closes #5802

## What happened

Owner-hit, real machine: web/connect (`reyn chat --connect`) の `/rewind` は候補リストが会話画面に流れるだけで、選択パネル（↑↓ピッカー）が出てこない。ローカルの `/rewind` と一致すべき、という報告。

Root cause (architect's diagnosis): `REMOTE_CHAT_READ_CAPABILITIES.pending_command_ui`/`.has_command_ui_region` were declared `False` in the #5773 baseline — a disposition I (tui-coder) myself wrote, whose own comment claimed "permanently session-local; no `project_status` twin is ever planned". This owner's report falsifies that "permanently" — the gate mechanism worked correctly (the gap was a *declared* row, not silence), but the declared *value* needed correcting.

## Fix, per architect's 3-point design

**① Wire `pending_command_ui` onto `project_status`, correct the baseline with the reason.**
- `status.py`'s `_snapshot_for_session` now carries `pending_command_ui_request` — named to avoid a real naming collision I found while implementing: `reported_snapshot_keys()` already spreads a literal `"pending_command_ui": <bool>` key onto the SAME dict (the `ChatReadModelCapabilities` flag value, not this data). Reusing that name would have silently let one overwrite the other in the same dict literal.
- `agui/state.py`'s `project_status` forwards it on the SAME STATE_SNAPSHOT/STATE_DELTA channel every other remote-wired field (#5774, #5771) rides.
- `scripts/check_remote_snapshot_placeholder_declared.py`'s baseline comment is corrected WITH the reason (never silently deleted) — the flag's own 2 entries **stay `_LOCAL`** (the flag NAME itself is still never a `project_status` key, per the established `mcp_probe_states_reported`/`session_cache_usage_reported` spread-field precedent), but now document that the underlying DATA these flags describe is genuinely wired, under the different name.

**② Build the actual CUI region substance for web/connect.** Investigated first, before writing code: `reyn chat --connect` (interactive TTY) and local `reyn chat` both funnel through the SAME `run_textual_chat()` → `TextualChatApp` construction path (D2, ADR-0039 P3 "local ≡ remote"), differing only in which `ChatReadModel` is passed. The `RewindPicker` widget is already read-model-agnostic (#5769④). So this reduces to: make `RemoteReadModel.pending_command_ui()`/`.has_command_ui_region` return real data instead of the hardcoded `None`/`False` — no new UI code needed.

**③ Keep the text fallback for region-less clients.** Traced `run_output_loop`'s own `uses_app_input()` gate — confirmed structurally unreachable with `has_command_ui_region=True` in the actual `--cui` remote scenario (the Textual/alt-screen branch already returns early before `run_output_loop` is ever invoked in that case). `test_agui_remote_rewind_textfallback.py` is unmodified and still green.

## Test plan

- [x] New `tests/interfaces/test_5802_remote_rewind_cui_region.py` (7 tests): `project_status` carries the real dict / stays `None` when nothing pending; **the STATE_DELTA-only-on-open-close cost/observability contract architect explicitly required** — drives a real `StatusModel` through open→unchanged→unchanged→close and asserts the field rides the delta exactly on the 2 transitions, never on an unchanged tick; the capability flags flip to `True`; `RemoteReadModel` round-trips the real value (via a real `AgUiTransport` + real `RemoteStatusView`, no mocks) and degrades gracefully (no `KeyError`) for a pre-#5802 server that never sent the key.
- [x] Falsify-verified all 3 wiring points in-file (Edit-only, no `git checkout`/`stash`): `RemoteReadModel.pending_command_ui()`, `.has_command_ui_region`, and `project_status`'s own forwarding line — each independently confirmed to turn the new tests RED, then restored and reconfirmed green.
- [x] Scoped regression: the 9 directly-affected files (rewind/remote-status: new file + `test_4996_read_model_capabilities.py`, `test_agui_remote_rewind_textfallback.py`, `test_5769_stage3_rewind_default_scope_visible.py`, `test_5774_mcp_hooks_ctx_wired_to_remote.py`, `test_slash_rewind_1f.py`, `test_3987_rewind_picker_shows_branch_tree.py`, `test_4788_rewind_picker_escape_dismiss.py`, `test_4817_rewind_yields_to_open_intervention.py`) — 41 passed, all green, including the full local `/rewind` suite unchanged (acceptance criterion 7).
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (new test file), `verify_module_docstrings.py` (3 changed src files), `mypy_ratchet.py` (200/208 baselined findings, no new ones), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (run after `git add`), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green.
- [ ] Visual は owner 確認 — the picker's actual on-screen appearance in a real `--connect` browser/terminal session can't be verified outside a real client.

## Acceptance criteria (#5802, verbatim)

1. Picker actually appears on web/connect — ✅ via ②'s D2 finding + ①'s wiring (no code path left returning the old hardcoded degrade).
2. `default_scope` shown before selection — ✅ carried unchanged in the same dict `set_pending_command_ui` already builds (`{"kind", "points", "branches", "default_scope"}`).
3. Row owner display matches local including `(owner unknown)` — ✅ same widget, same data shape, no local-only branch existed.
4. Delta-only-on-open-close pinned by a test — ✅ see above.
5. Region-less clients still see the text list — ✅ `test_agui_remote_rewind_textfallback.py` unmodified, still green.
6. Baseline correction present with its reason — ✅ `check_remote_snapshot_placeholder_declared.py`.
7. Local `/rewind` completely unchanged — ✅ full local rewind suite green, zero non-test src changes outside the `RemoteReadModel`/`project_status`/`status.py` remote-only paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
