### PR TITLE
fix(#5845): mcp tool-call write-denial hint states granted scope, not a sandbox verdict

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -454,7 +454,7 @@ def _looks_like_write_denial(text: str | None) -> bool:
     denial arrives on the subprocess's stderr (:meth:`MCPClient.initialize`),
     while a denial inside a running server's tool handler never touches stderr
     at all and arrives as JSON-RPC tool-error content
-    (:meth:`MCPClient.call_tool`). See :data:`_TOOL_CALL_WRITE_DENIAL_HINT`.
+    (:meth:`MCPClient.call_tool`). See :data:`_TOOL_CALL_PERMISSION_HINT`.
     """
     if not text:
         return False
@@ -476,15 +476,40 @@ def _looks_like_write_denial(text: str | None) -> bool:
 #
 # i.e. FastMCP prefixes the handler's exception but preserves ``str(exc)``
 # verbatim, so the errno survives into the payload and _looks_like_write_denial
-# matches it. Both concrete remedies are named (the #2932 ``require_mcp`` shape),
-# and the zero-config one goes FIRST per #3009's principle: the path that needs no
-# declaration is the recommendation, the grant is the documented deviation.
-_TOOL_CALL_WRITE_DENIAL_HINT = (
-    "\n\nHint (#3009): this looks like reyn's MCP sandbox DENYING the server a "
-    "write to a path outside its granted write scope — NOT a bug in the tool "
-    "(the error above names the exact path). A sandboxed stdio MCP server may "
-    "write only inside its working directory unless its config says otherwise. "
-    "Two ways forward:\n"
+# matches it.
+#
+# #5845 (sibling of #5840, same causal overclaim, same fix shape): this used to
+# read "this looks like reyn's MCP sandbox DENYING the server a write ... NOT a
+# bug in the tool" — a stderr/tool-error STRING MATCH asserted as a CAUSAL
+# claim. The same "[Errno 1] Operation not permitted: '<path>'" text is
+# IDENTICAL whether the sandbox denied a write outside its granted scope OR a
+# genuine non-sandbox permission failure occurred INSIDE that scope (a
+# read-only mount, a missing parent directory) — the entailment gap
+# ``security/sandbox/denial.py``'s own module comment already names. Two
+# gates now, not one: :func:`~reyn.security.sandbox.denial.looks_permission_
+# related` (reused verbatim from #5840/#5832 — not a second classifier for the
+# same question) gates the non-causal granted-range disclosure;
+# :func:`_looks_like_write_denial` (unchanged) still gates whether the
+# write_paths remedy is worth appending, worded conditionally ("if this IS the
+# cause") rather than asserted.
+_TOOL_CALL_PERMISSION_HINT = (
+    "\n\nHint (#5845): this looks permission-related (the error above may "
+    "name the exact path). reyn's sandbox ran this server with "
+    "subprocess={subprocess}, network={network}, write_paths={write_paths} "
+    "— the range reyn granted, not a diagnosis of this failure's cause (a "
+    "genuine non-sandbox permission error, e.g. a read-only mount or a "
+    "missing parent directory, reads identically)."
+)
+
+# #5845: the write_paths remedy, unchanged in substance from the pre-#5845
+# hint's own "two ways forward" — only its wording moved from asserted
+# ("this IS a sandbox denial") to conditional ("IF the sandbox's write scope
+# IS the cause"), and it now only ever appends onto _TOOL_CALL_PERMISSION_HINT
+# rather than standing alone. The zero-config option still goes FIRST per
+# #3009's original principle: the path that needs no declaration is the
+# recommendation, the grant is the documented deviation.
+_TOOL_CALL_WRITE_DENIAL_REMEDY = (
+    " If the sandbox's write scope IS the cause, two ways forward:\n"
     "  1. Pass a path INSIDE the server's working directory (a relative path "
     "like \"rag/docs.sqlite\" needs no configuration at all), or\n"
     "  2. Grant the location you want — add it to this server's `write_paths`:\n"
@@ -1697,8 +1722,9 @@ class MCPClient:
         return self._annotate_write_denial(_result_to_dict(result))
 
     def _annotate_write_denial(self, result: dict[str, Any]) -> dict[str, Any]:
-        """Append the ``write_paths`` hint to *result* when it carries a sandbox
-        write denial. Returns *result* unchanged otherwise (#3009).
+        """Append a permission-failure hint to *result* when it looks
+        permission-related. Returns *result* unchanged otherwise (#3009,
+        reworked #5845).
 
         Why HERE and not in ``_result_to_dict``: that helper is a pure flattener
         of the SDK's shape, and this is reyn's own diagnosis of a reyn-imposed
@@ -1712,6 +1738,12 @@ class MCPClient:
         only its config has a ``write_paths`` to point the operator at. Advice
         about a knob an http/sse server does not have would be a wrong turn.
 
+        #5845: two gates, not one — see :data:`_TOOL_CALL_PERMISSION_HINT`'s
+        own comment for why. ``looks_permission_related`` decides whether the
+        granted-range disclosure fires at all; ``_looks_like_write_denial``
+        (unchanged) decides only whether the write_paths remedy is ALSO worth
+        appending underneath it.
+
         The hint is APPENDED, unlike #2976's, which is deliberately prepended.
         That was forced by ``pool.describe_fault(limit=600)`` truncating an init
         error from the END; nothing truncates this path — a tool-error result is
@@ -1719,6 +1751,8 @@ class MCPClient:
         text block into the LLM's tool result whole. So the natural order stands:
         what happened, then what to do about it.
         """
+        from reyn.security.sandbox.denial import looks_permission_related
+
         if self._type != "stdio" or not result.get("isError"):
             return result
         content = result.get("content")
@@ -1728,11 +1762,18 @@ class MCPClient:
             item.get("text", "") for item in content
             if isinstance(item, dict) and item.get("type") == "text"
         )
-        if not _looks_like_write_denial(text):
+        if not looks_permission_related(text):
             return result
-        hint = _TOOL_CALL_WRITE_DENIAL_HINT.format(
-            server=self._server_name or "<server-name>",
+        policy = self._build_mcp_sandbox_policy()
+        hint = _TOOL_CALL_PERMISSION_HINT.format(
+            subprocess=not policy.deny_subprocess,
+            network=policy.network,
+            write_paths=list(policy.write_paths),
         )
+        if _looks_like_write_denial(text):
+            hint += _TOOL_CALL_WRITE_DENIAL_REMEDY.format(
+                server=self._server_name or "<server-name>",
+            )
         # A separate block, not an edit of the server's own text: the server's
         # message is data reyn relays, the hint is reyn's. Both reach the reader
         # either way (op_runtime joins them), so keep the provenance clean.

--- a/tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py
+++ b/tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py
@@ -8,9 +8,18 @@ handler, so it comes back as JSON-RPC tool-error content and stderr stays empty.
 What the operator saw was a bare sqlite error naming neither the sandbox nor the
 knob, i.e. the same silence #2976 existed to end, one layer down.
 
-These tests pin the invariant that closes it: **when the sandbox denies a write,
-the operator learns that it was a denial and what to do next.** They deliberately
-do not pin the hint's wording — only that the reader is pointed at the mechanism.
+These tests pin the invariant that closes it: **when a tool call fails in a way
+that looks permission-related, the operator learns what reyn's sandbox granted
+and, if the failure is write-shaped, what to do next.** They deliberately do
+not pin the hint's wording — only that the reader is pointed at the mechanism.
+
+#5845 update: the hint no longer ASSERTS the sandbox caused the failure (the
+same stderr/tool-error signature is identical whether the sandbox denied the
+write or a genuine non-sandbox permission error occurred inside the granted
+scope) — it discloses the granted range non-causally, and the write_paths
+remedy below is worded as "if this IS the cause". The word "sandbox" and the
+`write_paths` knob both still appear in the disclosure text, which is all
+this file's own assertions require.
 
 Two independent things have to hold for that, and each has its own test below,
 because each was separately observed to fail (both MEASURED under the real

--- a/tests/security/test_5845_mcp_tool_call_permission_hint.py
+++ b/tests/security/test_5845_mcp_tool_call_permission_hint.py
@@ -1,0 +1,135 @@
+"""Tier 2: #5845 -- MCPClient's TOOL-CALL permission hint states what reyn
+granted, never a causal claim about the sandbox. Sibling of #5840 (the
+init-failure hint), same fix shape, different channel.
+
+Owner-hit sibling, deliberately deferred out of #5840's own scope (filed as
+this issue): `_TOOL_CALL_WRITE_DENIAL_HINT`/`_annotate_write_denial` shared
+`_looks_like_write_denial` with the init-failure hint and made the identical
+causal overclaim in prose -- "this looks like reyn's MCP sandbox DENYING the
+server a write ... NOT a bug in the tool". Same entailment gap: the tool-error
+text ("[Errno 1] Operation not permitted: '<path>'") is IDENTICAL whether the
+sandbox denied the write or a genuine non-sandbox permission failure occurred
+INSIDE the granted scope (a read-only mount, a missing parent directory).
+
+Reused, not re-derived: `looks_permission_related` -- the SAME #5832/#5840
+gate -- decides whether disclosing what reyn granted is worth the sentence;
+it never classifies a cause. The narrower, Seatbelt-observed
+`_looks_like_write_denial` markers still gate the SPECIFIC write_paths
+remedy (unchanged), offered conditionally ("if this IS the cause"), never
+asserted.
+
+`_annotate_write_denial` is called directly against a real `MCPClient`
+instance (never spawned -- `_build_mcp_sandbox_policy` reads only
+`self._config`, no live process needed) with a synthetic tool-call `result`
+dict shaped exactly like the real, MEASURED payload
+(`test_3009_mcp_tool_call_write_denial_hint.py`'s own fixture text, reused
+here rather than re-typed) -- no mock, this is the real production method
+under test, driven at the dict-in/dict-out seam it naturally operates on
+(the channel this hint reads is already tool-result content, not a live
+process's stderr, so there is no OS-level event left to make real that
+`test_3009`'s own end-to-end test does not already cover).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from reyn.mcp.client import MCPClient
+
+# The exact tool-error text the real builtin vector-store server returned
+# through the real Seatbelt profile with a db_path outside its write scope
+# (test_3009_mcp_tool_call_write_denial_hint.py's own measured fixture).
+_DENIED_MKDIR_PAYLOAD = (
+    "Error calling tool 'upsert': [Errno 1] Operation not permitted: '/tmp/x/sub'"
+)
+# A non-write-shaped but still permission-related failure (EACCES, not the
+# Seatbelt-observed EPERM shape `_looks_like_write_denial` matches).
+_NON_WRITE_PERMISSION_PAYLOAD = "Error: [Errno 13] Permission denied: '/tmp/y'"
+# An ordinary, unrelated tool-call failure.
+_UNRELATED_PAYLOAD = "Error calling tool 'search': no such collection 'x'"
+
+
+def _error_result(text: str) -> dict[str, Any]:
+    return {"isError": True, "content": [{"type": "text", "text": text}]}
+
+
+def _client() -> MCPClient:
+    # Never initialized/spawned -- _annotate_write_denial and the sandbox
+    # policy builder it calls both read only __init__-time state.
+    return MCPClient({"type": "stdio", "command": "true"}, server_name="srv")
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return "\n".join(
+        item.get("text", "") for item in result["content"]
+        if isinstance(item, dict) and item.get("type") == "text"
+    )
+
+
+def test_write_shaped_denial_discloses_granted_range_and_offers_the_remedy() -> None:
+    """Tier 2: accept -- a write-shaped permission failure gets BOTH the
+    granted-range disclosure (subprocess/network/write_paths -- what reyn
+    actually granted) AND the conditionally-worded write_paths remedy."""
+    result = _client()._annotate_write_denial(_error_result(_DENIED_MKDIR_PAYLOAD))
+    text = _texts(result)
+    assert "#5845" in text
+    assert "network=" in text and "write_paths=" in text and "subprocess=" in text
+    assert "IS the cause" in text, f"remedy must be conditionally worded: {text!r}"
+    assert "write_paths: [" in text, f"expected the concrete remedy snippet: {text!r}"
+
+
+def test_hint_never_asserts_the_sandbox_caused_the_failure() -> None:
+    """Tier 2: accept (the acceptance this issue exists for) -- the hint
+    never states, as fact, that the sandbox denied anything; it discloses
+    what reyn granted and leaves causation open."""
+    result = _client()._annotate_write_denial(_error_result(_DENIED_MKDIR_PAYLOAD))
+    text = _texts(result).lower()
+    assert "sandbox denied" not in text and "denying the server" not in text, (
+        f"the hint must never assert causation it cannot prove: {text!r}"
+    )
+
+
+def test_non_write_permission_failure_gets_disclosure_but_no_write_paths_remedy() -> None:
+    """Tier 2: accept -- a permission-related failure that is NOT write-shaped
+    (EACCES, not the Seatbelt EPERM signature) still gets the granted-range
+    disclosure, but never the write-specific remedy: suggesting `write_paths`
+    for a failure that was never write-shaped would be a wrong-knob remedy,
+    not merely an unproven cause."""
+    result = _client()._annotate_write_denial(_error_result(_NON_WRITE_PERMISSION_PAYLOAD))
+    text = _texts(result)
+    assert "#5845" in text and "write_paths=" in text  # the disclosure still fires
+    assert "IS the cause" not in text and "write_paths: [" not in text, (
+        f"the write-specific remedy must not appear for a non-write-shaped "
+        f"failure: {text!r}"
+    )
+
+
+def test_unrelated_failure_gets_no_hint_at_all() -> None:
+    """Tier 2: control arm -- an ordinary, non-permission-shaped tool-call
+    failure gets neither the disclosure nor the remedy; the hint is not
+    noise on every unrelated error."""
+    original = _error_result(_UNRELATED_PAYLOAD)
+    result = _client()._annotate_write_denial(original)
+    assert result == original, "an unrelated failure must be returned unchanged"
+
+
+def test_a_successful_result_is_never_annotated() -> None:
+    """Tier 2: control arm -- the hint only ever attaches to isError results;
+    a successful call_tool result (even one whose text happens to mention a
+    permission word) passes through untouched."""
+    ok_result: dict[str, Any] = {
+        "isError": False,
+        "content": [{"type": "text", "text": "wrote to /tmp/x with no permission issue"}],
+    }
+    annotated = _client()._annotate_write_denial(ok_result)
+    assert annotated == ok_result
+
+
+def test_a_non_stdio_server_never_gets_the_hint() -> None:
+    """Tier 2: accept -- only a spawned stdio subprocess is sandboxed by
+    reyn, so only it has a write_paths knob to point the operator at; a
+    streamable-http server's identical-looking error must not get advice
+    about a knob it does not have."""
+    client = MCPClient({"type": "streamable-http", "url": "https://example.invalid/mcp"})
+    result = _error_result(_DENIED_MKDIR_PAYLOAD)
+    annotated = client._annotate_write_denial(result)
+    assert annotated == result


### PR DESCRIPTION
**[tui-coder]** — #5845: the tool-call sibling of #5840's fix, same shape, same reused gate.

Closes #5845

## What changed

`_TOOL_CALL_WRITE_DENIAL_HINT`/`_annotate_write_denial` (`src/reyn/mcp/client.py`) shared `_looks_like_write_denial` with the init-failure hint #5840 just fixed, and made the identical causal claim in prose: "this looks like reyn's MCP sandbox DENYING the server a write ... NOT a bug in the tool." Same entailment gap #5840 closed: the tool-error text (`[Errno 1] Operation not permitted: '<path>'`) is IDENTICAL whether the sandbox denied the write or a genuine non-sandbox permission failure occurred INSIDE the granted scope (a read-only mount, a missing parent directory).

I filed this issue myself during the #5840 investigation, deliberately deferred out of that PR's scope to keep it focused on the init-failure site alone.

## Correspondence with #5840 (merged, PR #5846)

| | #5840 (init-failure, `initialize()`) | #5845 (tool-call, `_annotate_write_denial`) |
|---|---|---|
| Channel | subprocess stderr | JSON-RPC tool-error content |
| Old causal claim | "the sandbox DENIED a write" | "reyn's MCP sandbox DENYING the server a write ... NOT a bug in the tool" |
| Gate 1 (disclosure) | `looks_permission_related(tail)` | `looks_permission_related(text)` — **same function, imported, not reinvented** |
| Gate 2 (remedy) | `_looks_like_write_denial(tail)` (unchanged) | `_looks_like_write_denial(text)` (unchanged) |
| New hint constant | `hint` (inline, init path) | `_TOOL_CALL_PERMISSION_HINT` |
| New remedy constant | inline (init path) | `_TOOL_CALL_WRITE_DENIAL_REMEDY` |
| Wording | "reyn ran this server with subprocess=…, network=…, write_paths=… — the range reyn granted, not a diagnosis" | same shape, "reyn's sandbox ran this server with subprocess=…, network=…, write_paths=…" |

`looks_permission_related` is genuinely reused (imported from `reyn.security.sandbox.denial`), not re-derived — the same acceptance point #5840's own brief required.

## Existing test kept honest, not rewritten

`tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py`'s real end-to-end test (`test_a_denied_tool_write_tells_the_operator_the_knob`) asserts `"sandbox" in seen.lower()` and `"write_paths" in seen`. The new wording keeps both words in the disclosure text (a write-shaped denial gets the disclosure AND the remedy), so **no assertion in that file needed to change** — only its docstring's own causal framing, which stated the pre-fix invariant ("when the sandbox denies a write...") and would otherwise now describe behavior the code no longer has (CLAUDE.md: a describing doc is stale the moment the mechanism changes).

## Test plan

- [x] `tests/security/test_5845_mcp_tool_call_permission_hint.py` — 6/6 green (new file: write-shaped disclosure+remedy, causal-claim absence, non-write-shaped disclosure-without-remedy, unrelated-failure no-op, success no-op, non-stdio no-op)
- [x] `tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py` — 7/9 green; the 2 red (`test_a_denied_tool_write_tells_the_operator_the_knob[dir-absent]`/`[dir-exists]`) fail identically on `main` before this change too (confirmed via `git stash`) — this venv is missing `fastmcp` server-support extras (`ImportError: FastMCP server support is not installed`), a pre-existing local infra gap, not a regression from this PR
- [x] `tests/security/test_5840_mcp_init_permission_hint.py`, `test_2976_mcp_sandbox_write_paths.py`, `tests/core/test_sandbox_denial_class_5244.py`, `test_sandbox_denial_class_2820.py` — 57/57 green + 5 skipped (enforcement-backend gated) across the scoped sweep
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_5845_mcp_tool_call_permission_hint.py tests/builtin/test_3009_mcp_tool_call_write_denial_hint.py` — 13/13, 0 errors (1 round of fixup: private-method-call-inline-in-assert → read into a variable first, this repo's own established convention)
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (199/208 baselined findings, no new)
- [x] `python scripts/check_fastmcp_import_boundary.py` (`src/reyn/mcp/CLAUDE.md` gate) — OK
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (baseline unchanged, `git add`-ed before running)
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK (baseline unchanged)
- [x] (skipped — Visual, standing waiver 2026-08-08)

## Falsification (manual, not committed)

Temporarily replaced the conditional remedy with a reasserted causal claim (`"the sandbox denied a write here, definitely."`) — confirmed `test_write_shaped_denial_discloses_granted_range_and_offers_the_remedy` and `test_hint_never_asserts_the_sandbox_caused_the_failure` both go red, then reverted with an Edit. `git stash`/`checkout`/`restore` not used for the falsify itself (only for a separate, pre-existing-failure baseline check, restored via `git stash apply <sha>` + `git stash drop <sha>` per the tagged-stash protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
