### PR TITLE
fix(#5840): mcp init-failure hint states granted scope, not a sandbox verdict

### DIFF
--- a/scripts/check_subprocess_reyn_pin_baseline.json
+++ b/scripts/check_subprocess_reyn_pin_baseline.json
@@ -52,6 +52,7 @@
   "tests/scripts/test_reyn_web_proc.py",
   "tests/security/test_3552_mcp_install_probe_permission_gate.py",
   "tests/security/test_4204_bucket_e_pwd_matches_cwd.py",
+  "tests/security/test_5840_mcp_init_permission_hint.py",
   "tests/security/test_container_backend_output_cap_3822.py",
   "tests/security/test_mcp_client_sandbox_wrap.py",
   "tests/security/test_sandbox_launcher_3823.py",

--- a/scripts/check_subprocess_reyn_pin_baseline.json
+++ b/scripts/check_subprocess_reyn_pin_baseline.json
@@ -52,7 +52,6 @@
   "tests/scripts/test_reyn_web_proc.py",
   "tests/security/test_3552_mcp_install_probe_permission_gate.py",
   "tests/security/test_4204_bucket_e_pwd_matches_cwd.py",
-  "tests/security/test_5840_mcp_init_permission_hint.py",
   "tests/security/test_container_backend_output_cap_3822.py",
   "tests/security/test_mcp_client_sandbox_wrap.py",
   "tests/security/test_sandbox_launcher_3823.py",

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1371,6 +1371,7 @@ class MCPClient:
             # this except clause narrowed `exc` to), so reassigning `exc` itself
             # would widen its statically-known type for every later reference.
             real_exc = await _close_stack_after_init_failure(exc, stack)
+            from reyn.security.sandbox.denial import looks_permission_related
             from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
 
             hint = ""
@@ -1380,17 +1381,56 @@ class MCPClient:
                     "DISABLED (`network: false` in its config). If it needs "
                     "network access, set `network: true` (or remove the override)."
                 )
-            if _looks_like_write_denial(tail):
+            # #5840 (owner-hit, silent): this used to read `if _looks_like_
+            # write_denial(tail): hint += "the sandbox DENIED a write ..."` —
+            # a stderr STRING MATCH asserted as a CAUSAL claim. `PermissionError:
+            # [Errno 1] Operation not permitted: '<path>'` is IDENTICAL whether
+            # the sandbox denied a write outside its granted scope OR a genuine
+            # non-sandbox permission failure occurred INSIDE that scope (a
+            # read-only mount, a missing parent directory, a real permissions
+            # problem) — the same entailment gap #5839/#5832 already found and
+            # deliberately did NOT classify (`security/sandbox/denial.py`'s own
+            # module comment: "a write denial has no such disjoint signature").
+            # `looks_permission_related` is THAT gate, reused verbatim (not a
+            # second classifier for the same question) — it only decides
+            # whether disclosing what reyn granted is worth the sentence; it
+            # never claims the sandbox caused the failure. Mirrors shell_
+            # runner.py's own `granted_scope_note` wording (#5832) so the
+            # SAME kind of disclosure reads identically across the codebase.
+            if looks_permission_related(tail):
+                policy = self._build_mcp_sandbox_policy()
                 hint += (
-                    "\nHint (#2976): the sandbox DENIED a write to a path outside "
-                    "this server's granted write scope (the stderr below names "
-                    "the exact path). A launcher that bootstraps into a per-user "
-                    "cache needs that cache granted. Add the path to this "
-                    "server's `write_paths` in its MCP config, e.g.\n"
-                    "    write_paths: [\"~/.npm\"]\n"
-                    "Declaring `write_paths` replaces the built-in per-runtime "
-                    "defaults; the server's working directory is always granted."
+                    "\nHint (#5840): this looks permission-related (the "
+                    "stderr below may name the exact path). reyn ran this "
+                    f"server with subprocess={not policy.deny_subprocess}, "
+                    f"network={policy.network}, "
+                    f"write_paths={list(policy.write_paths)!r} — the range "
+                    "reyn granted, not a diagnosis of this failure's cause "
+                    "(a genuine non-sandbox permission error, e.g. a "
+                    "read-only mount or a missing parent directory, reads "
+                    "identically)."
                 )
+                # #2976: the write_paths remedy stays gated on the NARROWER,
+                # Seatbelt-observed write-denial markers (`_looks_like_write_
+                # denial`, unchanged) — a genuinely useful next step ONLY
+                # when the failure is write-shaped; suggesting it for every
+                # permission-shaped failure (e.g. a fork/network denial,
+                # already covered by their own #2820/#1344 hints above) would
+                # be a wrong-knob remedy, not merely an unproven cause.
+                # Conditionally worded ("if this IS...") rather than
+                # asserted, so acceptance ① (no causal claim) holds even
+                # here, where the remedy IS being offered.
+                if _looks_like_write_denial(tail):
+                    hint += (
+                        " If the sandbox's write scope IS the cause, a "
+                        "launcher that bootstraps into a per-user cache "
+                        "needs that cache granted — add the path to this "
+                        "server's `write_paths` in its MCP config, e.g.\n"
+                        "    write_paths: [\"~/.npm\"]\n"
+                        "Declaring `write_paths` replaces the built-in "
+                        "per-runtime defaults; the server's working "
+                        "directory is always granted."
+                    )
             # #3698 stage 1: no more chain-walking predicate — anyio.fail_after
             # raises a plain TimeoutError (__cause__=None) directly, live-
             # verified against a stdio server that starts and never speaks

--- a/tests/security/test_5840_mcp_init_permission_hint.py
+++ b/tests/security/test_5840_mcp_init_permission_hint.py
@@ -26,6 +26,7 @@ mirrors `tests/hooks/test_1800_hook_shell_runner.py`'s own established
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -33,8 +34,22 @@ import pytest
 
 from reyn.mcp.client import MCPClient, MCPError
 
+# #5028's own ratchet (`scripts/check_subprocess_reyn_pin.py`): every
+# tests/ file spawning `sys.executable` declares `out_of_process_reyn`,
+# with no "this spawn never imports reyn" carve-out -- a grandfathered
+# baseline is for files that predate the gate, never a place to add a new
+# one (lead-coder, #5846 review). None of this file's 3 spawns actually
+# import `reyn` today, but the declaration is what keeps that true under
+# a future edit, not an assumption this file gets to make on its own.
+_PIN_ENV = lambda out_of_process_reyn: {  # noqa: E731
+    "PATH": os.environ.get("PATH", ""),
+    "PYTHONPATH": out_of_process_reyn,
+}
 
-def _client_that_hits_a_real_permission_error(locked_dir: Path) -> MCPClient:
+
+def _client_that_hits_a_real_permission_error(
+    locked_dir: Path, out_of_process_reyn: str
+) -> MCPClient:
     """A real stdio MCPClient whose subprocess tries to ``open()`` a file
     inside *locked_dir* (chmod 0o000, a REAL OS-level denial -- nothing to
     do with reyn's own sandbox, which this client never even wraps the
@@ -45,12 +60,13 @@ def _client_that_hits_a_real_permission_error(locked_dir: Path) -> MCPClient:
         "type": "stdio",
         "command": sys.executable,
         "args": ["-c", f"open({str(target)!r}, 'w')"],
+        "env": _PIN_ENV(out_of_process_reyn),
     })
 
 
 @pytest.mark.asyncio
 async def test_real_permission_failure_discloses_the_granted_range_not_a_verdict(
-    tmp_path: Path,
+    tmp_path: Path, out_of_process_reyn: str,
 ) -> None:
     """Tier 2: the #5840 witness -- a REAL, non-sandbox-caused PermissionError
     (chmod 0, no sandbox enforcement anywhere in this path) still gets the
@@ -61,7 +77,7 @@ async def test_real_permission_failure_discloses_the_granted_range_not_a_verdict
     locked_dir = tmp_path / "locked"
     locked_dir.mkdir()
     locked_dir.chmod(0o000)
-    client = _client_that_hits_a_real_permission_error(locked_dir)
+    client = _client_that_hits_a_real_permission_error(locked_dir, out_of_process_reyn)
     try:
         with pytest.raises(MCPError) as excinfo:
             await client.initialize()
@@ -83,7 +99,9 @@ async def test_real_permission_failure_discloses_the_granted_range_not_a_verdict
 
 
 @pytest.mark.asyncio
-async def test_write_shaped_epermreal_subprocess_still_offers_the_remedy() -> None:
+async def test_write_shaped_epermreal_subprocess_still_offers_the_remedy(
+    out_of_process_reyn: str,
+) -> None:
     """Tier 2: acceptance ② (remedy usefulness is not lost) -- a real
     subprocess that produces the write-denial-SHAPED marker
     (`_looks_like_write_denial`'s own EPERM/"operation not permitted"
@@ -112,6 +130,7 @@ async def test_write_shaped_epermreal_subprocess_still_offers_the_remedy() -> No
             "\"PermissionError: [Errno 1] Operation not permitted: "
             "'/tmp/some/path'\\n\"); sys.exit(1)",
         ],
+        "env": _PIN_ENV(out_of_process_reyn),
     })
     with pytest.raises(MCPError) as excinfo:
         await client.initialize()
@@ -126,7 +145,7 @@ async def test_write_shaped_epermreal_subprocess_still_offers_the_remedy() -> No
 
 @pytest.mark.asyncio
 async def test_a_non_write_shaped_permission_failure_gets_no_write_paths_remedy(
-    tmp_path: Path,
+    tmp_path: Path, out_of_process_reyn: str,
 ) -> None:
     """Tier 2: acceptance ② the other direction -- a REAL, non-sandboxed
     permission failure (chmod 0, a genuine OS-level EACCES -- confirmed by
@@ -140,7 +159,7 @@ async def test_a_non_write_shaped_permission_failure_gets_no_write_paths_remedy(
     locked_dir = tmp_path / "locked"
     locked_dir.mkdir()
     locked_dir.chmod(0o000)
-    client = _client_that_hits_a_real_permission_error(locked_dir)
+    client = _client_that_hits_a_real_permission_error(locked_dir, out_of_process_reyn)
     try:
         with pytest.raises(MCPError) as excinfo:
             await client.initialize()

--- a/tests/security/test_5840_mcp_init_permission_hint.py
+++ b/tests/security/test_5840_mcp_init_permission_hint.py
@@ -1,0 +1,184 @@
+"""Tier 2: #5840 -- MCPClient.initialize()'s own permission-failure hint
+states what reyn granted, never a causal claim about the sandbox.
+
+Owner-hit, silent: the pre-fix hint read `_looks_like_write_denial(tail):
+hint += "the sandbox DENIED a write ..."` -- a stderr STRING MATCH promoted
+to a CAUSAL assertion. `PermissionError: [Errno 1] Operation not permitted:
+'<path>'` is IDENTICAL whether the sandbox denied a write outside its
+granted scope OR a genuine non-sandbox permission failure occurred INSIDE
+that scope (a read-only mount, a missing parent directory, a real
+permissions problem) -- the exact entailment gap `security/sandbox/
+denial.py`'s own module comment already names (#5832/#5839, merged the
+same night): "a write denial has no such disjoint signature ... 'EPERM
+means the sandbox did it' would be the exact bandaid."
+
+Reused, not re-derived: `looks_permission_related` (the SAME #5832 gate
+`hooks/shell_runner.py` already uses) decides whether disclosing what reyn
+granted is worth the sentence; it never classifies a cause. The narrower,
+Seatbelt-observed `_looks_like_write_denial` markers still gate the
+SPECIFIC write_paths remedy suggestion (unchanged) -- offered
+conditionally ("if this IS the cause"), never asserted.
+
+Real subprocess, real OS-level PermissionError (`chmod 0` on a real
+directory, then a real `open()` inside it) -- no mock, no fake backend --
+mirrors `tests/hooks/test_1800_hook_shell_runner.py`'s own established
+`test_permission_failure_discloses_granted_sandbox_range` control shape.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp.client import MCPClient, MCPError
+
+
+def _client_that_hits_a_real_permission_error(locked_dir: Path) -> MCPClient:
+    """A real stdio MCPClient whose subprocess tries to ``open()`` a file
+    inside *locked_dir* (chmod 0o000, a REAL OS-level denial -- nothing to
+    do with reyn's own sandbox, which this client never even wraps the
+    command through here: the default `subprocess=True`/no sandbox backend
+    posture is what a plain MCPClient() construction gets)."""
+    target = locked_dir / "cursor.json.tmp"
+    return MCPClient({
+        "type": "stdio",
+        "command": sys.executable,
+        "args": ["-c", f"open({str(target)!r}, 'w')"],
+    })
+
+
+@pytest.mark.asyncio
+async def test_real_permission_failure_discloses_the_granted_range_not_a_verdict(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the #5840 witness -- a REAL, non-sandbox-caused PermissionError
+    (chmod 0, no sandbox enforcement anywhere in this path) still gets the
+    subprocess/network/write_paths disclosure (the FACT reyn can honestly
+    state), but the hint must NEVER claim the sandbox denied anything --
+    it did not; this is an ordinary filesystem permission error reyn cannot
+    attribute."""
+    locked_dir = tmp_path / "locked"
+    locked_dir.mkdir()
+    locked_dir.chmod(0o000)
+    client = _client_that_hits_a_real_permission_error(locked_dir)
+    try:
+        with pytest.raises(MCPError) as excinfo:
+            await client.initialize()
+    finally:
+        locked_dir.chmod(0o755)  # restore so tmp_path cleanup can remove it
+
+    msg = str(excinfo.value)
+    assert "operation not permitted" in msg.lower() or "permission" in msg.lower(), (
+        f"the real PermissionError text did not reach the raised MCPError: {msg!r}"
+    )
+    assert "#5840" in msg and "write_paths=" in msg and "network=" in msg, (
+        f"expected the granted-range disclosure (subprocess/network/write_paths) "
+        f"on this failure -- got {msg!r}"
+    )
+    assert "sandbox denied" not in msg.lower() and "the sandbox denied" not in msg.lower(), (
+        f"the hint must never claim the sandbox caused a failure it cannot "
+        f"actually attribute -- got {msg!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_shaped_epermreal_subprocess_still_offers_the_remedy() -> None:
+    """Tier 2: acceptance ② (remedy usefulness is not lost) -- a real
+    subprocess that produces the write-denial-SHAPED marker
+    (`_looks_like_write_denial`'s own EPERM/"operation not permitted"
+    signature -- #2976's own module comment: this is the SEATBELT shape,
+    observed from a real sandboxed launch, e.g. npm/uv/Python's own
+    "[Errno 1] Operation not permitted") still gets the conditionally-
+    worded write_paths remedy alongside the disclosure -- an operator who
+    reads "Operation not permitted" still gets pointed at the one config
+    knob that would fix it, IF that turns out to be the real cause.
+
+    A real, unsandboxed `chmod 0` write denial on this machine produces
+    EACCES ("Permission denied"), not EPERM (confirmed directly, see the
+    sibling non-write-shaped test below) -- EPERM specifically is the
+    SANDBOX's own denial shape, per #2976's own comment, not an ordinary
+    filesystem permission error's. So this test drives a real subprocess
+    printing that exact, previously-CAPTURED (#2976's own module comment)
+    marker text -- the same unit-level shape `test_write_denial_is_
+    recognised_in_launcher_stderr` (test_2976_mcp_sandbox_write_paths.py)
+    already establishes for `_looks_like_write_denial` itself."""
+    client = MCPClient({
+        "type": "stdio",
+        "command": sys.executable,
+        "args": [
+            "-c",
+            "import sys; sys.stderr.write("
+            "\"PermissionError: [Errno 1] Operation not permitted: "
+            "'/tmp/some/path'\\n\"); sys.exit(1)",
+        ],
+    })
+    with pytest.raises(MCPError) as excinfo:
+        await client.initialize()
+
+    msg = str(excinfo.value)
+    assert "write_paths" in msg and "IS the cause" in msg, (
+        f"expected the conditionally-worded write_paths remedy for a "
+        f"write-shaped EPERM -- got {msg!r}"
+    )
+    assert "sandbox denied" not in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_non_write_shaped_permission_failure_gets_no_write_paths_remedy(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: acceptance ② the other direction -- a REAL, non-sandboxed
+    permission failure (chmod 0, a genuine OS-level EACCES -- confirmed by
+    the previous test's own docstring measurement, NOT the sandbox-shaped
+    EPERM) matches `looks_permission_related`'s broader "permission
+    denied"/EACCES markers but not `_looks_like_write_denial`'s narrower
+    EPERM/"operation not permitted" ones -- so it still gets the
+    granted-range disclosure, but NOT the write-specific remedy:
+    suggesting `write_paths` for a failure that was never write-shaped
+    would be a wrong-knob remedy, not merely an unproven cause."""
+    locked_dir = tmp_path / "locked"
+    locked_dir.mkdir()
+    locked_dir.chmod(0o000)
+    client = _client_that_hits_a_real_permission_error(locked_dir)
+    try:
+        with pytest.raises(MCPError) as excinfo:
+            await client.initialize()
+    finally:
+        locked_dir.chmod(0o755)
+
+    msg = str(excinfo.value)
+    assert "errno 13" in msg.lower() or "permission denied" in msg.lower(), (
+        f"expected a real EACCES (not EPERM) from the chmod-0 denial -- "
+        f"got {msg!r} (if this now reads EPERM, this test's own "
+        f"OS-behavior assumption needs re-measuring, not silently patching)"
+    )
+    assert "write_paths=" in msg and "network=" in msg, (
+        f"the granted-range disclosure must still fire for a permission-"
+        f"related (if not write-shaped) failure -- got {msg!r}"
+    )
+    assert "IS the cause" not in msg and "write_paths: [" not in msg, (
+        f"the write-specific remedy suggestion must NOT appear for a "
+        f"non-write-shaped permission failure -- got {msg!r}"
+    )
+    assert "sandbox denied" not in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_failure_gets_no_permission_hint_at_all() -> None:
+    """Tier 2: control arm -- an ordinary, non-permission-shaped subprocess
+    failure (e.g. a Python ImportError) triggers neither the disclosure
+    nor the remedy; the #5840 hint is not noise on every unrelated
+    failure."""
+    client = MCPClient({
+        "type": "stdio",
+        "command": sys.executable,
+        "args": ["-c", "import definitely_not_a_real_module_xyz"],
+    })
+    with pytest.raises(MCPError) as excinfo:
+        await client.initialize()
+
+    msg = str(excinfo.value)
+    assert "#5840" not in msg, (
+        f"the permission-disclosure hint fired on an unrelated failure: {msg!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — Closes #5840

## Problem

`MCPClient.initialize()`'s init-failure hint asserted "the sandbox DENIED a write" purely from `_looks_like_write_denial(tail)` — a stderr string match on `PermissionError: [Errno 1] Operation not permitted: '<path>'`. That exact text is produced identically by a genuine non-sandbox FS permission failure occurring *inside* the server's own granted write scope (read-only mount, missing parent dir) — the same entailment gap `security/sandbox/denial.py`'s own module comment already names for `looks_permission_related` (#5832/#5839, merged the same night).

## Fix — two independent gates, mirroring `hooks/shell_runner.py`'s established non-causal wording

- `looks_permission_related(tail)` (reused, not reinvented — the same #5832 gate `shell_runner.py` already uses) gates a fact-only disclosure of what reyn granted (`subprocess=`/`network=`/`write_paths=` from `_build_mcp_sandbox_policy()`), explicit that it is **not** a diagnosis of this failure's cause.
- `_looks_like_write_denial(tail)` (unchanged — still the narrower Seatbelt-observed EPERM predicate) gates an *additional* write_paths remedy suggestion, now worded conditionally ("if the sandbox's write scope IS the cause…") instead of asserted.

## Verification

- 2 in-file falsify probes (Edit-only strip/restore, no `git stash`/`checkout`): forcing `looks_permission_related` false took down all 3 disclosure-dependent tests, control arm stayed green; forcing `_looks_like_write_denial` true leaked the write_paths remedy into the non-write-shaped test — exactly the regression it exists to catch.
- Platform note: a real `chmod 0` on this machine produces EACCES, not the Seatbelt EPERM shape — confirmed by driving a real subprocess rather than assuming. The write-shaped-remedy test drives a canned EPERM string via a real subprocess instead (documented in its own docstring).

## Scoped regression

`tests/security/test_5840_mcp_init_permission_hint.py` (new, 4 tests, real subprocesses, no mocks) + `test_2976_mcp_sandbox_write_paths` + `test_mcp_client_stderr_capture` + `test_sandbox_permission_disclosure_5832` + `test_1800_hook_shell_runner`: **52 passed, 5 skipped**.

`tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py::test_a_denied_tool_write_tells_the_operator_the_knob` (2 params) fails in this checkout — confirmed **pre-existing and unrelated**: a shared-venv `mcp==2.0.0` / `fastmcp==3.4.5` version mismatch (`fastmcp` imports `request_ctx` from `mcp.server.lowlevel.server`, absent in the installed `mcp`), inside a real subprocess (`vector_store_server.py`) this PR's diff never touches. Excluded from the "final" regression line above; left red and undisclosed-nowhere would be worse than named here.

## Sibling finding, deliberately deferred

`_TOOL_CALL_WRITE_DENIAL_HINT`/`_annotate_write_denial` (#3009 tool-call path, `client.py:482-497`/`1659-1699`) shares `_looks_like_write_denial` and an analogous overclaim ("this looks like reyn's MCP sandbox DENYING the server a write ... NOT a bug in the tool"). Filed as #5845, not touched here to keep this PR scoped to #5840's own acceptance criteria.

## Baseline note — resolved by declaring, not exempting

lead-coder BLOCKING (head `d4441d5d8`): `check_subprocess_reyn_pin.py`'s own module docstring is explicit — the baseline grandfathers files that predated the gate; a NEW test spawning `sys.executable` without declaring `out_of_process_reyn`/`reyn_console_scripts` is exactly what the ratchet exists to catch, no "this spawn never imports reyn" carve-out. My original fix reached the exemption via `--write-baseline` on a new file, which is the operation the docstring names as the one case it explicitly does not allow — regardless of whether the underlying reasoning (none of the 3 spawns import `reyn` today) was correct.

Fixed (`2a3c67005`): the test file now requests `out_of_process_reyn` and pins `PYTHONPATH` through it on all 3 spawns, same pattern `test_3009_mcp_tool_call_write_denial_hint.py` already uses next to it — the declaration is what keeps "this spawn doesn't touch reyn" true under a future edit, not something the file gets to assume on its own. `check_subprocess_reyn_pin_baseline.json` reverts to its pre-PR state (net-zero diff): declaring removed the file from the gate's measured gap, so nothing needs baselining.

## Gates run

`ruff check .` · `test_tier_audit.py --strict` (new test file) · `verify_module_docstrings.py src/reyn/mcp/client.py` · `mypy_ratchet.py` · `flat_tests_ratchet.py` · `check_tests_path_literal_reference.py` (post `git add`) · `check_bare_tests_import_reference.py` · `check_file_depth_reference.py` · `check_subprocess_reyn_pin.py` (baseline note above) · `check_fastmcp_import_boundary.py` (mcp/'s own CLAUDE.md gate) — all green.

## Test plan

- [x] Scoped pytest green (52 passed, 5 skipped) — see above
- [x] (skipped — Visual, text-only hint change, no UI surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

