### PR TITLE
docs(FP-0069): owner rulings 2026-09-06 — network outside bounded's boundary (declared → silent, undeclared → ask), reviewed not now, floor vocabulary

### DIFF
--- a/docs/deep-dives/proposals/0069-permission-posture-dial.md
+++ b/docs/deep-dives/proposals/0069-permission-posture-dial.md
@@ -1,6 +1,6 @@
 # FP-0069: A permission posture dial — aligning reyn with the industry shape
 
-**Status**: partially ruled (owner 2026-09-06, verbatim 「ダイヤル入れる。宣言はoptin。3,4 解説して。あと plan モードは？」) — §2 and §5 are decided; §6 and the `reviewed` tier are open. See §10.
+**Status**: ruled (owner 2026-09-06, three verbatim rulings in §10) — §2 the dial, §5 opt-in declaration, §6.1 `bounded`'s boundary (network outside it: declared → silent, undeclared → **ask**), and `reviewed` (not now) are all decided. What remains is implementation, tracked on [#5825](https://github.com/tya5/reyn/issues/5825) (the network-ask seam design) and the FP's own acceptance (§8).
 **Proposed**: 2026-09-06
 **Author**: architect session
 **Track**: owner request 2026-09-06 —「reyn のパーミッションシステム仕様を業界標準に寄せたい」／「できるだけ寄せる案を作成できる？」
@@ -46,6 +46,8 @@ Make explicit what all four competitors have: **actions no mode grants.** reyn a
 
 Restated as a floor: **`unbounded` does not reach them either.** Hermes's hardline blocklist and OpenClaw's host floor are the precedent; Claude Code's is weaker here (`bypassPermissions` *does* write `.git`/`.claude`), so this is a place to follow the stricter two.
 
+**Floor vocabulary (architect ruling 2026-09-06, #5825 ③ / #5849 ②):** a per-axis `permissions.<axis>: deny` is floor language **only for an axis that has no other declaration** — `permissions.network: deny` qualifies (nothing else declares a subprocess's network; see §6.1). `permissions.exec: deny` does **not**: a tool is already floored by `CapabilityProfile.tool_deny: [exec]`, and a second declaration of the same axis is exactly the shape #5848 deleted. So `exec: deny` stays an unrecognized key (#5849 ③), not a floor entry.
+
 ## 4. What reyn keeps — every one of these is stricter than the standard and costs no UX
 
 - **The ledger's scope semantics** (actor / op / path + `agent:<name>` + inode identity re-checked per match, #5042 / #5052). No competitor has identity re-binding; Hermes has no per-path scope at all. This is what makes `ask` cheap — a correctly-scoped answer is given once.
@@ -68,7 +70,7 @@ Owner ruling #3901 (2026-06-05) set every non-`write` axis of `SandboxPolicy` to
 
 Competitors can delete the prompt precisely because their boundary is restrictive: Codex defaults network **off** and confines writes to the workspace; Claude Code merges `sandbox.filesystem` settings with Read/Edit deny rules and domain lists into one boundary, and only then does `autoAllowBashIfSandboxed` drop the prompt. **Deleting reyn's prompt against a compat-open boundary deletes the gate, not the friction.**
 
-**This is not a request to overturn #3901.** That ruling answers "what should a sandbox do behind an action the user already permitted." `bounded` asks a different question — "what may *replace* the permission question" — and the ruling's own rationale does not cover it. So `bounded` carries its **own** policy preset (write: workspace; network: deny unless declared; env/read: unchanged), leaving #3901's default in force wherever `sandboxed_exec` is launched outside the mode.
+**This is not a request to overturn #3901.** That ruling answers "what should a sandbox do behind an action the user already permitted." `bounded` asks a different question — "what may *replace* the permission question" — and the ruling's own rationale does not cover it. So `bounded` carries its **own** policy preset (write: workspace; network: **closed**, with leaving it a declaration-or-ask act — §6.1; env/read: unchanged), leaving #3901's default in force wherever `sandboxed_exec` is launched outside the mode.
 
 ### 6.1 What the preset actually has to close — the axis that decides it is **network**
 
@@ -77,18 +79,18 @@ Competitors can delete the prompt precisely because their boundary is restrictiv
 | Axis | In `bounded` | Why |
 |---|---|---|
 | **write** | workspace only (already the #3901 default) | unchanged |
-| 🔴 **network** | **deny unless declared** | The exfiltration path. If an unprompted command can reach the internet, the box has a hole and `bounded` is not a boundary — it is `unbounded` with a smaller write scope. This is exactly why Codex defaults network off. |
+| 🔴 **network** | **closed by the preset; crossing it is declared → silent, undeclared → ask** (owner ruling 2026-09-06, §10) | The exfiltration path. If an unprompted command can reach the internet, the box has a hole and `bounded` is not a boundary — it is `unbounded` with a smaller write scope. This is exactly why Codex defaults network off. The owner's ruling keeps the boundary and makes the crossing an **ask**, not a silent deny — §2's own `bounded` definition ("ask only for an action that would *leave* it"), applied to network. |
 | **subprocess** | open | A child inherits the same boundary (seccomp / Seatbelt bound the process tree), so it adds no reach. |
 | **env** | open | Safe **only because** network is closed: a command can read a secret but cannot send it. This is #1199's original argument, which `permission-model.md` records as having died when #3901 opened network — **under `bounded` it is restored**, because `bounded` closes network again. |
 | **read** | broad-allow | Unchanged; system paths are needed just to load a binary. |
 
 ⭕ **The preset already exists and is already correct.** `sandbox.mode: strict` (#3823) resolves exactly these defaults — `_SANDBOX_STRICT_MODE_DEFAULTS = {"network": False, "deny_subprocess": True, "allow_env_names": []}`, with `write` deliberately excluded (zeroing it would block the op's own workspace, per #3823's co-vet correction). **`bounded` does not need a new preset; it needs to select this one.**
 
-🔴 **But it is not wired**: no production caller passes `mode=` to `resolve_sandbox_policy` — see #5818. Setting `sandbox.mode: strict` today changes only a warning message, which calls itself "in force right now". **#5818 is therefore a prerequisite for `bounded`, and worth doing on its own merits regardless of this proposal.** With it done, §6's cost falls from "new enforcement work" to "the mode selects an existing key".
+~~🔴 But it is not wired~~ — **wired 2026-09-06** (#5818 → #5821: `resolve_sandbox_policy(..., mode=)` is now a required argument every production caller passes, and `sandbox.mode: strict` reaches the resolver). With that done, §6's cost fell from "new enforcement work" to "the mode selects an existing key" plus the ask seam below.
 
-**Where the declaration lands:** reyn already has the axis — `permissions.http.get: [{host: …}]`. So "deny unless declared" costs no new mechanism, and it gives §5's now-optional declaration **one place where it still earns its keep**: in `bounded`, declaring your hosts is what buys you a prompt-free workspace.
+**Where the declaration lands — corrected 2026-09-06:** an earlier draft of this paragraph pointed at `permissions.http.get: [{host: …}]`. That axis stays what it is — the per-host declaration + prompt for the LLM's own `web_fetch` tool (`require_http_get`), where the gate genuinely sees the host. It is **not** the declaration for a subprocess: no sandbox backend can scope a child process's network by host (Seatbelt is on/off for outbound, Linux carries the deny in the seccomp allowlist — Landlock has no network API — Docker is `--network none`), so a host list there would claim more than the boundary enforces. For `sandboxed_exec` the honest granularity is **boolean**: `permissions.network: allow` (config pre-approval) or a persisted ledger grant, and otherwise the **ask**. The seam — an explicit per-call `network` request on the exec op, one `require_network` check before spawn, ledger key `<actor>/sandbox.network/*`, operator-declared surfaces (hooks, MCP servers, `skill_install`) unchanged — is the architect ruling on [#5825](https://github.com/tya5/reyn/issues/5825) (2026-09-06). §5's now-optional declaration still earns its keep here: declaring network is what buys a prompt-free `bounded` workspace for commands that need it.
 
-**The alternative, stated so it is a choice and not an omission:** leaving network open in `bounded` is cheaper and needs no preset — but then `bounded` deletes prompts without adding a boundary, which is the one thing the measurement says the industry did **not** do.
+**The alternative, stated so it is a choice and not an omission (and not chosen — §10):** leaving network open in `bounded` is cheaper and needs no preset — but then `bounded` deletes prompts without adding a boundary, which is the one thing the measurement says the industry did **not** do.
 
 **Consequence for sequencing:** `read_only`, `ask` and `unbounded` are naming + wiring over machinery that exists. `bounded` is the only one that needs enforcement work, and it is also the one that produces most of the UX gain.
 
@@ -108,6 +110,8 @@ Today's behaviour is exactly `ask` **with** a mandatory declaration. So:
 - [ ] The floor (§3) is unreachable from `unbounded`, with a test that goes red if a mode is added that reaches it.
 - [ ] `mode: ask` on an existing project is byte-identical to today's behaviour apart from the declaration requirement.
 - [ ] `bounded` never runs an action outside its boundary without a prompt — the strip-falsifier is removing the boundary and watching the acceptance go red, not watching the prompt disappear.
+- [ ] In `bounded`, an exec that requests network with no declaration asks once; with `permissions.network: allow` or a ledger grant it passes silently; with `permissions.network: deny` it is refused without asking; an exec that does not request network is never asked (#5825's seven witnesses).
+- [ ] When the configured sandbox backend cannot enforce the network deny (`sandbox_policy_not_applied`), `bounded` is shown as degraded in the posture surface — a boundary that is not enforced is not silently called one.
 - [ ] Removing `unbounded` by config is possible, and a session cannot re-enable it.
 
 ## 9. `plan` is a phase, not a posture
@@ -126,12 +130,20 @@ Claude Code has `plan` on its mode dial. **This proposal deliberately does not**
 
 - **§2 the dial — ACCEPTED.**
 - **§5 the declaration becomes opt-in — ACCEPTED.**
-- §6 (`bounded`'s boundary) and the `reviewed` tier — **explanation requested, not ruled.** §6.1 and §2's `reviewed` paragraph are that explanation.
+- §6 (`bounded`'s boundary) and the `reviewed` tier — explanation requested at that point; ruled later the same day (below).
 - `plan` — answered in §9.
+
+**2026-09-06 (later), verbatim** 「**network は境界の外で良いよ。宣言 or ask で許可だよね？**」
+
+- **§6.1 `bounded`'s boundary — ACCEPTED with the crossing as an ask.** Network is outside the boundary; a declaration lets an exec cross it silently, and with no declaration the crossing is asked about — never a silent deny. The architect's earlier reading on #5838/#5825 ("undeclared → deny") was the wrong side of that choice and is corrected on #5825; the seam design lives there.
+
+**2026-09-06 (later), verbatim** 「**reviewed は今はいらない。今後入れる可能性はあるけどね。**」
+
+- **`reviewed` — NOT NOW.** The dial ships as `read_only` / `ask` / `bounded` / `unbounded`; the `reviewed` paragraph in §2 stays as the separable design so a later decision does not need a redesign.
 
 ## 9. Open questions — owner's, not this document's
 
 1. ~~Adopt the dial at all?~~ **Ruled: yes** (§10).
 2. ~~Make the declaration optional (§5)?~~ **Ruled: opt-in** (§10).
-3. **`bounded`'s boundary (§6.1)** — open. The axis that decides it is **network**: deny-unless-declared makes `bounded` a boundary, open makes it `unbounded` with a smaller write scope. Prerequisite #5818.
-4. **`reviewed` (§2)** — open, and independent of 1-3. It is the only element of this proposal that **adds** a trust assumption rather than removing one.
+3. ~~`bounded`'s boundary (§6.1)?~~ **Ruled: network is outside the boundary; crossing it is declared → silent, undeclared → ask** (§10, #5825). Prerequisite #5818 landed (#5821).
+4. ~~`reviewed` (§2)?~~ **Ruled: not now; the door stays open** (§10). It remains the only element of this proposal that **adds** a trust assumption rather than removing one, which is why it stays separable from the dial.


### PR DESCRIPTION
**[architect]** — FP-0069 (a proposal, mutable) brought to the owner's three rulings of 2026-09-06. part of #5825.

## What

`docs/deep-dives/proposals/0069-permission-posture-dial.md` only:

- **Status** → ruled; what remains is implementation (#5825's seam design) and §8.
- **§6 / §6.1** — network row: "deny unless declared" → "closed by the preset; crossing it is declared → silent, undeclared → **ask**" (owner verbatim in §10). The "declaration lands on `permissions.http.get`" paragraph is corrected: host lists belong to the LLM's `web_fetch` gate where the host is really seen; no sandbox backend can scope a subprocess's network by host, so for `sandboxed_exec` the honest declaration is boolean (`permissions.network: allow`) — seam design linked (#5825). The #5818 "not wired" block is struck through (landed as #5821).
- **§3** — floor vocabulary line: `permissions.network: deny` is floor language, `permissions.exec: deny` is not (tools are already floored by `tool_deny`; a second declaration of the same axis is what #5848 deleted) — the #5825 ③ / #5849 ② ruling.
- **§8** — two acceptance items: the network ask's seven witnesses; degraded posture display when the backend cannot enforce the deny.
- **§9 / §10** — open questions 3 and 4 closed with the verbatim rulings; the architect's earlier "undeclared → deny" reading is named as the wrong side and pointed at its correction on #5825.

## Gates

`mkdocs build --strict -f .mkdocs/mkdocs.yml` → built; `scripts/check_doc_anchors.py` → no dangling anchors; `scripts/check_retired_config_keys_denylist.py` → 0 hits. Run in this branch's worktree at `90ad2147f` + this file.

## Test plan

- [x] docs gates above — run, green
- [x] (skipped — Visual n/a, docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow
