### PR TITLE
fix(#5873): reyn.log rotation -- RotatingFileHandler + logs: config

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2172,6 +2172,23 @@ process_memory:
 
 Two independent facts, two keys — setting a cap does not itself turn on halting, and turning on halting requires a real, checkable cap. `process_footprint` / `process_footprint_unavailable` audit-events (`docs/reference/runtime/events.md`) record the measured value regardless of whether a cap or `enforce` is set at all — observe-only ships the observation.
 
+## `logs` block
+
+Size-based rotation for the interactive CUI's own log redirect, `.reyn/logs/reyn.log` (#5873, owner-hit: "放置してるだけで reyn.log 肥大化してシステム止まらないようにしてね" — reyn.log grew unbounded while idle). Same resource role as `history_resident`/`read_cap`/`process_memory` above: both fields are `Axis.BOUNDING`, bytes, model-independent. Reuses the stdlib `logging.handlers.RotatingFileHandler` rather than a second cron/purge mechanism — deterministic (cuts on bytes written, not a clock).
+
+```yaml
+logs:
+  max_bytes: 16777216   # 16 MiB — ceiling on the LIVE reyn.log before it rotates
+  backup_count: 4        # rotated generations kept (reyn.log.1 .. reyn.log.4)
+```
+
+| Field | Axis | Type | Default | Description |
+|---|---|---|---|---|
+| `max_bytes` | bounding | int | `16777216` (16 MiB) | Size, in bytes, at which the live `reyn.log` rotates to `reyn.log.1` and a fresh file starts. A non-positive or non-numeric value falls back to the default. |
+| `backup_count` | bounding | int | `4` | Number of rotated generations kept (`reyn.log.1` .. `reyn.log.<backup_count>`); the oldest is deleted once this is exceeded. A negative or non-numeric value falls back to the default. |
+
+Total on-disk footprint for `.reyn/logs/reyn.log*` is bounded by `max_bytes × (backup_count + 1)` — 80 MiB under the shipped defaults (see `reyn-dir-layout.md`'s own `logs/` entry). The defaults are provisional and owner-revisable, derived from #5870 stage 1's own per-episode stall-trace dump size (~10-20 KiB): one 16 MiB file holds roughly a thousand episodes, several days of idle-time WARNING traffic. Omitting the block keeps these defaults (behaviour unchanged from what ships).
+
 ## `image` block
 
 The fixed row height (in terminal rows/cells) every `present`-rendered inline image is shown at (#4474). Width is derived from this to preserve the image's real aspect ratio — `HalfBlockImage` (reyn's own image renderable, `interfaces/repl/present_renderer.py` — no third-party image-rendering dependency, #4474) takes an explicit width/height in cells with no aspect-ratio derivation of its own; passing a fixed height is what makes aspect-ratio-correct rendering possible at all.

--- a/docs/reference/runtime/reyn-dir-layout.md
+++ b/docs/reference/runtime/reyn-dir-layout.md
@@ -122,6 +122,23 @@ Everything else is excluded, by one of four reasons:
 │                           migrated into this once, on first touch, then inert history.
 ├── events/ traces/ logs/   AUDIT — append-only forensic record; never restored
 │   audit-trail/ tool-results/ media/
+│                           `logs/reyn.log` (#5873): the interactive CUI's
+│                           own log redirect target
+│                           (`_setup_interactive_logging`) is UNLIKE the
+│                           rest of this tier — it is size-ROTATED, not
+│                           append-forever, via a stdlib
+│                           `RotatingFileHandler`. Bounded by
+│                           `logs.max_bytes × (backup_count + 1)`
+│                           (`reyn.log` plus up to `backup_count` numbered
+│                           `reyn.log.N` generations), config-tunable —
+│                           see `reyn-yaml.md`'s own `logs:` block —
+│                           defaulting to 16 MiB × 5 = 80 MiB. Motivated
+│                           by an owner report of unbounded growth while
+│                           idle ("放置してるだけで reyn.log 肥大化して
+│                           システム止まらないようにしてね"); every OTHER
+│                           file under this bullet still grows unbounded
+│                           by design (a forensic record, not a rotated
+│                           log).
 │                           `media/` (#4478): flat `<file>` for a legacy
 │                           write with no agent identity, `<agent>/
 │                           <session_id>/<file>` for a real one (the

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -932,6 +932,21 @@
 
 
 # -----------------------------------------------------------------------------
+# logs: size-based rotation for the interactive CUI's own log redirect,
+# .reyn/logs/reyn.log (#5873, owner-hit: reyn.log grew unbounded while idle).
+# Same resource role as history_resident/read_cap/process_memory above —
+# bytes, model-independent. Reuses logging.handlers.RotatingFileHandler
+# rather than a second cron/purge mechanism. Omit the block to keep the
+# 16 MiB x 4 backups default below (80 MiB total); a non-positive/non-numeric
+# max_bytes, or a negative/non-numeric backup_count, falls back to that
+# default too.
+# -----------------------------------------------------------------------------
+# logs:
+#   max_bytes: 16777216   # 16 MiB — ceiling on the LIVE reyn.log before it rotates
+#   backup_count: 4        # rotated generations kept (reyn.log.1 .. reyn.log.4)
+
+
+# -----------------------------------------------------------------------------
 # image: the fixed row height (in terminal rows/cells) every present-rendered
 # inline image (reyn's own HalfBlockImage renderable, #4474) is shown at.
 # Width is derived from this to preserve the image's real aspect ratio —

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -614,6 +614,72 @@ class ProcessMemoryConfig:
     enforce: bool = field(default=False, metadata={"axis": Axis.BOUNDING})
 
 
+@dataclass
+class LogsConfig:
+    """`logs:` — #5873 (owner-hit, 2026-09-06: "放置してるだけで reyn.log
+    肥大化してシステム止まらないようにしてね"): size-based rotation for
+    `.reyn/logs/reyn.log`, ``Axis.BOUNDING``.
+
+    ``.reyn/logs/`` is `audit` tier (``reyn-dir-layout.md``: "write-only
+    record, never restored") — the SAME tier `events/` is, which already
+    has a #4479 purge. `logs/` had none: a bare `logging.basicConfig
+    (filename=...)` (a plain, unrotated `FileHandler`) writing WARNING
+    records from idle-time sources (MCP reconnect, the loop tripwire's
+    stall notice, asyncio's own exception handler) with no size ceiling —
+    the disk-side instance of ADR-0046's Falsification shape ("a
+    resource no band member bounds").
+
+    architect's ruling: size-based rotation, not a second cron/purge
+    mechanism — deterministic (cuts on bytes written, not a clock) and
+    reuses `logging.handlers.RotatingFileHandler` instead of adding new
+    machinery. ``max_bytes``/``backup_count`` are BOTH ``Axis.BOUNDING``
+    (same axis role as ``history_resident``/``process_memory`` above:
+    bytes, model-independent, config-driven).
+
+    **Defaults (provisional, owner-revisable — architect's own
+    disclosure)**: ``max_bytes=16 MiB``, ``backup_count=4`` (total ≤ 80
+    MiB). Derived from #5870 stage 1's own per-episode dump size (~10-20
+    KiB, one main thread) — one 16 MiB file holds roughly a thousand
+    episodes, several days of idle-time WARNING traffic — and 80 MiB
+    total is under 1% of the 10%-of-disk ceiling #4479 already permits
+    for `events/`, negligible on the owner's own machine (~194 GiB free,
+    ADR-0046) and unaffected by session count (rotation is per-process-
+    log, not per-session). Like ``process_footprint``'s own cap, these
+    numbers may be revised once real usage is measured — the point of
+    shipping a real default now is closing the *unbounded* gap, not
+    picking the perfect number on day one.
+    """
+    max_bytes: int = field(default=16 * 1024 * 1024, metadata={"axis": Axis.BOUNDING})  # 16 MiB
+    backup_count: int = field(default=4, metadata={"axis": Axis.BOUNDING})  # total <= max_bytes * 5
+
+
+def _build_logs_config(raw: object) -> "LogsConfig":
+    """Parse the `logs:` section (#5873).
+
+    Missing or malformed -> default (16 MiB / 4 backups) — same
+    discipline as ``_build_history_resident_config``: a typo must not
+    silently disable rotation (0/negative would rotate every write or
+    never rotate)."""
+    if not isinstance(raw, dict):
+        return LogsConfig()
+    defaults = LogsConfig()
+    max_bytes = raw.get("max_bytes", defaults.max_bytes)
+    try:
+        max_bytes = int(max_bytes)
+        if max_bytes <= 0:
+            max_bytes = defaults.max_bytes
+    except (TypeError, ValueError):
+        max_bytes = defaults.max_bytes
+    backup_count = raw.get("backup_count", defaults.backup_count)
+    try:
+        backup_count = int(backup_count)
+        if backup_count < 0:
+            backup_count = defaults.backup_count
+    except (TypeError, ValueError):
+        backup_count = defaults.backup_count
+    return LogsConfig(max_bytes=max_bytes, backup_count=backup_count)
+
+
 def _build_process_memory_config(raw: object) -> "ProcessMemoryConfig":
     """Parse the `process_memory:` section (#5851 stage (a)).
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -12,6 +12,7 @@ from reyn.config.chat import (  # #1682 #3 cross-section
     _build_cost_warn_config,
     _build_history_resident_config,
     _build_image_config,
+    _build_logs_config,
     _build_offload_config,
     _build_process_memory_config,
     _build_read_cap_config,
@@ -1228,6 +1229,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     read_cap = _build_read_cap_config(merged.get("read_cap"))
     history_resident = _build_history_resident_config(merged.get("history_resident"))
     process_memory = _build_process_memory_config(merged.get("process_memory"))
+    logs = _build_logs_config(merged.get("logs"))
     # #5416: known-key/malformed-value FAIL-OPEN rejections a builder
     # discovers while parsing — mutated in place by `_build_storage_config`
     # below, then merged into `unknown_config_keys_found` (same combined
@@ -1283,6 +1285,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         read_cap=read_cap,
         history_resident=history_resident,
         process_memory=process_memory,
+        logs=logs,
         image=image,
         tui=tui,
         web_fetch=_build_web_fetch_config(merged.get("web_fetch")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -28,6 +28,7 @@ from reyn.config.chat import (
     CostWarnConfig,
     HistoryResidentConfig,
     ImageConfig,
+    LogsConfig,
     OffloadConfig,
     ProcessMemoryConfig,
     ReadCapConfig,
@@ -241,6 +242,11 @@ class ReynConfig:
     # plumbing only, no halt (that's stage (c), after real
     # `process_footprint` data informs a default cap).
     process_memory: ProcessMemoryConfig = field(default_factory=ProcessMemoryConfig)
+    # #5873 (owner-hit): size-based rotation for .reyn/logs/reyn.log — bytes,
+    # config-driven, same Axis.BOUNDING role as history_resident/process_memory
+    # above. Default 16 MiB x 4 backups (80 MiB total); see LogsConfig's own
+    # docstring for the derivation.
+    logs: LogsConfig = field(default_factory=LogsConfig)
     # #4474: the fixed row-height (in cells) every present-rendered inline
     # image (reyn's own HalfBlockImage renderable) is shown at, so width
     # can be derived to preserve the image's real aspect ratio (see

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -359,32 +359,44 @@ def _setup_interactive_logging(project_root: Path) -> None:
     own warnings redirected.
 
     #5873 (owner-hit — "放置してるだけで reyn.log 肥大化してシステム止まら
-    ないようにしてね"): the handler is now a ``RotatingFileHandler``
-    (``_DEFAULT_LOG_MAX_BYTES``/``_DEFAULT_LOG_BACKUP_COUNT``), not a bare
-    unrotated ``FileHandler`` — ``.reyn/logs/`` is `audit` tier with no
+    ないようにしてね"): the handler is now a ``RotatingFileHandler``, not a
+    bare unrotated ``FileHandler`` — ``.reyn/logs/`` is `audit` tier with no
     ceiling otherwise (unlike `events/`, which #4479 already purges).
-    Installed with the hardcoded DEFAULTS here, not the real
-    ``reyn.yaml logs:`` config: this function runs BEFORE config load (see
-    this module's own call sites' comments — config-time WARNING records
-    must land in the file too), so the real config is not resolved yet.
+    Installed with ``LogsConfig()``'s own DATACLASS DEFAULTS here, not the
+    real ``reyn.yaml logs:`` config: this function runs BEFORE config load
+    (see this module's own call sites' comments — config-time WARNING
+    records must land in the file too), so the real, operator-configured
+    ``LogsConfig`` is not resolved yet — only the SHIPPED default is
+    available, and ``LogsConfig()`` (no args) IS that shipped default,
+    the one literal source #5851/FP-0069 §8 already require ("a default
+    stated in one place that a test reads") — architect co-vet finding,
+    #5873: an earlier version of this function duplicated the two numbers
+    as separate module-level constants, risking silent drift between them
+    and ``LogsConfig``'s own field defaults. ``from reyn.config.chat import
+    LogsConfig`` costs nothing extra here (measured): this module's own
+    top-level ``from ..invocation_context import InvocationContext``
+    already imports the whole ``reyn.config`` package, so it is fully
+    resident in ``sys.modules`` well before this function ever runs.
     ``_apply_logs_config`` (below) refines the already-installed handler's
-    ``maxBytes``/``backupCount`` in place once config IS available — the
-    handler's own class (a ``FileHandler`` subclass) never changes, so
-    existing readers that structurally detect it (``isinstance(handler,
-    logging.FileHandler)`` — ``litellm_bootstrap.py``, ``stall_trace.py``)
-    are unaffected either way.
+    ``maxBytes``/``backupCount`` in place once the REAL config IS
+    available — the handler's own class (a ``FileHandler`` subclass) never
+    changes, so existing readers that structurally detect it
+    (``isinstance(handler, logging.FileHandler)`` — ``litellm_bootstrap.py``,
+    ``stall_trace.py``) are unaffected either way.
     """
     from logging.handlers import RotatingFileHandler
 
+    from reyn.config.chat import LogsConfig
     from reyn.runtime import stall_trace
 
+    defaults = LogsConfig()
     log_dir = project_root / ".reyn" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / "reyn.log"
     handler = RotatingFileHandler(
         str(log_path),
-        maxBytes=_DEFAULT_LOG_MAX_BYTES,
-        backupCount=_DEFAULT_LOG_BACKUP_COUNT,
+        maxBytes=defaults.max_bytes,
+        backupCount=defaults.backup_count,
     )
     handler.setFormatter(
         logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
@@ -401,15 +413,6 @@ def _setup_interactive_logging(project_root: Path) -> None:
     # matches a hardcoded shape — see register_file_handler_path's own
     # docstring for why.
     stall_trace.register_file_handler_path(str(log_path))
-
-
-# #5873: mirrors reyn.config.chat.LogsConfig's own defaults — duplicated as
-# plain constants (not an import of LogsConfig itself) because
-# _setup_interactive_logging runs BEFORE reyn.yaml is loaded (see its own
-# docstring): there is no LogsConfig instance to read from yet at this
-# point, only a safe hardcoded floor _apply_logs_config refines later.
-_DEFAULT_LOG_MAX_BYTES = 16 * 1024 * 1024  # 16 MiB
-_DEFAULT_LOG_BACKUP_COUNT = 4
 
 
 def _apply_logs_config(logs_cfg: "LogsConfig") -> None:

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -11,12 +11,16 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reyn.interfaces.cli.env_backend import (
     build_environment_backend,
     register_env_backend_args,
 )
 from reyn.runtime.turn_origin import TurnOrigin
+
+if TYPE_CHECKING:
+    from reyn.config.chat import LogsConfig
 
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
@@ -353,16 +357,84 @@ def _setup_interactive_logging(project_root: Path) -> None:
     as the rest of this function — both of this module's two call sites
     are gated by it, so an embedder or non-interactive run never has its
     own warnings redirected.
+
+    #5873 (owner-hit — "放置してるだけで reyn.log 肥大化してシステム止まら
+    ないようにしてね"): the handler is now a ``RotatingFileHandler``
+    (``_DEFAULT_LOG_MAX_BYTES``/``_DEFAULT_LOG_BACKUP_COUNT``), not a bare
+    unrotated ``FileHandler`` — ``.reyn/logs/`` is `audit` tier with no
+    ceiling otherwise (unlike `events/`, which #4479 already purges).
+    Installed with the hardcoded DEFAULTS here, not the real
+    ``reyn.yaml logs:`` config: this function runs BEFORE config load (see
+    this module's own call sites' comments — config-time WARNING records
+    must land in the file too), so the real config is not resolved yet.
+    ``_apply_logs_config`` (below) refines the already-installed handler's
+    ``maxBytes``/``backupCount`` in place once config IS available — the
+    handler's own class (a ``FileHandler`` subclass) never changes, so
+    existing readers that structurally detect it (``isinstance(handler,
+    logging.FileHandler)`` — ``litellm_bootstrap.py``, ``stall_trace.py``)
+    are unaffected either way.
     """
+    from logging.handlers import RotatingFileHandler
+
+    from reyn.runtime import stall_trace
+
     log_dir = project_root / ".reyn" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "reyn.log"
+    handler = RotatingFileHandler(
+        str(log_path),
+        maxBytes=_DEFAULT_LOG_MAX_BYTES,
+        backupCount=_DEFAULT_LOG_BACKUP_COUNT,
+    )
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+    )
     logging.basicConfig(
-        filename=str(log_dir / "reyn.log"),
         level=logging.WARNING,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        handlers=[handler],
         force=True,  # safe: the interactive path has no prior logging setup
     )
     logging.captureWarnings(True)
+    # #5873 follow-up (architect, #5877 re-co-vet): declare the path
+    # directly rather than making stall_trace.find_file_handler_path()
+    # re-derive it by scanning root-logger handlers for one whose path
+    # matches a hardcoded shape — see register_file_handler_path's own
+    # docstring for why.
+    stall_trace.register_file_handler_path(str(log_path))
+
+
+# #5873: mirrors reyn.config.chat.LogsConfig's own defaults — duplicated as
+# plain constants (not an import of LogsConfig itself) because
+# _setup_interactive_logging runs BEFORE reyn.yaml is loaded (see its own
+# docstring): there is no LogsConfig instance to read from yet at this
+# point, only a safe hardcoded floor _apply_logs_config refines later.
+_DEFAULT_LOG_MAX_BYTES = 16 * 1024 * 1024  # 16 MiB
+_DEFAULT_LOG_BACKUP_COUNT = 4
+
+
+def _apply_logs_config(logs_cfg: "LogsConfig") -> None:
+    """#5873: refine the RotatingFileHandler ``_setup_interactive_logging``
+    already installed, once the real ``reyn.yaml logs:`` config is known.
+
+    Called right after config load, at the ONE call site that has a local
+    config to read (``_run_remote`` never loads one — no local reyn.yaml
+    concept applies to an attach-only session, so it stays on the
+    hardcoded defaults, unaffected). Mutates the handler's ``maxBytes``/
+    ``backupCount`` attributes in place rather than swapping the handler
+    out — replacing it would need to also re-run ``setFormatter`` and risk
+    a handler-identity change synchronization gap other readers rely on
+    (see ``_setup_interactive_logging``'s own docstring on why the class
+    itself, ``RotatingFileHandler`` — a ``logging.FileHandler`` subclass —
+    stays fixed regardless of config). A no-op when the interactive log
+    redirect was never installed (no ``RotatingFileHandler`` on the root
+    logger — e.g. ``--cui``/non-TTY runs, which never call
+    ``_setup_interactive_logging`` at all)."""
+    from logging.handlers import RotatingFileHandler
+
+    for handler in logging.root.handlers:
+        if isinstance(handler, RotatingFileHandler):
+            handler.maxBytes = logs_cfg.max_bytes
+            handler.backupCount = logs_cfg.backup_count
 
 
 def _run_remote(
@@ -553,6 +625,13 @@ def _run(args: argparse.Namespace) -> None:
 
     with _startup_stage("config"):
         session_cfg = InvocationContext.from_args(args)
+    # #5873: now that the real reyn.yaml `logs:` config is known, refine
+    # the RotatingFileHandler _setup_interactive_logging installed above
+    # (with hardcoded defaults) to the operator's own configured
+    # max_bytes/backup_count. A no-op when the log redirect was never
+    # installed (--cui / non-TTY runs).
+    if is_interactive:
+        _apply_logs_config(session_cfg.config.logs)
     # #3905: no per-surface startup credential check here (never was, since
     # #2708 P3.2b moved it onto the single LLM funnel) — and #3905 removed
     # that funnel-level pre-check too (an unnecessary hardcode, owner ruling).

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2441,6 +2441,25 @@ class TextualChatApp(App):
         destination was never a safe thing to attempt, in a test or
         anywhere else, so skipping it there costs nothing a real
         incident depended on.
+
+        **#5873 follow-up (architect co-vet finding)**: log rotation
+        (``RotatingFileHandler``) renames the path this fd was opened
+        against out from under it on every rollover — unlike a plain
+        churn-and-reuse of the fd NUMBER (the #5877 hazard above, which
+        this worker's self-opened fd is already immune to), a rollover
+        moves the underlying FILE the fd's own inode points at: ``.1``,
+        then ``.2``, and so on, until it is unlinked past
+        ``backup_count`` — permanently, not "one rollover behind" as an
+        earlier version of this docstring claimed (true only before this
+        module could ever rotate). Left unhandled, every dump after the
+        first rollover would write to an ever-more-stale, eventually
+        DELETED generation nobody reads. Each tick therefore compares
+        ``os.stat(path).st_ino`` (the CURRENT file at that path) against
+        ``os.fstat(_dump_fd).st_ino`` (what this fd still points at) —
+        deterministic, cut on the file identity changing, not a clock —
+        and on a mismatch: disarm, close the stale fd, and open a fresh
+        one against the same path before re-arming. A ``stat`` call
+        every :data:`~.loop_probe._TICK_SECONDS` (50 ms) is negligible.
         """
         import asyncio  # noqa: PLC0415
         import os  # noqa: PLC0415
@@ -2525,6 +2544,41 @@ class TextualChatApp(App):
                 last = now
                 stack_dumped: "bool | None" = None
                 if _dump_fd is not None:
+                    # `_dump_fd is not None` only ever became true inside
+                    # the `_log_path is not None` branch above, and
+                    # `_log_path` itself is never reassigned — so this
+                    # narrows `_log_path` for mypy the same way the
+                    # runtime invariant already guarantees it.
+                    assert _log_path is not None
+                    # #5873 follow-up (architect co-vet finding): a
+                    # rotation renames _log_path's file out from under
+                    # this fd (see this method's own docstring paragraph
+                    # above) — detect it via inode identity, deterministic
+                    # and cheap, and reopen against the CURRENT file
+                    # before re-arming, so a dump never lands in an
+                    # already-rotated-out (eventually unlinked)
+                    # generation nobody reads.
+                    try:
+                        stale = os.stat(_log_path).st_ino != os.fstat(_dump_fd).st_ino
+                    except OSError:
+                        stale = False
+                    if stale:
+                        _disarm_stall_trace()
+                        try:
+                            os.close(_dump_fd)
+                        except OSError:
+                            pass
+                        try:
+                            _dump_fd = os.open(
+                                _log_path, os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+                            )
+                        except OSError:
+                            logger.exception(
+                                "textual chat: could not reopen the tripwire's "
+                                "own stall-dump fd after a log rotation"
+                            )
+                            _dump_fd = None
+                if _dump_fd is not None:
                     # Re-arm for the NEXT wait immediately — cancels the
                     # pending one-shot from the wait that just ended (whether
                     # or not it already fired; faulthandler.cancel_dump_
@@ -2532,11 +2586,12 @@ class TextualChatApp(App):
                     # disarm's own docstring) and re-points it :data:
                     # `_STACK_DUMP_SECONDS` into the future, against the SAME
                     # self-opened fd every time (#5877 — never re-resolved,
-                    # see this method's own docstring for why). A tick that
-                    # lands on time always beats this deadline, so a healthy
-                    # loop never triggers a dump; one that doesn't land in
-                    # time leaves the PENDING timer to fire on its own,
-                    # mid-stall, on faulthandler's own OS thread.
+                    # see this method's own docstring for why), unless the
+                    # rotation check just above reopened it this very tick.
+                    # A tick that lands on time always beats this deadline,
+                    # so a healthy loop never triggers a dump; one that
+                    # doesn't land in time leaves the PENDING timer to fire
+                    # on its own, mid-stall, on faulthandler's own OS thread.
                     _arm_stall_trace(_STACK_DUMP_SECONDS, file=_dump_fd, repeat=False)
                     # Best-effort proxy for "did the dump above just fire" —
                     # see LoopTripwire.observe's own docstring for why this

--- a/src/reyn/runtime/stall_trace.py
+++ b/src/reyn/runtime/stall_trace.py
@@ -109,11 +109,47 @@ def stall_trace_seconds_from_env() -> "float | None":
     return seconds if seconds > 0 else None
 
 
+#: #5873 follow-up (architect, #5877 re-co-vet — "決定論側の改善...path 形状に
+#: 依存しない"): the registered ``.reyn/logs/reyn.log`` path, declared by
+#: ``chat.py``'s ``_setup_interactive_logging`` at the ONE moment it actually
+#: knows it (see :func:`register_file_handler_path`). ``None`` means no
+#: interactive log redirect is installed for this process.
+_registered_file_handler_path: "str | None" = None
+
+
+def register_file_handler_path(path: "str | None") -> None:
+    """Declare the path :func:`find_file_handler_path` should return.
+
+    Called by ``chat.py``'s ``_setup_interactive_logging`` right after it
+    installs the ``RotatingFileHandler`` (``path`` = its ``baseFilename``,
+    which stays fixed across every later rotation — a rollover renames the
+    file ON DISK and reopens a NEW one at this SAME path, never touching
+    the path itself). Pass ``None`` to declare "no handler installed"
+    explicitly (a test tearing one down should do this too, not just rely
+    on the default at import time — see this module's own test file for
+    the isolation pattern).
+
+    #5873 follow-up (architect, #5877 re-co-vet): replaces the PRE-#5873
+    version of :func:`find_file_handler_path`, which re-derived "is this
+    THE reyn.log handler" by scanning every root-logger handler and
+    matching its path against a hardcoded SHAPE (``.reyn/logs/reyn.log``)
+    each call — a heuristic good enough to see through pytest's own
+    ``/dev/null``-pointed ``FileHandler`` (measured directly, tui-coder's
+    own finding), but still a guess reconstructed from the outside. The
+    ONE place that knows the real path with certainty is the function that
+    just opened it — this makes that a declaration instead of something
+    every reader re-derives, and removes the "matches only THIS shape"
+    fragility entirely (a future reyn.log rename/relocation needs no
+    matching update here)."""
+    global _registered_file_handler_path
+    _registered_file_handler_path = path
+
+
 def find_file_handler_path() -> "str | None":
-    """The ``baseFilename`` of the root logger's own installed
-    ``FileHandler`` (``.reyn/logs/reyn.log``, when ``chat.py``'s
-    ``_setup_interactive_logging`` has run), or ``None`` when no such
-    handler is installed.
+    """The path :func:`register_file_handler_path` was last given (the
+    ``baseFilename`` of the root logger's installed ``RotatingFileHandler``,
+    ``.reyn/logs/reyn.log``, when ``chat.py``'s ``_setup_interactive_logging``
+    has run), or ``None`` when no interactive log redirect is installed.
 
     A READ-ONLY lookup — deliberately returns the PATH, never the
     handler's own ``stream``/``fileno()``. #5877 (architect finding,
@@ -139,26 +175,13 @@ def find_file_handler_path() -> "str | None":
     harmless, the dump is still readable, just possibly one rollover
     behind) and is never touched by anything else's open/close churn.
 
-    Matches ONLY a ``FileHandler`` whose own path ends in ``.reyn/logs/
-    reyn.log`` — never "any ``FileHandler``". Measured directly (a real
-    pytest run, not assumed): pytest's OWN logging plugin unconditionally
-    installs a ``logging.FileHandler`` SUBCLASS pointed at ``/dev/null``
-    on the root logger, for its own internal log-capture/routing — an
-    early, naive "first ``FileHandler`` wins" version of this function
-    picked up THAT handler instead of a test-installed reyn one (or,
-    absent one, armed against ``/dev/null`` rather than genuinely
-    skipping — silently defeating the "no stable destination -> no arm
-    at all" property this whole fix depends on). This path-shape check
-    is what makes pytest's own handler, and any other unrelated
-    ``FileHandler`` a future plugin might install, transparent to this
-    lookup."""
-    for handler in logging.getLogger().handlers:
-        if not isinstance(handler, logging.FileHandler):
-            continue
-        path = Path(handler.baseFilename)
-        if path.name == "reyn.log" and path.parts[-3:-1] == (".reyn", "logs"):
-            return handler.baseFilename
-    return None
+    #5873 follow-up: this used to scan ``logging.getLogger().handlers``
+    for a ``FileHandler`` whose path matched the ``.reyn/logs/reyn.log``
+    SHAPE (to see through pytest's own ``/dev/null``-pointed
+    ``FileHandler``, measured directly) — now a plain read of
+    :func:`register_file_handler_path`'s own declaration. See that
+    function's own docstring for why."""
+    return _registered_file_handler_path
 
 
 def default_log_stream():

--- a/src/reyn/runtime/stall_trace.py
+++ b/src/reyn/runtime/stall_trace.py
@@ -170,10 +170,22 @@ def find_file_handler_path() -> "str | None":
     (``os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT)``) and hold
     it for its own entire armed lifetime — a self-opened fd is immune to
     a HANDLER-side rotation reopen (it still points at the original
-    inode after the handler's own path is renamed out from under it;
-    the next rollover's writes simply land in the renamed file instead —
-    harmless, the dump is still readable, just possibly one rollover
-    behind) and is never touched by anything else's open/close churn.
+    inode after the handler's own path is renamed out from under it) and
+    is never touched by anything else's open/close churn.
+
+    #5873 follow-up (architect co-vet finding, corrects an earlier
+    version of this paragraph): the self-opened fd staying valid across
+    ONE rollover does NOT mean drift is harmless to leave unhandled — a
+    caller that stays armed and re-arms across MANY ticks (this module's
+    #5870 stage 1 dead-man's-switch caller, the one long-lived case this
+    paragraph is actually about) will see its fd's file renamed `.1`,
+    then `.2`, and so on every further rollover, until it is unlinked
+    past `backup_count` — PERMANENTLY, not "one rollover behind" as this
+    paragraph previously claimed (true only before this module could
+    ever rotate). Such a caller must detect the rename (compare
+    ``os.stat(path).st_ino`` against ``os.fstat(fd).st_ino`` each re-arm)
+    and reopen against the CURRENT file before re-arming — see
+    ``TextualChatApp._watch_loop_responsiveness`` for the implementation.
 
     #5873 follow-up: this used to scan ``logging.getLogger().handlers``
     for a ``FileHandler`` whose path matched the ``.reyn/logs/reyn.log``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,6 +550,44 @@ def _clear_find_project_root_cache() -> Iterator[None]:
     yield
     _find_project_root_uncached.cache_clear()
 
+
+@pytest.fixture(autouse=True)
+def _isolate_stall_trace_file_handler_registration() -> Iterator[None]:
+    """Save + restore ``reyn.runtime.stall_trace``'s registered log-handler
+    path around every test (#5873 follow-up, #5879 CI finding).
+
+    ``stall_trace.register_file_handler_path`` declares a SINGLE process-
+    global path (set by ``chat.py``'s ``_setup_interactive_logging``, the
+    one production writer) — any test that calls
+    ``_setup_interactive_logging`` directly (5 files across ``tests/``, at
+    last count: ``test_litellm_lazy_load.py``, ``test_loop_probe_3539.py``,
+    ``test_3671_stall_trace_startup_wiring.py``,
+    ``test_config_warning_chrome_4194.py``,
+    ``test_inline_interactive_logging.py``) mutates this SAME global.
+
+    Measured (CI, 2026-09-06): `test_first_use_routes_litellm_logger_to_
+    file_not_console` (`test_litellm_lazy_load.py`) called
+    ``_setup_interactive_logging`` and never restored the registration —
+    under xdist, whichever LATER test happened to land on the same worker
+    and asserted the OTHER premise (``find_file_handler_path() is None``,
+    e.g. ``test_the_tripwire_never_arms_without_a_file_handler``) then
+    failed on a leaked path from a wholly unrelated test file. 3.11 passed
+    by luck (a different worker-assignment order); 3.12 did not.
+
+    Folding this into ONE autouse fixture here — rather than adding a 6th,
+    7th, ... manual save/restore block to each individual test that calls
+    ``_setup_interactive_logging`` — closes the CLASS of hole (any CURRENT
+    or FUTURE caller of ``_setup_interactive_logging``/
+    ``register_file_handler_path`` anywhere in ``tests/``), matching
+    ``_isolate_rich_style_ansi_memo``/``_isolate_budget_limit_context``
+    above: process-global state a test can set is this file's own
+    responsibility to isolate, not each individual test's."""
+    from reyn.runtime import stall_trace
+
+    saved = stall_trace.find_file_handler_path()
+    yield
+    stall_trace.register_file_handler_path(saved)
+
 # ── Marker registration ────────────────────────────────────────────────────────
 
 

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -55,17 +55,30 @@ def installed_file_handler(tmp_path: Path):
     installs its own ``logging.FileHandler`` subclass pointed at
     ``/dev/null`` on the root logger — a bare ``tmp_path / "reyn.log"``
     here would sit BEHIND that pytest-owned handler in the lookup order
-    and never be the one this fixture's own callers actually want)."""
+    and never be the one this fixture's own callers actually want).
+
+    #5873 follow-up: ``find_file_handler_path`` no longer scans
+    ``handlers`` for a path-shape match — it returns whatever was last
+    declared via ``stall_trace.register_file_handler_path``. This
+    fixture bypasses ``_setup_interactive_logging`` (the one production
+    caller of that registration function), so it must register the path
+    itself, and restore the PRIOR registration on teardown rather than
+    unconditionally clearing it — a leaked registration must not survive
+    into a later test, but nor may this fixture assume it is the only
+    registrant during its own lifetime."""
     log_dir = tmp_path / ".reyn" / "logs"
     log_dir.mkdir(parents=True)
     log_path = log_dir / "reyn.log"
     handler = logging.FileHandler(str(log_path))
     logging.getLogger().addHandler(handler)
+    saved_registered_path = stall_trace._registered_file_handler_path
+    stall_trace.register_file_handler_path(str(log_path))
     try:
         yield log_path
     finally:
         logging.getLogger().removeHandler(handler)
         handler.close()
+        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -71,7 +71,7 @@ def installed_file_handler(tmp_path: Path):
     log_path = log_dir / "reyn.log"
     handler = logging.FileHandler(str(log_path))
     logging.getLogger().addHandler(handler)
-    saved_registered_path = stall_trace._registered_file_handler_path
+    saved_registered_path = stall_trace.find_file_handler_path()
     stall_trace.register_file_handler_path(str(log_path))
     try:
         yield log_path
@@ -251,6 +251,87 @@ async def test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists(
             "the armed fd does not point at the installed FileHandler's "
             "own baseFilename"
         )
+
+
+@pytest.mark.asyncio
+async def test_the_tripwire_reopens_its_fd_after_a_log_rotation(monkeypatch, tmp_path: Path) -> None:
+    """Tier 2: #5873 co-vet finding (architect 🔴-1) — a ``RotatingFileHandler``
+    rollover renames the path this worker's self-opened fd points at
+    (``reyn.log`` -> ``reyn.log.1``, then ``.2``, ...), eventually UNLINKING
+    it past ``backup_count`` — PERMANENTLY, not "one rollover behind" as an
+    earlier version of ``find_file_handler_path``'s own docstring claimed
+    (true only before this module could ever rotate, #5877). Left
+    unhandled, every dump after the first rollover this worker's fd
+    survives writes to an ever-more-stale, eventually deleted generation
+    nobody reads.
+
+    Each tick now compares ``os.stat(path).st_ino`` (the file currently AT
+    that path) against ``os.fstat(fd).st_ino`` (what this worker's fd still
+    points at) and, on a mismatch, disarms + closes + reopens against the
+    CURRENT file before re-arming — deterministic (cut on file identity,
+    not a clock).
+
+    Drives the rollover directly (``handler.doRollover()``, real production
+    API, not a simulated size threshold), then waits UNBOUNDED for the
+    worker's own next ``arm()`` call to carry a fd whose inode matches the
+    POST-rollover file (testing policy: wait on the condition, never a
+    fixed tick count — CI's own ``--timeout=120`` is the ceiling). strip
+    (recorded during this fix): removing the inode-comparison block in
+    ``_watch_loop_responsiveness`` leaves every later ``arm()`` call's fd
+    permanently pointing at the pre-rollover (renamed) generation, so this
+    assertion never becomes true and the test times out."""
+    from logging.handlers import RotatingFileHandler
+
+    monkeypatch.delenv("REYN_STALL_TRACE", raising=False)
+
+    log_dir = tmp_path / ".reyn" / "logs"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "reyn.log"
+    # backupCount >= 1 is load-bearing for this test's own premise:
+    # RotatingFileHandler.doRollover() with backupCount == 0 just closes
+    # and reopens the SAME path with no rename, which keeps the SAME
+    # inode — no rotation for this test to detect at all.
+    handler = RotatingFileHandler(str(log_path), maxBytes=1, backupCount=2)
+    logging.getLogger().addHandler(handler)
+    saved_registered_path = stall_trace.find_file_handler_path()
+    stall_trace.register_file_handler_path(str(log_path))
+
+    calls: "list[tuple[float, object, bool | None]]" = []
+    monkeypatch.setattr(
+        stall_trace, "arm",
+        lambda seconds, **kw: calls.append((seconds, kw.get("file"), kw.get("repeat"))),
+    )
+    monkeypatch.setattr(stall_trace, "disarm", lambda: None)
+
+    try:
+        app = TextualChatApp(transport=QueueTransport())
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert calls, (
+                "the tripwire's own worker never armed the dead-man's "
+                "switch before this test could even drive a rotation"
+            )
+            pre_ino = os.fstat(calls[-1][1]).st_ino  # type: ignore[arg-type]
+            assert pre_ino == log_path.stat().st_ino, (
+                "setup: the worker's own arm() fd must start out pointing "
+                "at the installed handler's own path"
+            )
+
+            handler.doRollover()
+            post_ino = log_path.stat().st_ino
+            assert post_ino != pre_ino, (
+                "setup: doRollover() must produce a NEW inode at the same "
+                "path (backupCount=2 makes this a rename, not a truncate) "
+                "for this test's own premise to hold"
+            )
+
+            while os.fstat(calls[-1][1]).st_ino != post_ino:  # type: ignore[arg-type]
+                await pilot.pause()
+    finally:
+        logging.getLogger().removeHandler(handler)
+        handler.close()
+        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -62,23 +62,22 @@ def installed_file_handler(tmp_path: Path):
     declared via ``stall_trace.register_file_handler_path``. This
     fixture bypasses ``_setup_interactive_logging`` (the one production
     caller of that registration function), so it must register the path
-    itself, and restore the PRIOR registration on teardown rather than
-    unconditionally clearing it — a leaked registration must not survive
-    into a later test, but nor may this fixture assume it is the only
-    registrant during its own lifetime."""
+    itself — restoring the PRIOR registration on teardown is
+    `tests/conftest.py`'s own `_isolate_stall_trace_file_handler_
+    registration` autouse fixture's job now (CI finding, 2026-09-06: a
+    6th hand-rolled save/restore here would be the exact per-test
+    duplication that fixture's own docstring says to stop adding)."""
     log_dir = tmp_path / ".reyn" / "logs"
     log_dir.mkdir(parents=True)
     log_path = log_dir / "reyn.log"
     handler = logging.FileHandler(str(log_path))
     logging.getLogger().addHandler(handler)
-    saved_registered_path = stall_trace.find_file_handler_path()
     stall_trace.register_file_handler_path(str(log_path))
     try:
         yield log_path
     finally:
         logging.getLogger().removeHandler(handler)
         handler.close()
-        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 @pytest.mark.asyncio
@@ -293,7 +292,10 @@ async def test_the_tripwire_reopens_its_fd_after_a_log_rotation(monkeypatch, tmp
     # inode — no rotation for this test to detect at all.
     handler = RotatingFileHandler(str(log_path), maxBytes=1, backupCount=2)
     logging.getLogger().addHandler(handler)
-    saved_registered_path = stall_trace.find_file_handler_path()
+    # Registration restore is tests/conftest.py's own autouse
+    # _isolate_stall_trace_file_handler_registration fixture's job — see
+    # installed_file_handler's own docstring above for why this file no
+    # longer hand-rolls it per test.
     stall_trace.register_file_handler_path(str(log_path))
 
     calls: "list[tuple[float, object, bool | None]]" = []
@@ -331,7 +333,6 @@ async def test_the_tripwire_reopens_its_fd_after_a_log_rotation(monkeypatch, tmp
     finally:
         logging.getLogger().removeHandler(handler)
         handler.close()
-        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_inline_interactive_logging.py
+++ b/tests/interfaces/test_inline_interactive_logging.py
@@ -16,6 +16,14 @@ real-litellm-use chokepoint).
 ようにしてね"): the handler installed here is now a size-bounded
 ``RotatingFileHandler``, not a bare unrotated ``FileHandler``. The tests
 below pin the 5 acceptance witnesses from that fix.
+
+#5873 follow-up (CI finding, 2026-09-06): `_setup_interactive_logging` also
+registers its handler's path with `reyn.runtime.stall_trace` — a process-
+global this file's own tests used to save/restore individually, per test.
+That is now handled once, for every test in the whole suite, by
+`tests/conftest.py`'s `_isolate_stall_trace_file_handler_registration`
+autouse fixture — see its own docstring for the CI failure that motivated
+folding it there instead of adding a 6th per-test block here.
 """
 from __future__ import annotations
 
@@ -34,11 +42,8 @@ from tests._support.paths import REPO_ROOT
 
 def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
     """Tier 2: a WARNING record lands in .reyn/logs/reyn.log, not on stderr."""
-    from reyn.runtime import stall_trace
-
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -61,11 +66,6 @@ def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
-        # #5873 follow-up: _setup_interactive_logging now also registers its
-        # handler's path with stall_trace (a FOURTH piece of process-global
-        # state) — left uncleared here, this leaks into other test files
-        # that assert stall_trace.find_file_handler_path() is None.
-        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
@@ -92,11 +92,8 @@ def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
     already having triggered this exact warning can't make it silently not
     fire here.
     """
-    from reyn.runtime import stall_trace
-
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -117,7 +114,6 @@ def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
-        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 # ── #5873: size-based rotation (5 acceptance witnesses) ─────────────────────
@@ -130,11 +126,8 @@ def test_small_max_bytes_rotates_and_bounds_the_live_file(tmp_path) -> None:
     RotatingFileHandler to a bare FileHandler (this fix's own before-state)
     never produces a .1 file and lets reyn.log grow past max_bytes freely
     (verified during this fix)."""
-    from reyn.runtime import stall_trace
-
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         _apply_logs_config(LogsConfig(max_bytes=4096, backup_count=2))
@@ -154,7 +147,6 @@ def test_small_max_bytes_rotates_and_bounds_the_live_file(tmp_path) -> None:
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
-        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 def test_backup_count_bounds_total_disk_usage(tmp_path) -> None:
@@ -162,11 +154,8 @@ def test_backup_count_bounds_total_disk_usage(tmp_path) -> None:
     deleted (never reyn.log.<backup_count+1>), and the total on-disk size
     across reyn.log + every reyn.log.N stays <= max_bytes *
     (backup_count + 1)."""
-    from reyn.runtime import stall_trace
-
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         _apply_logs_config(LogsConfig(max_bytes=2048, backup_count=2))
@@ -187,7 +176,6 @@ def test_backup_count_bounds_total_disk_usage(tmp_path) -> None:
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
-        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 def test_no_bare_basicconfig_filename_call_remains_in_src() -> None:
@@ -250,7 +238,6 @@ def test_existing_file_handler_readers_still_find_the_rotating_handler(
 
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -266,4 +253,3 @@ def test_existing_file_handler_readers_still_find_the_rotating_handler(
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
-        stall_trace.register_file_handler_path(saved_registered_path)

--- a/tests/interfaces/test_inline_interactive_logging.py
+++ b/tests/interfaces/test_inline_interactive_logging.py
@@ -11,19 +11,34 @@ no longer imports litellm — see `test_litellm_lazy_load.py` for the
 sys.modules-clean-at-startup proof and the moved #2929 log-routing tests
 (now targeting `reyn.llm.litellm_bootstrap.ensure_litellm_ready`, the first-
 real-litellm-use chokepoint).
+
+#5873 (owner-hit — "放置してるだけで reyn.log 肥大化してシステム止まらない
+ようにしてね"): the handler installed here is now a size-bounded
+``RotatingFileHandler``, not a bare unrotated ``FileHandler``. The tests
+below pin the 5 acceptance witnesses from that fix.
 """
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
 import warnings
 
-from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+from reyn.config.chat import LogsConfig
+from reyn.interfaces.cli.commands.chat import (
+    _apply_logs_config,
+    _setup_interactive_logging,
+)
+from tests._support.paths import REPO_ROOT
 
 
 def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
     """Tier 2: a WARNING record lands in .reyn/logs/reyn.log, not on stderr."""
+    from reyn.runtime import stall_trace
+
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
+    saved_registered_path = stall_trace._registered_file_handler_path
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -46,6 +61,11 @@ def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
+        # #5873 follow-up: _setup_interactive_logging now also registers its
+        # handler's path with stall_trace (a FOURTH piece of process-global
+        # state) — left uncleared here, this leaks into other test files
+        # that assert stall_trace.find_file_handler_path() is None.
+        stall_trace.register_file_handler_path(saved_registered_path)
 
 
 def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
@@ -72,8 +92,11 @@ def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
     already having triggered this exact warning can't make it silently not
     fire here.
     """
+    from reyn.runtime import stall_trace
+
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
+    saved_registered_path = stall_trace._registered_file_handler_path
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -94,3 +117,153 @@ def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
+        stall_trace.register_file_handler_path(saved_registered_path)
+
+
+# ── #5873: size-based rotation (5 acceptance witnesses) ─────────────────────
+
+
+def test_small_max_bytes_rotates_and_bounds_the_live_file(tmp_path) -> None:
+    """Tier 2: #5873 accept ① — a small configured max_bytes, written past
+    repeatedly, produces a rotated reyn.log.1 AND keeps the LIVE reyn.log
+    from growing past max_bytes without bound. strip: reverting the
+    RotatingFileHandler to a bare FileHandler (this fix's own before-state)
+    never produces a .1 file and lets reyn.log grow past max_bytes freely
+    (verified during this fix)."""
+    from reyn.runtime import stall_trace
+
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    saved_registered_path = stall_trace._registered_file_handler_path
+    try:
+        _setup_interactive_logging(tmp_path)
+        _apply_logs_config(LogsConfig(max_bytes=4096, backup_count=2))
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+        logger = logging.getLogger("reyn.rotation_test")
+        # ~60 bytes/record with the timestamp+level prefix; 400 records is
+        # ~24 KiB unrotated — several multiples of the 4 KiB cap, so a
+        # genuinely bounded file (not just "happens to be small this run")
+        # is the only way to stay under it.
+        for i in range(400):
+            logger.warning("x" * 50 + f" line {i}")
+        for h in root.handlers:
+            h.flush()
+        assert (tmp_path / ".reyn" / "logs" / "reyn.log.1").exists()
+        assert log_file.stat().st_size < 4096 * 2
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        stall_trace.register_file_handler_path(saved_registered_path)
+
+
+def test_backup_count_bounds_total_disk_usage(tmp_path) -> None:
+    """Tier 2: #5873 accept ② — old rotated files beyond backup_count are
+    deleted (never reyn.log.<backup_count+1>), and the total on-disk size
+    across reyn.log + every reyn.log.N stays <= max_bytes *
+    (backup_count + 1)."""
+    from reyn.runtime import stall_trace
+
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    saved_registered_path = stall_trace._registered_file_handler_path
+    try:
+        _setup_interactive_logging(tmp_path)
+        _apply_logs_config(LogsConfig(max_bytes=2048, backup_count=2))
+        logger = logging.getLogger("reyn.rotation_test2")
+        # Enough volume to roll past backup_count+1 generations several
+        # times over (2000 records * ~60 bytes ~= 120 KiB, vs a 6 KiB cap).
+        for i in range(2000):
+            logger.warning("y" * 50 + f" line {i}")
+        for h in root.handlers:
+            h.flush()
+        log_dir = tmp_path / ".reyn" / "logs"
+        assert not (log_dir / "reyn.log.3").exists()
+        total = sum(f.stat().st_size for f in log_dir.glob("reyn.log*"))
+        # (backup_count + 1) capped files, plus slack for the live file's
+        # own in-flight overshoot (see the previous test's own margin).
+        assert total <= 2048 * 3 + 2048
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        stall_trace.register_file_handler_path(saved_registered_path)
+
+
+def test_no_bare_basicconfig_filename_call_remains_in_src() -> None:
+    """Tier 2: #5873 accept ③ — exactly one function
+    (``_setup_interactive_logging``) installs the interactive log
+    redirect, at both of this module's own call sites; no bare
+    ``logging.basicConfig(filename=...)`` CALL (the un-rotated shape this
+    fix replaces) remains anywhere in ``src/``. A comment/docstring MENTION
+    of the old literal (``litellm_bootstrap.py``'s own historical note on
+    why it used to scan ``handlers[0]``) is not a call site and is
+    deliberately excluded — the accept criterion is about live code, not
+    prose that documents what code used to do."""
+    result = subprocess.run(
+        ["git", "grep", "-n", "basicConfig(", "--", "src/"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True,
+    )
+    hits = []
+    for line in result.stdout.splitlines():
+        _, _, code = line.partition(":")  # path:lineno:code -> partition once more
+        _, _, code = code.partition(":")
+        if "filename=" in line and not code.strip().startswith("#"):
+            hits.append(line)
+    assert hits == []
+
+
+def test_logs_config_typo_is_an_unknown_key_warning() -> None:
+    """Tier 2: #5873 accept ④ — a typo'd `logs:` sub-key (`max_byte`
+    instead of `max_bytes`) is caught as an unknown config key, the same
+    mechanism every other typed `ReynConfig` field gets automatically
+    (``config_schema`` walks ``ReynConfig``'s own dataclass fields — see
+    ``LogsConfig``'s own registration, unlike `permissions:`/`sandbox:`,
+    needs no separate #5849③-style registry since it is a real dataclass
+    field, not a raw dict)."""
+    from reyn.config import config_schema
+
+    hits = config_schema.unknown_config_keys({"logs": {"max_byte": 1024}})
+    assert "logs.max_byte" in hits
+
+
+def test_existing_file_handler_readers_still_find_the_rotating_handler(
+    tmp_path,
+) -> None:
+    """Tier 2: #5873 accept ⑤ — the two existing readers that structurally
+    detect the interactive log handler (``stall_trace.find_file_handler_path``
+    and ``litellm_bootstrap._litellm_import_logs_to_file``) still find it
+    once it is a ``RotatingFileHandler``.
+
+    #5873 follow-up (architect-requested, riding with #5877):
+    ``find_file_handler_path`` no longer scans ``logging.getLogger().
+    handlers`` for a path-shape match — it returns whatever
+    ``_setup_interactive_logging`` last registered via
+    ``stall_trace.register_file_handler_path``. This test now pins THAT
+    contract (the registered path equals the real log file path), while
+    ``_litellm_import_logs_to_file`` is still checked against the real,
+    structural ``isinstance(handler, logging.FileHandler)`` reader
+    unchanged by this follow-up — a ``RotatingFileHandler`` is a
+    ``FileHandler`` subclass, so that check still passes unchanged."""
+    from reyn.llm.litellm_bootstrap import _litellm_import_logs_to_file
+    from reyn.runtime import stall_trace
+
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    saved_registered_path = stall_trace._registered_file_handler_path
+    try:
+        _setup_interactive_logging(tmp_path)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+
+        assert stall_trace.find_file_handler_path() == str(log_file)
+
+        with _litellm_import_logs_to_file():
+            print("litellm-reader-marker-2b91", file=sys.stdout)
+        for h in root.handlers:
+            h.flush()
+        assert "litellm-reader-marker-2b91" in log_file.read_text()
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        stall_trace.register_file_handler_path(saved_registered_path)

--- a/tests/interfaces/test_inline_interactive_logging.py
+++ b/tests/interfaces/test_inline_interactive_logging.py
@@ -38,7 +38,7 @@ def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
 
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace._registered_file_handler_path
+    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -96,7 +96,7 @@ def test_interactive_logging_routes_warnings_warn_to_the_file_not_stderr(
 
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace._registered_file_handler_path
+    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
@@ -134,7 +134,7 @@ def test_small_max_bytes_rotates_and_bounds_the_live_file(tmp_path) -> None:
 
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace._registered_file_handler_path
+    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         _apply_logs_config(LogsConfig(max_bytes=4096, backup_count=2))
@@ -166,7 +166,7 @@ def test_backup_count_bounds_total_disk_usage(tmp_path) -> None:
 
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace._registered_file_handler_path
+    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         _apply_logs_config(LogsConfig(max_bytes=2048, backup_count=2))
@@ -250,7 +250,7 @@ def test_existing_file_handler_readers_still_find_the_rotating_handler(
 
     root = logging.getLogger()
     saved_handlers, saved_level = root.handlers[:], root.level
-    saved_registered_path = stall_trace._registered_file_handler_path
+    saved_registered_path = stall_trace.find_file_handler_path()
     try:
         _setup_interactive_logging(tmp_path)
         log_file = tmp_path / ".reyn" / "logs" / "reyn.log"


### PR DESCRIPTION
**[e2e-coder]** — Closes #5873.

## What

`reyn.log` grew unbounded while the process sat idle (owner-hit, 2026-09-06: "放置してるだけで reyn.log 肥大化してシステム止まらないようにしてね"). `_setup_interactive_logging` now installs a `logging.handlers.RotatingFileHandler` instead of a bare `logging.basicConfig(filename=...)`, sized from a new `logs:` config block (`max_bytes`, `backup_count`; default 16 MiB × 4 backups, total ≤ 80 MiB — architect's own provisional-but-reasoned numbers, config-tunable). The redirect still installs immediately with `LogsConfig()`'s own dataclass defaults (so config-load-time warnings are still captured), then `_apply_logs_config` refines the already-installed handler's `.maxBytes`/`.backupCount` in place once the real config is known.

`logs:` is a real `ReynConfig` dataclass field (`LogsConfig`), so it gets `config_schema`'s automatic unknown-key detection for free — no manual #5849③-style registry needed, unlike `permissions:`/`sandbox:`.

**Rides along** (architect-requested, alongside the concurrently-landed #5877): `stall_trace.find_file_handler_path()` no longer scans root-logger handlers for a path-shape match — `_setup_interactive_logging` now registers its handler's path directly via a new `stall_trace.register_file_handler_path()`, the one authoritative writer declaring its own path instead of a reader re-deriving it. Existing `isinstance(handler, logging.FileHandler)`-based readers (`litellm_bootstrap`) are unaffected — `RotatingFileHandler` is a `FileHandler` subclass, and its `.baseFilename` stays fixed across rotations by design.

The issue's own "same PR" ask re: #5870 stage 1's per-episode dump cadence needed no code change — `LoopTripwire.observe`'s dump is already once-per-episode (verified in `loop_probe.py`), as the issue itself noted.

**Round 2 (architect co-vet response)** — see the 3 checklist items below and the follow-up comment: fixed the tripwire-fd-vs-rotation inode hazard, collapsed the two literal-default sites into one (`LogsConfig()`'s own dataclass defaults), and switched all 6 test sites off the private `stall_trace._registered_file_handler_path` onto the public `find_file_handler_path()`. Also fixed a CI-only failure lead-coder caught: `test_example_documents_every_config_field` wants every `ReynConfig` field documented in `reyn.local.yaml.example` — added the `logs:` block there too (same class of gap as #5858).

## Acceptance (from the issue)

- [x] Small `max_bytes` (e.g. 4 KiB) config + sustained WARNING writes produces `reyn.log.1`, and live `reyn.log` stays under `max_bytes` (strip-verified: reverting `RotatingFileHandler` → `FileHandler` lets it grow unbounded — confirmed during this fix).
- [x] Old rotated files beyond `backup_count` are deleted (total ≤ `max_bytes × (backup_count+1)`).
- [x] Both `chat.py` call sites use the same one handler-installing function; `git grep 'basicConfig(' -- src/` has no `filename=` call left.
- [x] A `logs: {max_byte: ...}` typo is caught as an unknown-config-key warning.
- [x] Existing "read reyn.log" paths (`stall_trace.find_file_handler_path`, `litellm_bootstrap.py`'s `FileHandler` search) still find the `RotatingFileHandler` — both structurally (`isinstance`) and via the new registration.
- [x] `reyn-dir-layout.md`'s `logs/` row documents `rotated, bounded by logs.max_bytes × (backup_count+1)`.
- [x] `reyn-yaml.md` gained a `logs:` config block.
- [x] `reyn.local.yaml.example` gained a matching `logs:` block (CI-caught, round 2).

(ADR-0046 Falsification entry is the architect's own to add, per the issue.)

## Gates (round 2, head `18b7902d5`)

- `ruff check .` — clean.
- `python scripts/test_tier_audit.py --strict tests/interfaces/test_3671_stall_trace_startup_wiring.py tests/interfaces/test_inline_interactive_logging.py` — 14/14 OK, 0 Tier-4 violations.
- `python scripts/verify_module_docstrings.py` on all 6 touched src files — OK.
- `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — OK.
- tests/-path gates (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`) — OK.
- docs/-path gates — unchanged from round 1 (no docs/ touched this round).
- `python scripts/mypy_ratchet.py` — its own internal `mypy tests` subprocess hit its 300s timeout again (same recurring hazard, no visible contention). Substituted a manual `mypy --follow-imports=silent` scoped to all 6 touched src files: 39 pre-existing errors reported across 3 files, **all outside every touched diff hunk** — cross-checked against `git diff origin/main -- <file> | grep '^@@'` for each (`app.py`'s touched hunks are the ~2402-2559 range around `_watch_loop_responsiveness`; the 39 findings sit well outside it, scattered across this 7000+-line file's many other pre-existing untyped spots).
- Scoped `pytest`: `tests/interfaces/test_inline_interactive_logging.py` + `tests/interfaces/test_3671_stall_trace_startup_wiring.py` — 14/14 passed (the new inode-reopen regression test included). `tests/config/test_config_mirror_coverage_1056.py` — 5/5 passed (confirms the `reyn.local.yaml.example` fix).
- New regression test (`test_the_tripwire_reopens_its_fd_after_a_log_rotation`) strip-falsified: reverting the inode-check block in `app.py` makes the test hang on its own unbounded wait until it times out — confirmed red, then restored.

## Test plan

- [x] Automated tests above.
- [x] (skipped — Visual, standing waiver 2026-08-08)
- [x] 🔴 (architect co-vet 1) tripwire の自前 fd は rollover の rename に付いて行き、`backup_count` 回目の rollover で unlink された inode に dump を書き続ける — tick ごとに `os.stat(path).st_ino != os.fstat(fd).st_ino` なら disarm → close → 開き直し。受入: `handler.doRollover()` を直接呼んだ 2 tick 後の `arm(file=)` の inode が新 `reyn.log` と一致。`find_file_handler_path` docstring の「one rollover behind」も訂正
- [x] 🔴 (architect co-vet 2) `_DEFAULT_LOG_MAX_BYTES`／`_DEFAULT_LOG_BACKUP_COUNT` の literal を消し、`LogsConfig()` の既定を読む（既定は 1 箇所）
- [x] 🔴 (architect co-vet 3) test の `stall_trace._registered_file_handler_path` 直読み 6 箇所を公開の `find_file_handler_path()` に

- [x] (CI finding, round 3) `test_first_use_routes_litellm_logger_to_file_not_console` leaked `stall_trace`'s registered-path global into `test_the_tripwire_never_arms_without_a_file_handler` — folded all per-test save/restore into one autouse fixture in `tests/conftest.py` (`_isolate_stall_trace_file_handler_registration`), covering every current and future `_setup_interactive_logging` caller in `tests/`, not just the ones this PR touched.

**mypy**: not run locally this round (machine swap pressure, lead-coder's own temporary directive) — CI's own mypy job is the verdict for head `c510e237d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S

