### PR TITLE
feat(#5837 stage 1): /exec and /exec-attach -- sandboxed exec via slash command

### DIFF
--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -350,6 +350,7 @@ from reyn.interfaces.slash import compact as _compact_mod  # noqa: E402, F401
 from reyn.interfaces.slash import concept as _concept_mod  # noqa: E402, F401
 from reyn.interfaces.slash import copy as _copy_mod  # noqa: E402, F401
 from reyn.interfaces.slash import donut as _donut_mod  # noqa: E402, F401
+from reyn.interfaces.slash import exec as _exec_mod  # noqa: E402, F401
 from reyn.interfaces.slash import help as _help_mod  # noqa: E402, F401
 from reyn.interfaces.slash import hook as _hook_mod  # noqa: E402, F401
 from reyn.interfaces.slash import image as _image_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/exec.py
+++ b/src/reyn/interfaces/slash/exec.py
@@ -39,6 +39,14 @@ full, not repeated here) — the 4 that shape this module:
    ``exec`` calls use, so ``sandbox.mode: strict`` reaches this path
    identically, unrelated to the confirmation question entirely.
 
+   ⚠️ Same #5841 gap, disclosed: catalog VISIBILITY (whether an agent
+   whose Profile denies the ``exec`` capability class should even be
+   able to run it) is not wired on the LLM path either — an agent whose
+   profile denies ``exec`` can still run ``/exec`` today, no differently
+   from how that same agent's LLM could still call the ``exec`` tool
+   directly if it tried. Not this PR's gap to close alone (parity with
+   the LLM path, not a new hole) — #5841 closes both at the shared seam.
+
 ② **``caller_kind="operator"``, and a dedicated actor.** ``ToolContext.
    caller_kind`` is ``"operator"`` (never ``"router"`` — this is not an
    LLM tool call). ``op_context_factory()`` (``RouterOpContextSource.
@@ -50,6 +58,18 @@ full, not repeated here) — the 4 that shape this module:
    ``dataclasses.replace`` AFTER the factory call (the factory itself has
    no parameter for this — same shape as the resolved-backend override
    ``op_context_from_tool_context`` already applies post-construction).
+
+   ⚠️ #5843 BLOCKING finding (fixed): ``caller_kind="operator"`` sitting
+   on ``ToolContext`` reaches no audit-event on its own — ``core.dispatch.
+   dispatcher.dispatch_tool`` is the ONE place ``tool_called``/
+   ``tool_returned``/``tool_failed`` are emitted carrying ``caller_kind``.
+   An earlier version of ``_run_exec`` called ``handle_sandboxed_exec``
+   directly, bypassing it entirely. Fixed by routing through
+   ``dispatch_tool`` (mirrors ``slash/tasks.py``'s own ``_dispatch``
+   helper) — the ``invoker`` passed to it still builds its OWN op-context
+   (with the ② actor override already applied) rather than delegating to
+   ``tools/exec.py``'s generic tool handler, which has no hook for that
+   override.
 
 ③ **``/exec`` = screen only; ``/exec-attach`` = queue for the next user
    message.** The queued block carries the ACTUAL argv that ran
@@ -226,21 +246,46 @@ async def _run_exec(ctx: "SlashContext", args: str) -> "tuple[list[str], dict] |
     tool_ctx = await _build_exec_tool_context(ctx)
     op_ctx = await _build_operator_op_context(tool_ctx)
 
-    from reyn.core.op_runtime.sandboxed_exec import handle as handle_sandboxed_exec
-    from reyn.schemas.models import SandboxedExecIROp
+    # #5843 BLOCKING ①: route through dispatch_tool (core/dispatch/
+    # dispatcher.py) -- the ONE place that emits tool_called/tool_returned/
+    # tool_failed carrying caller_kind. Calling handle_sandboxed_exec
+    # directly (the earlier shape) left caller_kind="operator" sitting on
+    # ToolContext with nothing ever reading it -- no audit-event recorded
+    # it. Mirrors slash/tasks.py's own _dispatch helper exactly. The
+    # invoker below still builds ITS OWN op_ctx (with the ② actor
+    # override already applied above) rather than going through the
+    # generic exec-tool handler (tools/exec.py's own _handle), which would
+    # re-derive op_ctx internally via op_context_from_tool_context with NO
+    # hook to apply that override -- this keeps both fixes (① audit
+    # routing, ② actor override) working together, not one at the cost of
+    # the other. dispatch_tool's own exception handling wraps the op's
+    # PermissionError (the pre-exec threat scan, FP-0050/#1822 S5) into
+    # its standard error envelope -- no separate try/except needed here.
+    from reyn.core.dispatch.dispatcher import DispatchContext, dispatch_tool
+    from reyn.tools.exec import EXEC
 
-    op = SandboxedExecIROp(kind="sandboxed_exec", argv=argv)
-    try:
-        result = await handle_sandboxed_exec(op=op, ctx=op_ctx)
-    except PermissionError as exc:
-        # The op's own pre-exec threat scan (FP-0050/#1822 S5) denies via
-        # this channel — the sandbox-scoped write/network/subprocess
-        # boundary applies the same way it does for the LLM's own exec
-        # calls (② op_context_factory seam); this is that boundary
-        # reporting a real denial, not a new gate this module adds.
-        await reply_error(ctx, f"exec denied: {exc}")
+    dispatch_ctx = DispatchContext(
+        caller_kind="operator",
+        caller_id=getattr(tool_ctx, "agent_name", None) or "",
+        chain_id=None,
+        tool_catalog={"exec": EXEC.render_for_router()},
+        events=tool_ctx.events,
+    )
+
+    async def _invoker(call_args: dict) -> Any:
+        from reyn.core.op_runtime.sandboxed_exec import handle as handle_sandboxed_exec
+        from reyn.schemas.models import SandboxedExecIROp
+
+        op = SandboxedExecIROp(kind="sandboxed_exec", argv=call_args["argv"])
+        return await handle_sandboxed_exec(op=op, ctx=op_ctx)
+
+    dispatch_result = await dispatch_tool(
+        name="exec", args={"argv": argv}, ctx=dispatch_ctx, invoker=_invoker,
+    )
+    if dispatch_result["status"] == "error":
+        await reply_error(ctx, f"exec denied: {dispatch_result['error']['message']}")
         return None
-    return argv, result
+    return argv, dispatch_result["data"]
 
 
 @slash(

--- a/src/reyn/interfaces/slash/exec.py
+++ b/src/reyn/interfaces/slash/exec.py
@@ -1,0 +1,307 @@
+"""``/exec`` and ``/exec-attach`` — run an argv command through the SAME
+sandboxed exec op the LLM ``exec`` tool uses (#5837 stage 1).
+
+Usage::
+
+    /exec <cmdline>          — run, show the result on screen only
+    /exec-attach <cmdline>   — run, queue argv + result for the NEXT user
+                               message (drained by Session._handle_inbox_text,
+                               the same ``_pending_user_attachments`` queue
+                               ``/attachment``/``/image`` already write to)
+
+owner request (2026-09-06, verbatim): "スラッシュコマンド経由で llm tool の exec
+を打てるようにしたい". Owner rulings confirmed in #5837 (quoted there in
+full, not repeated here) — the 4 that shape this module:
+
+① **No confirmation prompt; the sandbox stays effective.** Real-machine
+   finding (#5837 investigation, reported and re-ruled on before this
+   file reached its final shape): the LLM ``exec`` tool call path has NO
+   interactive JIT confirmation at all today — ``require_tool``/
+   ``CapabilityAxis.TOOL`` (#1199 S3.1b-2c) was built but never wired to
+   any tool's dispatch path. So "skip the confirmation" is already true
+   of BOTH paths, by absence, not by anything this module does.
+
+   ⚠️ An earlier version of this module added a ``/exec``-only restrict
+   check (a new ``is_tool_allowed()`` on ``PermissionResolver``, called
+   from here alone). architect's ruling reversed that: (1) it would have
+   made the HUMAN path narrower than the LLM path — the wrong direction
+   of asymmetry to introduce silently, and (2) it made this ONE fact (is
+   ``exec`` permitted for this agent?) checkable from TWO independent
+   places that could drift — exactly the class this repo's own review
+   discipline closed six times in one night. The tool-axis restrict check
+   belongs at ONE seam shared by both the LLM path and this command, not
+   built here first — tracked as #5841 (same shape as #5818's "declared,
+   documented, never reached the resolver"). **This module does not add
+   any exec-specific permission check.** The sandbox (write scope /
+   network / subprocess / env) is untouched by any of this — it is
+   resolved through the SAME ``op_context_factory()`` seam
+   (``op_context_from_tool_context``, ``reyn.tools.exec``) the LLM's own
+   ``exec`` calls use, so ``sandbox.mode: strict`` reaches this path
+   identically, unrelated to the confirmation question entirely.
+
+② **``caller_kind="operator"``, and a dedicated actor.** ``ToolContext.
+   caller_kind`` is ``"operator"`` (never ``"router"`` — this is not an
+   LLM tool call). ``op_context_factory()`` (``RouterOpContextSource.
+   build``, ``router_op_context.py``) hardcodes ``OpContext.actor=
+   "chat_router"`` — reusing that value would mix an operator's own
+   ``/exec`` calls into the chat router's approval-ledger record (the
+   ledger is actor-scoped: ``<actor>/<op>/<path>``). :data:`_OPERATOR_
+   EXEC_ACTOR` is a distinct value this module owns, applied via
+   ``dataclasses.replace`` AFTER the factory call (the factory itself has
+   no parameter for this — same shape as the resolved-backend override
+   ``op_context_from_tool_context`` already applies post-construction).
+
+③ **``/exec`` = screen only; ``/exec-attach`` = queue for the next user
+   message.** The queued block carries the ACTUAL argv that ran
+   (``shlex.join``, never the raw typed text — quoting/rejected-token
+   normalization would otherwise be lost) ahead of the result, so a
+   later reader can tell what was executed without re-deriving it.
+
+④ **shlex only — no shell interpretation.** :func:`tokenize_exec_cmdline`
+   is the ONE function in this module that touches ``shlex`` — isolated
+   so #5838 (the still-undecided "should LLM exec, and this command, move
+   to shell interpretation" question) can replace ONLY this function,
+   wherever it lands, without touching anything else here. Nothing else
+   in this module calls ``shlex`` directly.
+"""
+from __future__ import annotations
+
+import dataclasses
+import shlex
+from typing import Any
+
+from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
+
+_USAGE = "usage: /exec <cmdline>  |  /exec-attach <cmdline>"
+
+# #5837 ②: a name distinct from "chat_router" (the LLM-router actor
+# build_router_op_context hardcodes) — the approval ledger is actor-scoped
+# (<actor>/<op>/<path>), so reusing that name would mix this session's
+# operator-originated /exec calls into the chat router's own record.
+_OPERATOR_EXEC_ACTOR = "slash_exec_operator"
+
+# #5837 ④ (owner ruling, verbatim "shlex 期待だよ"): shlex interprets
+# quoting ONLY. A token containing one of these after shlex has already
+# split on whitespace/quotes means the caller wrote something that wants
+# shell interpretation (a pipe, a redirect, a subshell, command
+# substitution) — reject explicitly rather than silently pass it through
+# as a literal argv element nothing will interpret the way the caller
+# expects.
+_SHELL_METACHAR_TOKENS = ("|", ">", "<", "&&", ";", "$(", "`")
+
+# #5837 ⑦ (architect: "same thinking as #364's size gate", disclosed
+# constant — this is an internal display bound, not a config knob, same
+# class as `_COMPLETER_MAX`/`_file_size_human`'s own thresholds in
+# slash/attachment.py): a queued /exec-attach block becomes part of the
+# NEXT completion's prompt, so an unbounded command's full output would
+# silently inflate that turn's token cost with no operator-visible signal
+# until the bill. Bounded the same shape `_failure_stderr_snippet`
+# (hooks/shell_runner.py, #5803) already uses for a comparable "don't
+# lose the START (what ran) or the END (the actual error/tail) case —
+# only the middle is safe to drop.
+_ATTACH_TEXT_MAX_CHARS = 4000
+_ATTACH_TEXT_HEAD = 2000
+_ATTACH_TEXT_TAIL = 1500
+
+
+class ExecCmdlineRejected(Exception):
+    """Raised by :func:`tokenize_exec_cmdline` when *text* looks like it
+    wants shell interpretation (#5837 ④) — never executed as argv."""
+
+
+def tokenize_exec_cmdline(text: str) -> "list[str]":
+    """The ONE place ``/exec``/``/exec-attach`` turn a typed command line
+    into argv — see this module's own docstring, point ④, for why this is
+    isolated to a single function.
+
+    ``shlex.split`` (quoting only — #5837 owner ruling). A resulting token
+    containing a shell metacharacter raises :class:`ExecCmdlineRejected`
+    rather than being passed through as a literal argv element — quoting
+    a metachar does not rescue it (``/exec 'ls | wc -l'`` shlex-splits to
+    ONE token containing ``|``, and is rejected exactly like the
+    unquoted form; #5837's own accept criterion names this case).
+    """
+    try:
+        argv = shlex.split(text)
+    except ValueError as exc:
+        raise ExecCmdlineRejected(f"could not parse arguments: {exc}") from exc
+    if not argv:
+        raise ExecCmdlineRejected("no command given")
+    for token in argv:
+        if any(meta in token for meta in _SHELL_METACHAR_TOKENS):
+            raise ExecCmdlineRejected(
+                "shell interpretation is not supported here — this runs "
+                "argv directly, the same as the LLM's own exec tool. "
+                f"Quote the argument if you meant it literally (token: {token!r})."
+            )
+    return argv
+
+
+async def _build_exec_tool_context(ctx: "SlashContext") -> Any:
+    """Same shape as ``slash/plugin.py``'s/``slash/tasks.py``'s own tool-
+    context builders — see this module's docstring point ② for why
+    ``caller_kind`` differs from ``plugin.py``'s ``"router"``."""
+    from reyn.tools.types import ToolContext, build_resource_caller_state
+
+    host = ctx.session.router_host
+    router_state = await build_resource_caller_state(host)
+    return ToolContext(
+        events=host.events,
+        permission_resolver=getattr(host, "permission_resolver", None),
+        workspace=getattr(host, "workspace", None),
+        caller_kind="operator",
+        router_state=router_state,
+        resolver=getattr(host, "resolver", None),
+        hot_reloader=getattr(host, "hot_reloader", None),
+        state_log=getattr(host, "state_log", None),
+        agent_name=getattr(host, "agent_name", None),
+    )
+
+
+async def _build_operator_op_context(tool_ctx: Any) -> Any:
+    """The SAME ``op_context_factory()`` bridge the LLM's own ``exec`` tool
+    call uses (``reyn.tools.exec.op_context_from_tool_context``) — so the
+    sandbox policy (``sandbox.mode: strict`` included, #5818/#5827) is
+    resolved through the identical seam, never re-derived here. The
+    ``actor`` this bridge hardcodes (``"chat_router"``) is replaced
+    afterward — see this module's docstring point ②."""
+    from reyn.tools.exec import op_context_from_tool_context
+
+    op_ctx = await op_context_from_tool_context(tool_ctx)
+    return dataclasses.replace(op_ctx, actor=_OPERATOR_EXEC_ACTOR)
+
+
+def _format_exec_result(result: "dict[str, Any]") -> str:
+    """Screen/attach rendering: exit code, then stdout, then stderr (if
+    any) — the same three facts ``renderer.py``'s own short-form
+    ``sandboxed_exec`` summary (:725) leads with, expanded to full text
+    since this command's whole point is showing the operator everything,
+    not a truncated status-row summary."""
+    returncode = result.get("returncode")
+    stdout = str(result.get("stdout") or "").rstrip("\n")
+    stderr = str(result.get("stderr") or "").rstrip("\n")
+    lines = [f"exit {returncode}"]
+    if stdout:
+        lines.append(stdout)
+    if stderr:
+        lines.append("[stderr]")
+        lines.append(stderr)
+    return "\n".join(lines)
+
+
+def _bounded_attach_text(text: str) -> str:
+    """Head+tail bound for a queued ``/exec-attach`` block — see this
+    module's own ``_ATTACH_TEXT_*`` constants for why. Mirrors
+    ``hooks/shell_runner.py``'s ``_failure_stderr_snippet`` shape: keep
+    the START (what ran, the exit line) and the END (the part most likely
+    to carry the actual error), elide only the middle, and say so
+    visibly — never a silent cut."""
+    if len(text) <= _ATTACH_TEXT_MAX_CHARS:
+        return text
+    head = text[:_ATTACH_TEXT_HEAD]
+    tail = text[-_ATTACH_TEXT_TAIL:]
+    elided = len(text) - _ATTACH_TEXT_HEAD - _ATTACH_TEXT_TAIL
+    return f"{head}\n... [{elided} chars elided] ...\n{tail}"
+
+
+async def _run_exec(ctx: "SlashContext", args: str) -> "tuple[list[str], dict] | None":
+    """Shared body for ``/exec``/``/exec-attach``: tokenize, build the
+    operator OpContext (② sandbox seam + actor override), then run through
+    the SAME op_runtime handler the LLM's exec tool uses — no permission
+    check of its own (see this module's docstring, point ①: the tool-axis
+    restrict check is #5841's, not built here first). Returns
+    ``(argv, result)`` on success, ``None`` after already replying with an
+    error (usage/rejected-cmdline/run failure)."""
+    cmdline = args.strip()
+    if not cmdline:
+        await reply_error(ctx, _USAGE)
+        return None
+
+    try:
+        argv = tokenize_exec_cmdline(cmdline)
+    except ExecCmdlineRejected as exc:
+        await reply_error(ctx, str(exc))
+        return None
+
+    tool_ctx = await _build_exec_tool_context(ctx)
+    op_ctx = await _build_operator_op_context(tool_ctx)
+
+    from reyn.core.op_runtime.sandboxed_exec import handle as handle_sandboxed_exec
+    from reyn.schemas.models import SandboxedExecIROp
+
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=argv)
+    try:
+        result = await handle_sandboxed_exec(op=op, ctx=op_ctx)
+    except PermissionError as exc:
+        # The op's own pre-exec threat scan (FP-0050/#1822 S5) denies via
+        # this channel — the sandbox-scoped write/network/subprocess
+        # boundary applies the same way it does for the LLM's own exec
+        # calls (② op_context_factory seam); this is that boundary
+        # reporting a real denial, not a new gate this module adds.
+        await reply_error(ctx, f"exec denied: {exc}")
+        return None
+    return argv, result
+
+
+@slash(
+    "exec",
+    summary="Run a command through the sandboxed exec tool (screen only)",
+    locus="session",
+    usage=_USAGE,
+    see_also=("exec-attach",),
+)
+async def exec_cmd(ctx: "SlashContext", args: str) -> None:
+    outcome = await _run_exec(ctx, args)
+    if outcome is None:
+        return
+    _argv, result = outcome
+    await reply(ctx, _format_exec_result(result))
+
+
+@slash(
+    "exec-attach",
+    summary="Run a command and attach argv + result to your next message",
+    locus="session",
+    usage="usage: /exec-attach <cmdline>",
+    see_also=("exec",),
+)
+async def exec_attach_cmd(ctx: "SlashContext", args: str) -> None:
+    outcome = await _run_exec(ctx, args)
+    if outcome is None:
+        return
+    argv, result = outcome
+
+    # #5837 ③: the queued block leads with the ACTUAL argv that ran
+    # (shlex.join — never the raw typed cmdline, which may have differed
+    # after tokenize_exec_cmdline's own normalization), then the result.
+    attach_text = _bounded_attach_text(
+        f"$ {shlex.join(argv)}\n{_format_exec_result(result)}"
+    )
+
+    queue: "list[dict] | None" = getattr(ctx.session, "_pending_user_attachments", None)
+    if queue is None:
+        await reply_error(
+            ctx,
+            "attachment queue is unavailable on this session (=#366 wiring missing).",
+        )
+        return
+    # #5837 ③/architect "実装判断" (this module's docstring): a plain text
+    # block, not a path-ref (contrast /attachment's own {"type": "file",
+    # "path": ..., ...} shape). Chosen because Session._handle_inbox_text
+    # (session.py, drain point) appends every queued block into the SAME
+    # content list a leading {"type": "text", "text": ...} block already
+    # occupies (verified directly, not inferred) — a bare text block is
+    # already a proven-compatible shape at that exact site, no new
+    # rendering path needed. NOT chosen: writing exec output to a .reyn/
+    # temp file and queuing a path-ref `file` block (mirroring /attachment
+    # /image) — rejected because that shape's own rationale (#383 PR-C:
+    # "the user's file is the source of truth; reyn does not copy it")
+    # does not apply to exec output, which reyn itself produced; a temp
+    # file would add a naming/retention-cleanup surface for zero benefit.
+    queue.append({"type": "text", "text": attach_text})
+
+    await reply(
+        ctx,
+        f"attached: exec result ({len(attach_text)} chars). "
+        f"queued count: {len(queue)}. Send your next message to include it.",
+    )

--- a/tests/interfaces/test_5837_exec_slash_stage1.py
+++ b/tests/interfaces/test_5837_exec_slash_stage1.py
@@ -1,0 +1,261 @@
+"""Tier 2: #5837 stage 1 — ``/exec`` and ``/exec-attach``.
+
+Real ``Session``/``SandboxConfig`` throughout (``tests._support.agent_
+session.make_session``, ``tests._support.slash.slash_ctx``) — no mocks. The
+LLM ``exec`` tool path is untouched by this file's own subject; only the
+NEW operator-facing slash commands (``interfaces/slash/exec.py``) are
+under test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config import SandboxConfig
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.slash import REGISTRY
+from reyn.interfaces.slash.exec import (
+    ExecCmdlineRejected,
+    tokenize_exec_cmdline,
+)
+from tests._support.agent_session import make_session
+from tests._support.slash import slash_ctx
+
+
+def _session(tmp_path: Path, *, sandbox_config: "SandboxConfig | None" = None):
+    return make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        sandbox_config=sandbox_config,
+        workspace_state_dir=tmp_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ④ tokenize_exec_cmdline — the one isolated shlex function
+# ---------------------------------------------------------------------------
+
+
+def test_tokenize_splits_quoted_argument_as_one_token():
+    """Tier 2: accept — ``/exec ls "my dir"`` -> argv ``["ls", "my dir"]``."""
+    assert tokenize_exec_cmdline('ls "my dir"') == ["ls", "my dir"]
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        "ls | wc -l",
+        "'ls | wc -l'",  # quoting a pipe does not rescue it (whole quoted token)
+        "ls > out.txt",
+        "ls < in.txt",
+        "true && false",
+        "ls; rm -rf /",
+        "echo $(whoami)",
+        "echo `whoami`",
+    ],
+)
+def test_tokenize_rejects_every_shell_metacharacter_form(cmdline: str):
+    """Tier 2: accept — ``/exec 'ls | wc -l'`` is NOT executed, explicit
+    error (#5837 ④'s own named case, plus the sibling metacharacters)."""
+    with pytest.raises(ExecCmdlineRejected):
+        tokenize_exec_cmdline(cmdline)
+
+
+def test_tokenize_rejects_empty_command():
+    """Tier 2: an empty/whitespace-only command line is rejected, never
+    silently executed as an empty argv."""
+    with pytest.raises(ExecCmdlineRejected):
+        tokenize_exec_cmdline("   ")
+
+
+def test_tokenize_rejects_unbalanced_quotes():
+    """Tier 2: shlex's own ValueError (unbalanced quoting) surfaces as
+    ExecCmdlineRejected, not an uncaught exception from the slash handler."""
+    with pytest.raises(ExecCmdlineRejected):
+        tokenize_exec_cmdline("ls 'unterminated")
+
+
+# ---------------------------------------------------------------------------
+# ② operator actor + ① sandbox seam (op-context construction, no subprocess)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_operator_op_context_uses_a_dedicated_actor_not_chat_router(tmp_path):
+    """Tier 2: accept — the audit trail's actor is NOT "chat_router" (the
+    approval ledger is actor-scoped; reusing that name would mix an
+    operator's own /exec calls into the chat router's record)."""
+    from reyn.interfaces.slash.exec import (
+        _OPERATOR_EXEC_ACTOR,
+        _build_exec_tool_context,
+        _build_operator_op_context,
+    )
+
+    session = _session(tmp_path)
+    ctx = slash_ctx(session)
+    tool_ctx = await _build_exec_tool_context(ctx)
+    assert tool_ctx.caller_kind == "operator"
+
+    op_ctx = await _build_operator_op_context(tool_ctx)
+    assert op_ctx.actor == _OPERATOR_EXEC_ACTOR
+    assert op_ctx.actor != "chat_router"
+
+
+@pytest.mark.asyncio
+async def test_operator_op_context_threads_strict_sandbox_mode(tmp_path):
+    """Tier 2: accept — sandbox.mode: strict reaches /exec's own OpContext
+    through the SAME op_context_factory() seam the LLM's own exec tool
+    call uses (reyn.tools.exec.op_context_from_tool_context) — mirrors
+    test_5818_router_op_context_strict_mode_wiring.py's own assertion
+    shape, applied to this NEW bridge instead of the chat-router one.
+
+    Falsify note (verified in-file, Edit-only): temporarily replacing
+    ``_build_operator_op_context``'s call to ``op_context_from_tool_
+    context`` with a bare, mode="compat"-hardcoded OpContext construction
+    (the "minimal synthesis" shape that path already has as its OWN
+    fallback) turns this RED — ``network`` reads the compat default
+    (``True``) instead of ``False``. Confirmed directly, then reverted —
+    see this PR's own commit history / falsify report, never left in the
+    diff.
+    """
+    from reyn.interfaces.slash.exec import _build_exec_tool_context, _build_operator_op_context
+
+    session = _session(tmp_path, sandbox_config=SandboxConfig(mode="strict"))
+    ctx = slash_ctx(session)
+    tool_ctx = await _build_exec_tool_context(ctx)
+    op_ctx = await _build_operator_op_context(tool_ctx)
+
+    pol = op_ctx.default_sandbox_policy
+    assert pol is not None
+    assert pol["network"] is False, (
+        "strict mode must deny network on /exec's own OpContext — "
+        f"got default_sandbox_policy={pol!r}"
+    )
+    assert pol["deny_subprocess"] is True
+
+
+@pytest.mark.asyncio
+async def test_operator_op_context_compat_mode_unchanged(tmp_path):
+    """Tier 2: control arm — compat (no sandbox_config) is untouched,
+    same posture as test_5818's own compat-mode sibling."""
+    from reyn.interfaces.slash.exec import _build_exec_tool_context, _build_operator_op_context
+    from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
+
+    session = _session(tmp_path, sandbox_config=None)
+    ctx = slash_ctx(session)
+    tool_ctx = await _build_exec_tool_context(ctx)
+    op_ctx = await _build_operator_op_context(tool_ctx)
+
+    pol = op_ctx.default_sandbox_policy
+    assert pol is not None
+    assert pol["network"] is DEFAULT_SANDBOX_NETWORK
+
+
+# ---------------------------------------------------------------------------
+# The real slash commands themselves — /exec and /exec-attach end to end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_registered_and_shows_up_in_help_discovery():
+    """Tier 2: accept — /exec and /exec-attach are real, discoverable
+    commands (the `!`/`!!` prefixes are stage 2 — this only pins the
+    named forms this stage actually ships)."""
+    exec_cmd = REGISTRY.get("exec")
+    attach_cmd = REGISTRY.get("exec-attach")
+    assert exec_cmd is not None
+    assert attach_cmd is not None
+    assert "sandboxed exec" in exec_cmd.summary.lower()
+
+
+@pytest.mark.asyncio
+async def test_exec_runs_and_shows_result_on_screen_only_no_history_growth(tmp_path):
+    """Tier 2: accept — `/exec` shows exit code + stdout on screen, and
+    history.jsonl gains ZERO lines (slash replies are put_display only,
+    never appended to history — this command's whole point)."""
+    session = _session(tmp_path)
+    history_before = (
+        session.history_path.read_text() if session.history_path.exists() else ""
+    )
+
+    cmd = REGISTRY.get("exec")
+    outbox: list = []
+    ctx = slash_ctx(session, recorder=outbox)
+    await cmd.handler(ctx, 'python3 -c "print(2+2)"')
+
+    texts = [getattr(m, "text", "") for m in outbox]
+    assert any("exit 0" in t for t in texts), f"expected an exit-0 reply, got {texts!r}"
+    assert any("4" in t for t in texts), f"expected the command's own stdout, got {texts!r}"
+
+    history_after = (
+        session.history_path.read_text() if session.history_path.exists() else ""
+    )
+    assert history_after == history_before, (
+        "/exec must never grow history.jsonl -- it is a display-only slash reply"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exec_rejects_shell_metacharacters_with_no_execution(tmp_path):
+    """Tier 2: accept — `/exec 'ls | wc -l'` is not executed, explicit
+    error on screen."""
+    session = _session(tmp_path)
+    cmd = REGISTRY.get("exec")
+    outbox: list = []
+    ctx = slash_ctx(session, recorder=outbox)
+    await cmd.handler(ctx, "ls | wc -l")
+
+    texts = [getattr(m, "text", "") for m in outbox]
+    assert any("shell interpretation" in t.lower() for t in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_exec_attach_queues_argv_and_result_for_the_next_message(tmp_path):
+    """Tier 2: accept — the queued block carries shlex.join(argv), not the
+    raw typed text, ahead of the result."""
+    session = _session(tmp_path)
+    cmd = REGISTRY.get("exec-attach")
+    outbox: list = []
+    ctx = slash_ctx(session, recorder=outbox)
+    queue_before = list(session._pending_user_attachments)
+    await cmd.handler(ctx, 'python3 -c "print(1+1)"')
+
+    queue = session._pending_user_attachments
+    added = [b for b in queue if b not in queue_before]
+    assert added, "the command must queue at least one new block"
+    block = added[-1]
+    assert block["type"] == "text"
+    assert "python3 -c" in block["text"]
+    assert "exit 0" in block["text"]
+    assert "2" in block["text"]
+
+    texts = [getattr(m, "text", "") for m in outbox]
+    assert any("Send your next message to include it" in t for t in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_exec_attach_three_times_each_adds_its_own_distinguishable_block(tmp_path):
+    """Tier 2: accept — /exec-attach x3 -> the next user turn drains all of
+    them into ONE user message (the SAME `_pending_user_attachments` queue
+    `/attachment`/`/image` already share the drain contract for — this
+    test proves /exec-attach feeds that queue, not a re-derivation of the
+    drain itself, which session.py's own tests already cover). Each call's
+    OWN output (0, 1, 2) must be independently findable — a shared-mutable-
+    state bug would collapse them into copies of the same block."""
+    session = _session(tmp_path)
+    cmd = REGISTRY.get("exec-attach")
+    ctx = slash_ctx(session)
+
+    for i in range(3):
+        await cmd.handler(ctx, f'python3 -c "print({i})"')
+
+    queue = session._pending_user_attachments
+    assert all(b["type"] == "text" for b in queue)
+    for i in range(3):
+        assert any(f"print({i})" in b["text"] and f"\n{i}" in b["text"] for b in queue), (
+            f"block for call {i} not found (or not distinguishable) in {queue!r}"
+        )
+
+

--- a/tests/interfaces/test_5837_exec_slash_stage1.py
+++ b/tests/interfaces/test_5837_exec_slash_stage1.py
@@ -198,6 +198,40 @@ async def test_exec_runs_and_shows_result_on_screen_only_no_history_growth(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_exec_emits_tool_called_with_operator_caller_kind(tmp_path):
+    """Tier 2: accept (#5843 BLOCKING ①) — caller_kind="operator" must
+    reach a REAL audit-event, not just sit on an object nothing reads.
+    dispatch_tool (core/dispatch/dispatcher.py) is the ONE place that
+    emits tool_called/tool_returned carrying caller_kind — a direct call
+    to handle_sandboxed_exec (the earlier shape of this module) bypassed
+    it entirely, leaving zero audit-events with caller_kind at all.
+
+    Falsify note (verified in-file, Edit-only, then reverted): reverting
+    _run_exec's dispatch_tool call back to a direct handle_sandboxed_exec
+    call makes this RED -- no tool_called event is emitted at all."""
+    from tests._support.events import collect_events, settle
+
+    session = _session(tmp_path)
+    events = collect_events(session._audit_events)
+
+    cmd = REGISTRY.get("exec")
+    ctx = slash_ctx(session)
+    await cmd.handler(ctx, 'python3 -c "print(1)"')
+    await settle(session._audit_events)
+
+    tool_called = [e for e in events if e.type == "tool_called" and e.data.get("tool") == "exec"]
+    assert tool_called, f"no tool_called event for exec -- got types {[e.type for e in events]!r}"
+    assert tool_called[0].data.get("caller_kind") == "operator", (
+        f"/exec's own audit trail must attribute caller_kind='operator', "
+        f"got {tool_called[0].data!r}"
+    )
+
+    tool_returned = [e for e in events if e.type == "tool_returned" and e.data.get("tool") == "exec"]
+    assert tool_returned, "no tool_returned event for a successful exec run"
+    assert tool_returned[0].data.get("caller_kind") == "operator"
+
+
+@pytest.mark.asyncio
 async def test_exec_rejects_shell_metacharacters_with_no_execution(tmp_path):
     """Tier 2: accept — `/exec 'ls | wc -l'` is not executed, explicit
     error on screen."""
@@ -257,5 +291,98 @@ async def test_exec_attach_three_times_each_adds_its_own_distinguishable_block(t
         assert any(f"print({i})" in b["text"] and f"\n{i}" in b["text"] for b in queue), (
             f"block for call {i} not found (or not distinguishable) in {queue!r}"
         )
+
+
+@pytest.mark.asyncio
+async def test_exec_attach_three_times_then_submit_drains_to_one_message_one_completion(
+    tmp_path,
+):
+    """Tier 2: accept (architect's own closing prescription, #5843 BLOCKING
+    ②) — "queued" is not a witness for "drained". A plain ``{"type":
+    "text", ...}`` block is a NEW shape in `_pending_user_attachments`
+    (existing producers, `/attachment`/`/image`, only ever queue a
+    path-ref `file`/`image` block) — this drives a REAL Session end to
+    end to confirm it is not silently filtered out anywhere between the
+    queue and the actual outbound litellm call.
+
+    Real Session, real inbox processing (`run_one_iteration`), a real
+    (stubbed-at-the-litellm-boundary, #5103's own established
+    fixture-less pattern) completion — captures the EXACT `messages`
+    litellm.acompletion is called with, one layer beneath `LLMStub`'s own
+    fixed response so the call itself still returns a normal, harmless
+    completion (no gating/tool-call machinery needed for this witness).
+
+    Asserts BOTH halves architect named: (1) the durable history entry
+    (one `role="user"` turn) carries the "go" text AND all 3 `$ ...`
+    markers, and (2) the actual message litellm receives ALSO carries
+    them — proving the block survives history persistence AND the wire-
+    format conversion, not just the first of the two.
+    """
+    import litellm
+
+    from reyn.dev.testing.llm_stub import LLMStub
+
+    session = _session(tmp_path)
+    cmd = REGISTRY.get("exec-attach")
+    ctx = slash_ctx(session)
+
+    for i in range(3):
+        await cmd.handler(ctx, f'python3 -c "print({i})"')
+
+    stub = LLMStub()
+    stub.install()
+    captured_messages: "list[list[dict]]" = []
+    original_acompletion = litellm.acompletion
+
+    async def _capturing_acompletion(*, model, messages, **kwargs):
+        captured_messages.append(messages)
+        return await original_acompletion(model=model, messages=messages, **kwargs)
+
+    litellm.acompletion = _capturing_acompletion
+    try:
+        await session.submit_user_text("go")
+        await session.run_one_iteration()
+    finally:
+        stub.restore()
+        litellm.acompletion = original_acompletion
+
+    # (1) the durable history entry.
+    user_entries = [m for m in session.history if m.role == "user"]
+    (entry,) = [m for m in user_entries if _content_text(m.content) and "go" in _content_text(m.content)]
+    entry_text = _content_text(entry.content)
+    assert "go" in entry_text
+    for i in range(3):
+        assert f"print({i})" in entry_text, (
+            f"call {i}'s own $ ... marker missing from the persisted history "
+            f"entry: {entry_text!r}"
+        )
+
+    # (2) the ACTUAL message the model call received — ONE completion,
+    # carrying all 3 (architect's own "3回 -> 1通 -> completion 1回").
+    assert captured_messages, "litellm.acompletion was never called"
+    (sent_messages,) = captured_messages  # exactly one completion
+    sent_texts = " ".join(_content_text(m.get("content")) for m in sent_messages)
+    assert "go" in sent_texts
+    for i in range(3):
+        assert f"print({i})" in sent_texts, (
+            f"call {i}'s own $ ... marker missing from the message actually "
+            f"sent to the model: {sent_texts!r}"
+        )
+
+
+def _content_text(content: "str | list[dict] | None") -> str:
+    """Flatten a ChatMessage/litellm-message ``content`` (a plain string,
+    or a list of ``{"type": "text", "text": ...}``-shaped blocks) into one
+    searchable string — mirrors how both the history entry and the
+    litellm-wire message represent multi-block content."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    parts = []
+    for block in content:
+        if isinstance(block, dict) and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return "\n".join(parts)
 
 


### PR DESCRIPTION
**[e2e-coder]** — part of #5837 (stage 1 only — `!`/`!!` prefix normalization is stage 2, a separate PR per architect's plan).

## What this does

- `/exec <cmdline>`: runs argv through the SAME `op_runtime.sandboxed_exec` handler the LLM's own `exec` tool uses. Screen-only reply (exit code + stdout + stderr), never touches `history.jsonl`.
- `/exec-attach <cmdline>`: same run, queues one `{"type":"text",...}` block (`shlex.join(argv)` + result) onto `session._pending_user_attachments` — the SAME queue `/attachment`/`/image` already share the drain-on-next-turn contract for.
- `caller_kind="operator"` (never `"router"`); `actor` is a dedicated `slash_exec_operator` constant, never `"chat_router"` (the approval ledger is actor-scoped — reusing that name would mix records).
- Sandbox resolved through the SAME `op_context_factory()` seam (`tools.exec.op_context_from_tool_context`) the LLM's own exec calls use — `sandbox.mode: strict` reaches this path identically.
- `tokenize_exec_cmdline()`: the ONE function touching `shlex` (quoting only, owner ruling) — isolated so #5838 (still-undecided LLM-exec shell-interpretation question) can replace only this function later. Rejects any token containing a shell metacharacter (`| > < && ; $( ` `), including a fully-quoted whole-string form.

## A design pivot mid-PR (disclosed, per house discipline)

**Real-machine finding**, reported before writing any implementation: the LLM `exec` tool call path has **no interactive JIT confirmation at all today** — `require_tool`/`CapabilityAxis.TOOL` (#1199 S3.1b-2c) was built but never wired to any tool's dispatch path (traced the full call chain, zero `_approve`/bus calls). So "①: skip the confirmation" turned out to be a no-op — there's nothing to skip on either path.

An **earlier version of this PR** added a new `PermissionResolver.is_tool_allowed()` (restrict-layer-only, no confirmation) and called it **only from `/exec`**, to close the resulting gap for this command. **architect's ruling reverted this**: (1) it would make the human-typed path *narrower* than the LLM path — the wrong direction of asymmetry to introduce silently, and (2) it made one fact ("is `exec` permitted for this agent?") checkable from two independent places that could drift — the exact class this repo's review discipline closed six times in one night. That work was discarded via in-file `Edit` (confirmed **byte-identical diff against `origin/main`** on `permissions.py` before committing) — the tool-axis restrict check belongs at one seam shared by both paths, tracked separately as **#5841**. This PR adds **no permission check of its own**; the sandbox boundary (write/network/subprocess/env) is unaffected either way.

## Strip-falsify

Temporarily replaced `_build_operator_op_context`'s `op_context_factory()` call with a bare, `mode="compat"`-hardcoded `OpContext` (the "minimal synthesis" shape `op_context_from_tool_context` already has as its own fallback) — confirmed `test_operator_op_context_threads_strict_sandbox_mode` genuinely goes RED (`network` reads `True` instead of `False`), then reverted. Edit-only, no `git stash`/`checkout`.

## Known gap until #5841

> Until #5841 lands, an agent whose Profile denies `exec` can still run `/exec` (the tool-axis restrict check is not wired to this call path yet — same gap the LLM `exec` path already has, not new).

## Test plan

- [x] 21 new tests: `tokenize_exec_cmdline` (quoting, every shell-metacharacter form including the fully-quoted whole-string case, empty/unbalanced-quote rejection), operator-actor + sandbox-seam op-context assertions (strict + compat), real end-to-end `/exec`/`/exec-attach` runs through the registered slash commands, `history.jsonl` non-growth, 3x `/exec-attach` each independently identifiable, a real `tool_called`/`caller_kind="operator"` audit-event witness (BLOCKING ①), and a real end-to-end drain witness through `submit_user_text`+`run_one_iteration` with the actual outbound litellm `messages` captured (BLOCKING ②).
- [x] Broader regression sweep: `tests/interfaces/`, `tests/security/`, plus `test_5654_tasks_wiring.py`/`test_5818_router_op_context_strict_mode_wiring.py`/`test_op_sandboxed_exec.py` — 3166 passed, 35 skipped, 0 failed.
- [x] Gates: `ruff check .`, `test_tier_audit.py --strict` (12 tests, 0 errors), `verify_module_docstrings.py`, `mypy_ratchet.py` (199 findings, all baselined), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green.
- [x] (skipped — full suite is CI-only per standing rule, not run locally)
- [ ] (Visual — owner's real-screen confirmation, per architect's own note: display formatting is UX-visible, not held for this PR's own merge)

## Accept criteria not yet covered here (disclosed, not silently dropped)

- `collect="async"` and post-hoc "attach the previous result" are explicitly out of scope (architect's plan).
- `!`/`!!` prefix forms and `/help` short-form listing are stage 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthGJjaGi21Bk5dwe7nE51

