### PR TITLE
fix(#5820): stop the exec.py bridge from clobbering describe_session's write_scope

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -254,6 +254,21 @@ class OpContext:
     # DockerEnvironmentBackend bound to a specific container + host workspace)
     # that a name-based factory cannot construct. Generic: any caller owning such a resource may inject
     # one; None preserves the default name-based platform auto-selection.
+    #
+    # #5820 (scope correction, lead-coder review): this seam's own 2 real
+    # readers (``sandboxed_exec.py``, ``skill_install.py`` — both
+    # ``ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)``)
+    # never distinguish a genuinely stateful injected backend from one a
+    # caller resolved early by NAME through the SAME name-based table
+    # ``get_default_backend`` itself uses — "stateful" above names the
+    # motivating use case (why this seam exists at all), not a capability
+    # this field's readers gate on. ``tools/exec.py``'s bridge is such an
+    # early-resolved caller: it used to instead overwrite
+    # ``sandbox_config`` wholesale to thread a backend NAME through
+    # (#5820's own root cause — that overwrite clobbered the operator's
+    # declared policy `sandbox_config` also carries); it now resolves the
+    # name to an instance and sets THIS field instead, never touching
+    # ``sandbox_config`` post-construction.
     sandbox_backend: "SandboxBackend | None" = None
 
     # FP-0008 #1115 Stage 2 (D): phase-level default SandboxPolicy (dict of

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -233,10 +233,13 @@ async def _shallow_clone(git_url: str, dest: Path, ctx: OpContext) -> str | None
     The destination directory is REMOVED before cloning so this function
     is idempotent (re-install overwrites the previous clone).
 
-    Uses ``ctx.sandbox_backend`` (an injected stateful backend) or
-    ``get_default_backend(ctx.sandbox_config)`` for backend SELECTION (so the
-    operator's configured enforcement mechanism governs it, same as
-    ``sandboxed_exec``) but a purpose-built ``SandboxPolicy`` for this specific
+    Uses ``ctx.sandbox_backend`` (an injected instance — #5820: either a
+    genuinely stateful backend, or one a caller resolved early by NAME
+    through the same table ``get_default_backend`` uses; this read never
+    distinguishes the two) or ``get_default_backend(ctx.sandbox_config)``
+    for backend SELECTION (so the operator's configured enforcement
+    mechanism governs it, same as ``sandboxed_exec``) but a purpose-built
+    ``SandboxPolicy`` for this specific
     operation: ``network=True`` is not overridable here because cloning over
     the network is what the operation IS — an operator policy that forces
     ``network: false`` globally would make every git-sourced skill install

--- a/src/reyn/tools/exec.py
+++ b/src/reyn/tools/exec.py
@@ -99,34 +99,69 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
     reached this way) expects.
 
     Used by :func:`_handle` (the ``exec`` tool) — the
-    router_state → legacy-OpContext bridge (sandbox_config derivation +
-    op_context_factory-or-minimal-synthesis). #3226 Phase 1: the ``shell``
-    tool (:mod:`reyn.tools.shell`, #2593), which used to share this bridge,
-    was removed outright — it was the sole `/bin/sh -c <str>`
-    shell-injection surface in the codebase.
+    router_state → legacy-OpContext bridge (sandbox backend-instance
+    resolution + op_context_factory-or-minimal-synthesis). #3226 Phase 1:
+    the ``shell`` tool (:mod:`reyn.tools.shell`, #2593), which used to
+    share this bridge, was removed outright — it was the sole
+    `/bin/sh -c <str>` shell-injection surface in the codebase.
+
+    #5820 (owner-hit, security, silent): this bridge used to derive a
+    policy-less ``SandboxConfig(backend=...)`` from ``RouterCallerState.
+    sandbox_backend`` (a NAME string) and OVERWRITE ``legacy_ctx.
+    sandbox_config`` wholesale with it — clobbering the operator's real
+    declared policy `legacy_ctx.sandbox_config` already carried (from
+    ``op_context_factory()``), which ``describe_session``'s ``write_scope``
+    field then read as "nothing declared", falsely, for every session with
+    a real (non-``None``) sandbox backend. Fixed by giving the backend
+    NAME its own existing seam instead: resolved to a real
+    :class:`~reyn.security.sandbox.backend.SandboxBackend` INSTANCE here,
+    it goes onto ``OpContext.sandbox_backend`` (that field's own docstring
+    already documents "an injected instance wins over name-based auto-
+    selection" as its purpose) — ``sandbox_config`` is never rewritten
+    post-construction anywhere in this bridge any more.
     """
     from reyn.core.op_runtime.context import OpContext
     from reyn.security.permissions.permissions import PermissionDecl
 
-    # Derive sandbox_config from RouterCallerState.sandbox_backend when
-    # available, otherwise fall back to None (= op_runtime auto-detects).
-    sandbox_config = None
+    # #5820 (owner-hit, security, silent): derive a resolved SandboxBackend
+    # INSTANCE from RouterCallerState.sandbox_backend (a NAME string — a
+    # DIFFERENT thing from OpContext.sandbox_backend below, same name, see
+    # that field's own docstring for the disambiguation) when available.
+    # This used to build a policy-less SandboxConfig(backend=backend) and
+    # OVERWRITE legacy_ctx.sandbox_config with it wholesale (_with_sandbox_
+    # config, now removed) — legacy_ctx.sandbox_config, when op_context_
+    # factory is used below, already carries the REAL operator-declared
+    # config (policy included); that whole-object overwrite silently
+    # clobbered the declared policy with this synthesized, policy-less
+    # stand-in, which describe_session's write_scope field then read as
+    # "nothing declared" — false, for every session with a real (non-None)
+    # sandbox_backend. sandbox_config is never touched post-construction
+    # any more (test_repo/test_5820_... pins this structurally); the
+    # resolved backend instance goes onto OpContext.sandbox_backend
+    # instead — the field's OWN docstring already names "an injected
+    # instance wins over name-based auto-selection" as its seam, this NAME-
+    # resolved instance is simply an earlier-resolved member of that same
+    # seam (see that field's own docstring, corrected in this PR, for why
+    # its 2 real readers never distinguish "genuinely stateful" from
+    # "resolved early").
+    resolved_backend = None
     rs = ctx.router_state
     if rs is not None:
-        backend = getattr(rs, "sandbox_backend", None)
-        if backend is not None:
+        backend_name = getattr(rs, "sandbox_backend", None)
+        if backend_name is not None:
             from reyn.config import SandboxConfig
+            from reyn.security.sandbox import get_default_backend
             try:
-                sandbox_config = SandboxConfig(backend=backend)
+                resolved_backend = get_default_backend(SandboxConfig(backend=backend_name))
             except ValueError:
-                sandbox_config = None
+                resolved_backend = None
 
     # Use op_context_factory if provided, else minimal synthesis.
     if rs is not None and rs.op_context_factory is not None:
         legacy_ctx = rs.op_context_factory()
-        # Inject derived sandbox_config so the handler uses the configured backend.
-        if sandbox_config is not None:
-            legacy_ctx = _with_sandbox_config(legacy_ctx, sandbox_config)
+        if resolved_backend is not None:
+            import dataclasses
+            legacy_ctx = dataclasses.replace(legacy_ctx, sandbox_backend=resolved_backend)
         return legacy_ctx
 
     # Minimal synthesis path (= test sites / narrow callers).
@@ -150,7 +185,14 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
         intervention_bus=None,
         caller="direct",
         parent_run_id=None,
-        sandbox_config=sandbox_config,
+        # #5820: this path has no real config to populate sandbox_config
+        # with (see the comment on default_sandbox_policy below) — None,
+        # never the synthesized backend-only object the pre-#5820 code
+        # built here (that object's own None .policy is exactly what made
+        # describe_session's write_scope lie for the OTHER branch above;
+        # kept out of this field entirely now).
+        sandbox_config=None,
+        sandbox_backend=resolved_backend,
         # #3907①: this path had no access to reyn.yaml sandbox.policy at all
         # (no `rs`/op_context_factory here to read it through), so
         # ctx.default_sandbox_policy stayed None — the op_runtime handler's
@@ -163,21 +205,20 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
         # computed from op fields alone.
         #
         # #5818 (owner-hit, security, lead-coder ruling): `mode="compat"` is
-        # explicit here, not read from `sandbox_config.mode` — this
+        # explicit here, never read from any config object — this
         # construction point (reached only when `rs is None` or `rs.op_
         # context_factory is None`, i.e. no real router/host context at
-        # all) never reaches reyn.yaml, so `sandbox_config` above is never
-        # more than a `SandboxConfig(backend=backend)` synthesized from a
-        # backend NAME alone; its `.mode` is always the dataclass default,
-        # never the operator's real setting. The construction point that
-        # DOES have the real config is `router_op_context.py`'s own
-        # `build_router_op_context` (already fixed this issue) — reached
-        # here too, first, via `rs.op_context_factory` above, whenever a
-        # real host exists. Naming `mode=sandbox_config.mode` here instead
-        # would make this ONE path claim to honor an operator's `strict`
-        # setting it structurally cannot see — the setting would silently
-        # stay unenforced while `default_sandbox_policy` reported "compat"
-        # as if that were the operator's real, deliberate choice.
+        # all) never reaches reyn.yaml (there is no operator config
+        # available here at all, #5820's own fix left `sandbox_config`
+        # above `None` rather than a synthesized stand-in). The
+        # construction point that DOES have the real config is
+        # `router_op_context.py`'s own `build_router_op_context` (fixed by
+        # #5818) — reached here too, first, via `rs.op_context_factory`
+        # above, whenever a real host exists. This path claiming `strict`
+        # would assert an operator setting it structurally cannot see — the
+        # setting would silently stay unenforced while `default_sandbox_
+        # policy` reported "compat" as if that were the operator's real,
+        # deliberate choice.
         default_sandbox_policy=resolve_sandbox_policy(None, mode="compat"),
     )
 
@@ -229,15 +270,6 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     )
     legacy_ctx = await op_context_from_tool_context(ctx)
     return await handle_sandboxed_exec(op=op, ctx=legacy_ctx)
-
-
-def _with_sandbox_config(op_ctx: Any, sandbox_config: Any) -> Any:
-    """Return a copy of op_ctx with sandbox_config overridden.
-
-    OpContext is a dataclass; we replace() to avoid mutation.
-    """
-    import dataclasses
-    return dataclasses.replace(op_ctx, sandbox_config=sandbox_config)
 
 
 from reyn.core.offload.canonical import sandboxed_exec_to_canonical  # noqa: E402

--- a/tests/core/test_5820_write_scope_single_source.py
+++ b/tests/core/test_5820_write_scope_single_source.py
@@ -137,14 +137,30 @@ def test_no_source_file_rewrites_op_context_sandbox_config() -> None:
     (whose ``sandbox_config`` may already carry a real declared policy) and
     swaps that ONE field for something else — ``_with_sandbox_config``'s
     own #5820 root cause, exactly this shape. A reintroduced instance of it
-    anywhere in ``src/reyn`` fails this, naming file:line."""
+    anywhere in ``src/reyn`` fails this, naming file:line.
+
+    #5826 BLOCKING (lead-coder review of this PR's own first pass): the
+    scan must carry its OWN population witness — a ``src.rglob`` that
+    silently returned 0 files (or an ``is_replace`` branch that never once
+    matched) would leave ``offenders`` vacuously empty, green for the
+    wrong reason. Both are asserted inline, not delegated to a separate,
+    independently-mechanised test (a prior draft did that, and lead-coder
+    correctly rejected it — a DIFFERENT scan, e.g. off ``inspect.
+    getsource``, cannot witness THIS scan's own emptiness)."""
     import ast
 
     from tests._support.paths import REPO_ROOT
 
     src = REPO_ROOT / "src" / "reyn"
+    files_walked = 0
+    replace_calls_seen = 0  # #5826 BLOCKING (lead-coder): the population
+    # witness this scan's own detection branch actually fired, not merely
+    # that files were walked — a scan whose `is_replace` never once
+    # matched True anywhere would stay vacuously green even with files > 0,
+    # since `offenders` only grows past that branch.
     offenders: list[str] = []
     for py in sorted(src.rglob("*.py")):
+        files_walked += 1
         rel = str(py.relative_to(src))
         tree = ast.parse(py.read_text(encoding="utf-8"))
         for node in ast.walk(tree):
@@ -155,31 +171,25 @@ def test_no_source_file_rewrites_op_context_sandbox_config() -> None:
             ) or (isinstance(node.func, ast.Name) and node.func.id == "replace")
             if not is_replace:
                 continue
+            replace_calls_seen += 1
             for kw in node.keywords:
                 if kw.arg == "sandbox_config":
                     offenders.append(f"{rel}:{node.lineno}")
+    assert files_walked > 0, (
+        f"src.rglob('*.py') under {src} returned 0 files — this scan "
+        "cannot be trusted, its own offenders list would stay empty "
+        "regardless of what the codebase actually contains"
+    )
+    assert replace_calls_seen > 0, (
+        "0 dataclasses.replace(...) call sites detected anywhere in "
+        "src/reyn — the is_replace detection branch itself never fired, "
+        "so a green offenders list here proves nothing (this repo has "
+        "real replace() call sites, e.g. tools/exec.py's own backend-"
+        "instance injection; if this count is 0, the AST matcher itself "
+        "is broken, not the codebase)"
+    )
     assert not offenders, (
         "a dataclasses.replace(...) site passes sandbox_config= -- this "
         "reopens #5820's own class ('display source rewritable "
         f"independent of enforcement source'): {offenders}"
     )
-
-
-def test_dataclasses_replace_import_still_present_where_expected() -> None:
-    """Tier 1: a plain sanity pin — dataclasses.replace is still importable
-    the way this module's own AST-scan test above assumes (``import
-    dataclasses`` + ``dataclasses.replace``, the attribute form), so that
-    scan's own "is_replace" detection has a real positive case to prove it
-    is not vacuously green over zero matches anywhere in the tree."""
-    import inspect
-
-    import reyn.tools.exec as exec_module
-
-    src_text = inspect.getsource(exec_module)
-    assert "dataclasses.replace(" in src_text, (
-        "no dataclasses.replace( call found in tools/exec.py at all — the "
-        "AST scan's own is_replace branch would never be exercised by "
-        "this file, making its own green a vacuous one"
-    )
-    # And that ONE call site must not carry sandbox_config= any more.
-    assert "dataclasses.replace(legacy_ctx, sandbox_config=" not in src_text

--- a/tests/core/test_5820_write_scope_single_source.py
+++ b/tests/core/test_5820_write_scope_single_source.py
@@ -1,0 +1,185 @@
+"""Tier 2: #5820 -- describe_session's write_scope no longer lies about a
+declared sandbox.policy (owner-hit, silent).
+
+Real Session/RouterCallerState/OpContext throughout -- no mocks. Root
+cause (tui-coder's own throwaway reproduction, confirmed by lead-coder):
+``tools/exec.py``'s ``op_context_from_tool_context`` bridge used to derive
+a policy-less ``SandboxConfig(backend=name)`` from ``RouterCallerState.
+sandbox_backend`` (a NAME string) and OVERWRITE ``legacy_ctx.
+sandbox_config`` wholesale with it via ``_with_sandbox_config`` -- even
+though ``legacy_ctx.sandbox_config`` (from a real ``op_context_factory()``)
+already carried the operator's REAL declared ``sandbox.policy``.
+``describe_session``'s ``write_scope`` field (``describe_write_scope``,
+``runtime/session_write_scope.py``) reads exactly that field, so it
+started reporting ``{"declared": False}`` for every session with a real
+(non-None) sandbox backend, regardless of what the operator actually
+declared -- a false negative, never an exception, so nobody saw a red.
+
+Fix (lead-coder ruling: (a), use the EXISTING seam): the backend NAME is
+resolved to a real ``SandboxBackend`` instance and set on
+``OpContext.sandbox_backend`` instead -- the field whose own docstring
+already names "an injected instance wins over name-based auto-selection"
+as its purpose. ``sandbox_config`` is never touched post-construction any
+more; ``_with_sandbox_config`` (the one rewriter) is deleted outright.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import SandboxConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session_write_scope import describe_write_scope
+from reyn.security.sandbox.noop_backend import NoopBackend
+from reyn.tools.exec import op_context_from_tool_context
+from reyn.tools.types import RouterCallerState, ToolContext
+from tests._support.agent_session import make_session
+
+
+def _real_session_ctx(tmp_path, *, declared_write_paths):
+    """A real Session + real op-context-factory path, mirroring
+    ``test_5818_router_op_context_strict_mode_wiring.py``'s own
+    established pattern in this directory."""
+    session = make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        sandbox_config=SandboxConfig(
+            mode="strict", backend="noop", policy={"allow_write_paths": declared_write_paths},
+        ),
+    )
+    return session._make_router_op_context()
+
+
+@pytest.mark.asyncio
+async def test_bridge_preserves_the_declared_policy_through_a_real_backend(tmp_path) -> None:
+    """Tier 2: the concrete #5820 witness -- a session with a REAL declared
+    ``allow_write_paths`` AND a real (non-None) sandbox backend name. After
+    the bridge runs, ``sandbox_config.policy`` (what ``write_scope`` reads)
+    must still carry that declaration -- not silently replaced with a
+    policy-less stand-in."""
+    real_ctx = _real_session_ctx(tmp_path, declared_write_paths=["/declared/path"])
+    assert real_ctx.sandbox_config is not None
+    assert real_ctx.sandbox_config.policy == {"allow_write_paths": ["/declared/path"]}
+
+    rs = RouterCallerState(op_context_factory=lambda: real_ctx, sandbox_backend="noop")
+    tool_ctx = ToolContext(
+        events=real_ctx.events, permission_resolver=real_ctx.permission_resolver,
+        workspace=real_ctx.workspace, caller_kind="router", router_state=rs,
+    )
+    bridged_ctx = await op_context_from_tool_context(tool_ctx)
+
+    # The declared policy survives -- the actual #5820 regression pin.
+    assert bridged_ctx.sandbox_config is not None
+    assert bridged_ctx.sandbox_config.policy == {"allow_write_paths": ["/declared/path"]}
+    assert describe_write_scope(bridged_ctx.sandbox_config) == {
+        "declared": True,
+        "allow_write_paths": ["/declared/path"],
+        "deny_write_paths": None,
+    }
+
+    # Enforcement is unaffected -- was already correct, stays correct.
+    assert bridged_ctx.default_sandbox_policy["write_paths"] == ["/declared/path"]
+
+
+@pytest.mark.asyncio
+async def test_bridge_gives_the_backend_name_its_own_seam_not_sandbox_config(tmp_path) -> None:
+    """Tier 2: driven verification (not a static "same table" claim) that
+    resolving the backend NAME early, in the bridge, produces the SAME
+    concrete backend a caller resolving it later (at exec time, off
+    ``OpContext.sandbox_backend`` directly, per that field's own "an
+    injected instance wins" contract) would get -- and that
+    ``sandboxed_exec.py``'s own real ``resolve_backend`` call actually
+    uses the injected instance rather than re-resolving."""
+    from reyn.security.sandbox.launcher import resolve_backend
+
+    real_ctx = _real_session_ctx(tmp_path, declared_write_paths=[])
+    rs = RouterCallerState(op_context_factory=lambda: real_ctx, sandbox_backend="noop")
+    tool_ctx = ToolContext(
+        events=real_ctx.events, permission_resolver=real_ctx.permission_resolver,
+        workspace=real_ctx.workspace, caller_kind="router", router_state=rs,
+    )
+    bridged_ctx = await op_context_from_tool_context(tool_ctx)
+
+    assert isinstance(bridged_ctx.sandbox_backend, NoopBackend)
+    # sandboxed_exec.py's own exact call shape (op_runtime/sandboxed_exec.py:99)
+    # — the injected instance short-circuits `or`, never re-resolving.
+    resolved = resolve_backend(bridged_ctx.sandbox_backend, bridged_ctx.sandbox_config)
+    assert resolved is bridged_ctx.sandbox_backend
+
+
+@pytest.mark.asyncio
+async def test_bridge_leaves_sandbox_config_object_identity_unchanged(tmp_path) -> None:
+    """Tier 2: the bridge must not even reconstruct an equal-but-different
+    ``sandbox_config`` object -- ``is``, not ``==``, is the witness that no
+    rewrite path exists any more (a subtler regression than a VALUE change:
+    a future "helpfully" re-wrapping ``sandbox_config`` in a new object
+    with the same fields would pass a value-equality check but still be a
+    rewrite path reopening this exact class)."""
+    real_ctx = _real_session_ctx(tmp_path, declared_write_paths=["/x"])
+    rs = RouterCallerState(op_context_factory=lambda: real_ctx, sandbox_backend="noop")
+    tool_ctx = ToolContext(
+        events=real_ctx.events, permission_resolver=real_ctx.permission_resolver,
+        workspace=real_ctx.workspace, caller_kind="router", router_state=rs,
+    )
+    bridged_ctx = await op_context_from_tool_context(tool_ctx)
+    assert bridged_ctx.sandbox_config is real_ctx.sandbox_config
+
+
+def test_no_source_file_rewrites_op_context_sandbox_config() -> None:
+    """Tier 1: structural absence, src-wide AST (mirrors ``tests/repo/
+    test_router_op_context_single_source_1412.py``'s own established
+    pattern for "this class of drift must be impossible, not merely
+    avoided"). A FRESH ``OpContext(...)`` construction legitimately sets
+    ``sandbox_config`` once, from its own real source (``build_router_op_
+    context``, ``tools/exec.py``'s own minimal-synthesis branch) — that is
+    not a rewrite. What must never exist: a ``dataclasses.replace(<existing
+    ctx>, sandbox_config=...)`` call, which takes an ALREADY-BUILT context
+    (whose ``sandbox_config`` may already carry a real declared policy) and
+    swaps that ONE field for something else — ``_with_sandbox_config``'s
+    own #5820 root cause, exactly this shape. A reintroduced instance of it
+    anywhere in ``src/reyn`` fails this, naming file:line."""
+    import ast
+
+    from tests._support.paths import REPO_ROOT
+
+    src = REPO_ROOT / "src" / "reyn"
+    offenders: list[str] = []
+    for py in sorted(src.rglob("*.py")):
+        rel = str(py.relative_to(src))
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            is_replace = (
+                isinstance(node.func, ast.Attribute) and node.func.attr == "replace"
+            ) or (isinstance(node.func, ast.Name) and node.func.id == "replace")
+            if not is_replace:
+                continue
+            for kw in node.keywords:
+                if kw.arg == "sandbox_config":
+                    offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, (
+        "a dataclasses.replace(...) site passes sandbox_config= -- this "
+        "reopens #5820's own class ('display source rewritable "
+        f"independent of enforcement source'): {offenders}"
+    )
+
+
+def test_dataclasses_replace_import_still_present_where_expected() -> None:
+    """Tier 1: a plain sanity pin — dataclasses.replace is still importable
+    the way this module's own AST-scan test above assumes (``import
+    dataclasses`` + ``dataclasses.replace``, the attribute form), so that
+    scan's own "is_replace" detection has a real positive case to prove it
+    is not vacuously green over zero matches anywhere in the tree."""
+    import inspect
+
+    import reyn.tools.exec as exec_module
+
+    src_text = inspect.getsource(exec_module)
+    assert "dataclasses.replace(" in src_text, (
+        "no dataclasses.replace( call found in tools/exec.py at all — the "
+        "AST scan's own is_replace branch would never be exercised by "
+        "this file, making its own green a vacuous one"
+    )
+    # And that ONE call site must not carry sandbox_config= any more.
+    assert "dataclasses.replace(legacy_ctx, sandbox_config=" not in src_text


### PR DESCRIPTION
**[tui-coder]** — Closes #5820

## What happened

Owner-hit, silent: `describe_session`'s `write_scope` field falsely reported `{"declared": False}` for every session with a real (non-`None`) sandbox backend, regardless of what `sandbox.policy` actually declared. Enforcement (`default_sandbox_policy`) was correctly reflecting the real config the whole time — only the DISPLAY side lied, silently, with no exception, no red.

Root cause (my own throwaway reproduction against real `Session`/`exec.py` code, confirmed by lead-coder): `tools/exec.py`'s `op_context_from_tool_context` bridge derived a policy-less `SandboxConfig(backend=name)` from `RouterCallerState.sandbox_backend` (a NAME string) and OVERWROTE `legacy_ctx.sandbox_config` **wholesale** with it via `_with_sandbox_config` — even though `legacy_ctx.sandbox_config`, from a real `op_context_factory()`, already carried the operator's real declared policy. `describe_session`'s `write_scope` reads exactly that field.

## Class, not instance (lead-coder's own framing)

`ctx.sandbox_config` was carrying 2 independently-writable facts — "the operator's declared policy" and "this op's backend name" — and the bridge only had a mouth for the 2nd, so it silently destroyed the 1st to deliver it.

**Rejected fix** (architect's own #5012-A ruling, cited by lead-coder): deriving `write_scope` from `default_sandbox_policy` instead — that field's own module docstring names `ctx.sandbox_config` as the decided source, and the effective `write_paths` includes the workspace floor, which would make `write_scope` claim a floor NOBODY declared as "declared" — the opposite lie.

## Fix ((a), lead-coder ruling — existing seam, no new field)

Give the backend NAME its own mouth instead of overloading `sandbox_config`'s. `OpContext.sandbox_backend` already exists for exactly this ("an injected instance wins over name-based auto-selection", `context.py:257`) — its 2 real readers (`sandboxed_exec.py`, `skill_install.py`, both `ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)`) never distinguish a genuinely stateful injected backend from one resolved early by name through the SAME table `get_default_backend` itself uses (counted, reported, confirmed by lead-coder independently before implementation started).

The backend name is now resolved to a real `SandboxBackend` instance in the bridge and set on `OpContext.sandbox_backend`; `sandbox_config` is never touched post-construction any more. `_with_sandbox_config` (the one rewriter) is deleted outright.

## Doc corrections (same PR, per CLAUDE.md hard rule)

`context.py`'s own `sandbox_backend` field docstring and `skill_install.py`'s `_shallow_clone` docstring both corrected — "injected stateful backend" named the motivating use case, not a capability either real reader actually gates on; both now say so. `security/sandbox/backend.py:371` was reviewed and found to make no such overclaim (still accurate as-is, no edit needed).

## Test plan

- [x] New `tests/core/test_5820_write_scope_single_source.py` (**4 tests**): the concrete regression witness (a real declared `allow_write_paths` survives the bridge, `describe_write_scope` reports it correctly); an **object-identity** witness (`ctx.sandbox_config is` the SAME object before/after the bridge, not merely equal); a **DRIVEN** (not static) proof that the early-resolved backend instance is the one `sandboxed_exec.py`'s own real `resolve_backend` call actually uses, never re-resolved; and a **src-wide AST structural test** (mirrors `tests/repo/test_router_op_context_single_source_1412.py`'s own established pattern) asserting ZERO `dataclasses.replace(..., sandbox_config=...)` call sites anywhere in `src/reyn`, with its own inline population witness (`files_walked > 0`, `replace_calls_seen > 0`, added in the BLOCKING fix below) — the acceptance bar lead-coder set ("no path CAN rewrite it, not merely doesn't").
- [x] Falsify-verified in-file (Edit-only), 3 probes total: (1) reintroduced the exact pre-#5820 `dataclasses.replace(..., sandbox_config=...)` shape — 3 of the 4 tests went red, **including the AST structural test** (catches it without even running the bridge); (2) BLOCKING fix — pointed the AST scan at a nonexistent directory (`files_walked` stays 0) — caught; (3) forced the scan's own `is_replace` branch to always `False` — caught by `replace_calls_seen > 0`. All 3 restored, reconfirmed green.
- [x] Full scoped regression: the new file + `test_sandbox_model_completion_1339.py`, `test_sandbox_factory.py`, `test_5818_router_op_context_strict_mode_wiring.py`, `test_5012a_describe_session_tool.py`, `test_5012a_session_write_scope.py`, `test_4364_c5_sandbox_posture.py`, `test_router_op_context_single_source_1412.py`, and 4 skill_install-touching files — 97 tests, 2 pre-existing skips, all green.
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (new test file), `verify_module_docstrings.py` (3 changed src files), `mypy_ratchet.py` (199/208 baselined, no new findings), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (run after `git add`), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green.
- [ ] Visual — no UI surface.

## Acceptance (lead-coder's own, verbatim)

1. `ctx.sandbox_config` — no code path CAN rewrite it post-construction — ✅ (AST structural test with its own population witness, falsify-verified)
2. Doc corrections at the 3 named sites — ✅ 2 of 3 needed correction (`backend.py:371` reviewed, found accurate)

## BLOCKING fix (head 30ee0a5ad)

The AST scan's first pass lacked its own population witness — a `src.rglob` returning 0 files, or an `is_replace` branch that never matched, would leave `offenders` vacuously empty. Folded `files_walked > 0` and `replace_calls_seen > 0` directly into the scan (before `offenders`); removed a separate, non-witnessing sibling test that used a different mechanism (`inspect.getsource`) and could not witness this scan's own emptiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
