### PR TITLE
docs: name the near-miss trap where mentioning a marker word reds the gate

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -429,6 +429,23 @@ These rules then keep multi-session work coherent:
    same as it always was; a green here means "some note names the exact
    tree about to merge," never "the tree was reviewed by the right people."
 
+   🔴 **A marker word (`BLOCKING` / `BLOCKING-CLEARED` / `TESTS-READ`) in a
+   comment's first line trips near-miss detection (#5522) RED unless that
+   line is a genuine, well-formed marker** — the required `open-blocking-
+   checkbox` status goes red and auto-merge stops. Detection cannot tell
+   *mentioning* the word from *declaring* the marker, because the only
+   discriminator available is the sentence being classified itself — there
+   is no separate signal to read instead. Negation, a preview of what's
+   coming, a quote, or a reference to someone else's marker all land on the
+   wrong side of that same line, every time: two real incidents landed the
+   same night from two different sessions, both careful, considerate
+   sentences — lead-coder's own "not yet BLOCKING-CLEARED — will post once
+   the fix lands" (#5823), and architect's "lead-coder's BLOCKING (5 reds)
+   is theirs, not touching it" (#5827). **Fix: any negation, preview,
+   quotation, or reference to a marker goes on line 2 or later, never line
+   1.** Line 1 is either a real marker in its required form, or a sentence
+   that contains none of the three words at all.
+
 9. **Arming auto-merge and merging are the reviewer's act (lead-coder in
    this repo), never the implementer's — the implementer's turn ends at
    push + report.** Real incident (#5662, 2026-09-02): an implementer saw


### PR DESCRIPTION
**[docs-maintainer]** — small doc addition per lead-coder's direct request, no ticket (operational, handled in place per owner directive).

Adds a paragraph right after rule 8's existing discussion of a note's first-line marker shape, in `docs/deep-dives/contributing/pr-workflow.md`.

## What it says

A marker word — the three are named in the doc body, deliberately not repeated as a bare list here to keep this PR body itself clean of anything that could misfire on this exact gate — appearing on a comment's first line trips near-miss detection (#5522) red unless the line is a genuine, well-formed marker. Negation, a preview, a quotation, or a reference to someone else's instance all land on the wrong side of the same check, because the detector's only available discriminator is the sentence being classified itself — there's no separate signal to consult.

Two same-night incidents from two different sessions are cited by PR number: lead-coder's own careful "not yet cleared, will post once the fix lands" comment, and architect's careful "that's lead-coder's open point, not touching it" comment. Both tripped the gate despite being considerate, correct sentences.

States the reason (why the detector can't tell mention from declaration), not just "be careful" — so the next person can reason about edge cases themselves rather than memorize a list.

## Gates

```
mkdocs build --strict -f .mkdocs/mkdocs.yml           → exit 0
python scripts/check_doc_anchors.py                    → exit 0
python scripts/check_retired_config_keys_denylist.py   → exit 0
```

## Test plan

- [x] Wrote this PR body itself avoiding the exact trap it documents — no marker word on any comment's first line, including this one
- [x] (skipped — no visual surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
