### PR TITLE
fix(#5833): sent-queue self-recognition by client_ref fact, not msg_id guess

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -1322,13 +1322,6 @@ class TextualChatApp(App):
         "_streaming_replies",
         "_pending_own_cancels",
         "_call_parents",
-        # #4409: dict-shaped only in spirit (sets — ``.clear()`` is the
-        # same call either way), see ``_dispatched_before_ack``'s own
-        # docstring for what they track and why an OLD session's entries
-        # are meaningless once its queue view is gone too (same reasoning
-        # as ``_queue_item_meta`` just above).
-        "_dispatched_before_ack",
-        "_pending_local_send_ids",
     )
 
     #: #5131 (architect ruling): the FIRST "state down" migration target —
@@ -1656,38 +1649,6 @@ class TextualChatApp(App):
         # client that populated this entry ever restores anything; every
         # other client applies the SAME delta as a plain removal.
         self._pending_own_cancels: "dict[str, str]" = {}
-        # #4409: server ``msg_id``s this client has SEEN dispatched
-        # (``turn_started``, :meth:`_handle_turn_started_event`), used ONLY
-        # to resolve a race :meth:`_reconcile_local_send` cannot otherwise
-        # see: ``submit_user_text``'s ack and the ``user_submitted`` /
-        # ``turn_started`` broadcasts travel on independent channels
-        # (``client_transport.py``'s own ``submit_user_text`` docstring,
-        # F2), so a fast dispatch can promote-then-remove the REAL row
-        # before this client's own ack-driven reconcile ever runs — without
-        # this set, that reconcile would see "no row for msg_id yet" and
-        # wrongly rekey the local placeholder back INTO the queue for an
-        # item that already left it.
-        #
-        # Bound: the sent-queue widget renders EVERY client's queued items
-        # (ADR-0039 attribution — a peer's queue entry shows too), so
-        # ``turn_started`` fires for dispatches that are never this
-        # client's own submission at all; naively adding every one of
-        # those here would accumulate for as long as the attach lasts, not
-        # for as long as this client has anything of its own to reconcile
-        # — the accumulation :attr:`_pending_local_send_ids` exists to
-        # prevent. ``_handle_turn_started_event`` only adds to this set
-        # while that one is non-empty, and the moment it empties (this
-        # client's last outstanding submission resolved,
-        # :meth:`_reconcile_local_send`) this set is wiped too — so its
-        # size is bounded by how many dispatches (of ANY client's items)
-        # interleave during the brief window THIS client has an
-        # unresolved submission of its own, never by session lifetime.
-        self._dispatched_before_ack: "set[str]" = set()
-        # #4409: local placeholder ids (``on_composer_submitted``) still
-        # awaiting :meth:`_reconcile_local_send` — see
-        # ``_dispatched_before_ack``'s own docstring for the bound this
-        # gates.
-        self._pending_local_send_ids: "set[str]" = set()
         # Per-picker parallel SLASH COMMAND lists, keyed by tab id and kept in
         # lock-step with the OptionList options a pane was last refreshed with, so
         # an ``OptionSelected.option_index`` maps back to the command that applies
@@ -5783,7 +5744,17 @@ class TextualChatApp(App):
         for item in self._queue_view.queue():
             msg_id = item.get("msg_id")
             if msg_id:
-                self._sent_queue.show_item(msg_id, str(item.get("text", "")))
+                # #5833 ③: same guard :meth:`_handle_user_submitted_event`
+                # uses, closing the asymmetry an unconditional ``show_item``
+                # here had against that method's own ``has_row`` check — a
+                # row can already exist under ``msg_id`` at seed time (this
+                # client's own submission raced ahead of the very first
+                # frame this seed runs on), and re-showing it would
+                # remove+re-mount for no visible change, only a
+                # jump-to-bottom/flash risk (the same reasoning that
+                # method's own docstring gives).
+                if not self._sent_queue.has_row(msg_id):
+                    self._sent_queue.show_item(msg_id, str(item.get("text", "")))
                 # #3300 P2b co-vet fix: a snapshot-seeded item's ``meta``
                 # (ADR-0039 attribution — carried through by
                 # ``RemoteQueueView.apply_snapshot``'s ``dict(item)`` copy,
@@ -6064,7 +6035,20 @@ class TextualChatApp(App):
         immediately as a flow entry (that was P1 C's behavior; P2b replaces
         it with this staging step). Applies the seq-gate
         (:meth:`RemoteQueueView.apply_user_submitted`) before rendering, so a
-        stale/already-superseded delta is a no-op."""
+        stale/already-superseded delta is a no-op.
+
+        #5833: this is now the ONE place a submission of THIS client's own
+        (:attr:`_sent_queue`'s LOCAL placeholder row, ``on_composer_
+        submitted``) gets promoted onto its server ``msg_id`` — the moment
+        the echo carrying that id arrives, never waiting on ``submit_user_
+        text``'s own return value (see ``ClientTransport.submit_user_text``'s
+        docstring for the #3287 race this closes: the id that call returns
+        and this echo travel on independent channels, either can arrive
+        first). ``meta.client_ref`` is the FACT this decides on — the exact
+        local placeholder id THIS client minted at submit time, echoed back
+        opaque and unread by the server — replacing the old ``has_row(msg_id)``
+        GUESS (a row existing under the id this delta is ABOUT to use tells
+        you nothing about whose submission it was)."""
         data = event.data or {}
         msg_id = data.get("msg_id")
         chain_id = data.get("chain_id")
@@ -6074,15 +6058,20 @@ class TextualChatApp(App):
             msg_id=msg_id, chain_id=chain_id, text=text, seq=seq,
         )
         if applied and msg_id:
-            self._queue_item_meta[msg_id] = dict(data.get("meta") or {})
-            # #4409: if THIS client's own ``_reconcile_local_send`` already
-            # rekeyed a local placeholder onto ``msg_id`` (its ack, on the
-            # independent send-response channel, arrived before this
-            # broadcast), the row already shows this exact text — a plain
-            # ``show_item`` would remove+re-mount it (its own dedup guard)
-            # for no visible change, only a jump-to-bottom/flash risk. Skip
-            # the remount; the meta write above still lands either way.
-            if not self._sent_queue.has_row(msg_id):
+            meta = dict(data.get("meta") or {})
+            self._queue_item_meta[msg_id] = meta
+            client_ref = meta.get("client_ref")
+            if isinstance(client_ref, str) and self._sent_queue.has_row(client_ref):
+                # This client's own local placeholder, identified by FACT
+                # (this echo carries the exact id THIS client minted for
+                # THIS submission) — promote in place. Never a second row,
+                # never a guess.
+                self._sent_queue.rekey(client_ref, msg_id)
+            elif not self._sent_queue.has_row(msg_id):
+                # Some other client's submission, or a legacy/foreign
+                # server that never echoed ``client_ref`` — same guard
+                # :meth:`_seed_queue_view` uses for the identical reason
+                # (#5833 ③): avoid remounting a row that already exists.
                 self._sent_queue.show_item(msg_id, text)
             self._apply_compact_layout()
         elif not applied:
@@ -6149,11 +6138,6 @@ class TextualChatApp(App):
             msg_id = item.get("msg_id")
             if msg_id:
                 self._sent_queue.remove_item(msg_id)
-                # #4409: record BEFORE the pending-ack reconcile can run —
-                # see ``_dispatched_before_ack``'s own docstring for the
-                # race this closes and the bound this gate keeps.
-                if self._pending_local_send_ids:
-                    self._dispatched_before_ack.add(msg_id)
             meta = self._queue_item_meta.pop(msg_id, {}) if msg_id else {}
             # #4691 arc item ④: stamp THIS turn's own chain_id onto the
             # user row itself — the row is created here, at promotion time,
@@ -7316,11 +7300,12 @@ class TextualChatApp(App):
         # frame where the message is visible in NEITHER place (the owner's
         # own report: "msg enter -> sent 表示の間でメッセージ消えること
         # 多い"). See ``SentQueue``'s own module docstring for the full
-        # "fourth, LOCAL entry" account and ``_reconcile_local_send`` for
-        # how it resolves once the server acks.
+        # "fourth, LOCAL entry" account. #5833: this id is also this
+        # submission's ``client_ref`` (:meth:`_submit`) — the fact
+        # :meth:`_handle_user_submitted_event` promotes it by, once the
+        # echo carrying it arrives.
         local_id = f"local:{uuid.uuid4().hex}"
         self._sent_queue.show_item(local_id, text, sending=True)
-        self._pending_local_send_ids.add(local_id)
         self.query_one(Composer).clear_and_reset()
         await self._submit(text, local_id=local_id)
 
@@ -7392,7 +7377,22 @@ class TextualChatApp(App):
         exactly this). A no-op there is correct, not merely tolerated: no
         placeholder was ever shown pre-mount either (that only happens in
         ``on_composer_submitted``, which the framework never calls before
-        mount)."""
+        mount).
+
+        #5833: the ONE surviving direct removal of a local placeholder —
+        both of :meth:`_submit`'s failure paths (a slash dispatch, an
+        exception from ``submit_user_text`` itself). This is a genuinely
+        DIFFERENT failure axis from everything :meth:`_handle_user_
+        submitted_event` resolves: the submission never reached the server
+        at all (the POST/call itself failed, or was never sent — a slash
+        command), so no ``user_submitted`` echo will EVER arrive to
+        promote or drop this placeholder by ``client_ref``. There is
+        nothing to rekey against, only a row this client itself must take
+        down. Not a residual regulator kept "just in case" — the other two
+        (the old ``_reconcile_local_send``'s race-arbitration and
+        ``_dispatched_before_ack``) were deleted in the same change that
+        gave the echo path its own direct, fact-based promotion; this one
+        answers a question that path structurally cannot."""
         sent_queue = getattr(self, "_sent_queue", None)
         if sent_queue is not None:
             sent_queue.remove_item(msg_id)
@@ -7402,12 +7402,17 @@ class TextualChatApp(App):
 
         ``local_id`` (#4409): the sent-queue row ``on_composer_submitted``
         already showed, synchronously with clearing the composer, keyed by
-        a LOCAL id (no server ``msg_id`` exists yet). Every exit from this
-        method resolves it exactly once: dispatched as a slash command (was
-        never queued at all — see the ``#3595 S5`` paragraph below) drops
-        it, a submit failure drops it, and an ordinary submission hands the
-        server-acked ``msg_id`` to :meth:`_reconcile_local_send`, which
-        decides drop-vs-promote (see that method's own docstring).
+        a LOCAL id (no server ``msg_id`` exists yet), and ALSO passed
+        through as ``client_ref`` on the submit call below (#5833). A
+        dispatched slash command (never queued at all — see the ``#3595
+        S5`` paragraph below) or a submit failure drops it right here
+        (:meth:`_maybe_sent_queue_remove`) — an ordinary submission that
+        reaches the server resolves it entirely off THIS method: the
+        ``user_submitted`` echo carries ``meta.client_ref`` back and
+        :meth:`_handle_user_submitted_event` promotes the placeholder the
+        moment that arrives, whether before or after this call returns
+        (see that method's own docstring for why the old return-value
+        reconciliation is gone).
 
         #3299 P1: the Composer is now EXCLUSIVELY for new turns — it no longer
         reads ``pending_intervention_head()`` at all. Answering a pending
@@ -7454,7 +7459,14 @@ class TextualChatApp(App):
             if await maybe_dispatch_slash(self._transport, text):
                 self._maybe_sent_queue_remove(local_id)
                 return
-            msg_id = await self._transport.submit_user_text(text)
+            # #5833: no longer reconciled against this call's own return
+            # value (see ``ClientTransport.submit_user_text``'s docstring)
+            # — the echo (:meth:`_handle_user_submitted_event`) carries
+            # ``meta.client_ref`` == ``local_id`` and promotes this
+            # placeholder itself, the moment it arrives, whether that is
+            # before or after this call returns. The returned id has no
+            # remaining local use.
+            await self._transport.submit_user_text(text, client_ref=local_id)
         except Exception as exc:
             self._maybe_sent_queue_remove(local_id)
             logger.exception("textual chat: submit failed")
@@ -7468,68 +7480,6 @@ class TextualChatApp(App):
                 )
             except Exception:
                 pass
-        else:
-            self._reconcile_local_send(local_id, msg_id)
-        finally:
-            # #4409: every exit above resolved ``local_id`` one way or
-            # another — see ``_dispatched_before_ack``'s own docstring for
-            # why the moment NONE of this client's own submissions are
-            # still outstanding is exactly the moment that set can hold
-            # nothing worth keeping.
-            self._pending_local_send_ids.discard(local_id)
-            if not self._pending_local_send_ids:
-                self._dispatched_before_ack.clear()
-
-    def _reconcile_local_send(self, local_id: str, msg_id: str) -> None:
-        """#4409: resolve the local SENDING placeholder against the
-        server's ack, once ``submit_user_text`` returns.
-
-        The ack (this call) and the ``user_submitted`` broadcast that
-        materializes the AUTHORITATIVE row (:meth:`_handle_user_submitted_event`)
-        are two independent deliveries of the same fact, over two
-        independent channels (``client_transport.py``'s own
-        ``submit_user_text`` docstring, F2) — either can arrive first:
-
-        - the broadcast already arrived (:meth:`SentQueue.has_row` is
-          ``True`` for ``msg_id``) → the placeholder is now redundant;
-          drop it.
-        - ``msg_id`` was already seen DISPATCHED
-          (:attr:`_dispatched_before_ack` — ``turn_started`` can race
-          ahead of this ack too, see that attribute's own docstring) →
-          the item already left the queue entirely; drop the placeholder
-          rather than rekey it back INTO a queue it no longer belongs to.
-        - neither yet → promote the placeholder in place
-          (:meth:`SentQueue.rekey`), so the still-pending broadcast finds
-          an existing row under ``msg_id`` and updates it rather than
-          adding a second one.
-        - ``msg_id`` is falsy (no id echoed — an implementation detail of
-          ``ClientTransport.submit_user_text``'s own contract, never
-          ``None``) → nothing to reconcile against; the placeholder stays
-          exactly as it is, which is the honest state given no confirmed
-          id exists to promote it onto.
-        """
-        if not msg_id:
-            return
-        sent_queue = getattr(self, "_sent_queue", None)
-        if sent_queue is None:
-            # #4409: only reachable when this method is invoked directly,
-            # pre-mount, the way several existing tests already exercise
-            # ``_submit`` (``_sent_queue`` is a widget, constructed in
-            # ``compose()`` alongside every OTHER widget this App owns —
-            # same convention throughout this module, not something #4409
-            # changes). Nothing to reconcile a placeholder onto: no
-            # placeholder was ever shown pre-mount either (that only
-            # happens in ``on_composer_submitted``, which the framework
-            # never calls before mount).
-            return
-        if msg_id in self._dispatched_before_ack:
-            self._dispatched_before_ack.discard(msg_id)
-            sent_queue.remove_item(local_id)
-            return
-        if sent_queue.has_row(msg_id):
-            sent_queue.remove_item(local_id)
-            return
-        sent_queue.rekey(local_id, msg_id)
 
 
 async def run_textual_chat(

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -41,10 +41,13 @@ message leaving the input box and the (async, network-round-trip-bound)
 window where the message was visible NOWHERE. The row renders with
 :data:`_SENDING_GLYPH` (not :data:`_QUEUED_GLYPH`) while in this state —
 an honest "not yet confirmed sent" distinct from "confirmed queued,
-awaiting dispatch". :meth:`rekey` promotes it in place once
-``submit_user_text`` acks (``app.py``'s ``_reconcile_local_send``); if the
-real broadcast already materialized the row first (:meth:`has_row`), the
-placeholder is simply dropped as redundant.
+awaiting dispatch". :meth:`rekey` promotes it in place the moment the
+``user_submitted`` echo carrying it arrives — identified by
+``meta.client_ref`` matching this local id, a FACT the echo itself
+carries (#5833; ``app.py``'s ``_handle_user_submitted_event``), never by
+waiting on ``submit_user_text``'s own return value (the #3287 race that
+predated this: the returned id and this echo travel on independent
+channels, either can arrive first).
 
 **Cancel affordance (#3300 Y-client)**: this widget is focusable
 (``can_focus = True``) and keeps a highlighted row index, keyed by the SAME

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -221,8 +221,10 @@ class _ErrorWatchingTransport(ClientTransport):
     def reyn_state_root(self) -> "Path | None":
         return self._inner.reyn_state_root()
 
-    async def submit_user_text(self, text: str) -> str:
-        return await self._inner.submit_user_text(text)
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
+        return await self._inner.submit_user_text(text, client_ref=client_ref)
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -584,7 +584,9 @@ class AgUiTransport(ClientTransport):
         # to answer_intervention_text (delivered BY ID, R1) instead of a new turn.
         return self._pending_intervention_id
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
         # #3287: the server echoes the msg_id it assigned (the SAME
         # correlation id the broadcast user_submitted audit-event carries,
         # #3300 P2a) in the POST's JSON response — see
@@ -594,7 +596,19 @@ class AgUiTransport(ClientTransport):
         # foreign server that doesn't echo the field — so a caller can always
         # treat "no id" with a plain falsy check, same as `""` from
         # `InProcessTransport` when nothing is attached.
-        result = await self._send({"type": "user_message", "text": text})
+        #
+        # #5833: `client_ref` rides the POST body verbatim, opaque to this
+        # client too — it never reads it back off `result`. This client's
+        # own echo-recognition already has a race-free mechanism (this
+        # method's own docstring on the ABC, `meta.auth_connection_id`) that
+        # predates and does not need `client_ref`; the field exists here
+        # only to satisfy the ABC's own contract for A DIFFERENT caller
+        # (`textual_chat/app.py`'s sent-queue placeholder), which reads it
+        # back off the broadcast, not off this call's return value.
+        payload: "dict[str, object]" = {"type": "user_message", "text": text}
+        if client_ref is not None:
+            payload["client_ref"] = client_ref
+        result = await self._send(payload)
         msg_id = (result or {}).get("msg_id")
         return msg_id if isinstance(msg_id, str) else ""
 

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1502,12 +1502,21 @@ async def agui_submit(request: Request):
             # `user_submitted` audit-event (#3300 P1 C) that every attached
             # surface's event→display handler renders as this client's turn,
             # not just the agent's reply.
+            # #5833: `client_ref` is an opaque token the submitting client
+            # minted for its OWN later correlation (its sent-queue
+            # placeholder id) — read here and forwarded VERBATIM, never
+            # inspected or validated. See `ClientTransport.submit_user_
+            # text`'s own docstring for the full contract; `Session.
+            # submit_user_text` stores it in `meta` and this handler never
+            # branches on it either.
+            client_ref = payload.get("client_ref")
             msg_id = await session.submit_user_text(
                 text,
                 attribution={
                     "auth_user_id": identity.user_id,
                     "auth_connection_id": connection_id,
                 },
+                client_ref=client_ref if isinstance(client_ref, str) else None,
             )
             # #3287: echo the assigned msg_id back to the SUBMITTING client —
             # the SAME correlation id the broadcast user_submitted event above

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -70,8 +70,26 @@ class ClientTransport(ABC):
         """Yield the unified, ordered, tagged frame stream (display + event)."""
 
     @abstractmethod
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
         """Submit a user turn (the ordinary new-turn path).
+
+        ``client_ref`` (#5833): an OPAQUE, caller-minted correlation token
+        (never interpreted, never validated — a server that received it
+        stores it verbatim and echoes it back on the ``user_submitted``
+        broadcast's ``meta.client_ref``, and MUST NOT branch on its value).
+        A caller that also renders a local placeholder for this submission
+        (``textual_chat/app.py``'s sent-queue row) passes its own
+        placeholder id here, so it can recognise its OWN echo as a FACT the
+        moment that broadcast arrives — see ``TextualChatApp.
+        _handle_user_submitted_event`` — rather than by any race-prone
+        guess against this call's own return value, which is exactly the
+        #3287 entailment gap named below (the id this call returns and the
+        echo travel on independent channels, either can arrive first). A
+        caller with no such placeholder (the plain REPL, agent-to-agent
+        submission, most tests) omits it; ``None`` changes nothing for
+        them.
 
         Returns the server-assigned ``msg_id`` — the SAME correlation id the
         broadcast ``user_submitted`` audit-event carries (#3300 P2a). Two
@@ -660,8 +678,10 @@ class DelegatingClientTransport(ClientTransport):
     def frames(self) -> "AsyncIterator[Frame]":
         return self._inner.frames()
 
-    async def submit_user_text(self, text: str) -> str:
-        return await self._inner.submit_user_text(text)
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
+        return await self._inner.submit_user_text(text, client_ref=client_ref)
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -240,11 +240,13 @@ class InProcessTransport(ClientTransport):
         s = self._attached()
         return s.workspace_dir.parent.parent if s is not None else None
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
         s = self._attached()
         if s is None:
             return ""
-        return await s.submit_user_text(text)
+        return await s.submit_user_text(text, client_ref=client_ref)
 
     async def run_slash_command(self, name: str, args: str) -> bool:
         # #3595 S5: the local execution side of the shared client-side slash

--- a/src/reyn/interfaces/transport/session_bound.py
+++ b/src/reyn/interfaces/transport/session_bound.py
@@ -116,8 +116,10 @@ class SessionBoundTransport(ClientTransport):
         # existing public API rather than re-deriving anything).
         return self._session.workspace_dir.parent.parent
 
-    async def submit_user_text(self, text: str) -> str:
-        return await self._session.submit_user_text(text)
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
+        return await self._session.submit_user_text(text, client_ref=client_ref)
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -376,8 +376,10 @@ class ThreadedTransportProxy(ClientTransport):
         )
         return await asyncio.wrap_future(concurrent_future)
 
-    async def submit_user_text(self, text: str) -> str:
-        return await self._call_on_worker("submit_user_text", text)
+    async def submit_user_text(
+        self, text: str, *, client_ref: "str | None" = None,
+    ) -> str:
+        return await self._call_on_worker("submit_user_text", text, client_ref=client_ref)
 
     async def answer_intervention_text(
         self, text: str, *, intervention_id: "str | None" = None,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5130,6 +5130,7 @@ class Session:
 
     async def submit_user_text(
         self, text: str, *, attribution: "dict | None" = None,
+        client_ref: "str | None" = None,
     ) -> str:
         # PR14: every top-level user submission starts a fresh chain_id that
         # propagates through any agent_request / agent_response generated in
@@ -5139,6 +5140,14 @@ class Session:
         # (not just emitted on the event below) — a late-joiner seeding from
         # STATE_SNAPSHOT/queued_user_messages() needs it too. See agui-transport.md.
         meta = _user_frame_meta(attribution)
+        # #5833: `client_ref` is an OPAQUE token the submitting client minted
+        # for its own later correlation (see `ClientTransport.submit_user_
+        # text`'s own docstring). Stored and echoed verbatim, NEVER read
+        # branch-wise here or anywhere downstream — this method's own job
+        # ends at receiving it, same as `text`/`chain_id`.
+        if client_ref is not None:
+            meta = dict(meta)
+            meta["client_ref"] = client_ref
         msg_id = await self._put_inbox(
             TurnOrigin.CLIENT_INPUT,
             {"text": text, "chain_id": chain_id, "meta": meta},

--- a/tests/_support/slash.py
+++ b/tests/_support/slash.py
@@ -143,7 +143,7 @@ class RecordingTransport(ClientTransportStub):
             return None
         return self._session.workspace_dir.parent.parent
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return await self._session.submit_user_text(text)
 
     async def answer_intervention_text(

--- a/tests/_support/textual_chat_test_helpers.py
+++ b/tests/_support/textual_chat_test_helpers.py
@@ -49,7 +49,7 @@ class QueueTransport(ClientTransportStub):
             msg = await self._queue.get()
             yield DisplayFrame(msg)
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_2280_durability_halt_observability.py
+++ b/tests/interfaces/test_2280_durability_halt_observability.py
@@ -299,7 +299,7 @@ class _QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:  # pragma: no cover - unused
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover - unused
         return ""
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_3288_3c_tui_delta_coalesce.py
+++ b/tests/interfaces/test_3288_3c_tui_delta_coalesce.py
@@ -106,7 +106,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_3300_intervention_answer_eventify.py
+++ b/tests/interfaces/test_3300_intervention_answer_eventify.py
@@ -82,7 +82,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_3300_p2b_sentqueue_render.py
+++ b/tests/interfaces/test_3300_p2b_sentqueue_render.py
@@ -89,7 +89,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_3300_p2b_sentqueue_render.py
+++ b/tests/interfaces/test_3300_p2b_sentqueue_render.py
@@ -540,3 +540,138 @@ async def test_strip_snapshot_meta_carry_loses_attribution(monkeypatch) -> None:
             "the broken (meta-carry-stripped) seed should reproduce the "
             "misattribution — an empty meta on the promoted entry"
         )
+
+
+# ---------------------------------------------------------------------------
+# 6. ★#5833 ③ — ``_seed_queue_view``'s own has_row guard closes the SAME
+#    asymmetry the delta path (``_handle_user_submitted_event``) already had.
+# ---------------------------------------------------------------------------
+
+
+class _MutableQueueReadModel(_SnapshotSeededReadModel):
+    """Same shape as :class:`_SnapshotSeededReadModel`, but the queue
+    snapshot can be swapped IN PLACE after the read-model already exists —
+    lets one test drive :meth:`TextualChatApp._seed_queue_view` a SECOND
+    time against a snapshot that already reports an item this client's OWN
+    delta path already showed a row for (the exact precondition #5833 ③
+    names — see that method's own guard comment)."""
+
+    def __init__(self) -> None:
+        super().__init__({})
+        self.queue_items: "list[dict]" = []
+        #: Starts at 0 (empty queue, nothing applied yet) — NOT hardcoded
+        #: to a nonzero value, which would reseed the seq-gate ahead of a
+        #: delta this same test still needs to apply (a delta at seq N is
+        #: rejected as stale once the gate's ``_last_seq`` already sits at
+        #: N or above, ``RemoteQueueView.apply_user_submitted``'s own
+        #: monotonic contract).
+        self.queue_seq: int = 0
+
+    def snapshot(self, config=None):
+        return {
+            "queue": list(self.queue_items), "turn_active": False,
+            "queue_seq": self.queue_seq,
+        }
+
+
+@pytest.mark.asyncio
+async def test_seed_queue_view_does_not_reshow_a_row_the_delta_path_already_created() -> None:
+    """Tier 2b: #5833 ③ — ``_seed_queue_view`` must not re-``show_item`` a
+    row that already exists (``has_row(msg_id)``), the SAME guard
+    ``_handle_user_submitted_event``'s delta path already carried BEFORE
+    #5833. An unconditional re-show removes+re-mounts the row — dict
+    re-insertion order (``SentQueue.rekey``'s own docstring names this
+    exact mechanism) then moves it to the END, and it flashes off/on for
+    one frame — neither of which an item that has not actually changed
+    should ever cause.
+
+    Driven by calling :meth:`TextualChatApp._seed_queue_view` directly a
+    SECOND time (the same method this test file already names for
+    monkeypatch strip-witnesses above) — production fires it from two
+    call sites (first frame, and session-switch re-seed), and this test
+    needs the intermediate state neither site exposes alone: a row
+    already present for an item the snapshot ALSO reports."""
+    read_model = _MutableQueueReadModel()
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()  # first frame: empty snapshot, seed is a no-op
+        await transport.push_event(_user_submitted(msg_id="m1", chain_id="c1", text="alpha", seq=1))
+        await transport.push_event(_user_submitted(msg_id="m2", chain_id="c2", text="beta", seq=2))
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+        assert [t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()] == ["alpha", "beta"]
+
+        # The server's own current truth (what a reconnect snapshot would
+        # report) now ALSO includes both items — the exact input
+        # _seed_queue_view sees when it runs again.
+        read_model.queue_items = [
+            {"msg_id": "m1", "text": "alpha", "meta": {}},
+            {"msg_id": "m2", "text": "beta", "meta": {}},
+        ]
+        read_model.queue_seq = 2
+        app._seed_queue_view()
+        await pilot.pause()
+
+        assert [t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()] == ["alpha", "beta"], (
+            "an already-shown row must not be re-mounted by the seed — "
+            "order must stay stable, not jump 'alpha' behind 'beta'"
+        )
+
+
+@pytest.mark.asyncio
+async def test_strip_seed_has_row_guard_reorders_the_already_shown_row(monkeypatch) -> None:
+    """Tier 2b: non-vacuity — reverting ``_seed_queue_view`` to the
+    pre-#5833 unconditional ``show_item`` (dropping the ``has_row`` guard)
+    reproduces the asymmetry: re-showing "alpha" removes+re-mounts it, and
+    dict re-insertion order moves it PAST "beta" — proving the guard in
+    the positive test above is load-bearing, not incidental.
+
+    The re-seed's snapshot lists the items in REVERSED order (``m2`` then
+    ``m1``) — not the order this client's own rows are already in
+    (``m1`` then ``m2``, from live delta arrival order): the server's own
+    snapshot ordering has no reason to match a particular client's local
+    arrival order, and it is exactly this mismatch that makes an
+    unconditional re-show's reordering OBSERVABLE (reprocessing every item
+    in the SAME relative order it is already shown in would reproduce the
+    same order by construction — the bug needs a shuffle to be visible
+    at all)."""
+    from reyn.interfaces.inline.textual_chat import app as app_module
+
+    def _seed_without_has_row_guard(self) -> None:
+        snap = self._snapshot() or {}
+        self._queue_view.apply_snapshot(
+            queue=snap.get("queue", []),
+            turn_active=snap.get("turn_active", False),
+            queue_seq=snap.get("queue_seq", 0),
+        )
+        for item in self._queue_view.queue():
+            msg_id = item.get("msg_id")
+            if msg_id:
+                self._sent_queue.show_item(msg_id, str(item.get("text", "")))  # BUG under test
+                self._queue_item_meta[msg_id] = dict(item.get("meta") or {})
+
+    monkeypatch.setattr(app_module.TextualChatApp, "_seed_queue_view", _seed_without_has_row_guard)
+
+    read_model = _MutableQueueReadModel()
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(_user_submitted(msg_id="m1", chain_id="c1", text="alpha", seq=1))
+        await transport.push_event(_user_submitted(msg_id="m2", chain_id="c2", text="beta", seq=2))
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+
+        read_model.queue_items = [
+            {"msg_id": "m2", "text": "beta", "meta": {}},
+            {"msg_id": "m1", "text": "alpha", "meta": {}},
+        ]
+        read_model.queue_seq = 2
+        app._seed_queue_view()
+        await pilot.pause()
+
+        assert [t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()] == ["beta", "alpha"], (
+            "the broken (unguarded) seed should reorder 'alpha' behind "
+            "'beta' — proves the has_row guard in the positive test matters"
+        )

--- a/tests/interfaces/test_3300_y_client_cancel.py
+++ b/tests/interfaces/test_3300_y_client_cancel.py
@@ -91,7 +91,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
         return ""
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -114,7 +114,7 @@ class QueueTransport(ClientTransportStub):
     def push_event(self, etype: str, data: dict) -> None:
         self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.submitted.append(text)
         return ""
 

--- a/tests/interfaces/test_3327_keyboard_reachability_to_panel.py
+++ b/tests/interfaces/test_3327_keyboard_reachability_to_panel.py
@@ -66,7 +66,7 @@ class RecordingTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.submitted.append(text)
         return "m-" + str(len(self.submitted))
 

--- a/tests/interfaces/test_3338_tui_status_chrome_liveness.py
+++ b/tests/interfaces/test_3338_tui_status_chrome_liveness.py
@@ -766,7 +766,7 @@ class _EventOnlyTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_3354_composer_completion.py
+++ b/tests/interfaces/test_3354_composer_completion.py
@@ -110,7 +110,7 @@ class RecordingTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.submitted.append(text)
         return "m-" + str(len(self.submitted))
 

--- a/tests/interfaces/test_3540_intervention_answer_fold.py
+++ b/tests/interfaces/test_3540_intervention_answer_fold.py
@@ -88,7 +88,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_3987_rewind_picker_shows_branch_tree.py
+++ b/tests/interfaces/test_3987_rewind_picker_shows_branch_tree.py
@@ -138,7 +138,7 @@ class ScriptedTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_4387_read_model_load_older_conversation_history.py
+++ b/tests/interfaces/test_4387_read_model_load_older_conversation_history.py
@@ -50,7 +50,7 @@ class _InertTransport(ClientTransportStub):
         return
         yield
 
-    async def submit_user_text(self, text: str) -> str:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
         return ""
 
     async def run_slash_command(self, name: str, args: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
+++ b/tests/interfaces/test_4387_tui_paging_extends_from_disk.py
@@ -61,7 +61,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_4409_pre_send_indicator.py
+++ b/tests/interfaces/test_4409_pre_send_indicator.py
@@ -21,7 +21,10 @@ measure existing mechanisms before inventing a new state machine) — a
 FOURTH, LOCAL entry into it (``SentQueue``'s own module docstring), shown
 synchronously with the composer clearing, keyed by a client-generated id
 and rendered with a distinct glyph (:data:`~reyn.interfaces.inline.textual_chat.sent_queue._SENDING_GLYPH`)
-until the server acks the submission (``_reconcile_local_send``).
+until the ``user_submitted`` echo carrying this submission's own
+``client_ref`` promotes it (#5833; ``TextualChatApp._handle_user_
+submitted_event``) — see that method's own docstring for why this no
+longer waits on the server's POST-response ack at all.
 
 Owner requirement ① ("入力欄から消えるのと同時に" — the exact same moment):
 verified directly below by observing the composer and the sent-queue in
@@ -83,6 +86,13 @@ class _GatedTransport(ClientTransportStub):
         self._msg_id = msg_id
         self._fail = fail
         self.submitted_texts: "list[str]" = []
+        #: #5833: the ``client_ref`` this transport was actually called
+        #: with — the SAME id ``on_composer_submitted`` minted as this
+        #: submission's local placeholder key. A test reads this back to
+        #: build a ``user_submitted`` fixture event that carries the exact
+        #: fact ``_handle_user_submitted_event`` now promotes on, without
+        #: reaching into the app's own private state to learn the id.
+        self.last_client_ref: "str | None" = None
 
     async def push_event(self, event: Event) -> None:
         await self._queue.put(EventFrame(event))
@@ -97,8 +107,9 @@ class _GatedTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.submitted_texts.append(text)
+        self.last_client_ref = client_ref
         self.entered.set()
         await self.ack_gate.wait()
         if self._fail:
@@ -127,10 +138,13 @@ class _GatedTransport(ClientTransportStub):
         pass
 
 
-def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+def _user_submitted(
+    *, msg_id: str, chain_id: str, text: str, seq: int, client_ref: "str | None" = None,
+) -> Event:
+    meta = {"client_ref": client_ref} if client_ref is not None else {}
     return Event(
         type="user_submitted",
-        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": meta},
     )
 
 
@@ -248,62 +262,103 @@ async def test_placeholder_reaches_the_transport_with_the_typed_text() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ack_promotes_the_placeholder_in_place_no_duplicate() -> None:
-    """Tier 2b: once ``submit_user_text`` acks, the SAME row promotes from
-    SENDING to CONFIRMED (glyph flips ``◇`` → ``▷``) — never a second row,
-    never a remove-then-readd (item_count stays 1 throughout)."""
+async def test_echo_promotes_the_placeholder_in_place_no_duplicate() -> None:
+    """Tier 2b: #5833 — the ``user_submitted`` ECHO (carrying THIS
+    submission's own ``meta.client_ref``, ``transport.last_client_ref``)
+    promotes the SAME row from SENDING to CONFIRMED (glyph flips ``◇`` →
+    ``▷``) the moment it arrives — never a second row, never a
+    remove-then-readd (item_count stays 1 throughout) — regardless of
+    whether ``submit_user_text``'s own POST response (``ack_gate``, still
+    closed here) has come back at all. Pre-#5833 this promotion waited on
+    the ack instead; #5833 moves it entirely onto the echo (see
+    ``TextualChatApp._handle_user_submitted_event``'s own docstring for
+    why: the two travel on independent channels and either can arrive
+    first, so waiting on one of them by design leaves the other's
+    ordering unclosed)."""
     transport = _GatedTransport(msg_id="m1")
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
-        sent_queue = app.query_one(SentQueue)
-        assert sent_queue.item_count() == 1
-
-        transport.ack_gate.set()
-        await task
-        await pilot.pause()
-
-        assert sent_queue.item_count() == 1, "the ack must promote in place, not add a row"
-        (row,) = sent_queue.rendered_texts()
-        assert _is_confirmed(row)
-
-
-@pytest.mark.asyncio
-async def test_late_broadcast_after_ack_does_not_duplicate_the_row() -> None:
-    """Tier 2b: the ``user_submitted`` broadcast for the SAME msg_id,
-    arriving AFTER the ack already promoted the row, must be a no-op on
-    the widget (the row already shows the confirmed text) — not a second
-    remove+readd."""
-    transport = _GatedTransport(msg_id="m1")
-    app = TextualChatApp(transport=transport)
-    async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
-        transport.ack_gate.set()
-        await task
-        await pilot.pause()
         sent_queue = app.query_one(SentQueue)
         assert sent_queue.item_count() == 1
 
         await transport.push_event(
+            _user_submitted(
+                msg_id="m1", chain_id="c1", text=_TEXT, seq=1,
+                client_ref=transport.last_client_ref,
+            )
+        )
+        # #4409 test-only note: NOT ``pilot.pause()`` — see ``_yield_until``'s
+        # own docstring for why that would deadlock here (the backgrounded
+        # ``on_composer_submitted`` task is still open on ``ack_gate``).
+        await _yield_until(
+            lambda: bool(sent_queue.rendered_texts())
+            and _is_confirmed(sent_queue.rendered_texts()[0])
+        )
+        assert sent_queue.item_count() == 1, "the echo must promote in place, not add a row"
+        (row,) = sent_queue.rendered_texts()
+        assert _TEXT in row
+
+        transport.ack_gate.set()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_late_broadcast_does_not_duplicate_the_row() -> None:
+    """Tier 2b: a SECOND ``user_submitted`` delta for the SAME ``msg_id``
+    (a replay/duplicate — the seq-gate's own job to reject, or, failing
+    that, the ``has_row(msg_id)`` guard :meth:`_handle_user_submitted_
+    event` still carries for a non-``client_ref`` delta) must be a no-op
+    on the widget once the first one already promoted the row — never a
+    second remove+readd."""
+    transport = _GatedTransport(msg_id="m1")
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
+        sent_queue = app.query_one(SentQueue)
+
+        await transport.push_event(
+            _user_submitted(
+                msg_id="m1", chain_id="c1", text=_TEXT, seq=1,
+                client_ref=transport.last_client_ref,
+            )
+        )
+        await _yield_until(
+            lambda: bool(sent_queue.rendered_texts())
+            and _is_confirmed(sent_queue.rendered_texts()[0])
+        )
+        assert sent_queue.item_count() == 1
+
+        # A duplicate of the SAME seq — the gate ``apply_user_submitted``
+        # itself already applied must reject as stale.
+        await transport.push_event(
             _user_submitted(msg_id="m1", chain_id="c1", text=_TEXT, seq=1)
         )
-        await pilot.pause()
+        await asyncio.sleep(0)
 
         assert sent_queue.item_count() == 1
         (row,) = sent_queue.rendered_texts()
         assert _TEXT in row and _is_confirmed(row)
 
+        transport.ack_gate.set()
+        await task
+
 
 @pytest.mark.asyncio
-async def test_broadcast_before_ack_then_ack_drops_the_now_redundant_placeholder() -> None:
-    """Tier 2b: the opposite ordering — the ``user_submitted`` broadcast
-    materializes the AUTHORITATIVE row before ``submit_user_text`` itself
-    returns. The two rows (real + local placeholder) coexist momentarily;
-    once the ack finally arrives, ``_reconcile_local_send`` recognizes the
-    real row already exists (``SentQueue.has_row``) and drops the
-    placeholder — back to exactly one row, never a lingering duplicate."""
+async def test_echo_before_ack_promotes_immediately_ack_is_then_a_no_op() -> None:
+    """Tier 2b: #5833 — the OLD race this replaces (pre-#5833, verified by
+    reverting to that shape): the ``user_submitted`` broadcast materializing
+    the authoritative row BEFORE ``submit_user_text`` itself returns used
+    to leave two rows (real + local placeholder) coexisting until the ack
+    finally arrived and ``_reconcile_local_send`` dropped the redundant one.
+
+    #5833 closes this structurally, not narrower: the echo carries THIS
+    client's own ``client_ref``, so it recognises and rekeys its OWN
+    placeholder as a FACT, immediately — there is never a second row to
+    begin with, and the ack (once unblocked below) has nothing left to
+    reconcile at all."""
     transport = _GatedTransport(msg_id="m1")
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -313,22 +368,30 @@ async def test_broadcast_before_ack_then_ack_drops_the_now_redundant_placeholder
         assert sent_queue.item_count() == 1  # the local placeholder only
 
         await transport.push_event(
-            _user_submitted(msg_id="m1", chain_id="c1", text=_TEXT, seq=1)
+            _user_submitted(
+                msg_id="m1", chain_id="c1", text=_TEXT, seq=1,
+                client_ref=transport.last_client_ref,
+            )
         )
         # #4409 test-only note: NOT ``pilot.pause()`` — see ``_yield_until``'s
         # own docstring for why that would deadlock here (the backgrounded
         # ``on_composer_submitted`` task is still open).
-        await _yield_until(lambda: sent_queue.item_count() == 2)
-        assert sent_queue.item_count() == 2, (
-            "the real row and the still-unresolved local placeholder "
-            "legitimately coexist until the ack catches up"
+        await _yield_until(
+            lambda: bool(sent_queue.rendered_texts())
+            and _is_confirmed(sent_queue.rendered_texts()[0])
         )
+        assert sent_queue.item_count() == 1, (
+            "#5833: never a second row, even momentarily — the echo rekeys "
+            "the SAME placeholder by client_ref, it does not add a new one"
+        )
+        (row,) = sent_queue.rendered_texts()
+        assert _TEXT in row
 
         transport.ack_gate.set()
         await task
         await pilot.pause()
 
-        assert sent_queue.item_count() == 1, "the ack must drop the now-redundant placeholder"
+        assert sent_queue.item_count() == 1, "the now-irrelevant ack must not disturb the row"
         (row,) = sent_queue.rendered_texts()
         assert _TEXT in row and _is_confirmed(row)
 
@@ -337,12 +400,16 @@ async def test_broadcast_before_ack_then_ack_drops_the_now_redundant_placeholder
 async def test_dispatch_before_ack_drops_the_placeholder_without_requeuing_it() -> None:
     """Tier 2b: the sharpest race — ``user_submitted`` AND ``turn_started``
     (the item is dispatched and promoted to a flow entry) both arrive
-    before this client's own ack. Without ``_dispatched_before_ack``, the
-    ack's reconcile would see "no row for msg_id" (turn_started already
-    removed it) and wrongly REKEY the local placeholder back into the
-    queue for an item that already left it — this asserts that does not
-    happen: the placeholder is dropped, the queue ends empty, and the
-    flow entry from the dispatch is untouched."""
+    before this client's own ack.
+
+    #5833: the OLD mechanism this raced against (``_dispatched_before_ack``)
+    is deleted; the structural fix removes the need for it. Ordering
+    guarantees the server always emits ``user_submitted`` before it
+    dispatches the SAME item — so the echo (carrying ``client_ref``)
+    always rekeys the placeholder onto ``msg_id`` BEFORE ``turn_started``
+    can fire for it, and by the time that dispatch removes the sent-queue
+    row, it is already keyed by the server's own id. Nothing is left for
+    a late ack to wrongly requeue."""
     transport = _GatedTransport(msg_id="m1")
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -350,7 +417,10 @@ async def test_dispatch_before_ack_drops_the_placeholder_without_requeuing_it() 
         task = await _type_and_submit_in_flight(pilot, transport, _TEXT)
 
         await transport.push_event(
-            _user_submitted(msg_id="m1", chain_id="c1", text=_TEXT, seq=1)
+            _user_submitted(
+                msg_id="m1", chain_id="c1", text=_TEXT, seq=1,
+                client_ref=transport.last_client_ref,
+            )
         )
         await transport.push_event(_turn_started(chain_id="c1", seq=2))
         # #4409 test-only note: NOT ``pilot.pause()`` — see ``_yield_until``'s

--- a/tests/interfaces/test_4494_request_artifact_list.py
+++ b/tests/interfaces/test_4494_request_artifact_list.py
@@ -115,7 +115,7 @@ async def test_default_transport_implementation_returns_empty():
             return
             yield  # pragma: no cover
 
-        async def submit_user_text(self, text: str) -> str:
+        async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
             return ""
 
         async def answer_intervention_text(self, text, *, intervention_id=None):

--- a/tests/interfaces/test_4534_pr1_request_attach_switch.py
+++ b/tests/interfaces/test_4534_pr1_request_attach_switch.py
@@ -152,7 +152,7 @@ async def test_default_transport_implementation_returns_false():
             return
             yield  # pragma: no cover — makes this an async generator
 
-        async def submit_user_text(self, text: str) -> str:
+        async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
             return ""
 
         async def answer_intervention_text(self, text, *, intervention_id=None):

--- a/tests/interfaces/test_4691_phase_b_group_construction.py
+++ b/tests/interfaces/test_4691_phase_b_group_construction.py
@@ -126,7 +126,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_4691_turn_group_item1.py
+++ b/tests/interfaces/test_4691_turn_group_item1.py
@@ -149,7 +149,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
+++ b/tests/interfaces/test_4788_rewind_picker_escape_dismiss.py
@@ -78,7 +78,7 @@ class QueueTransport(ClientTransportStub):
     def push_event(self, etype: str, data: dict) -> None:
         self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_4817_rewind_yields_to_open_intervention.py
+++ b/tests/interfaces/test_4817_rewind_yields_to_open_intervention.py
@@ -74,7 +74,7 @@ class QueueTransport(ClientTransportStub):
     def push_event(self, etype: str, data: dict) -> None:
         self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_4983_session_switch_off_thread.py
+++ b/tests/interfaces/test_4983_session_switch_off_thread.py
@@ -73,7 +73,7 @@ class QueueTransport(ClientTransportStub):
     def push_event(self, etype: str, data: dict) -> None:
         self._queue.put_nowait(EventFrame(Event(type=etype, data=data)))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -92,7 +92,7 @@ class _RecordingTransport(ClientTransportStub):
         await self._never.wait()
         yield  # pragma: no cover - never reached, satisfies the generator shape
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.call_idents.append(threading.get_ident())
         if self._started is not None:
             self._started.set()

--- a/tests/interfaces/test_4996_read_model_capabilities.py
+++ b/tests/interfaces/test_4996_read_model_capabilities.py
@@ -79,7 +79,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
+++ b/tests/interfaces/test_5047_replayed_answered_intervention_not_pending.py
@@ -106,7 +106,7 @@ class _ReplayTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
+++ b/tests/interfaces/test_5048_threaded_proxy_pending_head_not_live_object.py
@@ -79,7 +79,7 @@ class _InterveningTransport(ClientTransportStub):
         yield DisplayFrame(OutboxMessage(kind="status", text="frame"))
         await self._never.wait()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
+++ b/tests/interfaces/test_5057_fake_pending_rewind_frame_not_registered.py
@@ -64,7 +64,7 @@ class _ReplayTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5096_slash_dispatch_routes_attach_directly.py
+++ b/tests/interfaces/test_5096_slash_dispatch_routes_attach_directly.py
@@ -43,7 +43,7 @@ class _RecordingTransport(ClientTransportStub):
         return
         yield  # pragma: no cover — makes this an async generator
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(self, text, *, intervention_id=None):

--- a/tests/interfaces/test_5117_delegating_client_transport.py
+++ b/tests/interfaces/test_5117_delegating_client_transport.py
@@ -49,7 +49,7 @@ class _RecordingInner(ClientTransportStub):
     def frames(self) -> "AsyncIterator[object]":
         raise NotImplementedError("not exercised by this test file")
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:

--- a/tests/interfaces/test_5139_remote_backlog_batch_hydrate.py
+++ b/tests/interfaces/test_5139_remote_backlog_batch_hydrate.py
@@ -87,7 +87,7 @@ class _BacklogThenLiveTransport(ClientTransportStub):
         if self._end:
             yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(self, text: str, **_kw) -> bool:

--- a/tests/interfaces/test_5139c_remote_reached_top_pull.py
+++ b/tests/interfaces/test_5139c_remote_reached_top_pull.py
@@ -75,7 +75,7 @@ class _PagingTransport(ClientTransportStub):
         if self._older_batch is not None:
             self._queue.put_nowait(self._older_batch)
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(self, text: str, **_kw) -> bool:

--- a/tests/interfaces/test_5149_client_destination_single_value.py
+++ b/tests/interfaces/test_5149_client_destination_single_value.py
@@ -89,7 +89,7 @@ class QueueTransport(ClientTransportStub):
     def put_display(self, msg) -> None:
         self._queue.put_nowait(DisplayFrame(msg))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5168_tui_stdio_capture.py
+++ b/tests/interfaces/test_5168_tui_stdio_capture.py
@@ -254,7 +254,7 @@ class _StubTransport(ClientTransportStub):
         return
         yield DisplayFrame(OutboxMessage(role="assistant", content=""))  # pragma: no cover — makes this a real async generator
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return "msg-1"
 
     async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:

--- a/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
+++ b/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
@@ -72,7 +72,7 @@ class _RaisingTransport(ClientTransportStub):
         yield DisplayFrame(OutboxMessage(kind="agent", text="before the failure"))
         raise _InjectedPumpFailure("simulated transport failure")
 
-    async def submit_user_text(self, text: str) -> "str | None":  # pragma: no cover - trivial
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> "str | None":  # pragma: no cover - trivial
         return None
 
     async def answer_intervention_text(
@@ -117,7 +117,7 @@ class _CleanEndTransport(ClientTransportStub):
         yield DisplayFrame(OutboxMessage(kind="agent", text="a normal reply"))
         yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
 
-    async def submit_user_text(self, text: str) -> "str | None":  # pragma: no cover - trivial
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> "str | None":  # pragma: no cover - trivial
         return None
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5329_pump_frames_supply_end_stays_open.py
+++ b/tests/interfaces/test_5329_pump_frames_supply_end_stays_open.py
@@ -64,7 +64,7 @@ class _CleanEndTransport(ClientTransportStub):
         yield DisplayFrame(OutboxMessage(kind="agent", text="a normal reply"))
         yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
 
-    async def submit_user_text(self, text: str) -> "str | None":  # pragma: no cover - trivial
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> "str | None":  # pragma: no cover - trivial
         return None
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -108,7 +108,7 @@ class _EventOnlyTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_5654_task_pane.py
+++ b/tests/interfaces/test_5654_task_pane.py
@@ -266,7 +266,7 @@ async def test_the_task_tab_shows_two_running_tasks_in_a_real_app():
             await asyncio.Event().wait()
             yield  # pragma: no cover — unreachable, satisfies the generator shape
 
-        async def submit_user_text(self, text: str) -> None:
+        async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
             pass
 
         async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_5729_agent_pane_status_glyphs.py
+++ b/tests/interfaces/test_5729_agent_pane_status_glyphs.py
@@ -301,7 +301,7 @@ class _EventOnlyTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()  # pragma: no cover - never actually sent
 
-    async def submit_user_text(self, text: str) -> str:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
         return ""
 
     async def run_slash_command(self, name: str, args: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_5731_pipeline_flowview_entry.py
+++ b/tests/interfaces/test_5731_pipeline_flowview_entry.py
@@ -36,7 +36,7 @@ class _PipelineTransport(ClientTransportStub):
     async def push(self, msg: OutboxMessage) -> None:
         await self._queue.put(DisplayFrame(msg))
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_5732_pump_swallow_visibility.py
+++ b/tests/interfaces/test_5732_pump_swallow_visibility.py
@@ -190,7 +190,7 @@ class _StubTransport(ClientTransportStub):
         return
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return "msg-1"
 
     async def answer_intervention_text(self, text: str, *, intervention_id=None) -> bool:

--- a/tests/interfaces/test_5769_stage3_rewind_default_scope_visible.py
+++ b/tests/interfaces/test_5769_stage3_rewind_default_scope_visible.py
@@ -97,7 +97,7 @@ class ScriptedTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_activity_row_3693.py
+++ b/tests/interfaces/test_activity_row_3693.py
@@ -65,7 +65,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_addressed_row_rail_3490.py
+++ b/tests/interfaces/test_addressed_row_rail_3490.py
@@ -52,7 +52,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_agent_delta_no_visible_garbage_3288.py
+++ b/tests/interfaces/test_agent_delta_no_visible_garbage_3288.py
@@ -117,7 +117,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_agent_delta_round_index_3656.py
+++ b/tests/interfaces/test_agent_delta_round_index_3656.py
@@ -55,7 +55,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_agui_ignore_unknown_both_directions.py
+++ b/tests/interfaces/test_agui_ignore_unknown_both_directions.py
@@ -60,7 +60,10 @@ class _FakeSession:
         self.submitted: list[str] = []
         self.answers: list[str] = []
 
-    async def submit_user_text(self, text: str, *, attribution: "dict | None" = None) -> None:
+    async def submit_user_text(
+        self, text: str, *, attribution: "dict | None" = None,
+        client_ref: "str | None" = None,
+    ) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_by_id(self, iv_id: str, text: str, **kw) -> bool:

--- a/tests/interfaces/test_chrome_uses_the_terminal_background_3503.py
+++ b/tests/interfaces/test_chrome_uses_the_terminal_background_3503.py
@@ -56,7 +56,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_click_does_not_copy_3624.py
+++ b/tests/interfaces/test_click_does_not_copy_3624.py
@@ -48,7 +48,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_compact_layout_3680.py
+++ b/tests/interfaces/test_compact_layout_3680.py
@@ -65,7 +65,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_config_warning_chrome_4194.py
+++ b/tests/interfaces/test_config_warning_chrome_4194.py
@@ -56,7 +56,7 @@ class _Transport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> str:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_conversation_chrome_separation.py
+++ b/tests/interfaces/test_conversation_chrome_separation.py
@@ -59,7 +59,7 @@ class _Transport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_conversation_cursor_3476.py
+++ b/tests/interfaces/test_conversation_cursor_3476.py
@@ -52,7 +52,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_conversation_pane_boundary_3692.py
+++ b/tests/interfaces/test_conversation_pane_boundary_3692.py
@@ -33,7 +33,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_conversation_scroll_keys_3470.py
+++ b/tests/interfaces/test_conversation_scroll_keys_3470.py
@@ -42,7 +42,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_copy_mode_3507.py
+++ b/tests/interfaces/test_copy_mode_3507.py
@@ -43,7 +43,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_copy_to_clipboard_sink_3616.py
+++ b/tests/interfaces/test_copy_to_clipboard_sink_3616.py
@@ -47,7 +47,7 @@ class _CancelTrackingTransport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="agent", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         return ""
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_ctrl_c_interrupt_3498.py
+++ b/tests/interfaces/test_ctrl_c_interrupt_3498.py
@@ -46,7 +46,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_drawer_readout_reachable_3699.py
+++ b/tests/interfaces/test_drawer_readout_reachable_3699.py
@@ -56,7 +56,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_empty_state_hint_3476.py
+++ b/tests/interfaces/test_empty_state_hint_3476.py
@@ -36,7 +36,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_esc_resumes_following_3806.py
+++ b/tests/interfaces/test_esc_resumes_following_3806.py
@@ -58,7 +58,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_focus_visible_3528.py
+++ b/tests/interfaces/test_focus_visible_3528.py
@@ -52,7 +52,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_ime_cursor_anchor_3621.py
+++ b/tests/interfaces/test_ime_cursor_anchor_3621.py
@@ -41,7 +41,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_lazy_history_paging_3476.py
+++ b/tests/interfaces/test_lazy_history_paging_3476.py
@@ -57,7 +57,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -62,7 +62,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_placeholder_dim_3522.py
+++ b/tests/interfaces/test_placeholder_dim_3522.py
@@ -61,7 +61,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_rail_right_gutter_3526.py
+++ b/tests/interfaces/test_rail_right_gutter_3526.py
@@ -41,7 +41,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_right_gutter_label_visible_3536.py
+++ b/tests/interfaces/test_right_gutter_label_visible_3536.py
@@ -46,7 +46,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_search_bar_3476.py
+++ b/tests/interfaces/test_search_bar_3476.py
@@ -52,7 +52,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_selection_not_bright_3542.py
+++ b/tests/interfaces/test_selection_not_bright_3542.py
@@ -56,7 +56,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_sent_queue_overflow_visible_3688.py
+++ b/tests/interfaces/test_sent_queue_overflow_visible_3688.py
@@ -57,7 +57,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_stream_client_own_echo_3287.py
+++ b/tests/interfaces/test_stream_client_own_echo_3287.py
@@ -134,7 +134,7 @@ class _QueueTransport(ClientTransportStub):
         while True:
             yield await self._frames.get()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.submitted.append(text)
         if self._submit_msg_ids:
             return self._submit_msg_ids.pop(0)

--- a/tests/interfaces/test_stream_spinner_3530.py
+++ b/tests/interfaces/test_stream_spinner_3530.py
@@ -44,7 +44,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_tail_away_indicator_3712.py
+++ b/tests/interfaces/test_tail_away_indicator_3712.py
@@ -62,7 +62,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
+++ b/tests/interfaces/test_textual_chat_attach_state_3671_p3.py
@@ -170,7 +170,7 @@ class _AttachStateTransport(ClientTransportStub):
         import asyncio
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> str:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
         self.submitted.append(text)
         return "msg-1"
 

--- a/tests/interfaces/test_textual_chat_copy_rewind_3362.py
+++ b/tests/interfaces/test_textual_chat_copy_rewind_3362.py
@@ -150,7 +150,7 @@ class ScriptedTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_textual_chat_esc_sufficiency_3365.py
+++ b/tests/interfaces/test_textual_chat_esc_sufficiency_3365.py
@@ -92,7 +92,7 @@ class _Transport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_intervention_panel_3299.py
+++ b/tests/interfaces/test_textual_chat_intervention_panel_3299.py
@@ -109,7 +109,7 @@ class RecordingTransport(ClientTransportStub):
         else:
             await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(

--- a/tests/interfaces/test_textual_chat_orphan_sweep_72.py
+++ b/tests/interfaces/test_textual_chat_orphan_sweep_72.py
@@ -91,7 +91,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_textual_chat_phase1_3273.py
+++ b/tests/interfaces/test_textual_chat_phase1_3273.py
@@ -60,7 +60,7 @@ class ScriptedTransport(ClientTransportStub):
         else:
             await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:
@@ -192,7 +192,7 @@ class T(ClientTransportStub):
         yield DisplayFrame(OutboxMessage(kind="user", text="hi"))
         yield DisplayFrame(OutboxMessage(kind="agent", text="hello"))
         yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
-    async def submit_user_text(self, text): pass
+    async def submit_user_text(self, text, *, client_ref=None): pass
     async def answer_intervention_text(self, text): return False
     async def answer_intervention_choice(self, cid): return False
     def has_session(self): return True

--- a/tests/interfaces/test_textual_chat_phase2_3273.py
+++ b/tests/interfaces/test_textual_chat_phase2_3273.py
@@ -90,7 +90,7 @@ class ScriptedTransport(ClientTransportStub):
         else:
             await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/interfaces/test_textual_chat_phase2b_live_tool_3283.py
@@ -116,7 +116,7 @@ class ScriptedTransport(ClientTransportStub):
         else:
             await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:
@@ -164,7 +164,7 @@ class QueueTransport(ClientTransportStub):
             msg = await self._queue.get()
             yield DisplayFrame(msg)
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_phase3_3273.py
+++ b/tests/interfaces/test_textual_chat_phase3_3273.py
@@ -57,7 +57,7 @@ class ScriptedTransport(ClientTransportStub):
         else:
             await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_phase4_3273.py
+++ b/tests/interfaces/test_textual_chat_phase4_3273.py
@@ -268,7 +268,7 @@ class ScriptedTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def run_slash_command(self, name: str, args: str) -> bool:

--- a/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_right_gutter_3283.py
@@ -121,7 +121,7 @@ class ScriptedTransport(ClientTransportStub):
         else:
             await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:
@@ -170,7 +170,7 @@ class QueueTransport(ClientTransportStub):
             msg = await self._queue.get()
             yield DisplayFrame(msg)
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
+++ b/tests/interfaces/test_textual_chat_phase4_turn_cost_gutter_3283.py
@@ -729,7 +729,7 @@ class _QueueTransport(ClientTransportStub):
         while True:
             yield DisplayFrame(await self._queue.get())
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_textual_chat_streaming_visibility_3283.py
+++ b/tests/interfaces/test_textual_chat_streaming_visibility_3283.py
@@ -105,7 +105,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/interfaces/test_tool_detail_on_highlight_3508.py
+++ b/tests/interfaces/test_tool_detail_on_highlight_3508.py
@@ -45,7 +45,7 @@ class _Transport(ClientTransportStub):
         await asyncio.Event().wait()
         yield DisplayFrame(OutboxMessage(kind="status", text=""))  # pragma: no cover
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:

--- a/tests/interfaces/test_user_submitted_render_3300.py
+++ b/tests/interfaces/test_user_submitted_render_3300.py
@@ -146,7 +146,7 @@ class QueueTransport(ClientTransportStub):
         while True:
             yield await self._queue.get()
 
-    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
         pass
 
     async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover

--- a/tests/runtime/test_5833_client_ref_never_branches.py
+++ b/tests/runtime/test_5833_client_ref_never_branches.py
@@ -1,0 +1,158 @@
+"""Tier 2: #5833 — ``client_ref`` is an opaque correlation token the SERVER
+receives, stores in ``meta``, and echoes back VERBATIM. It must never
+change server behavior, whatever value a client sends.
+
+The design ruling (lead-coder, #5833 issue thread) added this as an
+acceptance line on top of the chosen fix (client_ref-in-meta over
+identity-in-meta, option (b) rejected precisely because ``client_ref`` is
+"client-supplied opaque junk" — blurring it with identity would make trust
+flow from the classified side): "server は client_ref を一度も解釈しない
+こと ... server 側に client_ref で分岐する行が1つでも在れば、それがこの
+設計の破れ". Tested here by driving :meth:`Session.submit_user_text` with
+four deliberately adversarial values — an arbitrary string, another
+client's own former ref, an empty string, and a huge one — and asserting
+the OBSERVABLE behavior (the emitted event's shape, the returned msg_id,
+the inbox payload) is identical in every dimension EXCEPT the one field
+that carries the value through unchanged.
+
+No unittest.mock/AsyncMock/patch — a real ``Session`` (``tests/_support/
+agent_session.py``'s own construction helper, the same one ``test_user_echo_
+broadcast.py`` uses for the sibling #3300 audit-event contract) and a real
+subscriber callback.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config import SafetyConfig, TimeoutConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.events import settle
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    session = make_session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        safety=SafetyConfig(timeout=TimeoutConfig(chain_seconds=60.0)),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+    session.register_intervention_listener("test")
+    return session
+
+
+class _EventSink:
+    """A real (non-mock) audit-event subscriber — same shape as
+    ``test_user_echo_broadcast.py``'s own ``_EventSink``."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def __call__(self, event) -> None:
+        self.events.append(event)
+
+
+async def _user_submitted_event(session: Session, sink: _EventSink):
+    await settle(session)
+    matches = [e for e in sink.events if e.type == "user_submitted"]
+    assert matches, "no user_submitted event observed"
+    return matches[-1]
+
+
+# The four adversarial values the design ruling itself named verbatim:
+# "任意の値（他 client の値・空・巨大・記号）".
+_ADVERSARIAL_CLIENT_REFS = pytest.mark.parametrize(
+    "client_ref",
+    [
+        pytest.param("local:deadbeefcafebabe0000000000000001", id="arbitrary"),
+        pytest.param("local:not-my-own-id-belongs-to-another-client", id="foreign"),
+        pytest.param("", id="empty"),
+        pytest.param("x" * 100_000, id="huge"),
+        pytest.param("'; DROP TABLE sessions; --<script>", id="symbols"),
+    ],
+)
+
+
+@_ADVERSARIAL_CLIENT_REFS
+@pytest.mark.asyncio
+async def test_submit_user_text_never_branches_on_client_ref(
+    tmp_path: Path, client_ref: str,
+) -> None:
+    """Tier 2: whatever ``client_ref`` a caller sends, the enqueue/emit
+    shape is IDENTICAL to the no-``client_ref`` baseline — text, chain_id
+    presence, and the returned msg_id's own shape are all independent of
+    the value. The single permitted difference is ``meta.client_ref``
+    itself, and only when non-empty (an empty string round-trips too, but
+    is checked separately below since it is falsy and easy to conflate
+    with "absent")."""
+    session = _make_session(tmp_path)
+    sink = _EventSink()
+    session.subscribe_audit_events(sink)
+
+    msg_id = await session.submit_user_text("hello", client_ref=client_ref)
+
+    assert isinstance(msg_id, str) and msg_id, (
+        "a client_ref value must never change whether/how msg_id is assigned"
+    )
+    event = await _user_submitted_event(session, sink)
+    assert event.data.get("text") == "hello"
+    assert event.data.get("msg_id") == msg_id
+    meta = event.data.get("meta") or {}
+    assert meta.get("client_ref") == client_ref, (
+        "the value must round-trip VERBATIM, byte-for-byte, never normalized "
+        "or rejected"
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_ref_is_the_only_diff_between_two_otherwise_identical_submits(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the sharpest form of "never branches" — two submissions,
+    identical in every other respect, differing ONLY in ``client_ref``,
+    produce events identical in every field except ``msg_id`` (a fresh id
+    per call, unrelated to client_ref) and ``meta.client_ref`` itself."""
+    session = _make_session(tmp_path)
+    sink = _EventSink()
+    session.subscribe_audit_events(sink)
+
+    await session.submit_user_text("same text", client_ref="local:aaa")
+    ev_a = await _user_submitted_event(session, sink)
+    await session.submit_user_text("same text", client_ref="local:zzz-totally-different-shape")
+    ev_b = await _user_submitted_event(session, sink)
+
+    assert ev_a.data.get("text") == ev_b.data.get("text")
+    assert ev_a.data.get("msg_id") != ev_b.data.get("msg_id"), (
+        "msg_id assignment must be independent of client_ref's value"
+    )
+    meta_a = dict(ev_a.data.get("meta") or {})
+    meta_b = dict(ev_b.data.get("meta") or {})
+    del meta_a["client_ref"]
+    del meta_b["client_ref"]
+    assert meta_a == meta_b, (
+        f"only client_ref may differ between these two events' meta — got "
+        f"{meta_a!r} vs {meta_b!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omitting_client_ref_entirely_is_unaffected(tmp_path: Path) -> None:
+    """Tier 2: control arm — a caller that never passes ``client_ref`` at
+    all (every pre-#5833 call site, and most callers going forward: the
+    plain REPL, agent-to-agent submission) gets EXACTLY the pre-#5833
+    shape — no ``client_ref`` key appears in ``meta`` at all, not even as
+    ``None``."""
+    session = _make_session(tmp_path)
+    sink = _EventSink()
+    session.subscribe_audit_events(sink)
+
+    await session.submit_user_text("plain submit, no client_ref")
+
+    event = await _user_submitted_event(session, sink)
+    meta = event.data.get("meta") or {}
+    assert "client_ref" not in meta, (
+        f"omitting client_ref must not synthesize the key at all — got {meta!r}"
+    )

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -131,7 +131,7 @@ class ScriptedTransport(ClientTransportStub):
             yield DisplayFrame(msg)
         await asyncio.Event().wait()
 
-    async def submit_user_text(self, text: str) -> None:
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
         self.submitted.append(text)
 
     async def answer_intervention_text(self, text: str) -> bool:


### PR DESCRIPTION
**[tui-coder]** — client_ref-in-meta: closes the #3287 race structurally (echo carries the fact, not a guess).

Closes #5833

## What changed

The `#3287` design ("return `msg_id` so a submitting client can recognise its own echo by id") never worked as intended: the id `submit_user_text`'s POST response returns arrives on an independent channel from the `user_submitted` echo carrying it, and either can arrive first — so at echo time the client did not reliably have the id yet. The old code covered the gap with three regulators that each guessed identity after the fact (`_reconcile_local_send`'s 3-way branch, `_dispatched_before_ack`, and a `has_row(msg_id)` check).

This PR changes what the echo carries: the client now mints a `client_ref` (its own local placeholder id) at submit time, forwards it opaquely through the whole transport chain (`client_transport.py`, `threaded.py`, `agui/client.py`, `agui/endpoint.py`, `in_process.py`, `session_bound.py`, `slash/dispatch.py`, `session.py`), and the server places it — unread — into `meta.client_ref` on the `user_submitted` echo. `_handle_user_submitted_event` now recognizes its OWN submission by **fact** (does `meta.client_ref` match a pending local placeholder id?) instead of by **guess** (does a row happen to exist under this id already?).

Net effect: 2 of the 3 old regulators (`_reconcile_local_send`'s 3-way branch, `_dispatched_before_ack`) are deleted outright — not merely unreachable, removed with all references. The third (`_maybe_sent_queue_remove`'s post-failure cleanup) survives for a different reason, documented in its own docstring: a failed POST never produces an echo at all, so there is nothing to rekey against.

`_seed_queue_view` gets the same `has_row` guard `_handle_user_submitted_event` already had, closing an asymmetry the two call sites had against each other (a row can already exist under `msg_id` at seed time when this client's own submission raced ahead of the very first frame the seed runs on).

## Acceptance (from the lead-coder design ruling on #5833)

1. **Server never interprets `client_ref`** — receives it, stores it in `meta`, returns it, and nothing branches on its value anywhere server-side. Verified adversarially with 5 values (another client's id, empty string, a huge string, symbol-laden junk, omitted entirely) in `tests/runtime/test_5833_client_ref_never_branches.py` (7 tests).
2. **The two regulators are gone, not merely unreachable** — `_reconcile_local_send`, `_dispatched_before_ack`, and `_pending_local_send_ids` have zero remaining references in `src/` (grep-verified); the only text mentioning them is the explanatory docstring on why the third survives.
3. **`_maybe_sent_queue_remove` documents why it survives** — its docstring now states the reason directly: the failed-POST path has no echo to rekey against, a different failure axis from the other two.

## Falsification (manual, not committed — see below for the one that IS committed)

- Disabled the `client_ref` rekey branch in `_handle_user_submitted_event` (`if False and isinstance(client_ref, str)...`) and reran `tests/interfaces/test_4409_pre_send_indicator.py`: `test_echo_promotes_the_placeholder_in_place_no_duplicate` times out (the promotion never happens, so the wait condition never becomes true) and `test_dispatch_before_ack_drops_the_placeholder_without_requeuing_it` fails with a concrete stale-requeue assertion. Restored, both green again (7/7).
- `tests/interfaces/test_3300_p2b_sentqueue_render.py::test_strip_seed_has_row_guard_reorders_the_already_shown_row` is a **committed** falsify test — it monkeypatches `_seed_queue_view` back to the pre-fix unconditional `show_item` and asserts the asymmetry (row reordering) reproduces, proving the positive test above it is load-bearing.

## Test plan

- [x] `tests/runtime/test_5833_client_ref_never_branches.py` — 7/7 green (server never interprets `client_ref`, adversarial values)
- [x] `tests/interfaces/test_3300_p2b_sentqueue_render.py` — 13/13 green (includes the `_seed_queue_view` symmetry falsify test)
- [x] `tests/interfaces/test_4409_pre_send_indicator.py` — 7/7 green, rewritten for echo-time promotion; manually falsified per above
- [x] Representative sample of the ~89 mechanically fixture-patched test files (new `client_ref` kwarg only, no behavior change) — 48/48 green across 7 files spanning transport/slash/session-switch/orphan-sweep areas
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict <90 changed test files>` — 675 tests inspected, 0 errors, 0 warnings
- [x] `python scripts/verify_module_docstrings.py <10 changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — exit 0
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK, baseline unchanged
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK, baseline unchanged
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
