### PR TITLE
fix(#5822): require RouterLoopHost.make_router_op_context -- read it directly, no getattr default

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -907,6 +907,15 @@ class RouterLoopCore(Protocol):
         ...
 
     def resolve_model(self, name: str) -> str: ...
+    # OpContext factory for unified-registry handlers (ADR-0026 Phase 3.5).
+    # Builds a permission-aware OpContext with the operator-declared
+    # PermissionDecl + Workspace(actor="chat_router") + mcp_servers,
+    # so handlers in src/reyn/tools/{file,mcp,web*}.py can delegate to
+    # op_runtime with the same gating the legacy router branches had.
+    # #5822 (architect ruling): read DIRECTLY by ``tools/types.py``'s
+    # ``build_resource_caller_state`` (no ``getattr(..., None)`` default)
+    # -- every ``RouterLoopHost`` genuinely implements this, test hosts
+    # included (``tests/_support/router_loop.py``'s ``FakeRouterHost``).
     def make_router_op_context(self) -> Any: ...
     # #3633: ``persist`` makes the kind=="agent" → history-append coupling an
     # EXPLICIT per-call-site choice instead of an implicit blanket rule the
@@ -1158,12 +1167,12 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def mcp_get_prompt(self, server: str, name: str,
                               arguments: dict | None = None) -> dict: ...
 
-    # OpContext factory for unified-registry handlers (ADR-0026 Phase 3.5).
-    # Builds a permission-aware OpContext with the operator-declared
-    # PermissionDecl + Workspace(actor="chat_router") + mcp_servers,
-    # so handlers in src/reyn/tools/{file,mcp,web*}.py can delegate to
-    # op_runtime with the same gating the legacy router branches had.
-    def make_router_op_context(self) -> Any: ...
+    # #5822: make_router_op_context is inherited from RouterLoopCore above
+    # -- this used to be a redundant re-declaration (same signature, no
+    # override) that made two Protocol-declaration sites LOOK like they
+    # could be two different facts, costing a real reviewer's time
+    # tracking down whether they were (#5822's own genesis). See
+    # RouterLoopCore's own declaration for the method's rationale.
 
     # Safety-limit intervention bus factory (FP-0005 extension).
     # Returns the current RequestBus for handle_limit_exceeded interactive

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -187,7 +187,18 @@ class RouterCallerState:
     # so handlers can build a permission-aware OpContext (= populated
     # PermissionDecl + Workspace + actor="chat_router") matching the
     # legacy router branch behavior.  When None, handlers fall back to
-    # minimal OpContext synthesis (= test sites).
+    # minimal OpContext synthesis.
+    #
+    # #5822: ``build_resource_caller_state`` (below) never leaves this
+    # ``None`` for a host it was given — it reads ``host.
+    # make_router_op_context`` directly (no ``getattr`` default), so a
+    # host missing the method raises at construction instead of silently
+    # producing ``None`` here. ``None`` still reaches this field
+    # legitimately through the OTHER, structural path: a
+    # ``RouterCallerState`` built directly (not through
+    # ``build_resource_caller_state``) with no factory at all —
+    # ``capability_visibility.py`` / ``router_tools.py``'s own direct
+    # constructions, both display-only today, never set this field.
     op_context_factory: Callable[[], Any] | None = None
 
     # RouterLoopHost reference for handlers that need duck-typed access
@@ -319,7 +330,28 @@ async def build_resource_caller_state(host: Any) -> "RouterCallerState":
         # #5291: no longer reads .reyn/agents/ here — RouterCallerState.
         # available_agents was removed (0 real consumers); this was a
         # real disk read (list_available_agents()) on every call.
-        op_context_factory=getattr(host, "make_router_op_context", None),
+        #
+        # #5822 (architect ruling, security co-vet on #5821): a DIRECT
+        # attribute read, not `getattr(host, "make_router_op_context",
+        # None)`. The prior getattr form answered "does this host
+        # structurally have the method" with a silent `None` on "no" —
+        # `None` here means "use tools/exec.py's minimal-synthesis path",
+        # which builds an OpContext that can never see the operator's
+        # real reyn.yaml sandbox config (#5818: `sandbox.mode: strict`
+        # silently never reached the resolver, because THIS exact
+        # getattr answered `None` for a host that had simply never been
+        # updated to implement the method). A host reaching this
+        # constructor is asserting membership in the `RouterLoopHost`
+        # Protocol — every real production host does; the one that
+        # didn't (`tests/_support/router_loop.py`'s `FakeRouterHost`)
+        # gained the method in this same PR (#5822) rather than being
+        # left to fall through silently. A host that still lacks it now
+        # raises `AttributeError` here, at construction, instead of
+        # manufacturing a `None` indistinguishable from the legitimate
+        # `rs is None` / direct-`RouterCallerState`-construction callers
+        # (`capability_visibility.py`, `router_tools.py`) that
+        # `tools/exec.py`'s own synthesis branch still serves.
+        op_context_factory=host.make_router_op_context,
         host=host,
         available_rag_sources=rag_sources,
         action_embedding_index=(

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -126,6 +126,32 @@ class FakeRouterHost:
     def memory(self) -> MemoryService:
         return self._memory
 
+    def make_router_op_context(self) -> Any:
+        """#5822 (architect ruling): ``RouterLoopHost`` is now read
+        directly (``tools/types.py``'s ``build_resource_caller_state``,
+        no more ``getattr(host, "make_router_op_context", None)``
+        fallback) — a host reaching that constructor must genuinely
+        implement this method, this fake included, rather than being
+        tolerated as an exception to "the compose branch has a real
+        factory." A minimal, REAL ``OpContext`` (the same shape
+        ``tools/exec.py``'s own "minimal synthesis" path builds for a
+        caller with no factory to delegate to) — this fake carries none
+        of the real materials (a permission resolver, a declared sandbox
+        config, ...) a real ``RouterHostAdapter`` would, so those fields
+        stay at their own Optional defaults; a test asserting on THEM
+        specifically constructs its own ``OpContext``/uses a real host
+        instead (unchanged by this method's existence)."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     # --- Catalogue ---
 
     def list_available_skills(self) -> list[dict]:

--- a/tests/core/test_2575_pipeline_disk_registration.py
+++ b/tests/core/test_2575_pipeline_disk_registration.py
@@ -434,6 +434,21 @@ class _FakeHost:
     @property
     def events(self): return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def get_universal_wrappers_enabled(self) -> bool: return True
     def get_action_usage_tracker(self): return None
     def get_action_embedding_index(self): return None

--- a/tests/core/test_5822_router_op_context_protocol_required.py
+++ b/tests/core/test_5822_router_op_context_protocol_required.py
@@ -1,0 +1,106 @@
+"""Tier 2: OS invariant -- #5822 (architect ruling), security co-vet finding
+on PR #5821.
+
+`RouterCallerState.op_context_factory` used to be populated via
+`getattr(host, "make_router_op_context", None)` (`reyn.tools.types.
+build_resource_caller_state`) -- a STRUCTURAL Protocol check that answers
+"no" with a silent `None`, never an exception. `None` here means
+`tools/exec.py`'s minimal-synthesis OpContext path, which -- per #5818,
+the real incident this traces back to -- can never see the operator's
+own `reyn.yaml` `sandbox.mode: strict`. A host that simply forgot to
+implement `make_router_op_context` (not a deliberate "no capability"
+declaration) silently degraded every op it touches to that same
+unenforced floor, with zero signal.
+
+architect's own measurement (co-vet on this PR): only ONE test in the
+whole suite actually drives the minimal-synthesis branch and asserts on
+it (`test_sandbox_model_completion_1339.py::
+test_minimal_synthesis_path_enforces_the_floor_not_the_op_default`),
+and it names its own condition explicitly (`router_state=None`) rather
+than depending on a host lacking a method -- so making `FakeRouterHost`
+NOT structurally satisfy the Protocol (the type-level alternative
+considered and REJECTED) would have preserved 36 other tests' merely
+INCIDENTAL pass-through of that branch, never actual coverage of it
+("a helper that's incomplete, so branches reached [through it] are
+testing the helper's incompleteness, not the branch itself" --
+architect, verbatim).
+
+Ruling: read `host.make_router_op_context` DIRECTLY (no `getattr`
+default) -- a host reaching `build_resource_caller_state` must
+genuinely implement the method; one that doesn't now raises at
+construction instead of manufacturing a `None` indistinguishable from
+the legitimate `rs is None` / direct-`RouterCallerState`-construction
+paths (`capability_visibility.py`, `router_tools.py`) that
+`tools/exec.py`'s own minimal-synthesis branch still serves -- that
+branch itself is NOT removed (`rs is None` stays a real, structural
+reason to reach it).
+
+Real `RouterCallerState`/`build_resource_caller_state`/`FakeRouterHost`
+throughout -- no mocks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.tools.types import build_resource_caller_state
+from tests._support.router_loop import FakeRouterHost
+
+
+class _HostMissingOpContextFactory:
+    """A minimal, real object genuinely lacking `make_router_op_context`
+    -- not a mock, just a plain class implementing only what
+    `build_resource_caller_state` reads BEFORE it would reach the
+    now-direct attribute access, so the AttributeError this test expects
+    comes from that ONE line, not an earlier, unrelated omission."""
+
+    agent_name = "no-op-context-factory-host"
+    agent_role = ""
+
+    def list_available_skills(self) -> list[dict]:
+        return []
+
+    def list_available_agents(self) -> list[dict]:
+        return []
+
+    def get_memory_index(self) -> dict:
+        return {"status": "not_found", "content": ""}
+
+    def get_file_permissions(self) -> "dict | None":
+        return None
+
+    def get_mcp_servers(self) -> list[dict]:
+        return []
+
+    def get_chains(self):
+        return None
+
+    def get_inbox_depth(self) -> "int | None":
+        return None
+
+    def get_web_fetch_allowed(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_host_missing_make_router_op_context_raises_at_construction() -> None:
+    """Tier 2: #5822 -- a host that does not implement `make_router_op_context`
+    must fail LOUDLY, at `build_resource_caller_state` construction time --
+    never silently produce `op_context_factory=None` (the #5818-class hazard:
+    a real operator setting, unenforced, with nothing to notice)."""
+    host = _HostMissingOpContextFactory()
+    with pytest.raises(AttributeError, match="make_router_op_context"):
+        await build_resource_caller_state(host)
+
+
+@pytest.mark.asyncio
+async def test_a_conforming_host_still_builds_a_working_factory() -> None:
+    """Tier 2: #5822 accept-side -- a host that DOES implement
+    `make_router_op_context` (here, the shared `FakeRouterHost` test
+    fixture, which gained the method in this same PR) builds a
+    `RouterCallerState` whose `op_context_factory` is real and callable,
+    producing a genuine `OpContext` -- not merely "did not raise"."""
+    host = FakeRouterHost()
+    router_state = await build_resource_caller_state(host)
+    assert router_state.op_context_factory is not None
+    op_ctx = router_state.op_context_factory()
+    assert op_ctx.actor == "fake_router_host"

--- a/tests/dev/test_chat_turn_completed_inline.py
+++ b/tests/dev/test_chat_turn_completed_inline.py
@@ -109,6 +109,22 @@ class _FakeRouterHost:
     def events(self) -> EventLog:
         return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this. Mirrors tests/_support/router_loop.py's
+        FakeRouterHost's own minimal, real OpContext."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def get_universal_wrappers_enabled(self) -> bool:
         return self._universal_wrappers_enabled
 

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -79,6 +79,22 @@ class FakeRouterHost:
     def events(self) -> FakeEventLog:
         return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this. Mirrors tests/_support/router_loop.py's
+        FakeRouterHost's own minimal, real OpContext."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def list_available_skills(self) -> list[dict]:
         return self._skills
 

--- a/tests/llm/test_router_loop_non_interactive_live_1443.py
+++ b/tests/llm/test_router_loop_non_interactive_live_1443.py
@@ -57,6 +57,22 @@ class _FakeRouterHost:
     def events(self) -> EventLog:
         return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this. Mirrors tests/_support/router_loop.py's
+        FakeRouterHost's own minimal, real OpContext."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def get_universal_wrappers_enabled(self) -> bool:
         return True
 

--- a/tests/llm/test_router_loop_routing_decided.py
+++ b/tests/llm/test_router_loop_routing_decided.py
@@ -104,6 +104,22 @@ class _FakeRouterHost:
     def events(self) -> EventLog:
         return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this. Mirrors tests/_support/router_loop.py's
+        FakeRouterHost's own minimal, real OpContext."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def get_universal_wrappers_enabled(self) -> bool:
         return self._universal_wrappers_enabled
 

--- a/tests/runtime/test_router_caller_state_mcp_servers.py
+++ b/tests/runtime/test_router_caller_state_mcp_servers.py
@@ -42,6 +42,21 @@ class _FakeHost:
     @property
     def events(self): return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def get_universal_wrappers_enabled(self) -> bool: return True
     def get_action_embedding_index(self): return None
     def get_embedding_provider(self): return None
@@ -109,6 +124,22 @@ def test_mcp_servers_missing_method_falls_back_to_none() -> None:
             def emit(self, *a, **kw): pass
             subscribers: list = []
         events = _E()
+        def make_router_op_context(self):
+            """#5822: RouterLoopHost is read directly now (no getattr
+            default on tools/types.py's build_resource_caller_state) --
+            every host genuinely implements this, this deliberately-slim
+            one included (it omits get_mcp_servers ON PURPOSE -- that is
+            this test's own axis, unrelated to this field)."""
+            from reyn.core.op_runtime.context import OpContext
+            from reyn.data.workspace.workspace import Workspace
+            from reyn.security.permissions.permissions import PermissionDecl
+
+            return OpContext(
+                workspace=Workspace(events=self.events),
+                events=self.events,
+                permission_decl=PermissionDecl(),
+                actor="fake_router_host",
+            )
         def get_universal_wrappers_enabled(self): return True
         def get_action_embedding_index(self): return None
         def get_embedding_provider(self): return None

--- a/tests/runtime/test_session_cost_accumulation.py
+++ b/tests/runtime/test_session_cost_accumulation.py
@@ -58,6 +58,21 @@ class _FakeHost:
     def events(self):
         return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def list_available_skills(self) -> list[dict]:
         return []
 

--- a/tests/tools/test_pipeline_is5_surfacing.py
+++ b/tests/tools/test_pipeline_is5_surfacing.py
@@ -117,6 +117,21 @@ class _FakeHost:
     @property
     def events(self): return self._events
 
+    def make_router_op_context(self):
+        """#5822: RouterLoopHost is read directly now (no getattr default
+        on tools/types.py's build_resource_caller_state) -- every host
+        genuinely implements this."""
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.data.workspace.workspace import Workspace
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=Workspace(events=self._events),
+            events=self._events,
+            permission_decl=PermissionDecl(),
+            actor="fake_router_host",
+        )
+
     def get_universal_wrappers_enabled(self) -> bool: return True
     def get_action_usage_tracker(self): return None
     def get_action_embedding_index(self): return None


### PR DESCRIPTION
**[e2e-coder]**

Closes #5822

Security co-vet finding on PR #5821: `op_context_factory` was populated via `getattr(host, "make_router_op_context", None)` — a structural Protocol check that answers "no" with a silent `None`. `None` here means `tools/exec.py`'s minimal-synthesis OpContext path, which (per #5818, the real incident this traces back to) can never see the operator's `reyn.yaml` `sandbox.mode: strict`. A host that simply forgot to implement the method silently degraded every op it touches to that unenforced floor, with zero signal.

Architect's measurement rejected making the fake type-non-conforming (would preserve coverage-by-accident): only ONE test genuinely drives the minimal-synthesis branch and names its own condition (`router_state=None`); 36+ others merely pass through it incidentally.

**Implemented**: `types.py` reads `host.make_router_op_context` directly (no getattr default) — a non-conforming host now raises at construction. The minimal-synthesis branch itself stays (`rs is None` remains a legitimate, separate reason to reach it — untouched code, two direct-`RouterCallerState`-construction call sites unaffected). The shared `FakeRouterHost` gained the method, plus **8 more independently-defined host classes my own regression sweep found actually reaching this code path** (listed in the commit body) — 2 more (`test_slash_model_router_integration.py`, `test_5720_spill_carries_real_turn_provenance.py`) were left untouched.

**Why those 2 are left untouched**: not their own docstrings (a docstring records intent, not behavior). The real warrant: after this PR's own change, a non-conforming host reaching `build_resource_caller_state` raises immediately at construction. Both files ran as part of the regression sweep below with zero raises — so neither host reaches this path, demonstrated by the very fail-closed behavior this PR adds, not asserted from prose.

Also removed `router_loop.py:1166`'s redundant re-declaration (the origin of this issue's own opening "same name, 2 facts?" question).

### Test plan
- [x] Architect's 3 acceptance criteria, all verified (see commit body)
- [x] Strip-falsified: reverted to `getattr(..., None)` — new test goes RED; restored, reconfirmed green
- [x] Local gates: ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py` — all green
- [x] Regression sweep, exact-count reconciled against the correct fork point (`b80d911e9`, this branch's own merge-base with `origin/main` — NOT `origin/main`'s later tip, which by the time of a first pass had moved forward via an unrelated merge, #5820, and produced a mismatched count I initially reported wrong; corrected below, full untruncated logs kept):
  - This PR: `5 failed, 8137 passed, 36 skipped, 0 errors` (`tests/core tests/runtime tests/tools tests/security tests/dev tests/llm`)
  - `b80d911e9` (the actual fork point), identical command/order: `5 failed, 8135 passed, 36 skipped, 0 errors`
  - `8135 + 2` (this PR's own 2 new test functions, `test_5822_router_op_context_protocol_required.py`) `= 8137` — exact match, no unaccounted tests.
  - The 5 failures are **byte-for-byte identical** across both runs (same test IDs, same files):
    - `tests/dev/test_network_gate_3451.py::test_unpinned_reach_fails_the_inner_session`
    - `tests/dev/test_network_gate_3451.py::test_allow_marked_without_reason_is_rejected`
    - `tests/dev/test_network_gate_3451.py::test_replay_marker_alone_no_longer_authorizes_a_real_reach`
    - `tests/dev/test_network_gate_3451.py::test_record_env_alone_without_marker_still_rejected`
    - `tests/llm/test_embed_max_retries_wire_count_3047.py::test_chat_acompletion_wire_count_unaffected_by_embed_global_mutation`

  All 5 pre-existing, unrelated to this PR — confirmed against the correct commit, with the arithmetic reconciled exactly (not just "same names, close-enough counts").
- [x] `tests/mcp`/`tests/interfaces`: only one file in either directory touches this seam at all — `tests/mcp/test_cli_pipe.py:1142`, via a real `session.router_host` (already conforms). CI will run these as part of its own full suite.
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51