### PR TITLE
fix(#5831): route litellm's console output at the stream level, not handler construction

### DIFF
--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -5,10 +5,14 @@ cost). Every reyn call site that touches litellm does so lazily, inside a
 function — see ``reyn/__init__.py`` for the full inventory + the #2928
 ``LITELLM_LOCAL_*`` env-var defaults that must be set before ANY of them run.
 This module adds the SECOND piece: routing litellm's own console log output
-(StreamHandlers it attaches to its "LiteLLM" / "LiteLLM Router" / "LiteLLM
-Proxy" loggers, unconditionally, at import time) to reyn's log file instead of
+(handlers it attaches to its "LiteLLM" / "LiteLLM Router" / "LiteLLM Proxy"
+loggers, unconditionally, at import time) to reyn's log file instead of
 stderr, so an interactive CUI session's terminal is never corrupted by a
-litellm banner or warning.
+litellm banner or warning. #5831: this redirects the OS-facing
+``sys.stdout``/``sys.stderr`` streams themselves for the duration of the
+import, rather than patching handler construction — see
+``_litellm_import_logs_to_file``'s own docstring for why (litellm 1.100.0
+started rebinding a handler's stream at *emit* time, not just construction).
 
 ``ensure_litellm_ready()`` is the ONE place that should perform this
 first-import work — and (#4395 PR-1) the ONE place the actual ``import
@@ -119,35 +123,47 @@ class LitellmUnavailableError(Exception):
 
 @contextlib.contextmanager
 def _litellm_import_logs_to_file() -> "Iterator[None]":
-    """Route litellm's own loggers to reyn's log file instead of stderr.
+    """Route litellm's own console output to reyn's log file instead of the
+    terminal, for the duration of the (possibly first-ever) ``import litellm``.
 
-    litellm's ``_logging.py`` module attaches a fresh ``logging.StreamHandler()``
-    (→ stderr, by construction) to each of ``"LiteLLM"`` / ``"LiteLLM Router"`` /
-    ``"LiteLLM Proxy"`` **unconditionally at import time** (module-level code,
-    not gated on whether the logger already has a handler) — the first
-    ``import litellm`` anywhere in the process attaches it, which happens
-    inside this context manager's ``with`` body when routed through
-    ``ensure_litellm_ready``. Because the attach is unconditional, merely
-    pre-configuring these loggers *before* import does not stop litellm from
-    ALSO adding its own console handler — it would just add a second one. So
-    the console redirect has to intercept handler *construction* itself: for
-    the duration of the ``import litellm`` this swaps in a
-    ``logging.StreamHandler`` subclass whose default stream is reyn's log file
-    instead of stderr, so every StreamHandler litellm builds at import time —
-    including the one behind the cost-map-fetch-failure warning
-    ``litellm.litellm_core_utils.get_model_cost_map`` emits synchronously
-    during import — writes to the file, not the console.
+    #5831: an earlier version of this intercepted handler *construction* —
+    for the duration of ``import litellm`` it swapped in a
+    ``logging.StreamHandler`` subclass whose default ``stream`` was reyn's
+    log file, on the theory that every StreamHandler litellm builds during
+    that one import (including the one behind the cost-map-fetch-failure
+    warning ``litellm.litellm_core_utils.get_model_cost_map`` emits
+    synchronously during import) would inherit that default. litellm 1.100.0
+    broke that assumption: its ``_logging.py`` now attaches a
+    ``LevelRoutingStreamHandler`` whose ``emit()`` **re-reads** ``sys.stdout``/
+    ``sys.stderr`` and **rebinds** ``self.stream`` on every call (WARNING+ →
+    stderr), so whatever stream the handler was *constructed* with is
+    discarded the moment it emits — the construction-time patch above no
+    longer has anything to intercept.
 
-    On exit, the real ``StreamHandler`` class is restored and the three
-    loggers are stripped down to file-routed only: their handler lists are
-    cleared and ``propagate`` is set ``True``, so every *runtime* litellm log
-    (not just the import-time one) flows to the root logger's file handler
-    exactly once, with no leftover console sink. This also makes the
-    context manager safe to use when litellm was already imported earlier in
-    the process (e.g. by an unrelated call site's own lazy import racing ahead
-    of ``ensure_litellm_ready``) — the patch during ``import litellm`` becomes
-    a no-op (module cache hit, nothing re-runs), but the handler-strip on exit
-    still redirects it.
+    The fix moves one layer down: instead of patching handler construction,
+    this redirects the actual OS-facing ``sys.stdout``/``sys.stderr`` objects
+    themselves (via `contextlib.redirect_stdout`/`redirect_stderr`) to reyn's
+    log file for the whole ``import litellm`` window. This is independent of
+    *when* or *how often* a handler (re)binds its stream, because both the
+    old construction-time default (``logging.StreamHandler.__init__``'s own
+    ``stream = sys.stderr`` fallback) and the new emit-time rebind
+    (``LevelRoutingStreamHandler.emit``'s ``self.stream = sys.stderr``) get
+    their value from the SAME place: whatever ``sys.stdout``/``sys.stderr``
+    currently ARE. Substituting those for the whole window catches either
+    shape, and any future litellm handler shape that keeps reading from the
+    same two names. litellm's own choice of logger/handler/level/format is
+    untouched — only where the bytes ultimately land changes, keeping the
+    line "reyn decides the destination, litellm decides the content."
+
+    On exit, the three loggers are also stripped down to file-routed only:
+    their handler lists are cleared and ``propagate`` is set ``True``, so
+    every *runtime* litellm log (not just the import-time one) flows to the
+    root logger's file handler exactly once, with no leftover console sink.
+    This also makes the context manager safe to use when litellm was already
+    imported earlier in the process (e.g. by an unrelated call site's own
+    lazy import racing ahead of ``ensure_litellm_ready``) — the stream
+    redirect during ``import litellm`` becomes a no-op (module cache hit,
+    nothing re-runs), but the handler-strip on exit still redirects it.
     """
     # Find the reyn.log FileHandler the interactive startup installed. Unlike
     # the pre-lazy-load version — which ran only immediately after
@@ -164,28 +180,19 @@ def _litellm_import_logs_to_file() -> "Iterator[None]":
             break
     if file_stream is None:
         # No file handler in place (non-interactive / --cui / no prior
-        # basicConfig call) — do not patch anything, so litellm's normal
+        # basicConfig call) — do not redirect anything, so litellm's normal
         # stderr behavior applies.
         yield
         return
 
-    original_stream_handler = logging.StreamHandler
-
-    class _FileRoutedStreamHandler(logging.StreamHandler):
-        """``StreamHandler`` that defaults to reyn's log file, not stderr."""
-
-        def __init__(self, stream: object = None) -> None:
-            super().__init__(stream=file_stream if stream is None else stream)
-
-    logging.StreamHandler = _FileRoutedStreamHandler  # type: ignore[misc]
-    try:
-        yield
-    finally:
-        logging.StreamHandler = original_stream_handler  # type: ignore[misc]
-        for name in _LITELLM_LOGGER_NAMES:
-            logger = logging.getLogger(name)
-            logger.handlers.clear()
-            logger.propagate = True
+    with contextlib.redirect_stdout(file_stream), contextlib.redirect_stderr(file_stream):
+        try:
+            yield
+        finally:
+            for name in _LITELLM_LOGGER_NAMES:
+                logger = logging.getLogger(name)
+                logger.handlers.clear()
+                logger.propagate = True
 
 
 _litellm_import_failure_warned = False

--- a/tests/llm/test_litellm_lazy_load.py
+++ b/tests/llm/test_litellm_lazy_load.py
@@ -218,6 +218,79 @@ def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
         litellm_bootstrap._ready_registry.update(saved_registry)
 
 
+def test_import_time_redirect_survives_a_handler_that_rebinds_stream_at_emit(tmp_path) -> None:
+    """Tier 2: #5831 — the import-time redirect must not depend on WHEN a
+    handler binds its stream, since litellm can (and, in 1.100.0, does)
+    attach a handler that REBINDS its own ``self.stream`` from the live
+    ``sys.stderr``/``sys.stdout`` on every single ``emit()`` call, discarding
+    whatever it was constructed with. This test does not depend on litellm's
+    installed version at all — it constructs that exact hazard directly, so
+    "green on today's litellm" is not this test's witness; a future litellm
+    handler shape doing the same rebind-from-sys-module trick is what it
+    actually exercises.
+
+    FALSIFY: reverting `_litellm_import_logs_to_file` to its pre-#5831
+    mechanism (patch ``logging.StreamHandler``'s *construction*, not the
+    ``sys.stdout``/``sys.stderr`` objects themselves) makes this RED — the
+    synthetic handler below is constructed with a plain, unpatched stream
+    and then rebinds past it at emit time straight to whatever `sys.stderr`
+    the fake-terminal fixture below installed, leaking the marker there
+    instead of the log file.
+    """
+    import io
+    import logging
+    import sys
+
+    from reyn.llm.litellm_bootstrap import _LITELLM_LOGGER_NAMES, _litellm_import_logs_to_file
+
+    class _RebindsStreamAtEmit(logging.StreamHandler):
+        """Mimics litellm 1.100.0's ``LevelRoutingStreamHandler``: re-reads
+        the live `sys.stderr` and rebinds `self.stream` on every `emit()`,
+        regardless of what it was constructed with."""
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.stream = sys.stderr
+            super().emit(record)
+
+    logs_dir = tmp_path / ".reyn" / "logs"
+    logs_dir.mkdir(parents=True)
+    log_file = logs_dir / "reyn.log"
+    file_handler = logging.FileHandler(log_file)
+
+    root = logging.getLogger()
+    target_logger = logging.getLogger(_LITELLM_LOGGER_NAMES[0])
+    saved_root_handlers = root.handlers[:]
+    saved_target_handlers = target_logger.handlers[:]
+    saved_target_propagate = target_logger.propagate
+    saved_stderr = sys.stderr
+    fake_terminal = io.StringIO()  # stands in for the real terminal's stderr
+    sys.stderr = fake_terminal
+    root.handlers[:] = [file_handler]
+    try:
+        with _litellm_import_logs_to_file():
+            # Constructed with the module's OWN default (stream=None ->
+            # whatever sys.stderr IS right now) -- inside the context
+            # manager that is already reyn's file stream, but the point of
+            # this handler is that it does not matter: emit() rebinds past
+            # it anyway.
+            handler = _RebindsStreamAtEmit()
+            target_logger.addHandler(handler)
+            target_logger.warning("marker-5831-emit-time-rebind")
+        file_handler.flush()
+
+        assert "marker-5831-emit-time-rebind" in log_file.read_text(), (
+            "message never reached the log file"
+        )
+        assert "marker-5831-emit-time-rebind" not in fake_terminal.getvalue(), (
+            f"message leaked to the (fake) terminal: {fake_terminal.getvalue()!r}"
+        )
+    finally:
+        sys.stderr = saved_stderr
+        root.handlers[:] = saved_root_handlers
+        target_logger.handlers[:] = saved_target_handlers
+        target_logger.propagate = saved_target_propagate
+
+
 def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path, out_of_process_reyn) -> None:
     """Tier 2: litellm's cost-map-fetch-failure warning, emitted synchronously
     *during* ``import litellm`` (not a runtime call reyn controls, so exercised


### PR DESCRIPTION
**[e2e-coder]** — Fixes main red on `tests/llm/test_litellm_lazy_load.py` (2 tests, 3.11/3.12), part of #5831.

## Root cause (findings ①② reported to lead-coder-30 before this fix)

litellm 1.99.0 → 1.100.0 is a pure upstream version bump (not caused by #5827/#5822 — confirmed, that PR never touches logging).

① **Warning origin**: `litellm/litellm_core_utils/get_model_cost_map.py:454-455`'s `verbose_logger.warning("LiteLLM: Failed to fetch remote model cost map...")`, emitted through litellm 1.100.0's new `LevelRoutingStreamHandler` (`_logging.py:266`, attached to the `"LiteLLM"` logger at import time).

② **Why reyn's capture stopped working**: reyn's `_litellm_import_logs_to_file()` patched `logging.StreamHandler` *construction* for the duration of `import litellm`. `LevelRoutingStreamHandler.emit()` re-reads the live `sys.stdout`/`sys.stderr` and **rebinds** `self.stream` on every call (WARNING+ → `sys.stderr`) — independent of whatever it was constructed with. The construction-time patch has nothing left to intercept.

## Fix

Per owner's ruling (verified: litellm has no documented/official output-destination knob — only `LITELLM_LOG` for level and `JSON_LOGS` for format), moved one layer down: for the duration of `import litellm`, redirect the actual `sys.stdout`/`sys.stderr` objects themselves (`contextlib.redirect_stdout`/`redirect_stderr`) to reyn's log file, instead of patching handler construction. Both the old construction-time default and the new emit-time rebind read from the same place — whatever `sys.stdout`/`sys.stderr` currently *are* — so this is independent of when/how a handler binds its stream. litellm's own logger/handler/level/format choices are untouched; only the destination changes (boundary: reyn decides where output goes, litellm decides what to log).

The post-import handler-clear + `propagate=True` cleanup (for *runtime*, not just import-time, litellm logging) is unchanged.

## Acceptance criteria (lead-coder-30's ruling)

- [x] ① Not dependent on WHEN the stream binds — new test `test_import_time_redirect_survives_a_handler_that_rebinds_stream_at_emit` constructs the emit-time-rebind hazard directly (a synthetic handler, not litellm's own), so it is not a witness only for today's litellm version. Strip-falsified: reverting to the old construction-time-only patch (real, temporary in-file edit) turned this test AND the two originally-red tests RED with the exact reported mechanism, confirmed then reverted.
- [x] ② Existing asserts not loosened — both `in log_text` / `not in result.stderr` assertions in the two originally-failing tests are untouched.
- [x] ③ `in log_text` side kept — a fix that routes output nowhere would fail that half; the new test also asserts the file-side positively.

This PR only restores main to green — the architect's lock/canary (mentioned in the ruling) is out of scope here.

## Test plan

- [x] `tests/llm/test_litellm_lazy_load.py` — 11 passed locally (10 pre-existing + 1 new), including the two previously-red tests.
- [x] Gates: `ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green.
- [x] (skipped — full suite is CI-only per standing rule, not run locally)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
