### PR TITLE
docs: FP-0069 — permission posture dial, maximal alignment with the measured industry shape

### DIFF
--- a/docs/deep-dives/proposals/0069-permission-posture-dial.md
+++ b/docs/deep-dives/proposals/0069-permission-posture-dial.md
@@ -1,6 +1,6 @@
 # FP-0069: A permission posture dial — aligning reyn with the industry shape
 
-**Status**: proposed (not ruled on)
+**Status**: partially ruled (owner 2026-09-06, verbatim 「ダイヤル入れる。宣言はoptin。3,4 解説して。あと plan モードは？」) — §2 and §5 are decided; §6 and the `reviewed` tier are open. See §10.
 **Proposed**: 2026-09-06
 **Author**: architect session
 **Track**: owner request 2026-09-06 —「reyn のパーミッションシステム仕様を業界標準に寄せたい」／「できるだけ寄せる案を作成できる？」
@@ -70,6 +70,26 @@ Competitors can delete the prompt precisely because their boundary is restrictiv
 
 **This is not a request to overturn #3901.** That ruling answers "what should a sandbox do behind an action the user already permitted." `bounded` asks a different question — "what may *replace* the permission question" — and the ruling's own rationale does not cover it. So `bounded` carries its **own** policy preset (write: workspace; network: deny unless declared; env/read: unchanged), leaving #3901's default in force wherever `sandboxed_exec` is launched outside the mode.
 
+### 6.1 What the preset actually has to close — the axis that decides it is **network**
+
+`bounded` runs commands **nobody was asked about**. So the question the preset answers is not "what could the launching shell do" but "what can an action nobody approved reach". Per axis:
+
+| Axis | In `bounded` | Why |
+|---|---|---|
+| **write** | workspace only (already the #3901 default) | unchanged |
+| 🔴 **network** | **deny unless declared** | The exfiltration path. If an unprompted command can reach the internet, the box has a hole and `bounded` is not a boundary — it is `unbounded` with a smaller write scope. This is exactly why Codex defaults network off. |
+| **subprocess** | open | A child inherits the same boundary (seccomp / Seatbelt bound the process tree), so it adds no reach. |
+| **env** | open | Safe **only because** network is closed: a command can read a secret but cannot send it. This is #1199's original argument, which `permission-model.md` records as having died when #3901 opened network — **under `bounded` it is restored**, because `bounded` closes network again. |
+| **read** | broad-allow | Unchanged; system paths are needed just to load a binary. |
+
+⭕ **The preset already exists and is already correct.** `sandbox.mode: strict` (#3823) resolves exactly these defaults — `_SANDBOX_STRICT_MODE_DEFAULTS = {"network": False, "deny_subprocess": True, "allow_env_names": []}`, with `write` deliberately excluded (zeroing it would block the op's own workspace, per #3823's co-vet correction). **`bounded` does not need a new preset; it needs to select this one.**
+
+🔴 **But it is not wired**: no production caller passes `mode=` to `resolve_sandbox_policy` — see #5818. Setting `sandbox.mode: strict` today changes only a warning message, which calls itself "in force right now". **#5818 is therefore a prerequisite for `bounded`, and worth doing on its own merits regardless of this proposal.** With it done, §6's cost falls from "new enforcement work" to "the mode selects an existing key".
+
+**Where the declaration lands:** reyn already has the axis — `permissions.http.get: [{host: …}]`. So "deny unless declared" costs no new mechanism, and it gives §5's now-optional declaration **one place where it still earns its keep**: in `bounded`, declaring your hosts is what buys you a prompt-free workspace.
+
+**The alternative, stated so it is a choice and not an omission:** leaving network open in `bounded` is cheaper and needs no preset — but then `bounded` deletes prompts without adding a boundary, which is the one thing the measurement says the industry did **not** do.
+
 **Consequence for sequencing:** `read_only`, `ask` and `unbounded` are naming + wiring over machinery that exists. `bounded` is the only one that needs enforcement work, and it is also the one that produces most of the UX gain.
 
 ## 7. Migration
@@ -90,9 +110,28 @@ Today's behaviour is exactly `ask` **with** a mandatory declaration. So:
 - [ ] `bounded` never runs an action outside its boundary without a prompt — the strip-falsifier is removing the boundary and watching the acceptance go red, not watching the prompt disappear.
 - [ ] Removing `unbounded` by config is possible, and a session cannot re-enable it.
 
+## 9. `plan` is a phase, not a posture
+
+Claude Code has `plan` on its mode dial. **This proposal deliberately does not**, and the reason is not that reyn shouldn't have planning.
+
+`plan` conflates two independent axes. "Read-only" is a **permission posture**. "Explore, propose, then act on approval" is a **workflow phase**. Claude Code can merge them because it has one agent in one loop, so "the planning phase" and "the read-only posture" are the same interval. reyn is a multi-agent OS: a phase belongs to a turn, a posture belongs to a session, and a pipeline can want a planning phase inside any posture. Putting `plan` on the dial makes it answer "is planning stricter or looser than `bounded`?" — a question with no meaning.
+
+**Measured:** reyn has no plan machinery today (`git grep -niE "plan_mode|exit_plan|propose.*approve" -- src/` returns zero), and it does have the approval seam a plan phase would need (`ask_user`, the intervention bus).
+
+**If planning is wanted, the reyn-shaped form is:** posture stays `read_only` for the duration, and the plan→execute transition is an intervention event on the existing bus — the same "spec vs binding" separation `CapabilityProfile` already uses for its two adapters. That is a separate proposal, not a value on this dial.
+
+## 10. Owner rulings so far
+
+**2026-09-06, verbatim** 「**ダイヤル入れる。宣言はoptin。3,4 解説して。あと plan モードは？**」
+
+- **§2 the dial — ACCEPTED.**
+- **§5 the declaration becomes opt-in — ACCEPTED.**
+- §6 (`bounded`'s boundary) and the `reviewed` tier — **explanation requested, not ruled.** §6.1 and §2's `reviewed` paragraph are that explanation.
+- `plan` — answered in §9.
+
 ## 9. Open questions — owner's, not this document's
 
-1. **Adopt the dial at all?** §2 is the whole alignment; everything else is detail.
-2. **Make the declaration optional (§5)?** The single biggest UX change, and the one real deviation from the standard.
-3. **`bounded`'s own sandbox preset (§6)?** Needed for the UX win; a new default in a place a prior ruling deliberately left open.
-4. **`reviewed` (§2, optional)?** Independent of 1-3. Puts an LLM in the gate path.
+1. ~~Adopt the dial at all?~~ **Ruled: yes** (§10).
+2. ~~Make the declaration optional (§5)?~~ **Ruled: opt-in** (§10).
+3. **`bounded`'s boundary (§6.1)** — open. The axis that decides it is **network**: deny-unless-declared makes `bounded` a boundary, open makes it `unbounded` with a smaller write scope. Prerequisite #5818.
+4. **`reviewed` (§2)** — open, and independent of 1-3. It is the only element of this proposal that **adds** a trust assumption rather than removing one.

--- a/docs/deep-dives/proposals/0069-permission-posture-dial.md
+++ b/docs/deep-dives/proposals/0069-permission-posture-dial.md
@@ -1,0 +1,98 @@
+# FP-0069: A permission posture dial — aligning reyn with the industry shape
+
+**Status**: proposed (not ruled on)
+**Proposed**: 2026-09-06
+**Author**: architect session
+**Track**: owner request 2026-09-06 —「reyn のパーミッションシステム仕様を業界標準に寄せたい」／「できるだけ寄せる案を作成できる？」
+**Measurement this rests on**: [research/competitive/permission-modes.md](../research/competitive/permission-modes.md) (Claude Code / Codex / OpenClaw / Hermes, primary docs, 2026-09-06)
+
+---
+
+## Summary
+
+Adopt the one shape all four competitors share and reyn lacks: **a single named posture dial**, ordered strict-to-permissive, switchable at runtime, sitting *over* the machinery reyn already has. Keep every place reyn is stricter than the standard — none of them costs UX. Drop the one place reyn is genuinely heavier than the standard: **the mandatory declaration**.
+
+**This proposal is maximal alignment, as asked.** Its one hard dependency is stated in §6 and it is not free: the mode that produces most of the UX win cannot be built on reyn's current sandbox defaults.
+
+## 1. What "aligned" means, concretely
+
+From the measurement, four convergent properties. This proposal adopts all four.
+
+| # | Property | reyn today |
+|---|---|---|
+| 1 | One named posture dial, 3-6 values, runtime-switchable | **absent** — `grep -rniE "yolo\|dangerously\|skip.permission\|permission_mode" src/` returns 0 |
+| 2 | Posture is separate from the enforcement boundary | partially — the conjunctive restrict layers *are* this separation, but nothing names a posture |
+| 3 | A floor no mode can cross | partially — protected write paths exist, but they are not framed as a floor and no mode language exists to be exempt from |
+| 4 | Deny composes by intersection; nothing re-grants | **already stronger than the standard** — `all(layer.allows(...))` is structural, not evaluation-order |
+
+## 2. The dial
+
+`permissions.mode` in `reyn.yaml` (overridable in `reyn.local.yaml`, and at runtime). Named by **disposition — what you may do**, not by rank.
+
+| Mode | Meaning | Built from |
+|---|---|---|
+| `read_only` | Read and search. No write, no exec, no MCP call, no network. | AgentLayer denies the write / exec / mcp / http axes wholesale. No new mechanism. |
+| `ask` | Today's behaviour: just-in-time prompt at first use, decision persisted to the ledger with its actor / agent / inode scope. | Exactly the current layer-2 + ledger path, minus the mandatory declaration (§5). |
+| `bounded` | **The UX mode.** Inside the boundary, act without asking. Ask only for an action that would *leave* it. | Requires §6. `sandboxed_exec` with a mode-owned restrictive policy; the boundary replaces the prompt. |
+| `unbounded` | No prompts, no boundary. | Must be removable by config, the way Claude Code's `disableBypassPermissionsMode` removes `bypassPermissions`. |
+
+Ordering is total and strict-to-permissive, so "at least as strict as X" is expressible.
+
+**Optional fifth, deliberately separable:** `reviewed` — allowlist misses go to an automated reviewer before a human (Claude Code's classifier, OpenClaw's auto-reviewer, Hermes's `smart`; 3 of 4 have one). ⚠️ It puts **an LLM in the gate path**, which adds a cost axis and a new question ("on what basis is the reviewer trusted?"). Held out of the core so it can be dropped without redesigning the dial.
+
+## 3. The floor
+
+Make explicit what all four competitors have: **actions no mode grants.** reyn already has the material — the protected write paths (`.reyn/approvals.jsonl`, `.reyn/index/sources.yaml`) — but they are documented as a carve-out from a default grant, not as a floor mode language must respect.
+
+Restated as a floor: **`unbounded` does not reach them either.** Hermes's hardline blocklist and OpenClaw's host floor are the precedent; Claude Code's is weaker here (`bypassPermissions` *does* write `.git`/`.claude`), so this is a place to follow the stricter two.
+
+## 4. What reyn keeps — every one of these is stricter than the standard and costs no UX
+
+- **The ledger's scope semantics** (actor / op / path + `agent:<name>` + inode identity re-checked per match, #5042 / #5052). No competitor has identity re-binding; Hermes has no per-path scope at all. This is what makes `ask` cheap — a correctly-scoped answer is given once.
+- **The conjunctive restrict layers.** Claude Code achieves "deny always wins" by evaluation order across settings scopes; reyn achieves it structurally. Keep as is.
+- **Fail-closed when unattended.** Already reyn's behaviour (no bus → denied, not pending). Hermes reaches the same place with three config keys.
+
+## 5. What reyn drops — the mandatory declaration
+
+Layer 2 (`permissions:` in `reyn.yaml`) has **no analogue in any of the four**; all gate at the moment of use. This is the main source of "reyn is heavy", and it is **ceremony-by-default, not security-by-default**: removing it leaves the just-in-time gate untouched, so almost no enforcement is lost.
+
+**Proposal:** the declaration becomes **required only in `read_only` and `ask`-with-`strict_declaration`**, and optional elsewhere. What it buys — a permission inventory readable before anything runs — is preserved as a posture you can choose rather than the only path.
+
+⚠️ **This is a behaviour change and it is UX-visible.** It needs the owner's ruling, not this document's.
+
+## 6. 🔴 The dependency this proposal cannot hide
+
+**`bounded` cannot be built on reyn's current sandbox defaults.**
+
+Owner ruling #3901 (2026-06-05) set every non-`write` axis of `SandboxPolicy` to **open by default** — network, subprocess, env, read — with the stated rationale that "the sandbox's job is bounding what happens *behind* a permitted action, not re-deciding what the launching shell could already do."
+
+Competitors can delete the prompt precisely because their boundary is restrictive: Codex defaults network **off** and confines writes to the workspace; Claude Code merges `sandbox.filesystem` settings with Read/Edit deny rules and domain lists into one boundary, and only then does `autoAllowBashIfSandboxed` drop the prompt. **Deleting reyn's prompt against a compat-open boundary deletes the gate, not the friction.**
+
+**This is not a request to overturn #3901.** That ruling answers "what should a sandbox do behind an action the user already permitted." `bounded` asks a different question — "what may *replace* the permission question" — and the ruling's own rationale does not cover it. So `bounded` carries its **own** policy preset (write: workspace; network: deny unless declared; env/read: unchanged), leaving #3901's default in force wherever `sandboxed_exec` is launched outside the mode.
+
+**Consequence for sequencing:** `read_only`, `ask` and `unbounded` are naming + wiring over machinery that exists. `bounded` is the only one that needs enforcement work, and it is also the one that produces most of the UX gain.
+
+## 7. Migration
+
+Today's behaviour is exactly `ask` **with** a mandatory declaration. So:
+
+- Existing projects keep working with `mode: ask`; nothing about the JIT prompt or the ledger changes.
+- Dropping the declaration requirement *removes* prompts (the startup-guard surface), never adds one.
+- `reyn.local.yaml` stays the operator-local override, and gains `mode:` like any other key.
+
+## 8. Acceptance
+
+- [ ] `permissions.mode` is a required key with no silent default, or has a default stated in one place that a test reads. (Every mode-less caller drifting to the most permissive value is the failure this whole arc kept closing.)
+- [ ] The order is total and testable: for every pair, "strictly more permissive than" has one answer.
+- [ ] A capability denied by a restrict layer stays denied in **every** mode, `unbounded` included — the conjunction is not mode-aware.
+- [ ] The floor (§3) is unreachable from `unbounded`, with a test that goes red if a mode is added that reaches it.
+- [ ] `mode: ask` on an existing project is byte-identical to today's behaviour apart from the declaration requirement.
+- [ ] `bounded` never runs an action outside its boundary without a prompt — the strip-falsifier is removing the boundary and watching the acceptance go red, not watching the prompt disappear.
+- [ ] Removing `unbounded` by config is possible, and a session cannot re-enable it.
+
+## 9. Open questions — owner's, not this document's
+
+1. **Adopt the dial at all?** §2 is the whole alignment; everything else is detail.
+2. **Make the declaration optional (§5)?** The single biggest UX change, and the one real deviation from the standard.
+3. **`bounded`'s own sandbox preset (§6)?** Needed for the UX win; a new default in a place a prior ruling deliberately left open.
+4. **`reviewed` (§2, optional)?** Independent of 1-3. Puts an LLM in the gate path.

--- a/docs/deep-dives/proposals/README.md
+++ b/docs/deep-dives/proposals/README.md
@@ -127,3 +127,4 @@ Links to related ADRs, PRs, and docs.
 | [0065](0065-orchestration-foundation.md) | Orchestration foundation — external-event plugins as a first-class unit | Proposed (awaiting owner review, 2026-07-20) | LARGE |
 | [0066](0066-retrieval-two-groups-two-axes.md) | Retrieval redesign: two groups (action / knowledge) × two axes (scheme × transport) | Proposed — owner design-of-record (2026-07-24/25), awaiting owner GO to phase-implement | LARGE |
 | [0067](0067-task-model-and-arbiter.md) | Task model and the inbox arbiter — sequencing and interface for [ADR-0040](../decisions/0040-task-as-os-concept.md) | Accepted (2026-08-10, owner) — **not yet implemented**; tracking #3978 | LARGE |
+| [0069](0069-permission-posture-dial.md) | Permission posture dial — align with the shape all four competing agents share (measured 2026-09-06) | Proposed (owner asked for the proposal 2026-09-06; **not ruled on**) | MEDIUM |


### PR DESCRIPTION
**[architect]** — owner asked (2026-09-06) for a proposal that aligns reyn's permission spec with the industry standard as far as possible. This is that proposal. **It is not ruled on**; §9 lists what only the owner can decide.

Rests on the measurement in [research/competitive/permission-modes.md](https://github.com/tya5/reyn/pull/5814) (four agents, primary docs, dated).

## What it proposes

**One named posture dial over the machinery reyn already has** — `read_only` / `ask` / `bounded` / `unbounded`, ordered strict-to-permissive, with `reviewed` held out as a separable fifth because it puts an LLM in the gate path.

Three of the four modes are naming and wiring over existing mechanisms. The dial is the whole alignment: it is the one shape all four competitors share and reyn has none of — confirmed as a code fact, not a doc reading (`grep -rniE "yolo|dangerously|skip.permission|permission_mode" src/` returns zero).

## What it keeps, and why that matters

Everywhere reyn is stricter than the standard, it stays: the ledger's actor/agent/inode scope (no competitor re-checks path identity; Hermes has no per-path scope at all), the conjunctive restrict layers (reyn gets "deny always wins" structurally, where Claude Code gets it by evaluation order), fail-closed when unattended. **None of these cost UX** — the ledger's scoping is what makes `ask` cheap.

## What it drops

The mandatory declaration. No competitor requires declaring a capability before it can be requested; all gate at the moment of use. This is **ceremony-by-default, not security-by-default** — removing it leaves the just-in-time gate untouched. It becomes required only in the strict postures.

## The dependency the proposal does not hide

`bounded` — the mode that produces most of the UX win — **cannot be built on reyn's current sandbox defaults.** Owner ruling #3901 set every non-`write` axis open by default, so deleting the prompt against that boundary deletes the gate rather than the friction.

That ruling is not being challenged: it answers "what should a sandbox do behind an already-permitted action", and `bounded` asks "what may replace the permission question". Different subject, so `bounded` carries its own policy preset and #3901's default stays in force everywhere else. The owner still has to rule on that preset (§9.3).

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py`
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped — docs-only PR, no `src/` or `tests/` change)

Note: `proposals/README.md` was already missing a row for 0068 before this PR; I added only 0069's row rather than fill in a proposal whose status I have not checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow