### PR TITLE
fix(#5803): keep a failed shell-hook's own exception type+message in its logged stderr

### DIFF
--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -453,6 +453,33 @@ def _report_unapplied_agent_policy(
             _log.warning("shell-hook: emit_event failed for %r: %s", hook_label, exc)
 
 
+def _failure_stderr_snippet(stderr: bytes, *, head: int = 100, tail: int = 300) -> str:
+    """#5803: bound a FAILED hook's stderr for the diagnostic log line
+    without structurally dropping the part most likely to carry the actual
+    diagnosis.
+
+    The prior form (``stderr[:200]``, a head-only cap) reads correctly for
+    a short, single-line failure ("command not found") but a Python
+    traceback puts its own summary -- ``ExceptionType: message``, the one
+    line an operator actually needs -- LAST. A traceback longer than 200
+    bytes (routine: file paths + line numbers alone often exceed that)
+    always cut that line off; the log carried real bytes (never empty --
+    "stderr is non-empty" was never the right witness for this defect) but
+    never the part that explains WHY.
+
+    Keeps a small HEAD (which command, earliest context) and a larger TAIL
+    (where the traceback's own exception line lives), joined with an
+    explicit elision marker when the full text doesn't fit both -- #5210's
+    "never truncate the returned/parsed value" ruling is unaffected (this
+    is the LOGGED-only copy for a run that already failed, not the
+    ``exec_capture`` push-directive stdout that ruling governs)."""
+    text = stderr.decode("utf-8", errors="replace")
+    if len(text) <= head + tail:
+        return text.strip()
+    elided = len(text) - head - tail
+    return f"{text[:head]}...[{elided} chars elided]...{text[-tail:]}".strip()
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -857,7 +884,7 @@ async def run_shell_hook(
             )
 
         if result.returncode not in (0,):
-            stderr_snippet = result.stderr[:200].decode("utf-8", errors="replace").strip()
+            stderr_snippet = _failure_stderr_snippet(result.stderr)
             if denial_class == DENIAL_FORK:
                 # #2827/#2820-B: name the class and point at the fix. The raw
                 # stderr ("fork: Operation not permitted") reads as a broken

--- a/tests/hooks/test_1800_hook_shell_runner.py
+++ b/tests/hooks/test_1800_hook_shell_runner.py
@@ -28,6 +28,7 @@ Filesystem isolation: allowlist tests point at a tmp_path file so
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -281,6 +282,71 @@ async def test_nonapproved_command_nontty_refused(
 
     # Refused — fail-closed.
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# #5803: a failed hook's stderr must not lose its own exception's type+message
+# ---------------------------------------------------------------------------
+
+
+def _deeply_nested_traceback_script(tmp_path: Path) -> Path:
+    """A real .py file whose uncaught exception's traceback has enough
+    stack frames (each carrying this file's own long tmp_path) to exceed
+    200 bytes BEFORE the final ``ExceptionType: message`` line -- a bare
+    ``python -c`` one-liner's traceback is usually too short (1-2 frames)
+    to reproduce the real #5803 shape."""
+    lines = []
+    for i in range(12):
+        lines.append(f"def f{i}():")
+        lines.append(f"    return f{i + 1}()" if i < 11 else "    raise BrokerDrainError('the drain queue is wedged')")
+        lines.append("")
+    script = (
+        "class BrokerDrainError(Exception):\n"
+        "    pass\n\n"
+        + "\n".join(lines)
+        + "\nf0()\n"
+    )
+    path = tmp_path / "broker_drain.py"
+    path.write_text(script, encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_failed_hook_stderr_snippet_keeps_the_exceptions_own_type(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: #5803 -- a real subprocess that dies with an uncaught
+    exception, whose traceback exceeds 200 bytes before its own final
+    ``ExceptionType: message`` line, must still show that exception's
+    TYPE NAME in the logged stderr snippet.
+
+    "stderr is non-empty" is NOT the witness (it was always non-empty,
+    #5803's own root cause) -- this asserts the STRUCTURED content (the
+    type name) that the prior head-only ``[:200]`` cap dropped for any
+    traceback longer than that."""
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    allowlist = tmp_path / "allowlist.json"
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+    script_path = _deeply_nested_traceback_script(tmp_path)
+    argv = [_PY, str(script_path)]
+
+    with caplog.at_level(logging.WARNING, logger="reyn.hooks.shell_runner"):
+        result = await run_shell_hook(
+            argv,
+            event_context={"event": "turn_end"},
+            timeout_seconds=10,
+            sandbox_backend=_noop_backend(),
+            sandbox_policy=_policy(temp_dir=str(tmp_path)),
+            allowlist_path=allowlist,
+        )
+
+    assert result is None  # a failed exec run yields no push-directive
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("BrokerDrainError" in msg for msg in warnings), (
+        f"the failing subprocess's own exception type must appear in the "
+        f"logged stderr snippet -- got {warnings!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]**

Closes #5803

A Python traceback puts its own summary — `ExceptionType: message`, the one line an operator actually needs — on its LAST line. The failure-diagnostic log in `shell_runner.py` (all 3 warning branches: DENIAL_FORK / DENIAL_NETWORK / generic) capped stderr at the first 200 bytes, structurally dropping the exception type+message for any traceback longer than that (routine — file paths + line numbers alone commonly exceed it). "stderr is non-empty" was never the right witness — the log always had bytes, just never the diagnostic ones.

**Fix**: `_failure_stderr_snippet` keeps a small HEAD (early context) + larger TAIL (where the traceback's exception line lives), joined with an elision marker. Scoped to the failure-diagnostic path only — the separate, lower-severity success-path debug logs are unchanged. #5210's "never truncate the returned value" ruling is unaffected (this is the logged-only copy for an already-failed run).

Audit-event persistence (mentioned in the issue as worth considering) is left as a follow-up — the issue marked it optional (検討), and it's a separate, larger design question this fix's own scope shouldn't absorb unbidden.

### Test plan
- [x] Real-subprocess witness (not "stderr non-empty"): a genuine 12-frame-deep .py script raising a custom exception, run through the real `run_shell_hook`/sandbox path — the exception's own TYPE NAME asserted present in the logged warning via `caplog`
- [x] Strip-falsified: reverted to the head-only `[:200]` cap — new test goes RED (exception line missing past byte 200); restored, reconfirmed green
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] Regression sweep: `tests/hooks/` — 452 passed, 0 failed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51