### PR TITLE
feat(#5831): CI-only dependency lock + floating-latest drift canary

### DIFF
--- a/.github/workflows/check-doc-drift-fixture.yml
+++ b/.github/workflows/check-doc-drift-fixture.yml
@@ -55,7 +55,9 @@ jobs:
           cache: pip
 
       - name: Install test dependencies
-        run: pip install -e ".[dev]"
+        # `-c ci-constraints.txt` (#5831): pins the resolved dependency set
+        # for reproducibility across CI runs — see that file's own header.
+        run: pip install -e ".[dev]" -c ci-constraints.txt
 
       - name: Run the #5010 calibration fixture tests
         run: pytest tests/scripts/test_check_doc_drift_5003.py -k 5010 -v

--- a/.github/workflows/dependency-drift-canary.yml
+++ b/.github/workflows/dependency-drift-canary.yml
@@ -1,0 +1,101 @@
+name: Dependency-drift canary
+
+# #5831: on 2026-09-06, litellm released 1.100.0 and `main` went red with
+# ZERO reyn commits changing — CI (test.yml) resolves PyPI's latest on
+# every run, so a third-party release's timing decided whether main was
+# green. test.yml now pins every install to `ci-constraints.txt` (a
+# recorded, reviewed set) to make main's color depend only on reyn's own
+# commits. But pinning alone answers "reproducible", not "who notices when
+# an upstream release WOULD have broken us" — that is this workflow's job.
+#
+# This installs the SAME extras as test.yml, WITHOUT ci-constraints.txt
+# (floating latest, exactly matching pyproject.toml's own `>=` floor), on a
+# schedule. A break here means: the next `ci-constraints.txt` refresh (an
+# ordinary PR — see that file's own regen instructions) will need to
+# account for it, BEFORE it reaches main by surprise.
+#
+# ⚠️ #5831 architect's ruling, load-bearing for this file's own design:
+# "第三者の release 時刻が reyn の merge 可否を握らない" (a third party's
+# release timing must not decide whether reyn can merge) — this workflow
+# therefore:
+#   - triggers ONLY on `schedule` + `workflow_dispatch`, never on
+#     `push`/`pull_request`/`merge_group` — structurally, it cannot become
+#     a required status check for any PR, so it cannot block a merge no
+#     matter how branch protection is configured.
+#   - on a red result, opens or UPDATES one tracking issue (never fails a
+#     PR, never re-runs anything on main). Updating (not re-opening fresh
+#     each time) matters: a new issue per occurrence of the SAME upstream
+#     drift buries the history that would otherwise show a pattern.
+on:
+  schedule:
+    # Daily, 06:00 UTC. Frequency is a cost/latency trade, not a precision
+    # requirement — the point is "before too many PRs build on a drift no
+    # one noticed", not "the instant a release lands".
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    name: floating-latest install + test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies (floating latest — no ci-constraints.txt)
+        id: install
+        run: pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]"
+
+      - name: Run tests
+        id: run_tests
+        run: |
+          set -o pipefail
+          timeout 15m python -m pytest -q -n auto --timeout=120 -rs | tee /tmp/pytest-canary-output.log
+
+      # `if: failure()`: only reached if either step above (install or test)
+      # actually failed — a healthy canary run does nothing here at all, no
+      # issue traffic on a good day.
+      - name: Open or update the drift-tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PY_VER: ${{ matrix.python-version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -e
+          LABEL="dependency-drift-canary"
+          TITLE="Dependency-drift canary red — floating-latest install/test failed"
+          gh label create "$LABEL" --repo "${{ github.repository }}" \
+            --description "Opened/updated by dependency-drift-canary.yml (#5831) — never blocks a PR" \
+            --color "d93f0b" 2>/dev/null || true
+
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --label "$LABEL" --json number --jq '.[0].number // empty')
+
+          BODY="**[dependency-drift-canary]** — floating-latest install/test (Python ${PY_VER}, no ci-constraints.txt) failed on $(date -u +%F).
+
+          Run: ${RUN_URL}
+
+          This does **not** block any PR — this workflow only runs on \`schedule\`/\`workflow_dispatch\`, never on \`push\`/\`pull_request\`/\`merge_group\`. It signals an upstream dependency changed in a way that would break the pinned CI once \`ci-constraints.txt\` is next refreshed to pick it up — see that file's own header for the regen steps and #5831 for the original incident (litellm 1.99.0 -> 1.100.0 turning main red with zero reyn commits). Read the run log above for the actual failure before deciding whether/how to update the lock."
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "$BODY"
+          else
+            gh issue create --repo "${{ github.repository }}" --title "$TITLE" --label "$LABEL" --body "$BODY"
+          fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,9 @@ jobs:
         # `[docs]` for mkdocs + plugins; `pyyaml` for website/build.py
         # (pyyaml is already in core deps via pyproject, so `pip install -e .`
         # would suffice, but pin the docs extras explicitly here).
-        run: pip install -e ".[docs]"
+        # `-c ci-constraints.txt` (#5831): pins the resolved dependency set
+        # for reproducibility across CI runs — see that file's own header.
+        run: pip install -e ".[docs]" -c ci-constraints.txt
 
       - name: Build landing page (website/dist/)
         run: python website/build.py

--- a/.github/workflows/sandbox-landlock-deny-gate.yml
+++ b/.github/workflows/sandbox-landlock-deny-gate.yml
@@ -43,7 +43,12 @@ jobs:
       # the reyn-rag-chunker / reyn-rag-vector-store console scripts) RUN
       # rather than skip on this job.
       - name: Install sandbox-linux + builtin-rag extras
-        run: pip install -e ".[dev,sandbox-linux,builtin-rag]"
+        # `-c ci-constraints.txt` (#5831): pins the resolved dependency set
+        # for reproducibility across CI runs — see that file's own header.
+        # `sandbox-linux`'s own extra deps are not pinned by this file (the
+        # lock was generated without that extra); unpinned packages simply
+        # resolve normally, a constraints file never adds a requirement.
+        run: pip install -e ".[dev,sandbox-linux,builtin-rag]" -c ci-constraints.txt
 
       # #4302's own "install the plugin's own requirements.txt into the
       # runner venv" step USED TO live here — REMOVED (design correction,

--- a/.github/workflows/sandbox-linux-live-x86_64.yml
+++ b/.github/workflows/sandbox-linux-live-x86_64.yml
@@ -27,7 +27,10 @@ jobs:
       # present until this one. That gap is exactly why #2975's own live
       # validation (24/24, aarch64) could never have run in CI at all before now.
       - name: Install sandbox-linux extra
-        run: pip install -e ".[sandbox-linux]"
+        # `-c ci-constraints.txt` (#5831): see sandbox-landlock-deny-gate.yml's
+        # own comment on the same step for why, and why an extra this file
+        # doesn't pin is still safe (a constraints file only narrows, never adds).
+        run: pip install -e ".[sandbox-linux]" -c ci-constraints.txt
 
       # scripts/sandbox_seccomp_x86_64_live_smoke.py is intentionally NOT a
       # pytest file: loading a real seccomp filter is irrevocable for the rest

--- a/.github/workflows/sandbox-load-method-witness.yml
+++ b/.github/workflows/sandbox-load-method-witness.yml
@@ -31,7 +31,10 @@ jobs:
       # real default-deny filter is irrevocable for the process that does
       # it), so this dedicated job is the only place this witness can run.
       - name: Install sandbox-linux extra
-        run: pip install -e ".[dev,sandbox-linux]"
+        # `-c ci-constraints.txt` (#5831): see sandbox-landlock-deny-gate.yml's
+        # own comment on the same step for why, and why an extra this file
+        # doesn't pin is still safe (a constraints file only narrows, never adds).
+        run: pip install -e ".[dev,sandbox-linux]" -c ci-constraints.txt
 
       # The gate. No skip path: every precondition (Linux, x86_64, Landlock
       # present, seccomp present, a glibc ld-linux interpreter on disk) is a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,16 @@ jobs:
         #     tests/builtin/test_fp0063_p2_builtin_mcp_rag.py. Load-bearing: that file
         #     `pytest.importorskip`s all three, so WITHOUT this extra the whole
         #     module silently SKIPS and CI goes green having verified nothing.
-        run: pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]"
+        #
+        # `-c ci-constraints.txt` (#5831): pins every resolved dependency to a
+        # recorded exact version, so this install is byte-identical across
+        # CI runs regardless of what PyPI's "latest" is at run time — see
+        # that file's own header for why (2026-09-06: litellm 1.99.0 ->
+        # 1.100.0 turned main red with zero reyn commits changing). This
+        # does NOT change pyproject.toml's own `>=` floors — a constraints
+        # file only narrows what pip resolves FROM that floor, it adds
+        # nothing pyproject didn't already declare.
+        run: pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]" -c ci-constraints.txt
 
       - name: Run tests
         # --timeout=120: a per-test wall-clock cap (pytest-timeout). Without it a
@@ -196,7 +205,10 @@ jobs:
           cache: pip
 
       - name: Install dev dependencies
-        run: pip install -e ".[dev]"
+        # `-c ci-constraints.txt` (#5831): see the "Install dependencies"
+        # step in the `test` job above for why — same reproducibility pin,
+        # applied to every job that installs project dependencies.
+        run: pip install -e ".[dev]" -c ci-constraints.txt
 
       # `timeout 4m` (#3670): see the "Run tests" step above for why —
       # converts a would-be `cancelled` job-timeout into a legible `failure`.
@@ -223,7 +235,10 @@ jobs:
           cache: pip
 
       - name: Install dev dependencies
-        run: pip install -e ".[dev]"
+        # `-c ci-constraints.txt` (#5831): see the "Install dependencies"
+        # step in the `test` job above for why — same reproducibility pin,
+        # applied to every job that installs project dependencies.
+        run: pip install -e ".[dev]" -c ci-constraints.txt
 
       # #3726: mypy is configured (pyproject.toml [tool.mypy]) but was never
       # run in CI — a declared check with no execution. scripts/mypy_ratchet.py
@@ -259,7 +274,9 @@ jobs:
           cache: pip
 
       - name: Install docs dependencies
-        run: pip install -e ".[docs]"
+        # `-c ci-constraints.txt` (#5831): see the "Install dependencies"
+        # step in the `test` job above for why.
+        run: pip install -e ".[docs]" -c ci-constraints.txt
 
       # Mirrors the "Build documentation" step in pages.yml so broken links
       # and missing nav targets fail at PR time, not post-merge on the Pages

--- a/ci-constraints.txt
+++ b/ci-constraints.txt
@@ -1,0 +1,191 @@
+# #5831: CI-only dependency lock — pins the EXACT version every CI job
+# resolves, so a byte-identical `pip install -e ".[...]"` runs on every CI
+# invocation regardless of what PyPI's "latest" is at that moment.
+#
+# This is a `pip install -c ci-constraints.txt` CONSTRAINTS file, not a
+# requirements file: it does not add any package to the install, it only
+# pins the version pip picks IF that package is already pulled in by
+# `pyproject.toml`'s own dependency graph. `pyproject.toml` itself keeps
+# its `>=` floors unchanged (#4395/#5059's standing rule) — this file
+# governs reproducibility of THIS repo's CI runs, not what a user's own
+# environment is allowed to install. See architect's ruling on #5831 for
+# the full "CI resolves a recorded set / pyproject states a floor" split.
+#
+# Why this exists: on 2026-09-06, litellm released 1.100.0 (from 1.99.0)
+# and `main` went red with ZERO reyn commits changing — CI resolves
+# PyPI's latest on every run, so a third party's release time decided
+# whether main was green. This file makes "which exact versions CI
+# installs" a value under version control, changed only by a deliberate,
+# reviewed PR (see the regen command below) — never silently, by an
+# upstream release landing between two CI runs.
+#
+# To regenerate (an ordinary PR — the diff, and the PR's own CI, are the
+# review): build a fresh venv, install every extra any CI job uses, freeze,
+# strip the editable `reyn` line itself, replace this file whole:
+#
+#   python3.11 -m venv .venv-lockgen && source .venv-lockgen/bin/activate
+#   pip install --upgrade pip
+#   pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag,docs]"
+#   pip freeze | grep -v -i "^-e \|^reyn==" > ci-constraints.txt
+#
+# Generate from the LOWER of the two matrix Pythons (3.11), not 3.12:
+# confirmed directly (2026-09-06) that freezing from 3.12 pinned
+# numpy==2.5.2, a version with no 3.11 wheel at all — `pip install -c` on
+# 3.11 then fails with ResolutionImpossible instead of installing anything.
+# 3.11's own resolution (numpy==2.4.6) installs cleanly on BOTH 3.11 and
+# 3.12 (verified, both matrix versions, real `pip install -e . -c
+# ci-constraints.txt` runs) — every other package in this file was
+# identical between the two freezes, so this was the one real gotcha, not
+# a general rule that every package differs.
+#
+# The dependency-drift canary (`.github/workflows/dependency-drift-canary.yml`)
+# installs WITHOUT this file (floating latest, matching pyproject's own
+# floor) on a schedule, so an upstream break like today's is caught there
+# — as an issue, never as a red main — instead of surfacing here by luck.
+aiohappyeyeballs==2.7.1
+aiohttp==3.14.3
+aiosignal==1.4.0
+annotated-doc==0.0.5
+annotated-types==0.8.0
+anyio==4.15.1
+apsw==3.53.4.0
+ast_serialize==0.9.0
+attrs==26.1.0
+babel==2.18.0
+backrefs==8.0
+boto3==1.43.89
+botocore==1.43.89
+certifi==2026.7.22
+cffi==2.1.1
+cfgv==3.5.0
+charset-normalizer==3.5.1
+chonkie==1.7.0
+chonkie-core==0.10.2
+click==8.5.0
+colorama==0.4.6
+coverage==7.16.0
+croniter==6.2.4
+cryptography==50.0.1
+ddgs==9.16.0
+distlib==0.4.3
+distro==1.9.0
+execnet==2.1.2
+fastapi==0.136.3
+fastuuid==0.14.0
+filelock==3.32.5
+frozenlist==1.8.0
+fsspec==2026.7.0
+ghp-import==2.1.0
+googleapis-common-protos==1.75.3
+h11==0.16.0
+hf-xet==1.6.0
+httpcore==1.0.9
+httpcore2==2.12.0
+httptools==0.8.0
+httpx==0.28.1
+httpx2==2.12.0
+huggingface_hub==1.30.0
+identify==2.6.19
+idna==3.19
+importlib_metadata==8.9.0
+iniconfig==2.3.0
+Jinja2==3.1.6
+jiter==0.16.0
+jmespath==1.1.0
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+librt==0.15.0
+linkify-it-py==2.2.0
+litellm==1.100.0
+lxml==6.1.3
+Markdown==3.10.3
+markdown-it-py==4.2.0
+MarkupSafe==3.0.3
+mcp==2.1.1
+mcp-types==2.1.1
+mdit-py-plugins==0.6.1
+mdurl==0.1.2
+mergedeep==1.3.4
+mkdocs==1.6.1
+mkdocs-get-deps==0.2.2
+mkdocs-material==9.7.7
+mkdocs-material-extensions==1.3.1
+mkdocs-static-i18n==1.3.1
+multidict==6.7.1
+mypy==2.3.1
+mypy_extensions==1.1.0
+nodeenv==1.10.0
+numpy==2.4.6
+openai==2.54.0
+opentelemetry-api==1.44.0
+opentelemetry-exporter-otlp-proto-common==1.44.0
+opentelemetry-exporter-otlp-proto-http==1.44.0
+opentelemetry-proto==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-semantic-conventions==0.65b0
+packaging==26.3
+paginate==0.5.7
+pathspec==1.1.1
+pillow==12.3.0
+platformdirs==4.11.7
+pluggy==1.6.0
+pre_commit==4.6.2
+primp==2.0.0
+prompt_toolkit==3.0.53
+propcache==0.5.2
+protobuf==7.36.1
+pycparser==3.0
+pydantic==2.13.5
+pydantic-settings==2.15.0
+pydantic_core==2.46.5
+Pygments==2.21.0
+PyJWT==2.13.0
+pymdown-extensions==11.0.2
+pyperclip==1.11.0
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-cov==7.1.0
+pytest-timeout==2.4.0
+pytest-xdist==3.8.0
+python-dateutil==2.9.0.post0
+python-discovery==1.6.0
+python-dotenv==1.2.3
+python-multipart==0.0.32
+PyYAML==6.0.3
+pyyaml_env_tag==1.1
+referencing==0.37.0
+regex==2026.9.3
+requests==2.34.2
+rich==15.0.0
+rpds-py==2026.6.3
+ruff==0.16.6
+s3transfer==0.19.2
+setproctitle==1.3.7
+six==1.17.0
+sniffio==1.3.1
+sqlite-vec==0.1.9
+sse-starlette==3.4.11
+starlette==1.2.1
+tenacity==9.1.4
+textual==8.2.8
+# textual-flowview: intentionally NOT listed here — already pinned to an
+# exact commit directly in pyproject.toml's own dependency line (`@<sha>`),
+# and a `pip install -c` constraints file does not support a VCS/URL
+# requirement specifier (pip errors: "Unsupported URL"). Nothing to add.
+tiktoken==0.14.0
+tokenizers==0.23.2
+tokie==0.1.4
+tqdm==4.70.0
+truststore==0.10.4
+typing-inspection==0.4.4
+typing_extensions==4.16.0
+urllib3==2.7.0
+uvicorn==0.52.4
+uvloop==0.22.1
+virtualenv==21.7.8
+watchdog==6.0.0
+watchfiles==1.2.0
+wcwidth==0.8.3
+websockets==17.1
+yarl==1.24.5
+zipp==4.1.0


### PR DESCRIPTION
**[e2e-coder]** — Implements architect's ①②③④ ruling on #5831 (part of #5831, does not close it — the stderr-leak fix is #5834, a separate PR).

## What this does

1. **① CI-only constraints/lock** (`ci-constraints.txt`): every `pip install -e ...` step that installs project deps now adds `-c ci-constraints.txt`, so every CI run resolves the SAME recorded version set. Covers `test.yml`'s 4 jobs plus `check-doc-drift-fixture.yml`, `pages.yml`, `sandbox-landlock-deny-gate.yml`, `sandbox-load-method-witness.yml`, `sandbox-linux-live-x86_64.yml`. `litellm-proxy-patch-scaffold.yml` deliberately untouched (⑤ — its `==1.95.0` pin is for reproducing a past defect, a different purpose).
2. **② `pyproject.toml` untouched** — `litellm>=1.89.3` and every other floor stays a floor, no `==` introduced anywhere.
3. **③ `dependency-drift-canary.yml`** (new): schedule (daily) + `workflow_dispatch`, installs the same extras WITHOUT the constraints file (floating latest, matching pyproject's own floor), runs the suite on both matrix Pythons. On failure, opens or **updates** one dedicated tracking issue (label `dependency-drift-canary`) — never opens a fresh issue per occurrence. Triggers only on `schedule`/`workflow_dispatch`, never `push`/`pull_request`/`merge_group`, so it structurally cannot become a required check for any PR — a third party's release timing cannot decide merge-ability, by construction, not by branch-protection configuration.
4. **④ Lock refresh stays an ordinary PR** — `ci-constraints.txt`'s own header documents the regen command; this PR adds no automation that rewrites the lock itself.

## A real gotcha found and fixed during verification

Generating the lock by freezing a Python 3.12 venv pinned `numpy==2.5.2`, which has **no 3.11 wheel at all** — `pip install -c ci-constraints.txt` failed with `ResolutionImpossible` on 3.11 (a real, executed failure, not a hypothesis). Regenerated from 3.11 instead (the lower of the two matrix Pythons) — `numpy==2.4.6` was the only line that differed between the two freezes. Confirmed clean installs on **both** 3.11 and 3.12 afterward with the corrected file (real `pip install -e . -c ci-constraints.txt` runs, not reasoned through).

## An unrelated incident during this work (disclosed for completeness)

While generating the lock, a `python3.11 -m venv` command failed silently (wrong pyenv shim selection) and a follow-up `pip install` fell through to my real global pyenv 3.12.7 environment instead of a venv. I caught this, restored the exact packages/versions it overwrote, and reported it to the user directly — unrelated to this PR's content, mentioned here only so the review has full context if it shows up in my own history.

## Test plan

- [x] `pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]" -c ci-constraints.txt` — real run, Python 3.11: clean install.
- [x] Same command, Python 3.12: clean install.
- [x] `pyproject.toml` diff reviewed — no `==` introduced, floors unchanged.
- [x] Gates: `ruff check .`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green (no `src/`/`tests/` changes in this PR, so tier-audit/docstring-verify/mypy_ratchet/pytest are not applicable — no test or source files touched).
- [x] (skipped — full suite is CI-only per standing rule, not run locally)
- [x] (skipped — Visual, standing waiver)

Note: this PR targets `main` at a commit where `tests/llm/test_litellm_lazy_load.py` is still red (2 tests, pre-existing, tracked by #5834 — a separate PR, unmerged as of this push). CI on THIS PR will show that same pre-existing red; it is not caused by this PR's changes (no `src/`/`tests/` files touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
