### PR TITLE
fix(#5830): STATE_SNAPSHOT/STATE_DELTA ride the pump stream, not a side channel

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -72,6 +72,7 @@ from reyn.interfaces.transport.frames import (
     BacklogBatch,
     DisplayFrame,
     FrameTag,
+    StatusApplied,
 )
 
 from ._meta_keys import ELAPSED_SECS_KEY as _ELAPSED_SECS_KEY
@@ -6782,135 +6783,152 @@ class TextualChatApp(App):
                 if isinstance(frame, BacklogBatch):
                     self._apply_backlog_batch(frame)
                     continue
-                if not self._queue_seeded:
-                    try:
-                        self._seed_queue_view()
-                    except Exception:
-                        logger.exception("textual chat: queue-view seed failed")
-                    self._queue_seeded = True
-                if frame.tag is FrameTag.EVENT:
-                    etype = getattr(frame.event, "type", None)
-                    if etype == "session_attached":
-                        try:
-                            await self._handle_session_attached_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: session_attached reset+hydrate failed"
-                            )
-                    elif etype == "user_submitted":
-                        try:
-                            self._handle_user_submitted_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: user_submitted ingest failed"
-                            )
-                    elif etype == "turn_started":
-                        try:
-                            self._handle_turn_started_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: turn_started queue-promote failed"
-                            )
-                    elif etype == "inbox_cancel":
-                        try:
-                            self._handle_inbox_cancel_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: inbox_cancel ingest failed"
-                            )
-                    elif etype == "intervention_answer_submitted":
-                        try:
-                            self._handle_intervention_answer_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: intervention_answer_submitted "
-                                "ingest failed"
-                            )
-                    elif etype == "session_halted":
-                        try:
-                            self._handle_session_halted_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: session_halted status refresh failed"
-                            )
-                    elif etype == "agent_delta":
-                        try:
-                            self._handle_agent_delta_event(frame.event)
-                        except Exception:
-                            logger.exception(
-                                "textual chat: agent_delta coalesce failed"
-                            )
-                    elif etype in _TURN_END_EVENT_TYPES:
-                        # #3693: the turn is over — the row goes, whichever of
-                        # the three terminal events arrived. Guarded like its
-                        # siblings below: one frame's failure must not stop the
-                        # pump, and a chrome row is the last thing that should
-                        # be able to.
-                        try:
-                            self._activity.end()
-                        except Exception:
-                            logger.exception("textual chat: activity row clear failed")
-                        try:
-                            self._sweep_orphaned_running_tools()
-                        except Exception:
-                            logger.exception(
-                                "textual chat: orphaned-tool sweep failed"
-                            )
-                        try:
-                            self._sweep_orphaned_streaming_replies()
-                        except Exception:
-                            logger.exception(
-                                "textual chat: orphaned-stream sweep failed"
-                            )
-                        try:
-                            # #4691 arc item ①: settle the turn's own parent
-                            # LAST — after both sweeps above have already
-                            # given every one of its completion-Group
-                            # children a terminal state, so nothing here can
-                            # observe a child still RUNNING.
-                            self._settle_turn_parent()
-                        except Exception:
-                            logger.exception(
-                                "textual chat: turn-parent settle failed"
-                            )
+                if isinstance(frame, StatusApplied):
+                    # #5830 (architect FINAL ruling, same shape #5139
+                    # already established for BacklogBatch above) —
+                    # DELIBERATELY no ``continue`` here, unlike the
+                    # BacklogBatch branch: this item carries nothing to
+                    # apply of its own (the transport already applied the
+                    # STATE_SNAPSHOT/STATE_DELTA onto RemoteStatusView
+                    # before producing it — see StatusApplied's own
+                    # docstring), so falling through to this loop's own
+                    # trailing ``_refresh_live_chrome()`` call below is its
+                    # entire job: give that call something to fire ON, in
+                    # wire-arrival order, instead of waiting for whatever
+                    # OTHER frame happens to arrive next (the owner-hit:
+                    # web/connect's status bar stayed on the old agent
+                    # until the next turn's own frame arrived).
+                    pass
                 else:
-                    msg = frame.message
-                    if msg.kind == "__end__":
-                        break
-                    # #3362: the two CLIENT-consumed sentinels are handled here,
-                    # not skipped. Deliberately NOT written as an early
-                    # ``continue`` — the live-chrome refresh at the foot of this
-                    # loop must still run for these frames, and a ``continue``
-                    # past it is precisely the defect the F5b/#3338 note below
-                    # records (an EVENT-leg ``continue`` once starved the whole
-                    # status line).
-                    elif msg.kind == "__copy_last_reply__":
+                    if not self._queue_seeded:
                         try:
-                            await self._handle_copy_request(msg.text)
-                        except Exception as exc:
-                            logger.exception("textual chat: /copy sentinel failed")
-                            self._record_pump_swallow("__copy_last_reply__", exc)
-                    elif msg.kind == "__rewind_list__":
-                        try:
-                            await self._handle_rewind_request(msg)
-                        except Exception as exc:
-                            logger.exception("textual chat: /rewind sentinel failed")
-                            self._record_pump_swallow("__rewind_list__", exc)
-                    elif msg.kind == "__open_artifact__":
-                        try:
-                            await self._handle_open_artifact_request(msg.text)
-                        except Exception as exc:
-                            logger.exception("textual chat: /open sentinel failed")
-                            self._record_pump_swallow("__open_artifact__", exc)
-                    elif msg.kind not in _SKIP_KINDS:
-                        try:
-                            self._ingest_frame(msg)
-                        except Exception as exc:
-                            logger.exception(
-                                "textual chat: frame ingest failed for kind=%r",
-                                msg.kind,
-                            )
-                            self._record_pump_swallow(msg.kind, exc)
+                            self._seed_queue_view()
+                        except Exception:
+                            logger.exception("textual chat: queue-view seed failed")
+                        self._queue_seeded = True
+                    if frame.tag is FrameTag.EVENT:
+                        etype = getattr(frame.event, "type", None)
+                        if etype == "session_attached":
+                            try:
+                                await self._handle_session_attached_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: session_attached reset+hydrate failed"
+                                )
+                        elif etype == "user_submitted":
+                            try:
+                                self._handle_user_submitted_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: user_submitted ingest failed"
+                                )
+                        elif etype == "turn_started":
+                            try:
+                                self._handle_turn_started_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: turn_started queue-promote failed"
+                                )
+                        elif etype == "inbox_cancel":
+                            try:
+                                self._handle_inbox_cancel_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: inbox_cancel ingest failed"
+                                )
+                        elif etype == "intervention_answer_submitted":
+                            try:
+                                self._handle_intervention_answer_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: intervention_answer_submitted "
+                                    "ingest failed"
+                                )
+                        elif etype == "session_halted":
+                            try:
+                                self._handle_session_halted_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: session_halted status refresh failed"
+                                )
+                        elif etype == "agent_delta":
+                            try:
+                                self._handle_agent_delta_event(frame.event)
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: agent_delta coalesce failed"
+                                )
+                        elif etype in _TURN_END_EVENT_TYPES:
+                            # #3693: the turn is over — the row goes, whichever of
+                            # the three terminal events arrived. Guarded like its
+                            # siblings below: one frame's failure must not stop the
+                            # pump, and a chrome row is the last thing that should
+                            # be able to.
+                            try:
+                                self._activity.end()
+                            except Exception:
+                                logger.exception("textual chat: activity row clear failed")
+                            try:
+                                self._sweep_orphaned_running_tools()
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: orphaned-tool sweep failed"
+                                )
+                            try:
+                                self._sweep_orphaned_streaming_replies()
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: orphaned-stream sweep failed"
+                                )
+                            try:
+                                # #4691 arc item ①: settle the turn's own parent
+                                # LAST — after both sweeps above have already
+                                # given every one of its completion-Group
+                                # children a terminal state, so nothing here can
+                                # observe a child still RUNNING.
+                                self._settle_turn_parent()
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: turn-parent settle failed"
+                                )
+                    else:
+                        msg = frame.message
+                        if msg.kind == "__end__":
+                            break
+                        # #3362: the two CLIENT-consumed sentinels are handled here,
+                        # not skipped. Deliberately NOT written as an early
+                        # ``continue`` — the live-chrome refresh at the foot of this
+                        # loop must still run for these frames, and a ``continue``
+                        # past it is precisely the defect the F5b/#3338 note below
+                        # records (an EVENT-leg ``continue`` once starved the whole
+                        # status line).
+                        elif msg.kind == "__copy_last_reply__":
+                            try:
+                                await self._handle_copy_request(msg.text)
+                            except Exception as exc:
+                                logger.exception("textual chat: /copy sentinel failed")
+                                self._record_pump_swallow("__copy_last_reply__", exc)
+                        elif msg.kind == "__rewind_list__":
+                            try:
+                                await self._handle_rewind_request(msg)
+                            except Exception as exc:
+                                logger.exception("textual chat: /rewind sentinel failed")
+                                self._record_pump_swallow("__rewind_list__", exc)
+                        elif msg.kind == "__open_artifact__":
+                            try:
+                                await self._handle_open_artifact_request(msg.text)
+                            except Exception as exc:
+                                logger.exception("textual chat: /open sentinel failed")
+                                self._record_pump_swallow("__open_artifact__", exc)
+                        elif msg.kind not in _SKIP_KINDS:
+                            try:
+                                self._ingest_frame(msg)
+                            except Exception as exc:
+                                logger.exception(
+                                    "textual chat: frame ingest failed for kind=%r",
+                                    msg.kind,
+                                )
+                                self._record_pump_swallow(msg.kind, exc)
                 # F5b + #3338: refresh the live chrome (the always-visible
                 # status-values line, plus whichever drawer pane is OPEN) on EVERY
                 # frame — DISPLAY **and** EVENT alike. This used to sit inside the

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -29,7 +29,12 @@ from prompt_toolkit.patch_stdout import patch_stdout
 
 from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
 from reyn.interfaces.transport.client_transport import ClientTransport, pending_head_id
-from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, FrameTag
+from reyn.interfaces.transport.frames import (
+    BacklogBatch,
+    DisplayFrame,
+    FrameTag,
+    StatusApplied,
+)
 from reyn.runtime.outbox import OutboxMessage
 
 from ._copy_sentinel import COPY_BUFFER_MAX, handle_copy_sentinel
@@ -376,6 +381,17 @@ async def run_output_loop(
             for f in frame.frames:
                 if isinstance(f, DisplayFrame):
                     await _render_display_message(f.message)
+            continue
+        if isinstance(frame, StatusApplied):
+            # #5830 BLOCKING (lead-coder review of PR #5835's own first
+            # pass): this console/plain client has no live status-bar/
+            # chrome concept the way TextualChatApp does (see
+            # StatusApplied's own docstring, whose ONLY consumer before
+            # this fix was that class's `_refresh_live_chrome` fall-
+            # through) — nothing to refresh here, so this item is simply
+            # dropped. Checked BEFORE the unconditional `frame.tag` read
+            # below, the same way the BacklogBatch check above already is
+            # — StatusApplied is not a Frame either.
             continue
         # Event frame → the renderer's working-indicator entry point. The dual
         # stream is dispatched by tag at the CONSUMING end so the renderer keeps

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -11,10 +11,16 @@ The transport is decoupled from HTTP for testability and single-responsibility:
 it consumes an ``AsyncIterator[str]`` of raw SSE lines (production: an httpx
 ``aiter_lines`` over the SSE endpoint) and calls an injected ``send`` coroutine
 to POST a client→server message (production: an httpx POST). :meth:`frames`
-demuxes the one SSE stream three ways — render frames to the renderer, STATE_*
-to the :class:`~reyn.interfaces.transport.agui.state.RemoteStatusView`
-side-channel, and the reconnect MESSAGES/STATE snapshots — while re-guarding
-presentation nodes at the edge (A5).
+demuxes the one SSE stream: render frames go straight to the renderer;
+MESSAGES_SNAPSHOT becomes one in-stream :class:`~reyn.interfaces.transport.
+frames.BacklogBatch` item (#5139); STATE_* is applied onto
+:class:`~reyn.interfaces.transport.agui.state.RemoteStatusView` immediately
+AND (#5830) also yields one in-stream :class:`~reyn.interfaces.transport.
+frames.StatusApplied` item — NOT a side channel any more: #5830's own
+owner-hit (web/connect's status bar staying on the old agent until the next
+turn's frame arrived) was exactly that prior side-channel shape, the same
+class #5139 already closed for MESSAGES_SNAPSHOT. All of it is re-guarded at
+the edge (A5) where it carries presentation nodes.
 
 P3 (HITL answer round-trip): the client tracks the pending intervention BY ID
 off the intervention frontend-tool (:class:`InterventionTool`) the server emits
@@ -43,7 +49,13 @@ from reyn.interfaces.transport.agui.protocol import (
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.drain import suspend_between_frames
-from reyn.interfaces.transport.frames import BacklogBatch, DisplayFrame, EventFrame, Frame
+from reyn.interfaces.transport.frames import (
+    BacklogBatch,
+    DisplayFrame,
+    EventFrame,
+    Frame,
+    StatusApplied,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -261,13 +273,15 @@ class AgUiTransport(ClientTransport):
                 )
         return frame
 
-    def _consume_block(self, block_lines: "list[str]") -> "list[Frame | BacklogBatch]":
-        # Decode one SSE block into zero or more render frames, routing
-        # STATE_* to its side-channel and MESSAGES_SNAPSHOT into `out` as
-        # ONE BacklogBatch item (#5139) — everything this transport
-        # produces flows through the SAME queue/`frames()` stream, no
-        # second channel.
-        out: list[Frame | BacklogBatch] = []
+    def _consume_block(
+        self, block_lines: "list[str]",
+    ) -> "list[Frame | BacklogBatch | StatusApplied]":
+        # Decode one SSE block into zero or more render frames, folding
+        # STATE_* and MESSAGES_SNAPSHOT into `out` as ONE in-stream item
+        # each (#5139 for MESSAGES_SNAPSHOT, #5830 for STATE_*) — every-
+        # thing this transport produces flows through the SAME queue/
+        # `frames()` stream, no side channel.
+        out: "list[Frame | BacklogBatch | StatusApplied]" = []
         for ev in parse_sse_blocks(block_lines + [""]):
             decoded = decode_event(ev.type, ev.data)
             if decoded is None:
@@ -275,6 +289,18 @@ class AgUiTransport(ClientTransport):
             if isinstance(decoded, StateUpdate):
                 if decoded.snapshot is not None:
                     self._status.apply_snapshot(decoded.snapshot)
+                    # #5830 acceptance ④ (architect design ②: "snapshot も
+                    # listener を発火する"): a snapshot is a delta from ∅ —
+                    # before this, `_dispatch_status_listeners` only ever
+                    # fired for `decoded.delta`, so an attach's own
+                    # `all_sessions_status` row (arriving on the SNAPSHOT,
+                    # not a later delta) never reached
+                    # `TextualChatApp._on_session_status_delta` until some
+                    # UNRELATED future delta happened to touch that key —
+                    # the "もう1段悪い箇所" the issue names, permanently
+                    # stale otherwise (a frame-arrival fix alone cannot
+                    # close this: the listener call itself was never made).
+                    self._dispatch_status_listeners(decoded.snapshot)
                 if decoded.delta is not None:
                     self._status.apply_delta(decoded.delta)
                     self._dispatch_status_listeners(decoded.delta)
@@ -284,6 +310,17 @@ class AgUiTransport(ClientTransport):
                 # this is set here, independent of whether this block also
                 # yields any display Frame.
                 self._state_ready_event.set()
+                # #5830 (architect FINAL ruling, same shape #5139 already
+                # established for MESSAGES_SNAPSHOT below): the values are
+                # already applied above — this item's only job is to give
+                # `TextualChatApp._pump_frames` something to see IN THE
+                # SAME STREAM, in wire-arrival order, so its trailing
+                # `_refresh_live_chrome()` call fires right after this
+                # update lands instead of waiting for whatever OTHER frame
+                # happens to arrive next (the owner-hit: the status bar
+                # stayed on the old agent until the next turn's own
+                # frame). See `StatusApplied`'s own docstring.
+                out.append(StatusApplied())
             elif isinstance(decoded, MessagesSnapshot):
                 # #5139 (architect FINAL ruling, issuecomment-5383272756):
                 # ONE BacklogBatch item, appended to `out` like any other
@@ -454,11 +491,13 @@ class AgUiTransport(ClientTransport):
         finally:
             self._display_queue.put_nowait(_SSE_DONE)
 
-    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
+    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch | StatusApplied]":
         # #5139: widened from ``AsyncIterator[Frame]`` — this transport is
         # the only ``ClientTransport`` implementation that ever yields a
         # ``BacklogBatch`` (see that class's own docstring); every other
-        # implementation's ``frames()`` return type is unchanged.
+        # implementation's ``frames()`` return type is unchanged. #5830
+        # widens it again for ``StatusApplied`` — same reasoning, same
+        # single producer.
         #
         # Started lazily, once, on first iteration (production calls this
         # exactly once per connection — grepped, #5107 co-vet) rather than

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -303,10 +303,41 @@ class BacklogBatch:
 HYDRATE_PAGE_FRAMES = 200
 
 
+@dataclass(frozen=True)
+class StatusApplied:
+    """#5830 (architect FINAL ruling, same shape #5139 already established
+    for :class:`BacklogBatch`): one decoded ``STATE_SNAPSHOT``/``STATE_DELTA``
+    application, carried IN-STREAM — appended to the SAME list
+    :meth:`~reyn.interfaces.transport.agui.client.AgUiTransport._consume_block`
+    already builds for every other frame, not a side channel.
+
+    Owner-hit this closes: web/connect's status bar (agent name / model /
+    cost / ctx / session tree / …) stayed on the OLD agent right after
+    ``/attach <other agent>``, updating only once the next turn's own
+    frame arrived. Root cause (architect's own measurement): applying a
+    decoded ``StateUpdate`` onto :class:`~reyn.interfaces.transport.agui.
+    state.RemoteStatusView` (``AgUiTransport._consume_block``) never
+    produced anything for :meth:`TextualChatApp._pump_frames` to see — the
+    new values landed on the read-model instantly, but the ONE place that
+    calls :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.
+    _refresh_live_chrome` (this pump's own per-frame trailer) had nothing
+    to iterate for a snapshot/delta-only SSE block, so the redraw waited
+    for whatever frame happened to arrive next.
+
+    Carries no data of its own — the values are already on
+    :class:`~reyn.interfaces.transport.agui.state.RemoteStatusView` by the
+    time this item is even constructed (:meth:`_consume_block` applies the
+    ``StateUpdate`` first, in the SAME branch, before appending this). Its
+    only job is to exist as a stream item so ``_pump_frames``'s trailing
+    ``_refresh_live_chrome()`` call fires in wire-arrival order — unlike
+    :class:`BacklogBatch`, the pump does NOT ``continue`` past it."""
+
+
 __all__ = [
     "BacklogBatch",
     "DisplayFrame",
     "EventFrame",
+    "StatusApplied",
     "Frame",
     "FrameTag",
     "HYDRATE_PAGE_FRAMES",

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -18,6 +18,20 @@ A frame carries its :class:`FrameTag` so the consuming client dispatches to the
 renderer's two entry points (``message`` for display, ``on_audit_event`` for
 event) at the consuming end — one stream in, two renderer entry points out.
 
+#5830 BLOCKING (lead-coder review, PR #5835's own first pass): ``.tag`` is
+ONLY ever safe to read on a genuine :data:`Frame` member (``DisplayFrame``/
+``EventFrame``) — :meth:`~reyn.interfaces.transport.client_transport.
+ClientTransport.frames` is typed to also yield :class:`BacklogBatch` and
+:class:`StatusApplied`, NEITHER of which carries a ``.tag``. **Every**
+consumer of that stream must check for both with ``isinstance`` BEFORE
+touching ``.tag`` on whatever it got, the same way each already checks for
+``BacklogBatch`` — a consumer that does not (``interfaces/repl/stream_
+client.py``'s own plain/``--cui`` output loop, before this fix) raises
+``AttributeError`` the instant a remote server ever sends a ``STATE_*``
+update. ``git grep -n "BacklogBatch" src/reyn`` names every file that must
+be checked when a NEW non-``Frame`` stream item is added here — this is
+not optional per-consumer discretion, it is the vocabulary's own contract.
+
 The forward-set (:func:`forwarded_frame_kinds`) is mostly **DERIVED** from the
 renderer's own vocabulary — ``_WAITING_ON_BY_EVENT`` (the tool-axis table) plus
 the turn / intervention-answer events ``on_audit_event`` handles — never

--- a/tests/interfaces/test_5830_remote_attach_status_refresh.py
+++ b/tests/interfaces/test_5830_remote_attach_status_refresh.py
@@ -56,6 +56,24 @@ async def _build_snapshot_only_transport(state: dict) -> AgUiTransport:
     return AgUiTransport(_sse_lines(sse), _noop_send)
 
 
+async def _end_frame():
+    from reyn.interfaces.transport.frames import DisplayFrame
+    from reyn.runtime.outbox import OutboxMessage
+
+    yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+
+async def _build_snapshot_then_end_transport(state: dict) -> AgUiTransport:
+    """Same reconnect-protocol preamble as :func:`_build_snapshot_only_
+    transport`, but followed by ONE live ``__end__`` frame -- for driving a
+    consumer (``run_output_loop``) that runs to completion rather than
+    being drained by hand, one frame at a time."""
+    emitter = AgUiEmitter(_end_frame(), lambda: dict(state))
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+    return AgUiTransport(_sse_lines(sse), _noop_send)
+
+
 # --- client.py level: the transport itself yields StatusApplied ---------------
 
 
@@ -165,4 +183,94 @@ async def test_all_sessions_status_listener_fires_on_snapshot_not_only_delta() -
     assert ("researcher", "main", True, False) in seen, (
         f"all_sessions_status row from the SNAPSHOT never reached the "
         f"listener: {seen}"
+    )
+
+
+# --- the OTHER .tag readers: BacklogBatch's own precedent lives in 6 files ----
+#
+# #5830 BLOCKING (lead-coder review of PR #5835's own first pass): a
+# StatusApplied item flows through the SAME "git grep BacklogBatch" surface
+# every other non-Frame stream item does. Census, distinguishing "seen" from
+# "fix needed" (lead-coder's own explicit ask):
+#
+#   interfaces/inline/textual_chat/app.py   -- fix applied (this PR's own
+#                                               main change, see the other
+#                                               tests in this file).
+#   interfaces/repl/stream_client.py        -- fix needed AND applied
+#                                               (`run_output_loop`'s own
+#                                               `.tag` read crashed on a
+#                                               StatusApplied before this;
+#                                               THIS test drives it).
+#   interfaces/transport/agui/client.py     -- the PRODUCER of StatusApplied
+#                                               (`_consume_block`) -- not a
+#                                               `.tag` reader of its OWN
+#                                               output, no fix needed.
+#   interfaces/transport/agui/protocol.py   -- a docstring cross-reference
+#                                               to BacklogBatch only, no
+#                                               `.tag` read at all -- no fix
+#                                               needed (grepped, confirmed).
+#   interfaces/transport/client_transport.py -- same: docstring cross-
+#                                               reference only (the ABSTRACT
+#                                               base does not itself consume
+#                                               the stream it declares) --
+#                                               no fix needed.
+#   interfaces/transport/frames.py          -- the vocabulary's own
+#                                               definition file; its module
+#                                               docstring's ".tag selects
+#                                               the renderer entry" claim is
+#                                               corrected in this same PR.
+#   interfaces/transport/in_process.py      -- lead-coder's explicit ⚠️:
+#                                               "not-broken is not the same
+#                                               as safe" -- checked directly:
+#                                               InProcessTransport.frames()
+#                                               (in_process.py's own queue,
+#                                               fed exclusively by DisplayFrame/
+#                                               EventFrame construction sites)
+#                                               structurally CANNOT ever
+#                                               enqueue a BacklogBatch or a
+#                                               StatusApplied -- both are
+#                                               remote-only artifacts
+#                                               (AgUiTransport's own decode).
+#                                               No fix needed; confirmed by
+#                                               reading the whole method, not
+#                                               inferred from "it doesn't
+#                                               mention BacklogBatch".
+
+
+@pytest.mark.asyncio
+async def test_run_output_loop_survives_a_status_applied_item() -> None:
+    """Tier 2: #5830 BLOCKING (lead-coder review of PR #5835's own first
+    pass) -- the PREVIOUS test suite in this file only ever drove
+    StatusApplied through TextualChatApp's own `_pump_frames`.
+    `interfaces/repl/stream_client.py`'s `run_output_loop` (the console/
+    ``--cui`` consumer of the SAME transport stream) reads `frame.tag`
+    unconditionally right after its own BacklogBatch check -- an
+    AttributeError on a real remote server's very first STATE_SNAPSHOT,
+    confirmed failing CI on this PR's first pass (`AttributeError:
+    'StatusApplied' object has no attribute 'tag'`,
+    interfaces/repl/stream_client.py:384).
+
+    Real AgUiEmitter -> real SSE text -> real AgUiTransport decode -> real
+    ConsoleChatRenderer -> real run_output_loop, no mocks (mirrors
+    test_agui_remote_rewind_textfallback.py's own established pattern in
+    this directory). The loop completing at all (never raising, never
+    hanging) is the whole assertion -- a StatusApplied item is dropped
+    silently here (this console has no live status chrome to refresh, see
+    stream_client.py's own comment at that check)."""
+    import asyncio
+
+    from reyn.interfaces.repl.renderer import ConsoleChatRenderer
+    from reyn.interfaces.repl.stream_client import run_output_loop
+
+    transport = await _build_snapshot_then_end_transport(
+        {"attached_name": "researcher", "model": "opus"}
+    )
+    # A finite timeout is itself part of the witness: the pre-fix
+    # AttributeError propagated out of run_output_loop's own `async for`
+    # immediately (never a hang) -- this asserts "runs to completion",
+    # which a bare `await run_output_loop(...)` with no timeout would also
+    # do for a WRONG reason (an unrelated hang would time out the whole
+    # test suite instead of failing this one test specifically).
+    await asyncio.wait_for(
+        run_output_loop(transport, ConsoleChatRenderer()), timeout=2.0,
     )

--- a/tests/interfaces/test_5830_remote_attach_status_refresh.py
+++ b/tests/interfaces/test_5830_remote_attach_status_refresh.py
@@ -1,0 +1,168 @@
+"""Tier 2: #5830 -- web/connect's status bar refreshes on the attach-time
+STATE_SNAPSHOT itself, not on whatever frame happens to arrive next
+(owner-hit).
+
+Root cause (architect's own measurement, issue #5830): applying a decoded
+``StateUpdate`` onto ``RemoteStatusView`` (``AgUiTransport._consume_block``)
+never produced anything for :meth:`TextualChatApp._pump_frames` to iterate
+-- the new values landed on the read-model instantly, but the ONE place
+that calls ``_refresh_live_chrome`` (this pump's own per-frame trailer) had
+nothing to fire on for a snapshot/delta-only SSE block, so the redraw
+waited for the next turn's own frame.
+
+Fix (architect FINAL ruling, same shape #5139 already established for
+``MESSAGES_SNAPSHOT``/``BacklogBatch``): a decoded STATE_SNAPSHOT/STATE_DELTA
+now ALSO yields one in-stream ``StatusApplied`` item -- see that class's own
+docstring.
+
+Real ``AgUiEmitter``/``AgUiTransport``/``RemoteReadModel``/``TextualChatApp``
+throughout -- no mocks (mirrors test_agui_remote_inline_p3.py's own
+established pattern in this directory).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.repl.read_model import RemoteReadModel
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import StatusApplied
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+async def _empty_frames():
+    return
+    yield  # pragma: no cover -- makes this an async generator
+
+
+async def _noop_send(_payload):
+    return None
+
+
+async def _build_snapshot_only_transport(state: dict) -> AgUiTransport:
+    """A real ``AgUiTransport`` fed a real reconnect-protocol SSE stream
+    (``AgUiEmitter``'s own connect-time preamble: an EMPTY ``MESSAGES_
+    SNAPSHOT`` + one ``STATE_SNAPSHOT`` carrying *state*) with NO further
+    frames -- the exact "display frame を1つも流さない" shape the issue's
+    own acceptance criterion names."""
+    emitter = AgUiEmitter(_empty_frames(), lambda: dict(state))
+    sse = "".join([chunk async for chunk in emitter.stream()])
+    assert "STATE_SNAPSHOT" in sse
+    assert "MESSAGES_SNAPSHOT" in sse
+    return AgUiTransport(_sse_lines(sse), _noop_send)
+
+
+# --- client.py level: the transport itself yields StatusApplied ---------------
+
+
+@pytest.mark.asyncio
+async def test_state_snapshot_alone_yields_a_status_applied_item() -> None:
+    """Tier 2: draining a real AgUiTransport fed ONLY the connect-time
+    reconnect protocol (empty backlog + one STATE_SNAPSHOT, zero display
+    frames) yields a StatusApplied item -- not silently absorbed as a side
+    channel. Falsifiable: reverting client.py's own `out.append(
+    StatusApplied())` makes this collect zero StatusApplied items."""
+    state = {"attached_name": "researcher", "model": "opus"}
+    transport = await _build_snapshot_only_transport(state)
+
+    kinds = []
+    async for frame in transport.frames():
+        kinds.append(type(frame).__name__)
+
+    assert "StatusApplied" in kinds, (
+        f"no StatusApplied item in the decoded stream: {kinds}"
+    )
+    assert "BacklogBatch" in kinds  # the empty reconnect backlog, #5139
+
+
+@pytest.mark.asyncio
+async def test_status_applied_carries_no_data_values_already_landed() -> None:
+    """Tier 2: by the time StatusApplied is even constructed, RemoteReadModel
+    already reflects the new snapshot -- the item's only job is to exist as
+    a stream marker, never a second data path."""
+    state = {"attached_name": "researcher", "model": "opus"}
+    transport = await _build_snapshot_only_transport(state)
+    read_model = RemoteReadModel(transport)
+
+    saw_status_applied = False
+    async for frame in transport.frames():
+        if isinstance(frame, StatusApplied):
+            saw_status_applied = True
+            # Values are ALREADY on the read model at the instant this
+            # item is seen -- no additional apply step is needed.
+            snap = read_model.snapshot()
+            assert snap["attached_name"] == "researcher"
+    assert saw_status_applied
+
+
+# --- app.py level: the real status bar refreshes with ZERO display frames -----
+
+
+@pytest.mark.asyncio
+async def test_status_line_shows_the_new_agent_immediately_on_attach() -> None:
+    """Tier 2: the owner's own reported symptom, reproduced and closed --
+    a real TextualChatApp wired to a real AgUiTransport shows the NEW
+    agent's name in its status line the instant the attach-time STATE_
+    SNAPSHOT decodes, with NO turn started and NOT ONE display frame ever
+    pushed onto the wire. Before #5830's fix, this stayed on the
+    read-model's construction-time default (empty/placeholder) until some
+    later frame happened to arrive -- there is deliberately no later frame
+    here, so a regression that removes StatusApplied (or reverts _pump_
+    frames' own fall-through) leaves the OLD value on screen and this goes
+    red."""
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    state = {"attached_name": "researcher", "model": "opus", "cost_agent": 0.0}
+    transport = await _build_snapshot_only_transport(state)
+    read_model = RemoteReadModel(transport)
+    app = TextualChatApp(transport=transport, read_model=read_model)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        text = str(app.query_one(StatusLine).render())
+        assert "researcher" in text, (
+            f"status line did not pick up the attach-time snapshot with "
+            f"zero display frames: {text}"
+        )
+
+
+# --- the "もう1段悪い箇所": all_sessions_status listener fires on snapshot too --
+
+
+@pytest.mark.asyncio
+async def test_all_sessions_status_listener_fires_on_snapshot_not_only_delta() -> None:
+    """Tier 2: architect design ② -- a snapshot is a delta from the empty
+    set. Before #5830, `_dispatch_status_listeners` only ever fired for a
+    decoded STATE_DELTA (`AgUiTransport._consume_block`'s own pre-fix
+    branch), so an attach's own `all_sessions_status` row -- arriving on
+    the connect-time SNAPSHOT, never a later delta -- reached no listener
+    until an UNRELATED future delta happened to touch that key. This is
+    the "もう1段悪い箇所" the issue names as permanently stale without its
+    own fix (a frame-arrival fix alone cannot close it)."""
+    state = {
+        "attached_name": "researcher",
+        "all_sessions_status": [
+            {"agent": "researcher", "sid": "main", "turn_active": True, "iv_waiting": False},
+        ],
+    }
+    transport = await _build_snapshot_only_transport(state)
+
+    seen: list[tuple] = []
+    transport.add_status_listener(
+        lambda agent, sid, turn_active, iv_waiting, seq: seen.append(
+            (agent, sid, turn_active, iv_waiting)
+        )
+    )
+
+    async for _frame in transport.frames():
+        pass
+
+    assert ("researcher", "main", True, False) in seen, (
+        f"all_sessions_status row from the SNAPSHOT never reached the "
+        f"listener: {seen}"
+    )


### PR DESCRIPTION
**[tui-coder]** — Closes #5830

## What happened

Owner-hit: web/connect's status bar (agent name, model, cost, ctx, session tree, ...) stayed on the OLD agent right after `/attach <other agent>` — updating only once the next turn's own frame arrived ("turn 始まると切り替わる"). Owner also asked whether OTHER attach-reactive info has the same gap.

Root cause (architect's own measurement, issue #5830): `AgUiTransport._consume_block` applied a decoded `StateUpdate` onto `RemoteStatusView` (the values landed correctly and immediately) but never produced anything for `TextualChatApp._pump_frames` to iterate — `STATE_*` was a genuine side channel, so the ONE place that calls `_refresh_live_chrome` (the pump's own per-frame trailer) had nothing to fire on for a snapshot/delta-only SSE block. Structural: **all** of `project_status`'s keys ride this same channel, so this affected the whole status bar and any open drawer pane, not just the agent name — confirming the owner's own "他の情報も" suspicion.

A second, independently-broken piece: `all_sessions_status`'s own listener dispatch only ever fired for a DELTA, so an attach's own row (arriving on the connect-time SNAPSHOT) never reached `TextualChatApp._on_session_status_delta` until some unrelated future delta happened to touch that key.

## Fix (architect FINAL ruling — same shape #5139 already established for `MESSAGES_SNAPSHOT`/`BacklogBatch`: an in-stream item, never a side channel)

- **`frames.py`**: new `StatusApplied` frame — carries no data of its own (the values are already on `RemoteStatusView` by the time it's constructed); its only job is to exist as a stream item.
- **`agui/client.py`**: `AgUiTransport._consume_block` now appends one `StatusApplied` item to the SAME list `MESSAGES_SNAPSHOT`/live frames already flow through, for both a snapshot and a delta. Also: a snapshot now ALSO dispatches status listeners (treating it as a delta from the empty set) — closes the `all_sessions_status` gap independently of the frame-arrival fix (a frame fix alone cannot make a listener call that was never made).
- **`textual_chat/app.py`**: `_pump_frames` recognizes `StatusApplied` and — deliberately **unlike** `BacklogBatch`'s own `continue` — falls through to the SAME trailing `_refresh_live_chrome()` call every other frame already triggers, in wire-arrival order. App-side rendering code (`_refresh_live_chrome` itself) is unchanged, per the architect's own explicit scoping ("app 側の描画コードは変えない").

## Scope

Remote only. Server side (emitter/provider) was already correct and is untouched. Wire vocabulary (`project_status`) is unchanged — `StatusApplied` is a client-side decode artifact, never serialized, so the #5773 gate and older/newer server compatibility are unaffected. Local TUI is unaffected (`InProcessTransport` never produces a `StatusApplied`, mirroring `BacklogBatch`).

## Test plan

- [x] New `tests/interfaces/test_5830_remote_attach_status_refresh.py` (4 tests): a real `AgUiTransport` fed ONLY the connect-time reconnect protocol (empty backlog + one `STATE_SNAPSHOT`, zero display frames) yields a `StatusApplied` item; the read model already reflects the new values by the time that item is seen; a real `TextualChatApp`'s status line shows the NEW agent's name with the app never receiving a single display frame (the owner's own symptom, reproduced and closed — the acceptance criterion's own "display frame を1つも流さないtest"); the `all_sessions_status` listener fires on a SNAPSHOT, not only a delta.
- [x] Falsify-verified in-file (Edit-only), 3 separate probes: (1) removing `client.py`'s own `StatusApplied` append — 3 of 4 tests went red, **including the end-to-end status-line test** (reproduced the EXACT owner symptom: status line stuck on "default" instead of "researcher"); (2) reverting `app.py`'s own fall-through to a `BacklogBatch`-style `continue` — the end-to-end test went red; (3) removing the snapshot listener dispatch — the listener test went red. All 3 restored, reconfirmed green.
- [x] Full scoped regression: the new file + every #5139/status/backlog test in `tests/interfaces/` (`test_5139_remote_backlog_batch_hydrate`, `test_5139c_remote_reached_top_pull`, `test_5139c_older_backlog_wire_roundtrip`, `test_5736_remote_status_reactive`, `test_agui_remote_inline_p3`, `test_5694_pump_death_flips_attach_state`) plus the full local-TUI `test_3338_tui_status_chrome_liveness` suite (byte-identical local behavior) — 71 tests, all green.
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (new test file), `verify_module_docstrings.py` (3 changed src files), `mypy_ratchet.py` (199/208 baselined, no new findings), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (run after `git add`), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_tui_widget_boundary.py`, `check_tui_reactive_ratchet.py` (imperative-push count unchanged — reuses the EXISTING `_refresh_live_chrome` call site, adds no new one) — all green.
- [ ] Visual — **owner sign-off requested** per lead-coder's own standing instruction for this issue (visible UI behavior change).

**Note (pre-existing, unrelated — confirmed via zero diff on the flagged files before this PR):** `scripts/check_remote_snapshot_placeholder_declared.py` currently reports several unwired-key violations (`cost_usd`/`ctx_recent_usage`/`hooks_config_warnings`/`session_cached_tokens`/`usage` and others) against `origin/main`'s own `read_model.py`/`agui/state.py` — neither file is touched by this PR.

## Acceptance (architect's own, verbatim)

1. `/attach <別 agent>` した直後、turn を始めずに status bar の agent 名が新 agent — ✅
2. 同じ瞬間に model / cost / ctx / session tree が新 agent の値 — ✅ (structural: all of `project_status` rides the same fixed `StatusApplied` item)
3. `STATE_SNAPSHOT` の適用が pump の到着順の item として並び、その item で `_refresh_live_chrome` が走る（strip: item を流さなければ赤） — ✅ falsify-verified
4. `all_sessions_status` 由来の表示が attach（delta なし）で更新される — ✅
5. local TUI が 1 文字も変わらない — ✅ (71-test regression, `InProcessTransport` untouched)
6. wire 語彙（`project_status`）と #5773 gate に変更なし — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQgJMmML5BWBar7Sjjnfa7
