### PR TITLE
fix(#5850): mechanically stop a local full-suite pytest run via a collection-count guard

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1198,6 +1198,13 @@ same thing, correctly, in about 5 minutes. If that trade stops being worth it
 more than expected), that's a reason to revisit this section, not a reason to
 silently start running the full suite locally again without updating it.
 
+**#5850: this is now mechanically enforced, not just stated here.**
+`tests/conftest.py`'s `pytest_collection_modifyitems` hook
+(`reyn.dev.testing.full_suite_guard`) aborts any LOCAL run that collects
+more than 300 items — a number a genuinely diff-scoped run never crosses
+and a full/near-full sweep always does — unless `CI`/`GITHUB_ACTIONS` is
+set (CI's own full run) or `REYN_FULL_SUITE_OK=1` is passed explicitly.
+
 1. **pytest, scoped to your diff** — run the tests your change actually
    touches, by file path or `-k <keyword>`, not the whole suite:
    ```bash

--- a/src/reyn/dev/testing/full_suite_guard.py
+++ b/src/reyn/dev/testing/full_suite_guard.py
@@ -65,10 +65,8 @@ WHY CI IS UNCONDITIONALLY EXEMPT
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
 #: See "THE NUMBER" above for the measured justification.
 FULL_SUITE_COLLECTION_CEILING = 300
@@ -91,14 +89,26 @@ def _override_is_set() -> bool:
     return bool(os.environ.get(OVERRIDE_ENV_VAR))
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(
-    session: "pytest.Session", config: "pytest.Config", items: "list[pytest.Item]",
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item],
 ) -> None:
     """#5850: abort the SESSION (not just this one file) the moment
     collection produces more items than a genuinely diff-scoped local run
     ever legitimately would. Runs after collection, before any test
     executes — the memory this exists to protect is never spent running
     tests that were about to be aborted anyway.
+
+    ``trylast=True``: pytest's OWN keyword/mark deselection (``-k``, ``-m``
+    — `_pytest.mark`'s own `pytest_collection_modifyitems` hookimpl) fires
+    at DEFAULT priority. Without ``trylast``, pluggy calls implementations
+    in reverse-registration order, and this one can run BEFORE that
+    deselection has trimmed `items` — measured directly: a `-k`-scoped run
+    that collected 50 and deselected 39 down to 11 still saw `len(items)
+    == 50` here, aborting a genuinely scoped run over a wide directory
+    (testing.md's own recommended `-k` form). `trylast` guarantees this
+    hook is the LAST `pytest_collection_modifyitems` to run, so `items`
+    reflects every other plugin's filtering, including `-k`/`-m`'s.
 
     ``pytest.exit`` (not a bare ``sys.exit``/raise) is pytest's own
     session-abort primitive — it prints the message given, sets the exit
@@ -107,8 +117,6 @@ def pytest_collection_modifyitems(
         return
     if len(items) <= FULL_SUITE_COLLECTION_CEILING:
         return
-    import pytest
-
     pytest.exit(
         f"BLOCKED by tests/conftest.py's #5850 collection guard: this "
         f"local run collected {len(items)} tests, over the "

--- a/src/reyn/dev/testing/full_suite_guard.py
+++ b/src/reyn/dev/testing/full_suite_guard.py
@@ -1,0 +1,123 @@
+"""Mechanically stop a local pytest run that collected a full-or-near-full
+suite (#5850) — CI's own full run is unaffected.
+
+WHY THIS EXISTS
+    "Run pytest scoped to your diff, not the full suite locally" is stated
+    three separate places (CLAUDE.md's own PR-workflow section, every
+    session's own brief, and the coding session's own acknowledgment of
+    that brief) and was broken twice by different sessions the SAME night
+    (2026-09-06), each one honestly believing what they had just typed
+    was "scoped" — a diff can span many files after a real refactor, and
+    counting files (not collected test items) does not catch that. The
+    owner's own development machine ran out of memory running two
+    full-shaped local suites at once and had to force-kill three
+    sessions (e2e-coder / tui-coder / architect) to recover it.
+
+    CLAUDE.md's own editing rule: "If CI can catch the violation, write
+    the gate, not a rule here." A broadcast, a written brief, and an
+    honest ack are all still WORDS — none of them can be strip-falsified,
+    and each was independently broken. This is the strip-falsifiable
+    version: a session that removes/bypasses this file (or reverts this
+    change) makes the incident's own recorded collection counts pass
+    again, immediately, in this repo's own test suite.
+
+THE NUMBER (measured, #5850's own incident data)
+    Every LOCAL run this incident's own `.pytest_cache` measurement
+    recovered was one of two shapes: a genuinely SCOPED run (a handful of
+    explicit files — 26 to 106 collected items across every scoped run
+    measured) or a wide "sweep" a session ran anyway, believing it was
+    still scoped (1,311 / 3,218 / 6,200 items post-ban; 8,203 / 8,177
+    pre-ban, from a "run the identical command against main" instruction
+    that itself produced a near-full collection). The full suite CI runs
+    is ~13.6k items. :data:`FULL_SUITE_COLLECTION_CEILING` (300) sits
+    strictly above every real scoped number this incident's own data
+    shows and strictly below every real sweep/full number — the boundary
+    a genuinely diff-scoped run can never accidentally cross, and a
+    "just a few more files" sweep can only cross on purpose, by setting
+    the override below first.
+
+THE OVERRIDE
+    One explicit, visible env var: :data:`OVERRIDE_ENV_VAR`
+    (``REYN_FULL_SUITE_OK=1``) — never a silent path through this gate.
+    Matches the SAME override name ``block_wide_pytest.sh`` (the
+    Claude-Code-harness-side gate for a bare/directory-shaped `pytest`
+    invocation) already uses, so a session that has learned one override
+    name has learned both.
+
+WHY A COLLECTION-COUNT GATE, NOT JUST THE EXISTING SHAPE-BASED ONE
+    ``block_wide_pytest.sh`` blocks a bare/directory-shaped command
+    (``pytest`` with no args, ``pytest tests/``) — a SHAPE check, blind
+    to a command that lists many EXPLICIT files (e.g. every file touched
+    by a large refactor) and still collects thousands of items. It also
+    lives in the Claude Code harness, one specific environment — this
+    gate lives in the repo's OWN ``tests/conftest.py``, so it fires for
+    ANY local invocation regardless of which environment ran it. The two
+    are complementary, not redundant: one catches the command's SHAPE,
+    this one catches what that command actually COLLECTED.
+
+WHY CI IS UNCONDITIONALLY EXEMPT
+    CI's own full run (``CI`` / ``GITHUB_ACTIONS`` env vars, set by
+    GitHub Actions itself, never by a local shell) is *supposed* to
+    collect everything — that is its entire job. This gate exists to
+    stop a LOCAL developer machine from doing CI's job on CI's own
+    memory budget.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+#: See "THE NUMBER" above for the measured justification.
+FULL_SUITE_COLLECTION_CEILING = 300
+
+#: See "THE OVERRIDE" above — the ONE escape hatch, explicit and visible
+#: in the command itself, never inferred.
+OVERRIDE_ENV_VAR = "REYN_FULL_SUITE_OK"
+
+#: Both are set by GitHub Actions itself (never by a local shell) — CI's
+#: own full run is unconditionally exempt, see "WHY CI IS UNCONDITIONALLY
+#: EXEMPT" above.
+_CI_ENV_VARS = ("CI", "GITHUB_ACTIONS")
+
+
+def _is_ci() -> bool:
+    return any(os.environ.get(name) for name in _CI_ENV_VARS)
+
+
+def _override_is_set() -> bool:
+    return bool(os.environ.get(OVERRIDE_ENV_VAR))
+
+
+def pytest_collection_modifyitems(
+    session: "pytest.Session", config: "pytest.Config", items: "list[pytest.Item]",
+) -> None:
+    """#5850: abort the SESSION (not just this one file) the moment
+    collection produces more items than a genuinely diff-scoped local run
+    ever legitimately would. Runs after collection, before any test
+    executes — the memory this exists to protect is never spent running
+    tests that were about to be aborted anyway.
+
+    ``pytest.exit`` (not a bare ``sys.exit``/raise) is pytest's own
+    session-abort primitive — it prints the message given, sets the exit
+    code, and unwinds cleanly without running a single test."""
+    if _is_ci() or _override_is_set():
+        return
+    if len(items) <= FULL_SUITE_COLLECTION_CEILING:
+        return
+    import pytest
+
+    pytest.exit(
+        f"BLOCKED by tests/conftest.py's #5850 collection guard: this "
+        f"local run collected {len(items)} tests, over the "
+        f"{FULL_SUITE_COLLECTION_CEILING}-item ceiling for a local run "
+        f"(CLAUDE.md: local pytest is scoped to your diff; the full suite "
+        f"runs in CI). Run pytest against EXPLICIT test file(s), not a "
+        f"wide sweep or a directory. If a wider local run is genuinely "
+        f"required, ask lead-coder first, then set "
+        f"{OVERRIDE_ENV_VAR}=1 (visible in the command) to override this "
+        f"once.",
+        returncode=1,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -647,12 +647,17 @@ def pytest_configure(config: pytest.Config) -> None:
     stall_dump.pytest_configure(config)
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: list[pytest.Item],
 ) -> None:
     # #5850: mechanically stop a local run that collected a full-or-near-
     # full suite — see that module's own docstring for the incident, the
-    # measured ceiling, and why CI is unconditionally exempt.
+    # measured ceiling, and why CI is unconditionally exempt. trylast=True:
+    # this hookimpl (the one pytest actually calls for a real local run)
+    # must see `items` AFTER -k/-m deselection has trimmed it, not before
+    # — see full_suite_guard.pytest_collection_modifyitems's own docstring
+    # for the measured false-abort this fixes.
     from reyn.dev.testing import full_suite_guard
 
     full_suite_guard.pytest_collection_modifyitems(session, config, items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -647,6 +647,17 @@ def pytest_configure(config: pytest.Config) -> None:
     stall_dump.pytest_configure(config)
 
 
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item],
+) -> None:
+    # #5850: mechanically stop a local run that collected a full-or-near-
+    # full suite — see that module's own docstring for the incident, the
+    # measured ceiling, and why CI is unconditionally exempt.
+    from reyn.dev.testing import full_suite_guard
+
+    full_suite_guard.pytest_collection_modifyitems(session, config, items)
+
+
 def pytest_runtest_setup(item: pytest.Item) -> None:
     from reyn.dev.testing import memory_ceiling, network_gate
 

--- a/tests/dev/test_5850_full_suite_collection_guard.py
+++ b/tests/dev/test_5850_full_suite_collection_guard.py
@@ -50,19 +50,28 @@ def _make_test_items(n: int) -> str:
     return "\n".join(f"def test_item_{i}():\n    assert True\n" for i in range(n))
 
 
+def _make_mixed_test_items(keep_n: int, drop_n: int) -> str:
+    # Two keyword-distinguishable groups, for a `-k`-scoped run to select
+    # only one of (testing.md's own recommended local-scoping form).
+    keep = "\n".join(f"def test_keep_{i}():\n    assert True\n" for i in range(keep_n))
+    drop = "\n".join(f"def test_drop_{i}():\n    assert True\n" for i in range(drop_n))
+    return f"{keep}\n{drop}\n"
+
+
 def _spawn_inner_pytest(
     pytester: pytest.Pytester,
     src_root: str,
-    n_items: int,
+    body: str,
     extra_env: dict[str, str],
+    extra_args: "list[str] | None" = None,
 ) -> subprocess.CompletedProcess[str]:
     pytester.makeconftest(_INNER_CONFTEST)
-    pytester.makepyfile(test_inner=_make_test_items(n_items))
+    pytester.makepyfile(test_inner=body)
     env = {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_VARS}
     env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
     env.update(extra_env)
     return subprocess.run(
-        [sys.executable, "-m", "pytest", "-q", "test_inner.py"],
+        [sys.executable, "-m", "pytest", "-q", *(extra_args or []), "test_inner.py"],
         cwd=pytester.path, env=env, capture_output=True, text=True,
     )
 
@@ -74,7 +83,8 @@ def test_over_ceiling_collection_aborts_the_session(
     no override, no CI env -> pytest.exit() aborts the session with a
     nonzero returncode and the guard's own message, before any test runs."""
     result = _spawn_inner_pytest(
-        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING + 1, {},
+        pytester, out_of_process_reyn,
+        _make_test_items(FULL_SUITE_COLLECTION_CEILING + 1), {},
     )
     assert result.returncode == 1
     assert _GUARD_MESSAGE_MARKER in result.stdout
@@ -86,7 +96,8 @@ def test_override_env_var_lets_an_over_ceiling_run_pass_through(
     """Tier 1: the SAME over-ceiling collection, with REYN_FULL_SUITE_OK=1
     set -> the guard steps aside and the session completes normally."""
     result = _spawn_inner_pytest(
-        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING + 1,
+        pytester, out_of_process_reyn,
+        _make_test_items(FULL_SUITE_COLLECTION_CEILING + 1),
         {OVERRIDE_ENV_VAR: "1"},
     )
     assert result.returncode == 0
@@ -100,7 +111,8 @@ def test_ci_env_lets_an_over_ceiling_run_pass_through(
     Actions itself sets it, never a local shell) -> unconditionally exempt,
     the session completes normally without needing the override too."""
     result = _spawn_inner_pytest(
-        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING + 1,
+        pytester, out_of_process_reyn,
+        _make_test_items(FULL_SUITE_COLLECTION_CEILING + 1),
         {"CI": "1"},
     )
     assert result.returncode == 0
@@ -114,7 +126,32 @@ def test_exactly_at_ceiling_passes_through_unmodified(
     items, no override, no CI env -> the <= comparison lets it through.
     Guards the off-by-one directly, not just "some number under it"."""
     result = _spawn_inner_pytest(
-        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING, {},
+        pytester, out_of_process_reyn,
+        _make_test_items(FULL_SUITE_COLLECTION_CEILING), {},
+    )
+    assert result.returncode == 0
+    assert _GUARD_MESSAGE_MARKER not in result.stdout
+
+
+def test_dash_k_deselection_narrows_below_the_ceiling_before_the_guard_checks(
+    pytester: pytest.Pytester, out_of_process_reyn: str,
+) -> None:
+    """Tier 1: #5868 co-vet BLOCKING -- a real bug this witnesses: measured
+    directly (a run that collected 50 and deselected 39 down to 11 still
+    had the guard read the RAW, pre-deselection count), the guard without
+    `trylast=True` sees `items` BEFORE `-k`'s own deselection has trimmed
+    it, so a genuinely diff-scoped `-k <keyword>` run (testing.md's own
+    recommended local-scoping form) over a wide directory could be
+    falsely aborted. Here: RAW collection is over the ceiling, but the
+    `-k keep`-selected count is not -- the run must pass, proving the
+    guard's own hookimpl (both in `full_suite_guard.py` and in
+    `tests/conftest.py`'s delegating wrapper) sees the POST-deselection
+    count, not the raw one."""
+    keep_n = FULL_SUITE_COLLECTION_CEILING - 50
+    drop_n = 100  # keep_n + drop_n > ceiling; keep_n alone <= ceiling
+    result = _spawn_inner_pytest(
+        pytester, out_of_process_reyn,
+        _make_mixed_test_items(keep_n, drop_n), {}, extra_args=["-k", "keep"],
     )
     assert result.returncode == 0
     assert _GUARD_MESSAGE_MARKER not in result.stdout

--- a/tests/dev/test_5850_full_suite_collection_guard.py
+++ b/tests/dev/test_5850_full_suite_collection_guard.py
@@ -1,0 +1,120 @@
+"""Tier 1: Contract — reyn.dev.testing.full_suite_guard, the #5850 local
+full-suite collection-count abort.
+
+Same style as tests/dev/test_stall_dump_4986.py: the guard's own
+``pytest_collection_modifyitems`` calls ``pytest.exit()``, which ends the
+session it fires in before a single test runs. Exercising that from
+pytester's in-process ``runpytest()`` would abort THIS file's own outer
+collection along with it, so every scenario below spawns a real
+``sys.executable -m pytest`` SUBPROCESS instead (never the in-process
+runner) against a throwaway inner test tree of N trivial items, loading
+ONLY ``reyn.dev.testing.full_suite_guard`` as a pytest plugin — not this
+repo's own tests/conftest.py, whose other fixtures assume this repo's real
+directory layout and would break inside pytester's throwaway rootdir.
+
+``out_of_process_reyn`` pins the spawned subprocess's ``PYTHONPATH`` to the
+SAME reyn checkout this test itself imports (#5028) — required whenever a
+test spawns a `sys.executable` subprocess importing `reyn` (the guard
+module lives under `reyn.dev.testing`, so every inner run needs it).
+
+The outer CI/GITHUB_ACTIONS env (genuinely set when THIS suite itself runs
+in CI) and any inherited override are stripped from every spawn's env
+below — each scenario needs to control those two inputs precisely, not
+inherit whatever the outer process happens to be running under.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from reyn.dev.testing.full_suite_guard import (
+    FULL_SUITE_COLLECTION_CEILING,
+    OVERRIDE_ENV_VAR,
+)
+
+pytest_plugins = ["pytester"]
+
+_INNER_CONFTEST = 'pytest_plugins = ["reyn.dev.testing.full_suite_guard"]\n'
+
+# The guard's own abort message (full_suite_guard.py) — the identifying
+# substring this test's "did it actually fire" checks key on.
+_GUARD_MESSAGE_MARKER = "BLOCKED by tests/conftest.py's #5850 collection guard"
+
+_STRIPPED_ENV_VARS = ("CI", "GITHUB_ACTIONS", OVERRIDE_ENV_VAR)
+
+
+def _make_test_items(n: int) -> str:
+    return "\n".join(f"def test_item_{i}():\n    assert True\n" for i in range(n))
+
+
+def _spawn_inner_pytest(
+    pytester: pytest.Pytester,
+    src_root: str,
+    n_items: int,
+    extra_env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    pytester.makeconftest(_INNER_CONFTEST)
+    pytester.makepyfile(test_inner=_make_test_items(n_items))
+    env = {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_VARS}
+    env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
+    env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "test_inner.py"],
+        cwd=pytester.path, env=env, capture_output=True, text=True,
+    )
+
+
+def test_over_ceiling_collection_aborts_the_session(
+    pytester: pytest.Pytester, out_of_process_reyn: str,
+) -> None:
+    """Tier 1: N+1 collected items (one over FULL_SUITE_COLLECTION_CEILING),
+    no override, no CI env -> pytest.exit() aborts the session with a
+    nonzero returncode and the guard's own message, before any test runs."""
+    result = _spawn_inner_pytest(
+        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING + 1, {},
+    )
+    assert result.returncode == 1
+    assert _GUARD_MESSAGE_MARKER in result.stdout
+
+
+def test_override_env_var_lets_an_over_ceiling_run_pass_through(
+    pytester: pytest.Pytester, out_of_process_reyn: str,
+) -> None:
+    """Tier 1: the SAME over-ceiling collection, with REYN_FULL_SUITE_OK=1
+    set -> the guard steps aside and the session completes normally."""
+    result = _spawn_inner_pytest(
+        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING + 1,
+        {OVERRIDE_ENV_VAR: "1"},
+    )
+    assert result.returncode == 0
+    assert _GUARD_MESSAGE_MARKER not in result.stdout
+
+
+def test_ci_env_lets_an_over_ceiling_run_pass_through(
+    pytester: pytest.Pytester, out_of_process_reyn: str,
+) -> None:
+    """Tier 1: the SAME over-ceiling collection, with CI=1 set (as GitHub
+    Actions itself sets it, never a local shell) -> unconditionally exempt,
+    the session completes normally without needing the override too."""
+    result = _spawn_inner_pytest(
+        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING + 1,
+        {"CI": "1"},
+    )
+    assert result.returncode == 0
+    assert _GUARD_MESSAGE_MARKER not in result.stdout
+
+
+def test_exactly_at_ceiling_passes_through_unmodified(
+    pytester: pytest.Pytester, out_of_process_reyn: str,
+) -> None:
+    """Tier 1: the boundary itself -- exactly FULL_SUITE_COLLECTION_CEILING
+    items, no override, no CI env -> the <= comparison lets it through.
+    Guards the off-by-one directly, not just "some number under it"."""
+    result = _spawn_inner_pytest(
+        pytester, out_of_process_reyn, FULL_SUITE_COLLECTION_CEILING, {},
+    )
+    assert result.returncode == 0
+    assert _GUARD_MESSAGE_MARKER not in result.stdout


### PR DESCRIPTION
**[e2e-coder]** — Closes #5850

## What

`tests/conftest.py`'s new `pytest_collection_modifyitems` hook
(`reyn.dev.testing.full_suite_guard`) mechanically aborts any **local**
pytest run that collects more than 300 items, unless `CI`/`GITHUB_ACTIONS`
is set (GitHub Actions itself) or `REYN_FULL_SUITE_OK=1` is passed
explicitly. `pytest.exit()` fires before a single test runs — the memory
this exists to protect is never spent running tests that were about to be
aborted anyway.

## Why (from the issue)

"Run pytest scoped to your diff, not the full suite locally" was stated in
three places (CLAUDE.md, every session's brief, each session's own
acknowledgment) and broken twice by different sessions the same night
(2026-09-06), each honestly believing a many-file diff was still "scoped."
The owner had to force-kill three sessions (e2e-coder/tui-coder/architect)
that night to recover the machine from the resulting memory exhaustion.

**300** sits strictly above every real scoped run the incident's own data
shows (26-106 items) and strictly below every real sweep/full run
(1,311-8,203 locally; ~13.6k in CI) — the ceiling a genuinely diff-scoped
run can never accidentally cross.

CLAUDE.md: *"If CI can catch the violation, write the gate, not a rule
here."* This closes that gap with the strip-falsifiable version.

## Files

- `src/reyn/dev/testing/full_suite_guard.py` (new) — the guard, with the
  incident's measured numbers in its own module docstring.
- `tests/conftest.py` — wires the hook in via this file's own
  delegate-to-a-submodule convention.
- `tests/dev/test_5850_full_suite_collection_guard.py` (new, 4 tests) —
  the gate's own test. Real `sys.executable -m pytest` subprocess spawns
  (never pytester's in-process runner — the guard's own `pytest.exit()`
  would otherwise abort the OUTER test session, not just the inner one
  under test), matching `tests/dev/test_stall_dump_4986.py`'s established
  pattern. Declares `out_of_process_reyn` (#5028 ratchet). Covers: N+1
  items aborts; exactly N (the boundary itself, off-by-one guard);
  `REYN_FULL_SUITE_OK=1` passes through; `CI=1` passes through.
- `docs/deep-dives/contributing/testing.md` — one line noting the "do not
  run the full suite locally" rule is now mechanically enforced, not just
  stated.

## CLAUDE.md's 3 questions

1. **Who stops this if it repeats?** The gate itself — `pytest.exit()`,
   mechanically, every local invocation.
2. **Visible with the shipped config?** N/A — dev-time only.
3. **Does the repair destroy the evidence?** No — `.pytest_cache` is
   untouched.

## Local gates (all green)

- `ruff check .`
- `python scripts/test_tier_audit.py --strict tests/dev/test_5850_full_suite_collection_guard.py`
- `python scripts/verify_module_docstrings.py src/reyn/dev/testing/full_suite_guard.py`
- `python scripts/mypy_ratchet.py`
- `python scripts/flat_tests_ratchet.py`
- `python scripts/check_tests_path_literal_reference.py`
- `pytest tests/dev/test_5850_full_suite_collection_guard.py -q` — 4 passed
- tests/-path: `check_bare_tests_import_reference.py`,
  `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`
- docs/-path: `mkdocs build --strict`, `check_doc_anchors.py`,
  `check_retired_config_keys_denylist.py`

## Test plan

- [x] `pytest tests/dev/test_5850_full_suite_collection_guard.py -q` — 4 passed locally
- [x] (skipped — CI runs the full matrix; not re-run locally per this repo's own rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
