### PR TITLE
fix(#5832): hook permission failures disclose reyn's own granted sandbox range

### DIFF
--- a/src/reyn/hooks/shell_runner.py
+++ b/src/reyn/hooks/shell_runner.py
@@ -746,7 +746,11 @@ async def run_shell_hook(
     try:
         stdin_bytes = json.dumps(event_context, default=str).encode("utf-8")
 
-        from reyn.security.sandbox.denial import DENIAL_FORK, DENIAL_NETWORK  # noqa: PLC0415
+        from reyn.security.sandbox.denial import (  # noqa: PLC0415
+            DENIAL_FORK,
+            DENIAL_NETWORK,
+            looks_permission_related,
+        )
         from reyn.security.sandbox.launcher import run_and_classify  # noqa: PLC0415
 
         launched = await run_and_classify(
@@ -919,11 +923,37 @@ async def run_shell_hook(
                     stderr_snippet or "<empty>",
                 )
             else:
+                # #5832: real-machine incident (owner, 2026-09-06) — a hook's
+                # write was denied (`write_paths:` unset for it) and this
+                # branch's own message carried NOTHING beyond the child's raw
+                # traceback; lead-coder needed 10 steps to reach the actual
+                # cause, and the owner could not take step 1 from the screen
+                # alone. reyn already knows what it granted (`policy`, built
+                # above) — it just was not saying so.
+                #
+                # This does NOT classify the failure as a sandbox denial (see
+                # `looks_permission_related`'s own module comment in
+                # denial.py for why a write denial cannot be told apart from
+                # a genuine non-sandbox permission error by its stderr text
+                # alone) — it only decides whether disclosing the granted
+                # range is worth the sentence, then states that range as a
+                # FACT, never a diagnosis.
+                granted_scope_note = ""
+                if looks_permission_related(result.stderr):
+                    granted_scope_note = (
+                        " #5832: reyn ran this hook with subprocess="
+                        f"{not policy.deny_subprocess}, network={policy.network}, "
+                        f"write_paths={list(policy.write_paths)!r} — the range "
+                        "reyn granted, not a diagnosis of this failure's cause "
+                        "(a genuine non-sandbox permission error reads "
+                        "identically)."
+                    )
                 _log.warning(
-                    "shell-hook %r exited %d (stderr: %s).",
+                    "shell-hook %r exited %d (stderr: %s).%s",
                     command,
                     result.returncode,
                     stderr_snippet or "<empty>",
+                    granted_scope_note,
                 )
             return None  # fail-safe: a failed command yields no push-directive
 

--- a/src/reyn/security/sandbox/denial.py
+++ b/src/reyn/security/sandbox/denial.py
@@ -99,3 +99,49 @@ def classify_denial(returncode: int, stderr: bytes | str) -> str | None:
     if _NETWORK_DENIED.search(stderr):
         return DENIAL_NETWORK
     return None
+
+
+# #5832: real-machine incident (owner, 2026-09-06) — a shell hook's write
+# under `open()` was denied (`write_paths:` unset for that hook), and the
+# generic "shell-hook %r exited %d (stderr: %s)" fallback carried NO sandbox
+# context at all: just the child's raw `PermissionError: [Errno 1] Operation
+# not permitted: '<path>'`. lead-coder traced this to the actual cause in 10
+# steps; the owner, seeing only the raw traceback, could not take step 1.
+#
+# Deliberately NOT a new DENIAL_WRITE class alongside DENIAL_FORK/
+# DENIAL_NETWORK above: those two classifiers each name a SPECIFIC syscall
+# and a SPECIFIC knob that fixes it (fork -> `subprocess: true`, connect ->
+# `network: true`) -- a confident, narrow claim earned by a signature that
+# (per #5244's own module docstring above) does not also occur for an
+# ordinary non-sandbox failure. A write denial has no such disjoint
+# signature: `PermissionError: [Errno 1] Operation not permitted: '<path>'`
+# is IDENTICAL whether the sandbox denied the write or the real filesystem
+# did (a read-only mount, a missing parent directory, an actual permissions
+# problem) -- "EPERM means the sandbox did it" would be the exact bandaid
+# lead-coder's #5832 brief rejected. So this function does not classify a
+# denial at all -- it only decides whether a failure is PERMISSION-SHAPED
+# enough that disclosing what reyn granted is worth the sentence. The
+# caller states a FACT ("reyn ran this with write_paths=X"), never a
+# diagnosis ("the sandbox caused this") -- the fact is true regardless of
+# the real cause, and is exactly as far as reyn can honestly go on its own.
+_PERMISSION_FAILURE_MARKERS = (
+    "eperm",
+    "eacces",
+    "operation not permitted",
+    "permission denied",
+)
+
+
+def looks_permission_related(stderr: bytes | str) -> bool:
+    """Whether *stderr* looks like an OS-level permission failure of some
+    kind — NOT a denial classifier (contrast :func:`classify_denial` above).
+
+    This only gates whether reyn's granted sandbox range is worth disclosing
+    alongside a failure; it never claims the sandbox caused it. See the
+    module comment directly above this function for why a write denial
+    specifically cannot be classified the way fork/network denials are.
+    """
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in _PERMISSION_FAILURE_MARKERS)

--- a/tests/core/test_sandbox_permission_disclosure_5832.py
+++ b/tests/core/test_sandbox_permission_disclosure_5832.py
@@ -1,0 +1,74 @@
+"""Tier 2: `looks_permission_related` — the #5832 disclosure gate.
+
+Real-machine incident (owner, 2026-09-06): a shell hook's write was denied
+by the sandbox (`write_paths:` unset for that hook), and the generic
+failure log line carried nothing beyond the child's raw traceback. lead-
+coder needed 10 steps to trace it to the real cause; the owner could not
+take step 1 from the screen alone.
+
+`looks_permission_related` is deliberately NOT a denial classifier (contrast
+`classify_denial`, tested in `test_sandbox_denial_class_2820.py` /
+`test_sandbox_denial_class_5244.py`): `PermissionError: [Errno 1] Operation
+not permitted: '<path>'` is IDENTICAL whether the sandbox denied the write
+or a real filesystem did (a read-only mount, an actual permissions
+problem) — a write denial has no signature disjoint from a genuine
+non-sandbox failure the way fork/network denials do. So this function only
+gates whether reyn's granted sandbox range is worth disclosing; it makes no
+causal claim, and these tests pin that it does not.
+"""
+from __future__ import annotations
+
+from reyn.security.sandbox.denial import looks_permission_related
+
+# The owner's own captured incident text (#5832 issue body, verbatim):
+#   shell-hook 'python3 .../.reyn/hooks/broker_drain.py' exited 1
+#   (stderr: Traceback (most recent call last):
+#     ...
+#     return io.open(self, mode, buffering, encoding, errors, newline)
+#   PermissionError: [Errno 1] Operation not permitted:
+#     '.../.reyn/agents/coder-brown/state/broker_drain_cursor.json.tmp')
+_REAL_OWNER_INCIDENT_STDERR = (
+    b"Traceback (most recent call last):\n"
+    b'  File "<string>", line 5, in <module>\n'
+    b"    return io.open(self, mode, buffering, encoding, errors, newline)\n"
+    b"PermissionError: [Errno 1] Operation not permitted: "
+    b"'/home/coder-brown/.reyn/agents/coder-brown/state/broker_drain_cursor.json.tmp'\n"
+)
+
+
+def test_real_owner_incident_stderr_is_permission_related():
+    """Tier 2: the exact captured incident text triggers the disclosure gate."""
+    assert looks_permission_related(_REAL_OWNER_INCIDENT_STDERR) is True
+
+
+def test_eacces_variant_is_permission_related():
+    """Tier 2: Landlock's own denial errno (EACCES, "Permission denied") —
+    a DIFFERENT backend/OS shape than the Seatbelt EPERM incident above —
+    is recognized too. Widening beyond one platform's own error text is
+    the whole point of NOT tying this to a specific denial classifier."""
+    assert looks_permission_related(
+        b"PermissionError: [Errno 13] Permission denied: '/tmp/x'"
+    ) is True
+
+
+def test_is_case_insensitive():
+    """Tier 2: signature match must not hinge on exact casing."""
+    assert looks_permission_related(
+        b"PERMISSIONERROR: [ERRNO 1] OPERATION NOT PERMITTED: '/tmp/x'"
+    ) is True
+
+
+def test_unrelated_failure_is_not_permission_related():
+    """Tier 2: control arm — an ordinary bug (a syntax error, a assertion
+    failure) must NOT trigger the disclosure; it would be noise on every
+    unrelated hook failure, not signal."""
+    assert looks_permission_related(
+        b"  File \"<string>\", line 1\n    def f(:\n          ^\nSyntaxError: invalid syntax\n"
+    ) is False
+
+
+def test_accepts_str_as_well_as_bytes():
+    """Tier 2: same predicate over the decoded str form (production passes
+    both shapes depending on call site — see `classify_denial`'s own
+    str/bytes handling for the same reasoning)."""
+    assert looks_permission_related("PermissionError: [Errno 1] Operation not permitted") is True

--- a/tests/hooks/test_1800_hook_shell_runner.py
+++ b/tests/hooks/test_1800_hook_shell_runner.py
@@ -349,6 +349,77 @@ async def test_failed_hook_stderr_snippet_keeps_the_exceptions_own_type(
     )
 
 
+@pytest.mark.asyncio
+async def test_permission_failure_discloses_granted_sandbox_range(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: #5832 -- real-machine incident (owner, 2026-09-06). A hook's
+    write was denied and the generic failure log line carried nothing but
+    the child's raw traceback -- no hint that reyn itself has a sandbox
+    scope, let alone what it is. lead-coder needed 10 steps to reach the
+    real cause; the owner could not take step 1 from the screen alone.
+
+    Drives a REAL, non-sandboxed permission denial (chmod 0 on a real
+    directory -- an actual OS-level PermissionError, no mock, no fake
+    backend) through the generic (unclassified) failure branch, and
+    asserts the granted `subprocess`/`network`/`write_paths` values now
+    appear in the log line.
+
+    Deliberately NOT gated on the sandbox being the actual cause: this
+    failure is genuinely NOT a sandbox denial (`NoopBackend`, no
+    enforcement at all) -- it is a real filesystem permission error. The
+    disclosure fires anyway, because reyn's own contract here is
+    "state what I granted", never "diagnose why this failed" (see
+    `looks_permission_related`'s own docstring in
+    `reyn.security.sandbox.denial` for why the two must stay separate).
+    """
+    from reyn.hooks.shell_runner import run_shell_hook
+
+    allowlist = tmp_path / "allowlist.json"
+    monkeypatch.setenv("REYN_ACCEPT_HOOKS", "1")
+
+    locked_dir = tmp_path / "locked"
+    locked_dir.mkdir()
+    locked_dir.chmod(0o000)
+    target = locked_dir / "cursor.json.tmp"
+    script = tmp_path / "denied_write.py"
+    script.write_text(
+        f"open({str(target)!r}, 'w')\n",
+        encoding="utf-8",
+    )
+    argv = [_PY, str(script)]
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="reyn.hooks.shell_runner"):
+            result = await run_shell_hook(
+                argv,
+                event_context={"event": "turn_end"},
+                timeout_seconds=10,
+                sandbox_backend=_noop_backend(),
+                sandbox_policy=_policy(temp_dir=str(tmp_path)),
+                allowlist_path=allowlist,
+            )
+    finally:
+        locked_dir.chmod(0o755)  # restore so tmp_path cleanup can remove it
+
+    assert result is None  # a failed exec run yields no push-directive
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("PermissionError" in msg for msg in warnings), (
+        f"expected the real PermissionError to reach the log -- got {warnings!r}"
+    )
+    assert any("#5832" in msg and "write_paths=[]" in msg for msg in warnings), (
+        f"expected the granted-range disclosure (subprocess/network/write_paths) "
+        f"on the same failure -- got {warnings!r}"
+    )
+    # The disclosure is a FACT about what reyn granted, not a verdict on the
+    # cause -- this failure is a real FS permission error under a Noop
+    # (non-enforcing) backend, so reyn must not claim the sandbox caused it.
+    assert not any("sandbox denied" in msg.lower() for msg in warnings), (
+        f"disclosure must not claim the sandbox caused a failure it cannot "
+        f"actually attribute -- got {warnings!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helper: fake stdin object with configurable isatty()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[e2e-coder]** — Closes #5832.

## The gap

Owner hit a real hook write-denial (`write_paths:` unset for that hook); the screen showed only the child's raw `PermissionError` traceback. lead-coder needed 10 steps to reach the real cause; the owner could not take step 1.

## Fix

The generic (unclassified) failure branch in `run_shell_hook` now checks `looks_permission_related(stderr)` (new, `reyn.security.sandbox.denial`) and, when true, appends the actual `subprocess`/`network`/`write_paths` reyn granted this hook run.

**Deliberately not a new `DENIAL_WRITE` classifier** alongside the existing `DENIAL_FORK`/`DENIAL_NETWORK`: those two have a signature that does not also occur for an ordinary non-sandbox failure. A write denial has no such disjoint signature — `PermissionError: [Errno 1] Operation not permitted: '<path>'` is identical whether the sandbox denied it or a real filesystem did. "EPERM means the sandbox did it" is the bandaid the brief rejected. `looks_permission_related()` makes no causal claim — it only gates whether the disclosure sentence is worth adding; the message states a **fact** ("reyn ran this with write_paths=X"), never a **diagnosis**.

## A discrepancy worth the reviewer's own judgment

`reyn.mcp.client`'s existing `#3009` write-denial hint (a different mechanism, for MCP tool calls) **does** make the stronger causal claim ("this looks like reyn's MCP sandbox DENYING...") from the same kind of stderr-text match. This issue's brief explicitly asked for disclosure-only, not diagnosis, for the shell-hook case — I followed that brief as written rather than silently matching the other precedent. Flagging it here rather than deciding it myself.

## Test plan

- [x] `looks_permission_related()` pinned with the owner's own captured incident text, an EACCES variant, case-insensitivity, and a negative control (`tests/core/test_sandbox_permission_disclosure_5832.py`).
- [x] End-to-end: a REAL, non-sandboxed permission denial (chmod 0 on a real directory — genuine OS `PermissionError`, no mock, `NoopBackend` so the sandbox is not even the cause) through `run_shell_hook`, asserting the granted range appears AND the message never claims "sandbox denied" (`tests/hooks/test_1800_hook_shell_runner.py::test_permission_failure_discloses_granted_sandbox_range`).
- [x] Strip-falsified: `git stash` reverted the fix (real revert), confirmed both changed test files genuinely RED (ImportError) against the un-fixed code, restored, re-confirmed green.
- [x] Broader regression sweep: `tests/hooks/`, `tests/security/`, both existing denial-class test files — 1285 passed, 0 failed.
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (14 tests inspected, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py` (199 findings, all baselined), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green.
- [x] (skipped — full suite is CI-only per standing rule, not run locally)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51
