### PR TITLE
feat(#5837 stage 2): !/!! normalize to /exec-attach//exec, one recognition site

### DIFF
--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -41,6 +41,19 @@ queues, which is the invariant #3300 actually protects.
 ⚠️ Consequence worth naming rather than discovering: a slash handler now runs
 CONCURRENTLY with an in-flight turn instead of after it. #3327 established that
 shape for the answer funnel; S5 extends it to the whole catalog.
+
+★ **#5837 stage 2 — ``!``/``!!`` are a CLIENT-side spelling, not a second
+dispatch route.** Owner ruling (verbatim): "'!'/'!!' 解釈は core ではなく '/'
+と同様 remote 側責務期待" — the same client-owns-interpretation shape this
+module already gives ``/``. :func:`maybe_dispatch_slash` normalizes a
+``!``/``!!``-prefixed line into the equivalent ``/exec-attach``/``/exec`` text
+BEFORE its own ``/`` check, then falls straight through the SAME parsing,
+echo, and dispatch this module already had — there is no second interpreter,
+and the server never sees a bang (by the time anything crosses the transport
+it is an ordinary resolved command name + args, identical to what typing
+``/exec`` would have produced). ``!!`` is checked first because ``!!cmd``
+also satisfies ``text.startswith("!")`` — checking the single-bang form first
+would misroute every double-bang line to ``/exec-attach``.
 """
 from __future__ import annotations
 
@@ -101,7 +114,41 @@ async def maybe_dispatch_slash(
     bundled into ``args`` and ignored by whichever handler does not read them.
     The echo carries the WHOLE typed text, which is what makes the note about
     ignored lines legible.
+
+    #5837 stage 2: a leading ``!``/``!!`` is rewritten to ``/exec-attach``/
+    ``/exec`` right here, before anything below reads ``text`` — see this
+    module's own docstring for why order and placement both matter. The
+    ECHOED line is the rewritten ``/exec …`` form, not the original ``!…`` —
+    the same choice ``exec.py``'s own ``/exec-attach`` already made for its
+    queued block (log what actually ran, not what was typed before
+    normalization), applied here for the same "readable after the fact"
+    reason. A bare ``!``/``!!`` (no command text) is a mistake worth saying
+    so about, not a message to submit as a turn — same shape the bare-``/``
+    catalog branch below already gives an empty ``/``.
     """
+    if text.startswith("!!"):
+        rest = text[2:]
+        if not rest.strip():
+            if echo:
+                _display(transport, "user", text)
+            _display(
+                transport, "error",
+                "!! requires a command; usage: !!<cmdline> (same as /exec <cmdline>)",
+            )
+            return True
+        text = "/exec " + rest
+    elif text.startswith("!"):
+        rest = text[1:]
+        if not rest.strip():
+            if echo:
+                _display(transport, "user", text)
+            _display(
+                transport, "error",
+                "! requires a command; usage: !<cmdline> (same as /exec-attach <cmdline>)",
+            )
+            return True
+        text = "/exec-attach " + rest
+
     if not text.startswith("/"):
         return False
 

--- a/src/reyn/interfaces/slash/exec.py
+++ b/src/reyn/interfaces/slash/exec.py
@@ -4,10 +4,18 @@ sandboxed exec op the LLM ``exec`` tool uses (#5837 stage 1).
 Usage::
 
     /exec <cmdline>          — run, show the result on screen only
+    !!<cmdline>              — same as /exec (stage 2 shorthand)
     /exec-attach <cmdline>   — run, queue argv + result for the NEXT user
                                message (drained by Session._handle_inbox_text,
                                the same ``_pending_user_attachments`` queue
                                ``/attachment``/``/image`` already write to)
+    !<cmdline>               — same as /exec-attach (stage 2 shorthand)
+
+#5837 stage 2 (``interfaces/slash/dispatch.py``'s own ``maybe_dispatch_
+slash``): the ``!``/``!!`` prefixes are a CLIENT-side spelling of the two
+commands above, normalized to the equivalent ``/exec``/``/exec-attach`` text
+before dispatch even reaches the ``/`` check — this module itself never sees
+a bang and needs no changes to support it.
 
 owner request (2026-09-06, verbatim): "スラッシュコマンド経由で llm tool の exec
 を打てるようにしたい". Owner rulings confirmed in #5837 (quoted there in
@@ -290,9 +298,9 @@ async def _run_exec(ctx: "SlashContext", args: str) -> "tuple[list[str], dict] |
 
 @slash(
     "exec",
-    summary="Run a command through the sandboxed exec tool (screen only)",
+    summary="Run a command through the sandboxed exec tool (screen only) — shorthand: !!<cmdline>",
     locus="session",
-    usage=_USAGE,
+    usage=_USAGE + "  (shorthand: !!<cmdline>)",
     see_also=("exec-attach",),
 )
 async def exec_cmd(ctx: "SlashContext", args: str) -> None:
@@ -305,9 +313,9 @@ async def exec_cmd(ctx: "SlashContext", args: str) -> None:
 
 @slash(
     "exec-attach",
-    summary="Run a command and attach argv + result to your next message",
+    summary="Run a command and attach argv + result to your next message — shorthand: !<cmdline>",
     locus="session",
-    usage="usage: /exec-attach <cmdline>",
+    usage="usage: /exec-attach <cmdline>  (shorthand: !<cmdline>)",
     see_also=("exec",),
 )
 async def exec_attach_cmd(ctx: "SlashContext", args: str) -> None:

--- a/tests/interfaces/test_5837_exec_slash_stage2_bang.py
+++ b/tests/interfaces/test_5837_exec_slash_stage2_bang.py
@@ -1,0 +1,209 @@
+"""Tier 2: #5837 stage 2 — ``!``/``!!`` normalize to ``/exec-attach``/``/exec``
+inside ``maybe_dispatch_slash``, one CLIENT-side seam, before the server (or
+even the rest of this module's own dispatch) ever sees a bang.
+
+Real ``Session``/``SandboxConfig`` throughout (``tests._support.agent_
+session.make_session``, ``tests._support.slash.slash_ctx``) — no mocks. This
+file's own subject is the NORMALIZATION step in
+``interfaces/slash/dispatch.py``; stage 1's own command behavior (sandboxing,
+audit trail, attach queueing) is already covered by
+``test_5837_exec_slash_stage1.py`` and is not re-proven here.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
+from tests._support.agent_session import make_session
+from tests._support.paths import REPO_ROOT
+from tests._support.slash import slash_ctx
+
+
+def _session(tmp_path: Path):
+    return make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        workspace_state_dir=tmp_path,
+    )
+
+
+def _texts(ctx) -> list[str]:
+    return [getattr(m, "text", "") for m in ctx.transport.displayed]
+
+
+# ---------------------------------------------------------------------------
+# ⑦ — the 4 spellings land on the same handler, with the same observable
+#     effect (exit code, stdout, and — for the attach pair — the queue).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bang_bang_and_slash_exec_produce_the_same_reply(tmp_path):
+    """Tier 2: accept — ``!!<cmdline>`` and ``/exec <cmdline>`` both run the
+    SAME sandboxed exec op and produce the same screen-only reply (exit
+    code + stdout), never touching history or the attach queue."""
+    cmdline = 'python3 -c "print(2+2)"'
+
+    bang_session = _session(tmp_path / "bang")
+    bang_ctx = slash_ctx(bang_session)
+    consumed = await maybe_dispatch_slash(bang_ctx.transport, f"!!{cmdline}")
+    assert consumed is True
+
+    slash_session = _session(tmp_path / "slash")
+    slash_ctx_ = slash_ctx(slash_session)
+    await maybe_dispatch_slash(slash_ctx_.transport, f"/exec {cmdline}")
+
+    bang_texts = _texts(bang_ctx)
+    slash_texts = _texts(slash_ctx_)
+    assert any("exit 0" in t for t in bang_texts), bang_texts
+    assert any("4" in t for t in bang_texts), bang_texts
+    # Same command, same sandbox, same handler -> the same reply shape.
+    reply_kind_bang = [m.kind for m in bang_ctx.transport.displayed if m.kind != "user"]
+    reply_kind_slash = [m.kind for m in slash_ctx_.transport.displayed if m.kind != "user"]
+    assert reply_kind_bang == reply_kind_slash
+    assert any("exit 0" in t and "4" in t for t in slash_texts), slash_texts
+
+    bang_queue = bang_session._pending_user_attachments
+    slash_queue = slash_session._pending_user_attachments
+    assert not bang_queue
+    assert not slash_queue
+
+
+@pytest.mark.asyncio
+async def test_bang_and_slash_exec_attach_both_queue_the_same_block(tmp_path):
+    """Tier 2: accept — ``!<cmdline>`` and ``/exec-attach <cmdline>`` both
+    queue the same ``shlex.join(argv)`` + result text block for the next
+    user message."""
+    cmdline = 'python3 -c "print(1+1)"'
+
+    bang_session = _session(tmp_path / "bang")
+    bang_ctx = slash_ctx(bang_session)
+    await maybe_dispatch_slash(bang_ctx.transport, f"!{cmdline}")
+
+    slash_session = _session(tmp_path / "slash")
+    slash_ctx_ = slash_ctx(slash_session)
+    await maybe_dispatch_slash(slash_ctx_.transport, f"/exec-attach {cmdline}")
+
+    (bang_block,) = bang_session._pending_user_attachments
+    (slash_block,) = slash_session._pending_user_attachments
+    assert bang_block["type"] == slash_block["type"] == "text"
+    assert "2" in bang_block["text"] and "exit 0" in bang_block["text"]
+    assert bang_block["text"] == slash_block["text"], (
+        "the same cmdline through either spelling must queue an identical block"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ordering — !! must be recognized before the single-! check would fire.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_double_bang_is_not_misrouted_to_exec_attach(tmp_path):
+    """Tier 2: accept — ``!!<cmdline>`` runs ``/exec`` (screen only), never
+    ``/exec-attach``. ``!!cmd`` also satisfies ``str.startswith("!")``, so a
+    single-bang-first check would wrongly queue it for attachment instead."""
+    session = _session(tmp_path)
+    ctx = slash_ctx(session)
+    await maybe_dispatch_slash(ctx.transport, '!!python3 -c "print(3+3)"')
+
+    queue = session._pending_user_attachments
+    assert not queue, "!! must never queue an attachment -- that is /exec-attach's job"
+    texts = _texts(ctx)
+    assert any("6" in t for t in texts), texts
+
+
+# ---------------------------------------------------------------------------
+# bare ! / !! — explicit error, never a submitted message.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bare", ["!", "!!"])
+async def test_bare_bang_is_an_explicit_error_not_a_submitted_message(tmp_path, bare):
+    """Tier 2: accept — a bang with no command text is a mistake reported
+    on screen, consumed (``True``) so it is never sent as an ordinary turn."""
+    session = _session(tmp_path)
+    ctx = slash_ctx(session)
+    consumed = await maybe_dispatch_slash(ctx.transport, bare)
+
+    assert consumed is True, f"{bare!r} alone must be consumed, not forwarded as a turn"
+    kinds = [m.kind for m in ctx.transport.displayed]
+    assert "error" in kinds, ctx.transport.displayed
+    queue = session._pending_user_attachments
+    assert not queue
+
+
+# ---------------------------------------------------------------------------
+# structural — the server never sees a bang; exactly one client-side site
+# recognizes the single-! form.
+# ---------------------------------------------------------------------------
+
+
+def _startswith_bang_literal_hits(tree: "ast.AST") -> "list[int]":
+    """Every syntactic ``x.startswith("!")`` call in ``tree`` (the literal
+    single-bang form — NOT ``"!!"``, which is a distinct string and a
+    distinct call). Written from the value side (the literal itself), the
+    same shape ``test_3595_s5_session_does_not_interpret_text.py`` already
+    uses for its own ``"/"`` census, so a second single-bang recognizer
+    introduced under a different spelling (``x[0] == "!"``, a regex) is a
+    disclosed blind spot of this walk, not a silent pass — see that file's
+    own docstring for the general shape of this caveat."""
+    hits: "list[int]" = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "startswith"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "!"
+        ):
+            hits.append(node.lineno)
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# ⑧ — /help discovery of the shorthand.
+# ---------------------------------------------------------------------------
+
+
+def test_help_lists_the_bang_shorthand_for_exec_and_exec_attach():
+    """Tier 2: accept — the top-level ``/help`` listing (which reads
+    ``cmd.summary`` off the live registry, ``interfaces/slash/help.py``)
+    surfaces the ``!``/``!!`` shorthand for a user who never knew to look
+    for ``/exec``."""
+    from reyn.interfaces.slash import REGISTRY
+
+    exec_cmd = REGISTRY.get("exec")
+    attach_cmd = REGISTRY.get("exec-attach")
+    assert exec_cmd is not None and attach_cmd is not None
+    assert "!!<cmdline>" in exec_cmd.summary
+    assert "!<cmdline>" in attach_cmd.summary
+
+
+def test_single_bang_recognition_has_exactly_one_site_in_src():
+    """Tier 2: accept — ``startswith("!")`` (the single-bang form) appears
+    at exactly ONE call site under ``src/`` — ``maybe_dispatch_slash``
+    itself. A second site would mean two places decide what a bang means,
+    the same "2 source" shape the owner ruling on this issue named and
+    rejected for the call-site-level placement question."""
+    hits: "dict[str, list[int]]" = {}
+    for path in (REPO_ROOT / "src").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        found = _startswith_bang_literal_hits(tree)
+        if found:
+            hits[str(path.relative_to(REPO_ROOT))] = found
+
+    assert set(hits) == {"src/reyn/interfaces/slash/dispatch.py"}, (
+        f"expected the single-bang check only in dispatch.py, found: {hits!r}"
+    )
+    # Unpacking to a single-element tuple IS the "exactly one site" check —
+    # it raises (rather than silently passing) on zero or on two-or-more
+    # hits, without a magic-number size comparison.
+    (_only_site,) = hits["src/reyn/interfaces/slash/dispatch.py"]


### PR DESCRIPTION
**[tui-coder]** — #5837 stage 2: `!`/`!!` normalize to `/exec-attach`/`/exec`, one place, before the server ever sees a bang.

Closes #5837

## What changed

`maybe_dispatch_slash` (`interfaces/slash/dispatch.py`) recognizes a leading `!!`/`!` **before** its own `text.startswith("/")` check and rewrites the text into the equivalent `/exec …`/`/exec-attach …` line, then falls straight through the exact same parsing → echo → dispatch this module already ran for every other slash command. There is no second interpreter and no new dispatch route: by the time anything crosses the transport it is an ordinary resolved command name + args, indistinguishable from what typing `/exec` would have produced.

`!!` is checked first because `!!cmd` also satisfies `str.startswith("!")` — checking the single-bang form first would misroute every double-bang line to `/exec-attach`.

A bare `!`/`!!` (no command text) is an explicit error, consumed (`True`) so it is never submitted as an ordinary turn.

`exec.py`'s `/exec` and `/exec-attach` `summary`/`usage` now name the shorthand, so `/help`'s existing registry-driven listing surfaces it with no changes to `help.py` itself.

## Placement — the owner ruling this follows

Owner (verbatim, quoted in #5837): "'!'/'!!' 解釈は core ではなく '/' と同様 remote 側責務期待". lead-coder's follow-up ruling narrowed WHERE inside the client: `maybe_dispatch_slash` has 2 call sites (`textual_chat/app.py`, `repl/stream_client.py`) — normalization lives inside the shared function itself, not duplicated at either call site, closing the same "2 source" shape this repo's review discipline has repeatedly named.

## Acceptance ↔ test correspondence

| # | Acceptance (issue #5837, stage 2) | Test |
|---|---|---|
| 1 | 4 inputs (`!`, `!!`, `/exec-attach`, `/exec`) land on the same handler, same observable effect | `test_bang_bang_and_slash_exec_produce_the_same_reply`, `test_bang_and_slash_exec_attach_both_queue_the_same_block` |
| 2 | `!!` is checked before `!` | `test_double_bang_is_not_misrouted_to_exec_attach` (falsified manually: swapping the check order breaks this test — see below) |
| 3 | A bare `!`/`!!` is an explicit error, never sent as a message | `test_bare_bang_is_an_explicit_error_not_a_submitted_message` (parametrized `!`/`!!`) |
| 4 | `startswith("!")` (single-bang form) has exactly 1 hit in `src/`, client-side | `test_single_bang_recognition_has_exactly_one_site_in_src` (AST census over `src/`, same shape as `test_3595_s5_session_does_not_interpret_text.py`'s own `/`-prefix census) |
| 5 | `/help` names the shorthand | `test_help_lists_the_bang_shorthand_for_exec_and_exec_attach` |

## Falsification (manual, not committed)

Swapped the check order (`!` before `!!`) with an Edit, confirmed `test_double_bang_is_not_misrouted_to_exec_attach` goes red (a `!!cmd` line gets queued as an attachment instead of shown screen-only), then reverted with an Edit. `git stash`/`checkout`/`restore` not used.

## Test plan

- [x] `tests/interfaces/test_5837_exec_slash_stage2_bang.py` — 7/7 green (new file, this stage's own coverage)
- [x] `tests/interfaces/test_5837_exec_slash_stage1.py` — 14/14 green (stage 1 unaffected)
- [x] `tests/interfaces/test_3595_s5_session_does_not_interpret_text.py`, `test_5096_slash_dispatch_routes_attach_directly.py`, `test_slash_help_per_command.py`, `test_3611_cui_echo_wiring.py`, `test_3327_answer_bypasses_sentqueue.py`, `tests/core/test_slash_multi_line_dispatch.py` — 61/61 green across the scoped run (dispatch.py's other callers/consumers unaffected)
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_5837_exec_slash_stage2_bang.py` — 6/6, 0 errors (2 rounds of fixup: private-state-read-into-variable per this repo's own stage-1 convention, and a tuple-unpack instead of `len(...) == 1` for the exactly-one-site check)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/slash/dispatch.py src/reyn/interfaces/slash/exec.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (199/208 baselined findings, no new)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged, `git add`-ed before running)
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK (baseline unchanged)
- [x] (skipped — Visual, standing waiver 2026-08-08)

## Security note (per brief — architect co-vet requested)

This PR touches only client-side text normalization ahead of the existing `/exec`/`/exec-attach` handlers landed in stage 1 (#5843) — no sandbox, permission, or actor-attribution logic changes. The structural claim under test (single recognition site, server never sees a bang) is exactly the shape a co-vet would check first; census test included above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
