### PR TITLE
fix(#5818): wire sandbox.mode into resolve_sandbox_policy's production call sites

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -524,9 +524,24 @@ def _warn_unknown_config_keys(
             policy_raw if isinstance(policy_raw, dict) else None,
             write_paths=[], mode=str(mode),
         )
+        # #5818 (owner-hit, security): was "... in force right now" — a claim
+        # this function cannot actually back. `write_paths=[]` above is a
+        # diagnostic stand-in (this loader has no op in flight to read a
+        # real workspace floor from — the SAME "a context-free reader must
+        # not fabricate a per-op value" reasoning `router_op_context.py`'s
+        # own `sandbox_config` docstring states, #5012-A), so the write axis
+        # in `resolved` never reflects what any real op actually gets. Worse,
+        # before #5818 this message's own claim was false for EVERY axis:
+        # `sandbox.mode: strict` validated and reached this message, but
+        # never reached the production resolver at all — an operator could
+        # read "in force right now" here while the real op context ran
+        # under `compat`. Reworded to describe what this CONFIG resolves
+        # to, never what is live.
         lines.append(
-            f"Effective sandbox policy in force right now (unknown keys "
-            f"above are excluded from it): {resolved!r}"
+            f"Sandbox policy this config resolves to (unknown keys above are "
+            f"excluded from it; write_paths shown as [] here — the real "
+            f"per-op value is assigned at runtime, not visible to this "
+            f"loader): {resolved!r}"
         )
 
     log.warning("Unrecognized config key(s) found:\n" + "\n".join(f"  - {line}" for line in lines))

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -189,11 +189,22 @@ def build_router_op_context(
         sandbox_backend=sandbox_backend,
         # #1339: resolve the operator-or-default sandbox policy (was None → the
         # op_runtime handler fell back to LLM-set op fields = sandbox-escape gap).
+        # #5818 (owner-hit, security): `mode=` is now REQUIRED on the callee (no
+        # default) — this is the fix. Before this, `sandbox.mode: strict`
+        # validated and was documented but never reached the resolver: this
+        # call site silently relied on `resolve_sandbox_policy`'s own former
+        # "compat" default regardless of what the operator configured.
+        # `sandbox_config` can genuinely be None (no operator sandbox config
+        # wired at all, e.g. a bare test session) — "compat" there is an
+        # explicit decision (nothing to read strict FROM), not a silent
+        # fallback: this ternary is the ONE place that decision is made, not
+        # a repeat of the callee's old default.
         default_sandbox_policy=resolve_sandbox_policy(
             sandbox_policy,
             write_paths=[str(workspace.base_dir)],
             temp_dir=child_temp_dir_fn() if child_temp_dir_fn is not None else child_temp_dir,
             temp_source="session",
+            mode=sandbox_config.mode if sandbox_config is not None else "compat",
         ),
         cancel_event=cancel_event,
         ephemeral=ephemeral,

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -730,9 +730,22 @@ def resolve_sandbox_policy(
     write_paths: list[str] | None = None,
     temp_dir: str = "",
     temp_source: str = "inherited",
-    mode: str = "compat",
+    mode: str,
 ) -> dict:
     """Resolve the effective agent-level sandbox policy as a dict.
+
+    #5818 (owner-hit, security): ``mode`` has NO default — every caller must
+    pass it explicitly. It used to default to ``"compat"``, and both
+    production call sites (``router_op_context.py``, ``tools/exec.py``)
+    silently relied on that default instead of threading the operator's own
+    ``sandbox.mode``: ``sandbox.mode: strict`` validated, was documented,
+    and never once reached this function at runtime — the effective policy
+    was always ``compat`` regardless of what an operator configured. Making
+    the omission a ``TypeError`` (this repo's own established pattern for
+    "a silent fallback caused real harm" — #5772/#5784/#5778/#5783/#5788/
+    #5805 closed the identical shape 5 times the same night) is what makes
+    a FUTURE call site's own accidental omission impossible to write, not
+    merely unlikely.
 
     The concrete DEFAULT is a **floor** (never None) so the op_runtime handler
     always applies an operator-or-default policy and the LLM-supplied op fields

--- a/src/reyn/tools/exec.py
+++ b/src/reyn/tools/exec.py
@@ -161,7 +161,24 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
         # operator config to merge here — there's genuinely nothing to read
         # it from on this path) rather than leaving this one path uniquely
         # computed from op fields alone.
-        default_sandbox_policy=resolve_sandbox_policy(None),
+        #
+        # #5818 (owner-hit, security, lead-coder ruling): `mode="compat"` is
+        # explicit here, not read from `sandbox_config.mode` — this
+        # construction point (reached only when `rs is None` or `rs.op_
+        # context_factory is None`, i.e. no real router/host context at
+        # all) never reaches reyn.yaml, so `sandbox_config` above is never
+        # more than a `SandboxConfig(backend=backend)` synthesized from a
+        # backend NAME alone; its `.mode` is always the dataclass default,
+        # never the operator's real setting. The construction point that
+        # DOES have the real config is `router_op_context.py`'s own
+        # `build_router_op_context` (already fixed this issue) — reached
+        # here too, first, via `rs.op_context_factory` above, whenever a
+        # real host exists. Naming `mode=sandbox_config.mode` here instead
+        # would make this ONE path claim to honor an operator's `strict`
+        # setting it structurally cannot see — the setting would silently
+        # stay unenforced while `default_sandbox_policy` reported "compat"
+        # as if that were the operator's real, deliberate choice.
+        default_sandbox_policy=resolve_sandbox_policy(None, mode="compat"),
     )
 
 

--- a/tests/config/test_4174_t0_unknown_config_key_warn.py
+++ b/tests/config/test_4174_t0_unknown_config_key_warn.py
@@ -84,10 +84,18 @@ def test_unknown_sandbox_policy_key_warning_names_the_effective_policy(
     tmp_path, caplog,
 ) -> None:
     """Tier 2: #4174 T0 — lead-coder's condition ①: an unknown sandbox.policy
-    key's warning names the EFFECTIVE resolved policy alongside the
-    unknown-key notice, since dropping a policy key makes the config
-    LOOSER (not silently inert like an ordinary dropped key) — an operator
-    relying on it must see what's actually in force."""
+    key's warning names the resolved policy alongside the unknown-key
+    notice, since dropping a policy key makes the config LOOSER (not
+    silently inert like an ordinary dropped key) — an operator relying on
+    it must see what this config resolves to.
+
+    #5818 (owner-hit, security): the message used to say "Effective
+    sandbox policy in force right now" — a claim this function cannot back
+    (write_paths is always a diagnostic `[]` here, never the real per-op
+    value, and — separately, the actual owner-hit — `sandbox.mode: strict`
+    never reached the real production resolver at all before #5818's own
+    fix). Reworded to "Sandbox policy this config resolves to", matching
+    what this function can actually verify."""
     cfg = _load(
         tmp_path,
         "sandbox:\n"
@@ -101,9 +109,9 @@ def test_unknown_sandbox_policy_key_warning_names_the_effective_policy(
     assert any(
         "sandbox.policy.typo_field_name" in m and "NOT APPLIED" in m for m in messages
     ), messages
-    assert any("Effective sandbox policy" in m and "network" in m for m in messages), (
-        messages
-    )
+    assert any(
+        "Sandbox policy this config resolves to" in m and "network" in m for m in messages
+    ), messages
 
 
 def test_a_removed_top_level_key_warns_delete_not_rewrite(tmp_path, caplog) -> None:

--- a/tests/core/test_5818_router_op_context_strict_mode_wiring.py
+++ b/tests/core/test_5818_router_op_context_strict_mode_wiring.py
@@ -1,0 +1,105 @@
+"""Tier 2: #5818 -- ``sandbox.mode: strict`` actually reaches a real,
+production op context (owner-hit, security).
+
+Owner-hit: ``sandbox.mode: strict`` validated, was implemented
+(``_SANDBOX_STRICT_MODE_DEFAULTS``, ``policy.py``), and was documented --
+but no production call site ever passed ``mode=`` to
+``resolve_sandbox_policy``, so the resolved policy was ALWAYS ``compat``
+regardless of what an operator configured (architect's own real
+end-to-end measurement, #5818). Real ``Session``/``RouterHostAdapter`` --
+no mocks: this test drives the SAME
+``build_router_op_context``/``RouterOpContextSource`` path a real
+``reyn chat`` turn uses.
+
+Per architect's own explicit acceptance criterion: "the production call
+site strip-falsifies red" -- pinned by this file's own falsify note (see
+each test's own docstring) rather than merely asserting the field got
+filled (filled is not a witness that it is ENFORCED --
+test_sandbox_model_completion_1339.py's own established convention for
+this exact class of defect).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config import SandboxConfig
+from reyn.core.events.state_log import StateLog
+from tests._support.agent_session import make_session
+
+
+def _session(tmp_path: Path, *, sandbox_config: "SandboxConfig | None"):
+    return make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        sandbox_config=sandbox_config,
+    )
+
+
+def test_strict_mode_op_context_has_the_real_policy(tmp_path) -> None:
+    """Tier 2: a real Session constructed with ``SandboxConfig(mode="strict")``
+    produces a real chat-router OpContext whose ``default_sandbox_policy``
+    genuinely has network off / subprocess denied / env allow-list empty --
+    not merely a filled-in placeholder.
+
+    Falsify note (verified in-file, Edit-only, per this session's own
+    established discipline): reverting ``router_op_context.py``'s own
+    ``mode=sandbox_config.mode if sandbox_config is not None else "compat"``
+    kwarg back to omitted turns this RED (``network`` reads ``True``, the
+    compat default, instead of ``False``) -- the exact pre-#5818 defect."""
+    session = _session(tmp_path, sandbox_config=SandboxConfig(mode="strict"))
+    pol = session._make_router_op_context().default_sandbox_policy
+    assert pol is not None
+    assert pol["network"] is False
+    assert pol["deny_subprocess"] is True
+    assert pol["allow_env_names"] == []
+
+
+def test_compat_mode_op_context_keeps_the_pre_5818_default(tmp_path) -> None:
+    """Tier 2: acceptance criterion ③ -- ``compat``'s own default behavior
+    does not change by a single bit. Same real session/op-context path as
+    the strict-leg test above, ``mode`` omitted from ``SandboxConfig`` (its
+    own dataclass default), mirroring
+    ``test_chat_session_factory_resolves_concrete_policy``'s own established
+    assertion in ``test_sandbox_model_completion_1339.py``."""
+    from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
+
+    session = _session(tmp_path, sandbox_config=None)
+    pol = session._make_router_op_context().default_sandbox_policy
+    assert pol is not None
+    assert pol["network"] is DEFAULT_SANDBOX_NETWORK
+    assert "deny_subprocess" not in pol
+
+
+def test_strict_mode_yields_to_an_explicit_operator_network_allow(tmp_path) -> None:
+    """Tier 2: mode never decides DIRECTION -- an explicit operator
+    ``sandbox.policy.network: true`` under ``mode: strict`` still wins
+    (mirrors ``test_strict_mode_default_yields_to_an_explicit_operator_
+    allow``'s own established witness in ``test_sandbox_factory.py``, but
+    through the REAL production op-context path rather than a bare
+    ``resolve_sandbox_policy`` call)."""
+    session = _session(
+        tmp_path,
+        sandbox_config=SandboxConfig(mode="strict", policy={"network": True}),
+    )
+    pol = session._make_router_op_context().default_sandbox_policy
+    assert pol is not None
+    assert pol["network"] is True
+    # the OTHER strict-mode axes the operator did NOT write still apply.
+    assert pol["deny_subprocess"] is True
+
+
+def test_resolve_sandbox_policy_rejects_an_omitted_mode() -> None:
+    """Tier 2: acceptance criterion ② -- omitting ``mode`` is a ``TypeError``,
+    not a silent ``"compat"`` fallback (this repo's own established pattern
+    for "a caller silently falling back to a default caused real harm" --
+    5 identical closures the same night: ``build_active_predicate``,
+    ``checkout``, ``resume``, ``latest_pipeline_state``, ``_load_yaml``).
+    A future call site cannot reintroduce this issue's own root cause by
+    simply forgetting the keyword."""
+    from reyn.security.sandbox.policy import resolve_sandbox_policy
+
+    with pytest.raises(TypeError):
+        resolve_sandbox_policy(None, write_paths=["/repo"])  # type: ignore[call-arg]

--- a/tests/core/test_sandbox_model_completion_1339.py
+++ b/tests/core/test_sandbox_model_completion_1339.py
@@ -37,7 +37,7 @@ def test_resolve_returns_default_when_config_none():
     from the floor dict entirely now, so ``SandboxPolicy(**floor)`` falls
     through to the dataclass's own (now-empty) default. An operator who
     wants the old defense-in-depth back sets ``read_deny_paths`` explicitly."""
-    pol = resolve_sandbox_policy(None, write_paths=["/ws"])
+    pol = resolve_sandbox_policy(None, write_paths=["/ws"], mode="compat")
     assert pol["network"] is DEFAULT_SANDBOX_NETWORK
     assert pol["write_paths"] == ["/ws"]
     assert "read_deny_paths" not in pol
@@ -52,7 +52,7 @@ def test_resolve_merges_operator_config_onto_floor():
     # from the internal SandboxPolicy field name/sense — subprocess=False
     # means denied, translated internally to deny_subprocess=True) —
     # write_paths (caller) must survive (the #2964 silent-drop bug).
-    merged = resolve_sandbox_policy({"subprocess": False}, write_paths=["/ws"])
+    merged = resolve_sandbox_policy({"subprocess": False}, write_paths=["/ws"], mode="compat")
     assert merged["deny_subprocess"] is True          # operator field applied
     assert merged["write_paths"] == ["/ws"]           # caller value SURVIVES (was dropped)
     assert merged["network"] is DEFAULT_SANDBOX_NETWORK
@@ -60,7 +60,7 @@ def test_resolve_merges_operator_config_onto_floor():
 
 def test_resolve_operator_written_field_overrides_floor():
     """Tier 2: #2964 —a field the operator DID write wins over the floor."""
-    merged = resolve_sandbox_policy({"network": False}, write_paths=["/ws"])
+    merged = resolve_sandbox_policy({"network": False}, write_paths=["/ws"], mode="compat")
     assert merged["network"] is False                 # operator override wins
     assert merged["write_paths"] == ["/ws"]           # unwritten field keeps floor
 
@@ -70,8 +70,8 @@ def test_resolve_explicit_empty_write_paths_is_respected_not_defaulted():
     (the operator deliberately granted nothing), distinct from OMITTING it
     (which keeps the caller's value). dict-key presence expresses the
     explicit-empty-vs-omitted distinction the merge hinges on."""
-    explicit_empty = resolve_sandbox_policy({"allow_write_paths": []}, write_paths=["/ws"])
-    omitted = resolve_sandbox_policy({"network": False}, write_paths=["/ws"])
+    explicit_empty = resolve_sandbox_policy({"allow_write_paths": []}, write_paths=["/ws"], mode="compat")
+    omitted = resolve_sandbox_policy({"network": False}, write_paths=["/ws"], mode="compat")
     assert explicit_empty["write_paths"] == []        # deliberate empty grant respected
     assert omitted["write_paths"] == ["/ws"]          # omission keeps the floor
 

--- a/tests/security/test_sandbox_factory.py
+++ b/tests/security/test_sandbox_factory.py
@@ -76,10 +76,21 @@ def test_config_accepts_compat_mode():
 
 def test_config_accepts_strict_mode_and_resolves_it() -> None:
     """Tier 2: #3823 — 'strict' is now WIRED (was: raised "not implemented
-    yet" — the earlier #3823 ② stub). Real end-to-end: a SandboxConfig with
-    mode='strict' validates, AND resolve_sandbox_policy actually applies the
-    strict defaults (network off, subprocess denied, env allow-list empty) —
-    not just "the enum accepts the string"."""
+    yet" — the earlier #3823 ② stub): a SandboxConfig with mode='strict'
+    validates, AND resolve_sandbox_policy actually applies the strict
+    defaults (network off, subprocess denied, env allow-list empty) — not
+    just "the enum accepts the string".
+
+    #5818 (BLOCKING correction, architect + lead-coder review): this
+    test's docstring used to claim "Real end-to-end" — false. This test's
+    OWN line below (`mode=cfg.mode`) is what connects `cfg` to the
+    resolver; no PRODUCTION call site was ever exercised here, so deleting
+    every real caller of `resolve_sandbox_policy` in `src/` would leave
+    this test green. It is a genuine, valuable Tier 2 unit test of
+    `resolve_sandbox_policy`'s OWN mode-handling contract — but that is
+    ALL it is. The real end-to-end witness (a production op context, strip-
+    falsifiable) is
+    ``test_router_op_context_strict_mode_wiring.py``'s own test."""
     from reyn.security.sandbox.policy import resolve_sandbox_policy
 
     cfg = SandboxConfig(mode="strict")


### PR DESCRIPTION
**[tui-coder]** — Closes #5818

## What happened

Owner-hit, security: `sandbox.mode: strict` validated (`config/infra.py`), was implemented (`_SANDBOX_STRICT_MODE_DEFAULTS`, `security/sandbox/policy.py`), and was documented — but `resolve_sandbox_policy`'s own `mode` kwarg defaulted to `"compat"` and **neither production call site ever passed it explicitly**. The resolved policy was always `compat` regardless of what an operator configured; the only visible effect of setting `sandbox.mode: strict` was a changed warning-message string, which itself claimed the strict policy was "in force right now" while it never reached the real resolver at all (architect's real end-to-end measurement, #5818).

## Fix (lead-coder ruling: (A) wire it, `mode` becomes a required keyword)

- **`security/sandbox/policy.py`**: `resolve_sandbox_policy`'s `mode` kwarg has **no default** any more — every caller must decide explicitly. Same "make the omission a `TypeError`" pattern this repo closed 5 times tonight for the identical "caller silently falls back to a default" shape (`build_active_predicate` #5772, `checkout` #5784, `resume` #5778/#5783, `latest_pipeline_state` #5788, `_load_yaml` #5805).
- **`runtime/router_op_context.py`**: wires `sandbox_config.mode` into the real chat-router op-context path (`build_router_op_context`) — the path every real `reyn chat` / `reyn pipe run` op dispatch actually uses. `sandbox_config is None` (no operator config wired at all) explicitly resolves to `mode="compat"` — a decision made at the one call site that can make it, not a repeat of the callee's old default.
- **`tools/exec.py`**: the "minimal synthesis" bridge (reached only when there is no real router/host context at all — self-documented as "test sites / narrow callers") now passes `mode="compat"` **explicitly**, with a comment naming what breaks if this were read from the synthesized `sandbox_config` instead: that object never has a real `.policy` (it's built from a backend NAME alone, `SandboxConfig(backend=backend)`), so claiming its `.mode` would make this ONE path assert an operator's `strict` setting it structurally cannot see — the setting would stay silently unenforced while `default_sandbox_policy` reported `"compat"` as the operator's real, deliberate choice.
- **`config/loader.py`**: corrected the unknown-sandbox-key warning's own message — "Effective sandbox policy in force right now" was false on two counts: (1) `write_paths` in that message is always a diagnostic `[]` stand-in (this loader has no op in flight to read a real workspace floor from, #5012-A's own established "context-free reader must not fabricate" reasoning), (2) before this fix, `sandbox.mode: strict` never reached the real production resolver at all, so an operator could read "in force right now" while the real op context ran under `compat`. Reworded to "Sandbox policy this config resolves to".
- **`tests/security/test_sandbox_factory.py`**: corrected `test_config_accepts_strict_mode_and_resolves_it`'s own docstring overclaim ("Real end-to-end") — its own `mode=cfg.mode` line is what connects config to resolver, not any production call site; still a genuine, valuable Tier 2 unit test of `resolve_sandbox_policy`'s own contract, now honestly scoped.
- **New `tests/core/test_5818_router_op_context_strict_mode_wiring.py`**: real `Session` + real `SandboxConfig(mode="strict")`, driving the actual `build_router_op_context` path end-to-end.
- Fixed 5 existing `tests/core/test_sandbox_model_completion_1339.py` call sites that omitted `mode=`.

## Construction-site census (🔴 architect co-vet target — please falsify this)

Per lead-coder's explicit instruction: list which construction sites were actually looked at, not "I looked at everything". Every real `RouterCallerState` construction site in `src/` was traced:

- **`tools/types.py`'s `build_resource_caller_state`** — the one real op-dispatch caller, backed by a real `RouterHostAdapter.make_router_op_context()`, confirmed reaching the SAME `build_router_op_context` this PR fixes.
- **`interfaces/cli/commands/plugin.py`** — supplies its own `op_context_factory`.
- **`capability_visibility.py`** and **`runtime/router_tools.py`** — both catalog/MCP-listing-only constructions, confirmed to never dispatch an op (no `default_sandbox_policy` consumer downstream).

No other production construction site of `RouterCallerState` was found. This census is the specific claim architect's co-vet should try to falsify — a 5th real site with `op_context_factory=None` and a non-`None` `sandbox_backend` would mean the `tools/exec.py` "narrow path" branch this PR leaves at `mode="compat"` is reachable in production after all.

## Test plan

- [x] New `test_5818_router_op_context_strict_mode_wiring.py` (4 tests): strict mode genuinely resolves `network=False`/`deny_subprocess=True`/`allow_env_names=[]`; compat stays unchanged; an explicit operator `network: true` still wins under strict; an omitted `mode` is a `TypeError`.
- [x] Falsify-verified in-file (Edit-only): stripped `router_op_context.py`'s own `mode=` kwarg back to a hardcoded `"compat"` — 2 of the 4 new tests went red (the exact pre-#5818 defect reproduced), then restored, reconfirmed all green.
- [x] Full scoped regression: `test_sandbox_model_completion_1339.py`, `test_sandbox_factory.py`, `test_4174_t0_unknown_config_key_warn.py`, `test_5818_router_op_context_strict_mode_wiring.py` — 58 tests, 1 pre-existing Darwin-only skip, all green.
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (4 changed/new test files), `verify_module_docstrings.py` (4 changed src files), `mypy_ratchet.py` (200/208 baselined, no new findings), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (run after `git add`), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green.
- [ ] Visual — no UI surface; a config-resolution + warning-text fix.

## Acceptance (architect's list, verbatim)

1. `strict` actually changes the real policy (network off / subprocess deny / env empty) — ✅
2. Stripping the production call site turns a test red — ✅ (falsify-verified above)
3. `compat`'s own default behavior is unchanged — ✅
4. Omitting `mode` is a `TypeError` — ✅
5. `write` stays excluded from strict's own defaults — ✅ (unchanged, per lead-coder's explicit "don't touch this")

## Filed separately (NOT in this PR — lead-coder's explicit instruction)

This measurement surfaced a real, confirmed divergence between `ctx.sandbox_config` (display source, `describe_session`'s `write_scope`) and `ctx.default_sandbox_policy` (enforcement source) after `tools/exec.py`'s own `_with_sandbox_config` overwrite — reported to lead-coder for separate triage/filing, out of this PR's scope.

⚠️ **security PR — architect co-vet required before merge (lead-coder: "co-vet 無しでは merge しません").**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
