### PR TITLE
fix(#5816): applied_seq is a lower bound, not an exact position or an owner -- declare it, pin the dangerous direction

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -1,9 +1,11 @@
 """AgentSnapshot — per-agent state snapshot for crash recovery (PR21).
 
-Stores the agent's recovery-critical runtime state plus the WAL `seq`
-already absorbed (`applied_seq`). On restart, the registry replays WAL
-entries past every snapshot's `applied_seq`, then hands each agent its
-final snapshot to populate in-memory queues / dicts.
+Stores the agent's recovery-critical runtime state plus a WAL `seq`
+LOWER BOUND on what's already absorbed (`applied_seq` — see that field's
+own docstring, #5816: not the exact position, and not an ownership
+claim). On restart, the registry replays WAL entries past every
+snapshot's `applied_seq`, then hands each agent its final snapshot to
+populate in-memory queues / dicts.
 
 Atomic write: dump to `<path>.tmp`, fsync, rename. mid-write crash leaves
 the previous file intact.
@@ -56,9 +58,41 @@ class SchemaVersionError(Exception):
 class AgentSnapshot:
     """Recovery-critical state for one agent.
 
-    `applied_seq` is the highest WAL seq whose effects are already baked
-    into `inbox` / `pending_chains`. WAL replay applies events with
-    `seq > applied_seq`.
+    #5816 (architect ruling — read the FULL WAL `seq` reader census in
+    that issue before touching this field again): `applied_seq` is a
+    LOWER BOUND on absorption — "every WAL entry belonging to this
+    (agent, session) at `seq <= applied_seq` is already baked into
+    `inbox` / `pending_chains`." It is NOT the exact position of "this
+    agent's own last event", and NOT an ownership claim over that WAL
+    position — a WAL position has no single owner, only a set of
+    entries that happen to sit there (#5815: `gen-<seq>.json` existing
+    for two different agents at the SAME seq is routine, not a defect).
+    The prior wording here ("the **highest** WAL seq whose effects are
+    already baked in") read as an exact/tight claim — that reading is
+    what #5782 mistook this field for an OWNER, before #5815 corrected
+    the readers that relied on it.
+
+    Two real writers pick DIFFERENT, independently-safe values of P
+    satisfying the same one invariant: `SnapshotJournal` stamps the
+    GLOBAL WAL head at record time (never wrong to be too small —
+    everything after head, by definition, has not happened yet);
+    `apply_events` (below) stamps the last matching entry it actually
+    replayed (also never wrong to be too small — a caller that hands it
+    a gapless slice from `applied_seq + 1` never overshoots). Both
+    satisfy "P is a real, accurate-or-conservative lower bound"; neither
+    ever needs, or provides, "this agent's own last WAL entry"
+    specifically (0 real readers in `src/` ask for that — #5816's own
+    read-side census).
+
+    **The dangerous direction**: a writer that claims a HIGHER P than
+    what it actually absorbed permanently loses whatever WAL entry sits
+    between the real absorption point and the false P, the moment the
+    WAL truncates below it — see
+    `tests/core/test_5816_applied_seq_lower_bound_invariant.py`'s own
+    pin on `reconstruct()`'s gapless delta construction, the one thing
+    standing between this invariant and that hazard today.
+
+    WAL replay applies events with `seq > applied_seq`.
     """
 
     agent_name: str

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -43,6 +43,20 @@ class SnapshotGenerationStore:
         self._dir = Path(generations_dir)
 
     def _path_for(self, seq: int) -> Path:
+        """The on-disk path for the generation cut at WAL position ``seq``.
+
+        #5816/#5815: this builds a filename from a POSITION, not from an
+        owner — ``seq`` is whatever ``AgentSnapshot.applied_seq`` a caller
+        passes (itself a lower bound, never an exact/owned position, see
+        that field's own docstring). Multiple STORES (different agents'
+        own ``SnapshotGenerationStore`` instances, each rooted at that
+        agent's own ``generations_dir``) legitimately having a
+        ``gen-<seq>.json`` at the SAME ``seq`` is normal (#5815's own
+        finding: two agents' generations existed at the same WAL
+        position, whose own WAL entry belonged to a third agent
+        entirely) — this store never needs to disambiguate that, since
+        each store only ever reads/writes inside its own directory.
+        """
         return self._dir / f"gen-{seq}.json"
 
     def record(self, snapshot: AgentSnapshot) -> Path:

--- a/tests/core/test_2259_pr2b_crash_recovery_falsify.py
+++ b/tests/core/test_2259_pr2b_crash_recovery_falsify.py
@@ -91,12 +91,34 @@ async def test_crash_before_wal_durable_loses_the_undurable_tail(tmp_path):
 
 @pytest.mark.asyncio
 async def test_concurrent_journals_each_snapshot_keyed_to_own_wal_seq(tmp_path):
-    """Tier 2: invariant #2 under CONCURRENCY — two journals sharing one durability worker mutate
-    interleaved; each journal's snapshot.applied_seq == the seq of ITS OWN last WAL entry, never a
-    peer's interleaved entry. The (`_wal_append_nowait`, `save_nowait`) pair is enqueued with no
-    await between, so the worker can never slot a peer's WAL job between a journal's pair → the snap
-    job's `last_assigned_seq` read is always its own paired WAL seq. RED if a save_nowait stamped
-    applied_seq from a peer's interleaved last_assigned_seq."""
+    """Tier 2: invariant #2 under CONCURRENCY — two journals share ONE durability
+    worker while mutating interleaved.
+
+    #5816 (architect ruling — this test's own prose used to conflate two
+    different facts): ``save_nowait`` always stamps the GLOBAL
+    ``state_log.last_assigned_seq`` — never "this journal's own last
+    event" specifically (see ``AgentSnapshot.applied_seq``'s own
+    docstring: a lower bound, not an ownership claim). What actually
+    protects a journal's own stamp from a PEER's later, interleaved
+    append is a real mechanism, not "keyed to its own event": ``append_
+    inbox`` calls ``_wal_append_nowait`` then ``save_nowait`` with NO
+    ``await`` between them, so on this ONE shared serial worker those two
+    jobs are submitted, and therefore execute, ADJACENT to each other —
+    no other WAL-assigning job (a peer's own append included) can be
+    interleaved between a journal's own WAL-append job and its own
+    paired snapshot-save job. So by the time ja's snapshot-save job reads
+    ``last_assigned_seq``, the global head has not moved since ja's OWN
+    append assigned it. That the resulting stamped value therefore equals
+    a1's own last WAL entry's seq is the CONSEQUENCE of this mechanism in
+    THIS test's own construction (2 journals, each mutating only its own
+    entries) — not evidence that ``save_nowait`` reads anything scoped to
+    one agent. Verified load-bearing (#5816, strip-falsified by hand):
+    inserting a real ``await asyncio.sleep(0)`` between the WAL-append and
+    the snapshot mutation in ``append_inbox`` (breaking the "no await
+    between" half of the mechanism) turns this exact assertion RED.
+
+    RED if a save_nowait stamped applied_seq from a peer's interleaved
+    last_assigned_seq — i.e. if the adjacency mechanism above ever broke."""
     log = StateLog(tmp_path / "shared.wal")
     store_a = SnapshotGenerationStore("a1", tmp_path / "gen_a")
     store_b = SnapshotGenerationStore("a2", tmp_path / "gen_b")
@@ -126,14 +148,18 @@ async def test_concurrent_journals_each_snapshot_keyed_to_own_wal_seq(tmp_path):
     order = [e["target"] for e in entries if e.get("target") in ("a1", "a2")]
     assert "a1" in order[:3] and "a2" in order[:3], f"streams did not interleave: {order}"
 
-    # each journal's snapshot is keyed to its OWN last WAL entry — no peer seq bled across the pair.
+    # #5816: the no-await-between-pair + single-serial-worker adjacency (this
+    # test's own docstring) is what stamps the GLOBAL head undisturbed by a
+    # peer's later append -- in THIS construction (each journal mutating only
+    # its own entries) that global-head value equals a1's own last WAL seq.
     assert ja.snapshot.applied_seq == max(a_seqs), (
-        f"a1 snapshot applied_seq={ja.snapshot.applied_seq} must == a1's own last WAL seq "
-        f"{max(a_seqs)} (no cross-contamination from a2's interleaved pair)"
+        f"a1 snapshot applied_seq={ja.snapshot.applied_seq}, expected {max(a_seqs)} "
+        f"(the global head at a1's own save-job execution time -- a2's later, "
+        f"interleaved append must not have bled into it)"
     )
     assert jb.snapshot.applied_seq == max(b_seqs), (
-        f"a2 snapshot applied_seq={jb.snapshot.applied_seq} must == a2's own last WAL seq "
-        f"{max(b_seqs)}"
+        f"a2 snapshot applied_seq={jb.snapshot.applied_seq}, expected {max(b_seqs)} "
+        f"(the global head at a2's own save-job execution time)"
     )
 
 

--- a/tests/core/test_5816_applied_seq_lower_bound_invariant.py
+++ b/tests/core/test_5816_applied_seq_lower_bound_invariant.py
@@ -1,0 +1,188 @@
+"""Tier 2: OS invariant -- #5816, architect ruling on `AgentSnapshot.
+applied_seq`'s own contract.
+
+`applied_seq` is not an exact position and not an ownership claim -- it
+is a LOWER BOUND: "every WAL entry belonging to this agent at seq <= P is
+already absorbed." The two real writers (`SnapshotJournal`'s own
+`last_assigned_seq` stamp, and `AgentSnapshot.apply_events`'s own "last
+matching entry seen") both satisfy this same one invariant by picking
+different, independently-safe values for P -- see the issue's own
+architect-ruling comment for the full read-side census (`git grep -nE
+"applied_seq" -- src/` finds zero readers that need "this agent's last
+event" specifically).
+
+**The dangerous direction** (architect, verbatim): a writer must never
+claim a WAL position P as absorbed when an earlier, THIS-agent-owned
+entry at a LOWER seq was never actually applied -- once a generation
+recording that P is saved and the WAL truncates below it, that earlier
+entry is gone forever, with no error. The safe direction (P too small)
+only widens what gets re-replayed; harmless.
+
+`AgentSnapshot.apply_events` itself trusts its own input completely --
+it has no way to detect a GAP in the events it's handed (it only skips
+`seq <= self.applied_seq`, it never checks "did I see every matching
+seq back to my own applied_seq?"). The real protection today is
+entirely in how the two real callers (`reconstruct` /
+`AgentRegistry.restore_all`) BUILD that input: always starting the WAL
+slice at `base.applied_seq + 1` (or the global `min(applied_seq) + 1`
+for `restore_all`, safe because each snapshot's own `apply_events` still
+filters `seq <= self.applied_seq` per-agent) -- gapless by construction.
+This file pins THAT construction directly, on the real, reachable
+`reconstruct()` call (the architect's own named check, #5816 ②):
+nothing in this repo's test suite asserted it before this PR (measured:
+`git grep -n "apply_events" -- tests/` found 0 tests exercising a
+GAPPED delta).
+
+Real `AgentRegistry`/`StateLog`/`SnapshotGenerationStore` throughout --
+no mocks."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, reconstruct
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+def _seed_agent(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _put(log: StateLog, agent: str, msg_id: str) -> int:
+    return await log.append(
+        "inbox_put", target=agent, msg_id=msg_id, msg_kind="user",
+        payload={"text": msg_id},
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconstruct_replay_delta_starts_immediately_after_the_base_no_gap(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5816 -- the WAL entry immediately after a base generation's
+    own `applied_seq` must be absorbed, not skipped. Two real WAL events
+    for the SAME agent, both after the base: the NEARER one (at exactly
+    `base.applied_seq + 1`) is the one a gapped delta would silently
+    drop -- if it went missing, `applied_seq` would still advance past it
+    (to the farther event's own seq), permanently hiding its loss."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    base_seq = await _put(log, "alpha", "base")
+    store = reg._store_for("alpha")
+    base_snap = AgentSnapshot.empty("alpha")
+    base_snap.applied_seq = base_seq
+    store.record(base_snap)
+
+    near_seq = await _put(log, "alpha", "near")  # == base_seq + 1
+    far_seq = await _put(log, "alpha", "far")
+
+    snap = reconstruct("alpha", store, log, far_seq, scope=GLOBAL_SCOPE)
+
+    ids = [m["id"] for m in snap.inbox]
+    assert "near" in ids, (
+        f"the WAL entry immediately after the base generation must be absorbed -- "
+        f"got {ids!r} (a gap here silently, permanently loses it once the WAL "
+        f"truncates below the resulting generation's own applied_seq)"
+    )
+    assert "far" in ids
+    assert snap.applied_seq == far_seq
+
+
+@pytest.mark.asyncio
+async def test_apply_events_trusts_its_input_and_cannot_detect_a_withheld_own_event(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5816 -- names the hazard directly at the unit level (not
+    just "the two real callers happen to avoid it"): `apply_events` has
+    no mechanism of its own to refuse a gapped event list. Given ONLY a
+    later matching event (the earlier one withheld, simulating a
+    hypothetical future caller bug), it advances `applied_seq` to that
+    later seq while the withheld event's own effect is genuinely,
+    silently absent -- exactly the "claims P is absorbed when it isn't"
+    shape the architect's ruling names as dangerous. This is not a
+    defect in `apply_events` itself (its contract is "trust the caller",
+    documented) -- it is the reason the OTHER test in this file, pinning
+    the real callers' own gapless construction, is the actual guard."""
+    snap = AgentSnapshot(agent_name="alpha")
+    withheld = {
+        "kind": "inbox_put", "seq": 1, "target": "alpha",
+        "msg_id": "withheld", "msg_kind": "user", "payload": {},
+    }
+    seen = {
+        "kind": "inbox_put", "seq": 4, "target": "alpha",
+        "msg_id": "seen", "msg_kind": "user", "payload": {},
+    }
+
+    snap.apply_events([seen])  # `withheld` never passed -- the simulated gap
+
+    assert snap.applied_seq == 4, (
+        "apply_events advances to whatever seq it was actually given, with no "
+        "way to know a lower, matching seq existed and was withheld"
+    )
+    assert not any(m["id"] == "withheld" for m in snap.inbox), (
+        "the withheld event's own effect must be genuinely absent here -- this "
+        "IS the hazard: applied_seq=4 now silently claims seq 1 is absorbed too"
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_applied_seq_lower_bound_survives_wal_truncation(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: CLAUDE.md hard rule (recovery-feature PRs need a
+    truncate-falsify test) -- checked, and it DOES apply: this PR touches
+    the recovery-core invariant `applied_seq` documents. Set X (a
+    generation whose own `applied_seq` correctly reflects "near" already
+    absorbed) -> truncate the WAL past X's own supporting events -> assert
+    X survives (reconstructing again still shows "near", now sourced from
+    the SAVED generation, not the truncated-away raw WAL entry)."""
+    reg = _make_registry(tmp_path)
+    _seed_agent(tmp_path, "alpha")
+    log = reg.state_log
+
+    base_seq = await _put(log, "alpha", "base")
+    store = reg._store_for("alpha")
+    base_snap = AgentSnapshot.empty("alpha")
+    base_snap.applied_seq = base_seq
+    store.record(base_snap)
+
+    near_seq = await _put(log, "alpha", "near")
+    far_seq = await _put(log, "alpha", "far")
+
+    # X: a real generation correctly absorbing both -- applied_seq=far_seq
+    # is a real, accurate lower bound (both near and far are baked in).
+    materialized = reconstruct("alpha", store, log, far_seq, scope=GLOBAL_SCOPE)
+    store.record(materialized)
+
+    # Truncate the WAL past far_seq's own supporting events -- near_seq's
+    # raw WAL entry is now gone; only the saved generation remembers it.
+    await log.truncate_below(far_seq + 1)
+    await log.flush()
+
+    reconstructed_after_truncation = reconstruct(
+        "alpha", store, log, far_seq, scope=GLOBAL_SCOPE,
+    )
+    ids = [m["id"] for m in reconstructed_after_truncation.inbox]
+    assert "near" in ids, (
+        f"applied_seq's own lower-bound invariant must survive WAL truncation -- "
+        f"got {ids!r}"
+    )
+    assert "far" in ids
+    assert reconstructed_after_truncation.applied_seq == far_seq


### PR DESCRIPTION
**[e2e-coder]**

Closes #5816

Architect ruling (full read-side census): `applied_seq`'s two writers are NOT two meanings — 0 real readers need "this agent's own last event" specifically. Both satisfy one invariant at different tightness: `applied_seq` = a WAL position P where every entry belonging to this (agent, session) at seq <= P is already absorbed. The field's own docstring was wrong ("the **highest** WAL seq..." reads as exact/tight — the entry point for #5782's "owner" misreading, corrected by #5815).

**(1) Declare the invariant**: `AgentSnapshot.applied_seq`'s docstring rewritten as a lower bound, names both writers and why each is safe (errs small, never large), names the dangerous direction explicitly (claiming a higher P than actually absorbed → permanent loss on truncation). `_path_for` documented as "builds a filename from a position" — same-position multi-store is normal (#5815). On-disk format unchanged, 0 bytes.

**(2) The core of this issue**: measured first — 51 test files reference `applied_seq`, 0 assert the deprecated "last event" reading via a phrase-search, 0 exercise a gapped delta. 3 new tests: `apply_events` itself trusts its input (named, not fixed — its contract is "trust the caller"); `reconstruct()`'s WAL delta must be gapless from `base.applied_seq + 1` (the real, reachable protection today, unpinned before this PR); truncate-falsify (checked and applicable — recovery-core invariant).

**(3) Not touched**: #5815's own reader-side fix, on-disk migration, no new runtime guard inside `apply_events` (declare + pin per the ruling's own scope, not a contract redesign).

**(4) Census-lesson update (post-review)**: lead-coder-30's own single query (searching what `applied_seq` is *compared against*, not phrase-matching "last event") found `test_2259_pr2b_crash_recovery_falsify.py`'s `test_concurrent_journals_each_snapshot_keyed_to_own_wal_seq` pinning the deprecated "own last event" reading via `== max(a_seqs)` — my original file-count census missed it entirely. Investigated (not decided by me): confirmed `save_nowait` always stamps the GLOBAL head; the test's own real guarantee is the atomic append+save pair (no `await` between) making the two jobs adjacent on one shared serial worker, so no peer's later append can bleed in — a1's own last seq only *coincides* with the global head as a consequence of that mechanism, not because anything reads "this agent's last event". Verified load-bearing by hand (inserting a real `await asyncio.sleep(0)` between the WAL-append and the snapshot mutation turns the assertion RED). Reworded the docstring/comment/assert-messages to lead with the mechanism, not the conclusion — no assertion changed. **Census lesson**: grepped for phrases, not for what `applied_seq` is compared against.

### Test plan
- [x] Measured `tests/` first per architect's ask — 0 hits for the deprecated reading via phrase-search (methodology gap found post-review, see (4))
- [x] Strip-falsified: bumped `reconstruct`'s delta start by 1 (the exact gap shape) — both dependent tests go RED; restored, reconfirmed green
- [x] Strip-falsified (4): inserted a real `await asyncio.sleep(0)` breaking the atomic append+save pair — `test_2259`'s own assertion goes RED against both the original and the corrected prose; restored, reconfirmed green
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] Regression sweep: `tests/core` snapshot/reconstruct/rewind/checkout/restore/journal keyword scope — 229 passed, 0 failed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51