### PR TITLE
fix(#5815): boundary seq is a WAL position, not an owner -- stop asserting uniqueness, add a scoped read path

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2334,7 +2334,10 @@ class AgentRegistry:
             )
         return await self.checkout(target_n, scope=GLOBAL_SCOPE)
 
-    def list_rewind_points(self, *, include_abandoned: bool = False) -> list[dict]:
+    def list_rewind_points(
+        self, *, include_abandoned: bool = False,
+        scope: "tuple[str, str] | None" = None,
+    ) -> list[dict]:
         """Enumerate rewind targets for the time-travel UI (1f / Phase-2 fork).
 
         Returns one row per snapshot-generation boundary, ascending by seq::
@@ -2374,24 +2377,33 @@ class AgentRegistry:
         disk+in-memory discovery the rewind materialiser already depends
         on for crash recovery) now supplies every sid to fold in.
 
-        A boundary seq is *architecturally* the origin of exactly one
-        ``(name, sid)`` pair (a WAL entry belongs to one session's own
-        turn/step by construction — the same "seq is globally unique per
-        event" property today's per-agent union already relies on).
-        **Architecturally guaranteed is not the same as checked** (#5782
-        review, architect BLOCKING): this method used to look the pair up
-        with ``.get(s, _DEFAULT_SID)``, which — had the invariant ever been
-        violated by a future bug — would have silently handed back
-        ``"main"``: not a placeholder, a REAL session's own name, wired
-        straight into the row the operator clicks to choose which session
-        to rewind. That is the exact "answer from a fallback instead of
-        admitting the owner can't be named" shape decision 7 (ADR-0047)
-        already forbids — it had simply reappeared inside this row instead
-        of a scope predicate. So the lookup is now checked, not assumed:
-        a seq claimed by two DIFFERING ``(name, sid)`` pairs is logged
-        (this should never happen) and ``name``/``sid`` come back ``None``
-        for that row rather than either owner's real value — an admitted
-        "don't know", never a fabricated one. The pair also travels
+        #5815 (real-world correction, owner incident): a boundary seq is
+        NOT the origin of exactly one ``(name, sid)`` pair — that was
+        this docstring's own false claim until measured otherwise.
+        ``applied_seq`` records the WAL POSITION at the moment a
+        generation was written, not an event this ROW's own agent
+        uniquely owns; a THIRD agent's unrelated WAL entry at that same
+        position is a routine coincidence, not a violation, and any
+        number of agents recording a generation at that same position is
+        exactly as routine (confirmed: ``gen-<seq>.json`` existed for
+        BOTH ``coder-brown`` and ``coder-smith`` at the SAME seq, whose
+        WAL entry belonged to a third agent, ``default``, entirely).
+        **This method used to look the pair up with ``.get(s,
+        _DEFAULT_SID)``** (#5782 review, architect BLOCKING), which — on
+        one of these genuinely routine multi-owner seqs — would have
+        silently handed back ``"main"``: not a placeholder, a REAL
+        session's own name, wired straight into the row the operator
+        clicks to choose which session to rewind. That is the exact
+        "answer from a fallback instead of admitting the owner can't be
+        named" shape decision 7 (ADR-0047) already forbids. So the lookup
+        is checked, not assumed: a seq claimed by two DIFFERING ``(name,
+        sid)`` pairs (routine, #5815 — not an anomaly) is logged and
+        ``name``/``sid`` come back ``None`` for that row rather than
+        either owner's real value — an admitted "don't know", never a
+        fabricated one. (Which row's OWNER derivation should read here
+        instead — e.g. keying by ``(agent, sid, seq)`` — is #5815's own
+        open design question; this docstring only stops asserting a
+        uniqueness that measurement disproved.) The pair also travels
         TOGETHER on one row (not ``sid`` alone) — a consumer that obtained
         ``name`` from a different source (e.g. "whichever agent tab is
         open") could otherwise present a ``(name, sid)`` combination that
@@ -2403,6 +2415,23 @@ class AgentRegistry:
         a column, a filter) is a presentation decision left to whoever
         wires the timeline UI to it (owner-gated) — not decided here.
 
+        #5815 (2): ``scope`` (optional, ``None`` = today's cross-agent
+        union, unchanged) lets a caller ask for ONE session's own rows
+        directly — sourced from THAT session's own generation store alone,
+        never a cross-store union. The row unit for a scoped call is
+        genuinely ``(agent, sid, seq)``: every seq that store ever
+        recorded, each row's owner being ``scope`` itself, by
+        construction — there is no second store's claim to disagree with,
+        so the multi-owner ambiguity below cannot arise for a scoped call
+        at all (architect ruling, #5815: "``applied_seq`` は位置であって
+        持ち主ではない。位置から持ち主を引く読み手を作らない" — a scoped
+        call never asks "who owns position N", only "what did MY store
+        record"). No existing caller passes ``scope`` yet — which view
+        (global vs session-local) the UI shows is the owner-gated
+        presentation decision this docstring's own scope boundary already
+        names; this parameter only makes the session-local shape
+        available to whoever that decision lands with.
+
         Empty when there is no WAL or no generations.
         """
         if self._state_log is None:
@@ -2413,6 +2442,24 @@ class AgentRegistry:
         # construction. Points below this floor would always be
         # rejected by checkout — advertising them is misleading.
         oldest_seq = self._oldest_kept_seq()
+
+        if scope is not None:
+            # #5815 (1)(2): sourced from ONE store -- see this method's
+            # own docstring for why this branch structurally cannot hit
+            # the multi-owner ambiguity the unscoped branch below still
+            # has to detect.
+            name, sid = scope
+            is_active = build_active_predicate(self._state_log, scope=scope)
+            scoped_seqs = {
+                s for s in self._store_for(name, sid).seqs()
+                if not (oldest_seq is not None and s < oldest_seq)
+                and (include_abandoned or is_active(s))
+            }
+            if not scoped_seqs:
+                return []
+            return self._rewind_rows(
+                scoped_seqs, dict.fromkeys(scoped_seqs, scope), oldest_seq,
+            )
 
         # Union of generation boundary seqs across every known agent AND every
         # sid of each (#5769 stage 3 ③ — was agent-default-sid-only through
@@ -2444,29 +2491,49 @@ class AgentRegistry:
                         continue  # #2236: truncated out of WAL — not reachable
                     if include_abandoned or is_active(s):
                         seqs.add(s)
-                        # A boundary seq is the origin of exactly one (name,
-                        # sid) pair by construction (see this method's own
-                        # docstring) — this SHOULD never fire. #5769 stage 3
+                        # #5815: a boundary seq CAN be claimed by more than
+                        # one (name, sid) pair — this fires ROUTINELY
+                        # (measured: multiple agents recording a generation
+                        # at the same WAL position, itself often a THIRD
+                        # agent's unrelated event; see this method's own
+                        # docstring for the real incident). #5769 stage 3
                         # ④ (architect's re-written acceptance item, #5782
                         # review): a seq without EXACTLY one owner must be
                         # represented AS SUCH — never a fabricated value, not
                         # even a first-seen-wins guess. So a second, DIFFERING
                         # claim flips the entry to ``None`` rather than
-                        # keeping either owner.
+                        # keeping either owner. (A caller that can name its
+                        # own scope avoids this branch entirely — see the
+                        # ``scope=`` parameter above.)
                         claim = (name, sid)
                         if s not in seq_owner:
                             seq_owner[s] = claim
                         elif seq_owner[s] is not None and seq_owner[s] != claim:
                             logger.warning(
                                 "list_rewind_points: seq %d claimed by both "
-                                "%r and %r — this should be structurally "
-                                "impossible; reporting no owner rather than "
-                                "either guess (see #5769 stage 3 ④)",
+                                "%r and %r — routine (#5815: applied_seq is a "
+                                "WAL position, not a uniquely-owned event), "
+                                "reporting no owner rather than either guess "
+                                "(see #5769 stage 3 ④)",
                                 s, seq_owner[s], claim,
                             )
                             seq_owner[s] = None
         if not seqs:
             return []
+        return self._rewind_rows(seqs, seq_owner, oldest_seq)
+
+    def _rewind_rows(
+        self, seqs: "set[int]", seq_owner: "dict[int, tuple[str, str] | None]",
+        oldest_seq: "int | None",
+    ) -> list[dict]:
+        """The shared row-assembly tail both branches of
+        :meth:`list_rewind_points` use — ``seq_owner`` already carries
+        each seq's owner (unambiguous by construction for the scoped
+        branch; possibly ``None`` for the unscoped branch's genuinely
+        ambiguous case, #5815). This function owns none of the ambiguity
+        logic itself, only the WAL/anchor/branch-id assembly common to
+        both."""
+        assert self._state_log is not None  # both callers already checked
 
         # One pass over the WAL to map boundary seq → (ts, kind). The audit
         # EventStore is NOT consulted — keeping WAL and audit decoupled.
@@ -2484,11 +2551,12 @@ class AgentRegistry:
         # scoped records), never one global tree blindly applied to every
         # owner's seqs (the same class of bug #5786 fixed for
         # `reconstruct`). `seq_owner` already has each seq's real owner
-        # (or `None` for the structurally-impossible ambiguous case, see
-        # above) -- grouped here and called once per owner, merged into
-        # one dict. An unresolved (`None`) owner gets `GLOBAL_SCOPE`: with
-        # no nameable owner to ask for, the global-only view is the
-        # honest "don't know" answer, not a guess (ADR-0047 decision 7).
+        # (or `None` for the ambiguous multiple-owner case -- routine,
+        # #5815, see the caller's own docstring) -- grouped here and
+        # called once per owner, merged into one dict. An unresolved
+        # (`None`) owner gets `GLOBAL_SCOPE`: with no nameable owner to
+        # ask for, the global-only view is the honest "don't know" answer,
+        # not a guess (ADR-0047 decision 7).
         by_owner: "dict[tuple[str, str] | None, list[int]]" = {}
         for s in seqs:
             by_owner.setdefault(seq_owner.get(s), []).append(s)
@@ -2509,11 +2577,11 @@ class AgentRegistry:
             # (a consumer sourcing ``name`` separately could otherwise
             # present a pair that never actually owned this seq). ``None``
             # for BOTH when ``seq_owner`` never saw exactly one claim for
-            # this seq (structurally shouldn't happen — see the method's
-            # own docstring) — an admitted "don't know", never the old
-            # ``.get(s, _DEFAULT_SID)`` fallback, which fabricated a REAL
-            # session's name ("main") for a row the operator clicks to
-            # choose which session to rewind.
+            # this seq -- routine for the unscoped caller (#5815, not a
+            # structural impossibility) -- an admitted "don't know", never
+            # the old ``.get(s, _DEFAULT_SID)`` fallback, which fabricated
+            # a REAL session's name ("main") for a row the operator clicks
+            # to choose which session to rewind.
             owner = seq_owner.get(s)
             owner_name, owner_sid = owner if owner is not None else (None, None)
             rows.append({

--- a/tests/core/test_registry_list_rewind_points_1f.py
+++ b/tests/core/test_registry_list_rewind_points_1f.py
@@ -303,15 +303,25 @@ async def test_list_rewind_points_reports_no_owner_on_conflicting_claims(tmp_pat
     """Tier 2: #5769 stage 3 (④, architect BLOCKING on #5782's own review) --
     a seq claimed by two DIFFERING (name, sid) pairs must come back with
     ``name`` AND ``sid`` both ``None``, never a fabricated guess (not even a
-    first-seen-wins one). This is architecturally impossible in production
-    (a WAL entry routes to exactly one session), so the setup forces the
-    conflict directly at the store layer -- the same shape a real defect
-    would take, without needing one.
+    first-seen-wins one).
 
-    Before this fix the lookup was ``seq_sid.get(s, _DEFAULT_SID)``: had the
-    invariant ever broken, it would have silently reported the row as
-    belonging to ``"main"`` -- a REAL session's own name wired into the very
-    row the operator clicks to choose which session to rewind."""
+    #5815 (real owner incident, correcting this docstring's own earlier
+    claim): this is NOT "architecturally impossible in production" --
+    ``applied_seq`` is the WAL POSITION at record time, not an event a
+    row's own agent uniquely owns, so two agents recording a generation at
+    the same position is ROUTINE (measured: ``gen-<seq>.json`` existed for
+    both ``coder-brown`` and ``coder-smith`` at a seq whose WAL entry
+    belonged to a third agent entirely). The setup below is the real
+    shape, not a synthetic forcing of an otherwise-impossible case.
+
+    Before this fix the lookup was ``seq_sid.get(s, _DEFAULT_SID)``: on a
+    genuinely routine multi-owner seq like this one, it would have
+    silently reported the row as belonging to ``"main"`` -- a REAL
+    session's own name wired into the very row the operator clicks to
+    choose which session to rewind. See
+    ``test_list_rewind_points_scoped_avoids_the_conflicting_claim_ambiguity``
+    below for #5815's own fix: a caller that can name its own scope avoids
+    this ambiguity entirely."""
     reg = _make_registry(tmp_path)
     _seed_agent(tmp_path, "alpha")
     _seed_agent(tmp_path, "beta")
@@ -330,3 +340,68 @@ async def test_list_rewind_points_reports_no_owner_on_conflicting_claims(tmp_pat
     # Exactly one row for the seq -- a conflict collapses to one "unknown
     # owner" row, it does not fan out into two.
     assert [r["seq"] for r in rows].count(shared_seq) == 1
+
+
+# ── #5815: scope= (session-local rows, sourced from ONE store) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_scoped_returns_only_that_sessions_own_rows(tmp_path) -> None:
+    """Tier 2: #5815 (1)(2), architect ruling -- ``scope=(name, sid)`` builds
+    the row list directly from THAT session's own generation store, not a
+    cross-agent union. Another agent's own boundary (even a numerically
+    HIGHER seq) must not appear."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    s_alpha = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_gen(reg, "alpha", s_alpha)
+    s_beta = await log.append("inbox_consume", target="beta", msg_id="m2")
+    _record_gen(reg, "beta", s_beta)
+
+    rows = reg.list_rewind_points(scope=("alpha", "main"))
+    assert [r["seq"] for r in rows] == [s_alpha]
+    assert rows[0]["name"] == "alpha"
+    assert rows[0]["sid"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_scoped_avoids_the_conflicting_claim_ambiguity(tmp_path) -> None:
+    """Tier 2: #5815 (1)(2), the actual fix -- the SAME multi-owner seq that
+    forces ``name``/``sid`` to ``None`` for the unscoped caller (see
+    ``test_list_rewind_points_reports_no_owner_on_conflicting_claims``
+    above) comes back FULLY OWNED when the caller names its own scope: a
+    scoped call only ever reads its own store, so there is no second
+    store's claim to collide with. Real-content witness (not "no
+    warning"): the row's ``name``/``sid`` are the real scope, never
+    ``None``."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    _seed_agent(tmp_path, "beta")
+    log = reg.state_log
+
+    shared_seq = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_gen(reg, "alpha", shared_seq)
+    _record_gen(reg, "beta", shared_seq)  # same seq, a DIFFERENT (name, sid)
+
+    rows = reg.list_rewind_points(scope=("alpha", "main"))
+    (row,) = rows
+    assert row["seq"] == shared_seq
+    assert row["name"] == "alpha", f"a scoped call must never report None -- got {row}"
+    assert row["sid"] == "main", f"a scoped call must never report None -- got {row}"
+
+
+@pytest.mark.asyncio
+async def test_list_rewind_points_scoped_empty_store_returns_empty(tmp_path) -> None:
+    """Tier 2: #5815 -- a scope with no generations of its own returns an
+    empty list, not another session's rows."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+    s = await log.append("inbox_consume", target="alpha", msg_id="m1")
+    _record_gen(reg, "alpha", s)
+
+    rows = reg.list_rewind_points(scope=("alpha", "sub-never-used"))
+    assert rows == []


### PR DESCRIPTION
**[e2e-coder]**

Closes #5815

Architect ruling (verbatim, relayed): "applied_seq は位置であって持ち主ではない。位置から持ち主を引く読み手を作らない" (applied_seq is a POSITION, not an OWNER — don't build a reader that derives an owner from a position).

Real owner incident: `list_rewind_points` reported "seq 3051 claimed by both ('coder-brown','main') and ('coder-smith','main')". Measured: `gen-3051.json` genuinely exists for both agents, and WAL seq 3051's own entry belongs to a THIRD agent entirely — multiple agents recording a generation at the same position is routine, not a violation.

**Prose corrected (5 sites)**: every "exactly one pair by construction" / "structurally impossible" / "architecturally impossible in production" claim was false and dangerous (the next reader designs on a disproven premise) — fixed in the method's docstring, both inline comments at the detection site, the log message, and the pre-existing test's own docstring.

**Mechanism (architect's items 1+2)**: new optional `scope=(name, sid)` parameter on `list_rewind_points` — when given, rows are sourced from ONE session's own store alone, so the multi-owner ambiguity cannot arise (no second store to disagree with). The pre-existing unscoped path (today's default, still what every real caller passes) is untouched behaviorally — the `None`-fallback stays exactly as-is (architect: the branch we called "impossible" was actually the only detector — kept alive for the case the mechanism doesn't yet eliminate).

**(3) Not decided here**: which view (global vs session-local) the UI presents is an owner-gated presentation decision (ADR-0047's own split) — no existing call site touched, `rewind.py` included.

**Out of scope**: `applied_seq`'s own two-meanings problem is split to #5816, not touched here.

### Test plan
- [x] 3 new tests: scoped call returns only that session's own rows; the SAME multi-owner seq that forces `None`/`None` unscoped comes back fully owned scoped; empty scope returns `[]`
- [x] Strip-falsified: disabled the new branch — all 3 new tests go RED; restored, reconfirmed green
- [x] mypy_ratchet caught a genuine `[no-redef]` (fixed with a distinct variable name, not suppressed)
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] Regression sweep: `tests/core` rewind/checkout/registry/pipeline keyword scope — 651+ passed, 0 failed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51