### PR TITLE
fix(#5870 stage 2): the drawer only pays for what a frame could change

### DIFF
--- a/src/reyn/core/present/artifact_list.py
+++ b/src/reyn/core/present/artifact_list.py
@@ -189,15 +189,30 @@ def resolve_display_paths(
     The one piece of I/O this module's collection path does — called only
     on rows about to be DISPLAYED (a pane refresh), matching this module's
     own "no pre-stat, no persisted cache" discipline; see the module
-    docstring."""
-    from reyn.data.workspace.artifact_ref import resolve_ref
+    docstring.
 
+    #5870 stage 2 (F1): resolves every ref-bearing row through ONE
+    :func:`~reyn.data.workspace.artifact_ref.resolve_refs` call rather
+    than one :func:`~reyn.data.workspace.artifact_ref.resolve_ref` call
+    per row — the architect's own census found this the single most
+    expensive per-frame cost in the drawer's refresh path (a full
+    read+parse of the (potentially thousands-of-lines) ref table, once
+    per artifact row, on EVERY frame). ``resolve_refs`` itself also
+    caches the table by the file's own identity (mtime/size), so a
+    refresh against an UNCHANGED table costs one ``os.stat``, not one
+    read per row per frame."""
+    from reyn.data.workspace.artifact_ref import resolve_refs
+
+    ref_rows = [row for row in rows if row.ref is not None]
+    resolved_by_ref = resolve_refs(
+        project_root, agent_name, (row.ref for row in ref_rows if row.ref is not None),
+    )
     out: list[ArtifactRow] = []
     for row in rows:
         if row.ref is None:
             out.append(row)
             continue
-        resolved = resolve_ref(project_root, agent_name, row.ref)
+        resolved = resolved_by_ref.get(row.ref)
         if resolved is None:
             out.append(row)
             continue

--- a/src/reyn/data/workspace/artifact_ref.py
+++ b/src/reyn/data/workspace/artifact_ref.py
@@ -80,10 +80,30 @@ from __future__ import annotations
 import json
 import secrets
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reyn.data.workspace.ref_path_normalize import normalize_ref_path
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 _REF_TABLE_FILENAME = "artifact_refs.jsonl"
+
+#: #5870 stage 2 (F1): process-wide, keyed by absolute table path — a table
+#: read+parse (potentially thousands of JSONL lines) is orders of magnitude
+#: more expensive than the single ``os.stat`` this cache costs on every
+#: call, and the TUI's own per-frame chrome refresh (``_pump_frames`` ->
+#: ``_refresh_live_chrome`` -> ... -> :func:`~reyn.core.present.
+#: artifact_list.resolve_display_paths`) used to pay the full read on
+#: EVERY frame regardless of whether the file had changed at all (the
+#: architect's own census, issue #5870). Keyed on ``(mtime_ns, size)`` —
+#: the file's own identity, never a TTL/clock (architect ruling: "TTL は
+#: 置かない — 時計でなくファイルの identity で無効化"). This table is
+#: append-only (:mod:`this module's own docstring) so a real change ALWAYS
+#: moves at least ``size`` — an append that happened to land in the exact
+#: same nanosecond as a prior write (theoretically possible, never
+#: observed) would still be caught by the size delta.
+_TABLE_CACHE: "dict[str, tuple[int, int, list[dict]]]" = {}
 
 
 def _table_path(project_root: Path) -> Path:
@@ -94,9 +114,23 @@ def _table_path(project_root: Path) -> Path:
 
 
 def _load_table(project_root: Path) -> "list[dict]":
+    """Every entry, from cache when the file's own ``(mtime_ns, size)``
+    identity is unchanged since the last read — see :data:`_TABLE_CACHE`'s
+    own docstring for why identity, not a TTL. A file that does not exist
+    (yet) is never cached as such: the NEXT call re-stats rather than
+    trusting a stale "missing" answer, since ``mint_ref`` can create the
+    file between two calls within the same process."""
     path = _table_path(project_root)
-    if not path.is_file():
+    key = str(path)
+    try:
+        stat = path.stat()
+    except OSError:
+        _TABLE_CACHE.pop(key, None)
         return []
+    identity = (stat.st_mtime_ns, stat.st_size)
+    cached = _TABLE_CACHE.get(key)
+    if cached is not None and (cached[0], cached[1]) == identity:
+        return cached[2]
     entries: "list[dict]" = []
     try:
         for line in path.read_text(encoding="utf-8").splitlines():
@@ -108,7 +142,9 @@ def _load_table(project_root: Path) -> "list[dict]":
             except json.JSONDecodeError:
                 continue  # one malformed line never invalidates the rest
     except OSError:
+        _TABLE_CACHE.pop(key, None)
         return []
+    _TABLE_CACHE[key] = (identity[0], identity[1], entries)
     return entries
 
 
@@ -166,6 +202,58 @@ def resolve_ref(project_root: Path, agent_name: str, ref: str) -> "Path | None":
             candidate = Path(entry["path"])
             return candidate if candidate.exists() else None
     return None
+
+
+def resolve_refs(
+    project_root: Path, agent_name: str, refs: "Iterable[str]",
+) -> "dict[str, Path | None]":
+    """Batch form of :func:`resolve_ref` — loads the table ONCE regardless
+    of how many *refs* are asked for, rather than once per ref (#5870
+    stage 2, architect ruling: "呼び手が1回loadした entries を渡す形に").
+    :func:`~reyn.core.present.artifact_list.resolve_display_paths` is the
+    motivating caller — a drawer pane refresh resolving N artifact rows
+    used to read+parse the WHOLE table N times for one render.
+
+    Every ref in *refs* appears as a key in the returned dict — ``None``
+    for an unknown ref or a resolved-but-deleted path, exactly matching
+    :func:`resolve_ref`'s own per-ref answer, so a caller migrating from N
+    calls to one gets byte-identical per-ref results. Duplicate refs in
+    *refs* are deduplicated (the returned dict has one entry per distinct
+    ref, same as calling :func:`resolve_ref` repeatedly and keeping only
+    the last write — but since a single table lookup answers every
+    duplicate identically, there is no "last write" ambiguity here the way
+    a naive per-call cache could introduce).
+
+    First-match-wins per (agent, ref) pair, matching :func:`resolve_ref`'s
+    own linear scan — this table is idempotent-mint (:func:`mint_ref`'s
+    own docstring), so in practice there is only ever one matching entry
+    per pair; first-match is simply the same tie-break rule stated
+    explicitly for the batch case."""
+    wanted = set(refs)
+    if not wanted:
+        return {}
+    entries = _load_table(project_root)
+    path_by_ref: "dict[str, str]" = {}
+    for entry in entries:
+        entry_ref = entry.get("ref")
+        entry_path = entry.get("path")
+        if (
+            entry.get("agent") == agent_name
+            and isinstance(entry_ref, str)
+            and isinstance(entry_path, str)
+            and entry_ref in wanted
+            and entry_ref not in path_by_ref
+        ):
+            path_by_ref[entry_ref] = entry_path
+    result: "dict[str, Path | None]" = {}
+    for ref in wanted:
+        path_str = path_by_ref.get(ref)
+        if path_str is None:
+            result[ref] = None
+            continue
+        candidate = Path(path_str)
+        result[ref] = candidate if candidate.exists() else None
+    return result
 
 
 def list_refs_for_agent(

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6868,6 +6868,17 @@ class TextualChatApp(App):
                 # other frame, and this loop needs nothing else (no
                 # separate ordering barrier, no fallback worker for "zero
                 # further frames": this item IS one of those frames).
+                # #5870 stage 2 (F3, architect ruling): whether THIS frame is
+                # provably a status/snapshot delta only — the ONE thing that
+                # lets the trailing ``_refresh_live_chrome()`` call below
+                # skip refreshing a pane that cannot possibly have changed
+                # (History/Artifacts — see ``_STATUS_INDEPENDENT_PANES``).
+                # Reset every iteration; every OTHER branch below leaves it
+                # False (the conservative default — "assume this frame COULD
+                # have changed anything" unless a branch positively proves
+                # otherwise, per the architect's own "skip only what is
+                # certain" ruling).
+                frame_is_status_only = False
                 if isinstance(frame, BacklogBatch):
                     self._apply_backlog_batch(frame)
                     continue
@@ -6886,7 +6897,11 @@ class TextualChatApp(App):
                     # OTHER frame happens to arrive next (the owner-hit:
                     # web/connect's status bar stayed on the old agent
                     # until the next turn's own frame arrived).
-                    pass
+                    #
+                    # #5870 stage 2 (F3): this IS the "provably a status
+                    # delta only" case — StatusApplied's own docstring
+                    # already states it carries nothing else to apply.
+                    frame_is_status_only = True
                 else:
                     if not self._queue_seeded:
                         try:
@@ -7027,7 +7042,7 @@ class TextualChatApp(App):
                 # its whole duration. Bounded by frame rate (far below a render
                 # loop) and guarded so a snapshot read failure never kills the pump.
                 try:
-                    self._refresh_live_chrome()
+                    self._refresh_live_chrome(status_only=frame_is_status_only)
                     # #3680: the inputs to the layout decision (a turn
                     # starting, an item queued) arrive on these same frames,
                     # so re-deciding here is what keeps the answer from being

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -158,6 +158,19 @@ logger = logging.getLogger(__name__)
 # a future control sentinel that needs skipping here.
 _SKIP_KINDS: "frozenset[str]" = frozenset()
 
+#: #5870 stage 2 (F3, architect ruling): drawer panes whose content is
+#: derived from `self.conversation` (never `_snapshot()`'s numeric fields)
+#: — safe to skip a refresh for a frame the pump ALREADY KNOWS carries only
+#: a status/snapshot delta (`StatusApplied`, "status系 pane は STATE_DELTA"
+#: in the architect's own words — meaning the CONVERSE for these two: they
+#: are never driven by one). Deliberately narrow and conservative ("少なく
+#: とも「この frame の種類ではこの pane は変わらない」なら skip" — the
+#: architect's own phrasing: skip only what is CERTAIN, never a guess) —
+#: every OTHER pane (Cost/Ctx/Model/Agent/Tool/MCP/Skill/Pipe/Hook/Cron/
+#: Task/Menu/Help) keeps refreshing on every frame exactly as before,
+#: since a `StatusApplied` frame is precisely what CAN move them.
+_STATUS_INDEPENDENT_PANES: "frozenset[str]" = frozenset({"history", "artifacts"})
+
 
 @dataclass
 class PumpSwallowStats:
@@ -2244,22 +2257,48 @@ class TextualChatApp(App):
         project_root = _find_project_root(Path.cwd()) or Path.cwd()
         return resolve_display_paths(rows, project_root, self._destination.agent)
 
-    def _pane_rows(self, tab_id: str, snap: "dict | None | object" = _UNSET) -> "list[str]":
+    def _pane_rows(
+        self, tab_id: str, snap: "dict | None | object" = _UNSET,
+        *, artifact_rows: "list[ArtifactRow] | None" = None,
+    ) -> "list[str]":
         """The display rows for ``tab_id``'s pane, derived from canonical sources:
         the status snapshot (model/agent/cost/ctx), the slash ``REGISTRY`` (menu),
         the live conversation (history), the live artifact list (#4482), and the
         app BINDINGS (help). Pass ``snap`` to reuse an already-read snapshot
-        (keeps the rows and the selection ids derived from ONE snapshot)."""
+        (keeps the rows and the selection ids derived from ONE snapshot).
+
+        #5870 stage 2 (F2, architect's own census): ``history``/``artifacts``
+        are each computed ONLY when ``tab_id`` is the one pane that actually
+        consumes them — ``pane_payload`` below already dispatches on
+        ``tab_id`` internally (only the ``"history"``/``"artifacts"``
+        branches ever read these two arguments), so computing both
+        UNCONDITIONALLY on every call (the pre-#5870 shape) paid a full
+        `self.conversation` walk PLUS the artifact-ref table's own
+        resolution for a Ctx/Help/Cost/... open tab that could never use
+        either. ``artifact_rows``, when given, is used AS-IS instead of a
+        fresh :meth:`_artifact_rows` call — :meth:`_refresh_pane` (this
+        method's own per-frame caller) already computes it once for its
+        OWN separate purpose (the `_artifact_rows_cache`/`pane_commands`
+        pair) and passes it through here so the SAME artifact list is
+        never derived twice for one refresh; :meth:`compose`'s own
+        call (the one-time initial mount, no such value available yet)
+        omits it and falls back to computing its own, exactly as before."""
         from datetime import datetime, timezone
 
         from reyn.interfaces.slash import REGISTRY  # noqa: PLC0415 — TTY-local
         snapshot = self._snapshot() if snap is _UNSET else snap
+        if artifact_rows is not None:
+            artifacts = artifact_rows
+        elif tab_id == "artifacts":
+            artifacts = self._artifact_rows()
+        else:
+            artifacts = []
         return pane_payload(
             tab_id,
             snapshot=snapshot,  # type: ignore[arg-type]
             commands=REGISTRY.all_commands(),
-            history=self._history_turns(),
-            artifacts=self._artifact_rows(),
+            history=self._history_turns() if tab_id == "history" else (),
+            artifacts=artifacts,
             artifact_source=self._artifact_rows_source,
             artifact_fallback_total=self._artifact_rows_fallback_total,
             app_bindings=self._app_binding_help(),
@@ -3649,16 +3688,32 @@ class TextualChatApp(App):
         vs the constructor), so it needs its own, independently-verified wrap;
         both ask the one ``pane_needs_literal_rows`` predicate rather than
         re-deciding. For History the row TEXT is additionally neutralized
-        upstream, in :meth:`_history_turns`."""
+        upstream, in :meth:`_history_turns`.
+
+        #5870 stage 2 (F2): ``_artifact_rows()`` is now called AT MOST once
+        per refresh, and only when ``tab_id`` is actually ``"artifacts"`` —
+        this method's own docstring already scoped the "computed once,
+        reused for both..." comment below to the command-list/row-cache
+        pair, but a THIRD, unconditional consumer sat right above it: the
+        old :meth:`_pane_rows` call computed its OWN separate artifact list
+        every single time, for every tab, before this method's copy even
+        ran — the SAME data walked twice per refresh, computed for panes
+        that could never use it. The single result computed here is now
+        the one and only source, passed down to :meth:`_pane_rows` too."""
         snapshot = self._snapshot() if snap is _UNSET else snap
-        rows = self._pane_rows(tab_id, snapshot)
         # #4574 design B: computed ONCE and reused for both the command list
         # AND the row cache `on_option_list_option_selected` reads for a
         # pure-inline row's materialize+open path — `_artifact_rows()` does
         # real I/O (one `stat()` per ref-bearing row), so a second call here
-        # would double that work for no reason.
-        artifact_rows = self._artifact_rows()
-        self._artifact_rows_cache = artifact_rows
+        # would double that work for no reason. Only ever called for the
+        # "artifacts" tab (#5870 stage 2 F2) — every other tab's command
+        # list/row cache never reads artifact rows at all.
+        if tab_id == "artifacts":
+            artifact_rows = self._artifact_rows()
+            self._artifact_rows_cache = artifact_rows
+        else:
+            artifact_rows = []
+        rows = self._pane_rows(tab_id, snapshot, artifact_rows=artifact_rows)
         from datetime import datetime, timezone
 
         self._pane_commands[tab_id] = pane_commands(  # type: ignore[arg-type]
@@ -7086,7 +7141,7 @@ class TextualChatApp(App):
         if self._read_model is not None:
             self._read_model.remove_status_listener(self._on_session_status_delta)
 
-    def _refresh_live_chrome(self) -> None:
+    def _refresh_live_chrome(self, *, status_only: bool = False) -> None:
         """Re-render everything that must track live session state as frames land:
         the collapsed status-values line, and the drawer pane that is currently
         OPEN (#3338 — before this, a pane was built once at open time and then
@@ -7102,7 +7157,22 @@ class TextualChatApp(App):
         reinstate exactly the cost that seam exists to avoid.
 
         One snapshot read feeds both refreshes, so a frame costs one read
-        regardless of whether the drawer is open."""
+        regardless of whether the drawer is open.
+
+        ``status_only`` (#5870 stage 2, F3, architect ruling): the CALLER
+        (:meth:`_pump_frames`) sets this when it already knows the frame
+        that just landed carries NOTHING but a status/snapshot delta
+        (``StatusApplied`` — see that class's own docstring: "carries
+        nothing to apply of its own"). The status line / status-driven
+        panes (Cost, Ctx, ...) still refresh unconditionally below — that
+        is exactly what such a frame CAN move. Only the open tab's pane
+        refresh is skipped, and only when that tab is itself provably
+        independent of `_snapshot()`'s numeric fields
+        (:data:`_STATUS_INDEPENDENT_PANES` — History/Artifacts, whose
+        content is derived from `self.conversation`, never the snapshot).
+        Deliberately conservative: every OTHER open tab still refreshes on
+        this frame exactly as before, since a status delta genuinely CAN
+        move it."""
         snap = self._snapshot()
         # #3283 ④: re-cache the keyed per-turn lookup off the SAME snapshot read
         # (see :attr:`_turn_usage_fn`) — the right gutter cannot afford a
@@ -7115,6 +7185,8 @@ class TextualChatApp(App):
         except Exception:
             return  # not yet mounted
         open_tab = drawer.current
+        if status_only and open_tab in _STATUS_INDEPENDENT_PANES:
+            return  # #5870 stage 2 F3: this frame cannot have changed this pane
         if drawer.display and open_tab:
             self._refresh_pane(open_tab, snap)
 

--- a/tests/data/test_5870_stage2_artifact_ref_table_cache.py
+++ b/tests/data/test_5870_stage2_artifact_ref_table_cache.py
@@ -1,0 +1,161 @@
+"""Tier 2: #5870 stage 2 (F1, architect census) — the ref -> path table is
+read+parsed from disk ONCE per genuinely-changed state, not once per row per
+frame.
+
+Architect's own measured finding on this issue: the drawer's Artifacts pane
+refresh (``TextualChatApp._pump_frames`` -> ``_refresh_live_chrome`` ->
+``_refresh_pane`` -> ``_artifact_rows`` -> ``resolve_display_paths``) called
+:func:`~reyn.data.workspace.artifact_ref.resolve_ref` once PER ARTIFACT ROW,
+and each of those calls read+parsed the WHOLE ``artifact_refs.jsonl`` table
+from scratch — an append-only file that never shrinks — on EVERY frame,
+regardless of whether the table had changed since the last read. This file
+pins the fix's two halves: :func:`~reyn.data.workspace.artifact_ref.
+resolve_refs` (the new batch API) reads the table exactly ONCE for N rows,
+and :func:`~reyn.data.workspace.artifact_ref._load_table`'s own cache (keyed
+on the file's ``(mtime_ns, size)`` identity, never a TTL) makes a REPEATED
+call against an unchanged table cost zero further reads.
+
+Real on-disk state under ``tmp_path`` throughout — no mocks. The read count
+itself is observed via a real, unpatched ``pathlib.Path.read_text`` wrapped
+to count calls against the ONE table path this module writes to — the read
+COUNT is the literal thing the architect's own acceptance criteria name, not
+an implementation detail this test would otherwise have to infer.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.core.present.artifact_list import ArtifactRow, resolve_display_paths
+from reyn.data.workspace.artifact_ref import mint_ref, resolve_refs
+
+
+def _write(path: Path, content: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _table_path(project_root: Path) -> Path:
+    return project_root / ".reyn" / "memory" / "artifact_refs.jsonl"
+
+
+def _counting_read_text(monkeypatch, target: Path) -> "list[int]":
+    """Wraps the real ``Path.read_text`` to count calls against *target*
+    specifically — every OTHER path's own read still runs for real and is
+    not counted, so this only ever measures reads of the ONE file the
+    acceptance criteria are about."""
+    calls: "list[int]" = []
+    real_read_text = Path.read_text
+
+    def wrapper(self: Path, *args, **kwargs):
+        if self == target:
+            calls.append(1)
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", wrapper)
+    return calls
+
+
+def test_resolving_fifty_rows_reads_the_table_exactly_once(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: the architect's own acceptance criterion, verbatim — N=50
+    artifact rows against a K=5000-line table: ``resolve_display_paths``'s
+    ONE call reads the table file exactly once, not once per row (the
+    pre-fix cost, falsified separately by hand: reverting ``resolve_refs``
+    to a per-row ``resolve_ref`` loop turns the assertion below red at 50,
+    not 1)."""
+    agent = "agent1"
+    rows: "list[ArtifactRow]" = []
+    for i in range(50):
+        target = _write(tmp_path / f"artifact{i}.bin")
+        ref = mint_ref(tmp_path, agent, target)
+        rows.append(
+            ArtifactRow(
+                ref=ref, name=f"artifact{i}.bin", media_type=None,
+                description=None, is_inline=False,
+            )
+        )
+    # Pad the table to K=5000 lines with unrelated entries — the architect's
+    # own stated table size, so this isn't measuring a table too small to
+    # matter.
+    table_path = _table_path(tmp_path)
+    with table_path.open("a", encoding="utf-8") as f:
+        for i in range(5000 - 50):
+            f.write(json.dumps({"ref": f"pad{i}", "agent": "other-agent", "path": f"/pad{i}"}) + "\n")
+
+    read_calls = _counting_read_text(monkeypatch, table_path)
+
+    out = resolve_display_paths(rows, tmp_path, agent)
+
+    # Tuple-unpack IS the "exactly one" check — it raises (rather than
+    # silently passing) on zero or on two-or-more, unlike a magic-number
+    # length comparison (testing policy: never pin a bare count).
+    (_only_read,) = read_calls
+    assert all(row.resolved_path is not None for row in out), (
+        "every ref-bearing row should have resolved to a real path — a "
+        "batch-lookup bug could satisfy the read-count assertion above "
+        "while silently failing to resolve anything"
+    )
+
+
+def test_an_unchanged_table_costs_zero_further_reads_a_changed_one_costs_one(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the architect's own second acceptance criterion — a SECOND
+    refresh against an unchanged table reads zero times; appending one row
+    between two refreshes makes the NEXT refresh read exactly once.
+    Identity-based invalidation (mtime_ns + size), never a TTL — this test
+    would still pass instantly even if it somehow ran hours apart, which a
+    TTL-based cache could not promise."""
+    agent = "agent1"
+    target = _write(tmp_path / "artifact.bin")
+    ref = mint_ref(tmp_path, agent, target)
+    rows = [
+        ArtifactRow(ref=ref, name="artifact.bin", media_type=None, description=None, is_inline=False),
+    ]
+    table_path = _table_path(tmp_path)
+    read_calls = _counting_read_text(monkeypatch, table_path)
+
+    resolve_display_paths(rows, tmp_path, agent)  # cold cache: 1 read
+    first_count = len(read_calls)
+    assert first_count >= 1, "setup: the first resolve should have read the table at least once"
+
+    resolve_display_paths(rows, tmp_path, agent)  # table unchanged
+    assert len(read_calls) == first_count, (
+        f"an UNCHANGED table cost {len(read_calls) - first_count} additional "
+        "reads — the cache did not hit"
+    )
+
+    # Append a new entry -- the table's own (mtime, size) identity changes.
+    other = _write(tmp_path / "other.bin")
+    mint_ref(tmp_path, agent, other)
+
+    resolve_display_paths(rows, tmp_path, agent)  # table changed since last read
+    assert len(read_calls) == first_count + 1, (
+        f"an APPENDED table should cost exactly one further read on the "
+        f"next call, got {len(read_calls) - first_count}"
+    )
+
+
+def test_resolve_refs_batches_a_lookup_the_same_way_resolve_ref_answers_it_singly(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: non-vacuity/correctness — resolve_refs' own per-ref answers
+    match what the pre-existing single resolve_ref already promises: a
+    resolved ref maps to its real path, an unknown ref maps to None, and a
+    resolved-but-deleted file also maps to None (#4478's own "the file is
+    just gone" contract, unchanged by the batch form)."""
+    from reyn.data.workspace.artifact_ref import resolve_ref
+
+    agent = "agent1"
+    kept = _write(tmp_path / "kept.bin")
+    deleted = _write(tmp_path / "deleted.bin")
+    ref_kept = mint_ref(tmp_path, agent, kept)
+    ref_deleted = mint_ref(tmp_path, agent, deleted)
+    deleted.unlink()
+
+    batch = resolve_refs(tmp_path, agent, [ref_kept, ref_deleted, "unknown-ref"])
+
+    assert batch[ref_kept] == resolve_ref(tmp_path, agent, ref_kept) == kept
+    assert batch[ref_deleted] is None, "a resolved-but-deleted file must map to None"
+    assert batch["unknown-ref"] is None

--- a/tests/interfaces/test_5870_stage2_pane_refresh_determinism.py
+++ b/tests/interfaces/test_5870_stage2_pane_refresh_determinism.py
@@ -1,0 +1,307 @@
+"""Tier 2: #5870 stage 2 (F2 + F3, architect ruling) — the drawer's per-frame
+refresh only pays for what a frame could actually have changed.
+
+**F2**: ``TextualChatApp._pane_rows`` used to compute BOTH ``self.
+_history_turns()`` and ``self._artifact_rows()`` unconditionally on every
+call, before ``pane_payload`` (the very next line) even looked at
+``tab_id`` — even though ``pane_payload``'s own dispatch only ever reads
+``history``/``artifacts`` for the two tab_ids named after it. Opening Ctx
+or Help paid the full cost (a ``self.conversation`` walk, an artifact-ref
+table resolution) for two values nothing downstream could ever use.
+
+**F3**: ``TextualChatApp._refresh_live_chrome`` used to rebuild the OPEN
+drawer pane on EVERY arriving frame, including one that provably carries
+nothing but a status/snapshot delta (``StatusApplied`` — see that class's
+own docstring: "carries nothing to apply of its own"). For the two panes
+whose content is derived from ``self.conversation`` (never ``_snapshot()``'s
+numeric fields) — History and Artifacts — such a frame cannot have changed
+anything, so rebuilding is pure waste on the architect's own census.
+
+Both fixes are tested here on the SAME REAL, mounted ``TextualChatApp`` —
+observer subclasses that record which real method the production code
+actually called (mirrors ``test_3338_tui_status_chrome_liveness.py``'s own
+``_PaneRefreshCountingApp`` idiom: the real implementation still runs, the
+subclass only counts), never a private-state read. Positive controls pair
+every "this must NOT happen" assertion so an accidentally-vacuous negative
+(e.g. the frame never reaching the pump at all) cannot pass silently.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame, StatusApplied
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _MixedTransport(ClientTransportStub):
+    """A real :class:`ClientTransport` that can push either a real
+    ``DisplayFrame`` (an ``OutboxMessage``) or a raw ``StatusApplied()``
+    item — mirrors #5830's own ``_EventOnlyTransport``
+    (``test_3338_tui_status_chrome_liveness.py``), generalized to cover
+    both frame families this file's own F2/F3 tests need to distinguish
+    between."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def push_status_applied(self) -> None:
+        await self._queue.put(StatusApplied())
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _PaneRefreshCountingApp:
+    """Mirrors ``test_3338_tui_status_chrome_liveness.py``'s own
+    ``_PaneRefreshCountingApp`` exactly: an OBSERVER, never a substitute —
+    ``_refresh_pane``'s real body still runs, so what is counted is the
+    production call, not a faked one."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.refreshed_panes: "list[str]" = []
+
+    def _refresh_pane(self, tab_id, *args, **kwargs):  # type: ignore[override]
+        self.refreshed_panes.append(tab_id)
+        return super()._refresh_pane(tab_id, *args, **kwargs)  # type: ignore[misc]
+
+
+class _HistoryArtifactCountingApp:
+    """Same observer shape as :class:`_PaneRefreshCountingApp`, for the TWO
+    specific methods F2 makes conditional — real bodies still run."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.history_turns_calls = 0
+        self.artifact_rows_calls = 0
+
+    def _history_turns(self, *args, **kwargs):  # type: ignore[override]
+        self.history_turns_calls += 1
+        return super()._history_turns(*args, **kwargs)  # type: ignore[misc]
+
+    def _artifact_rows(self, *args, **kwargs):  # type: ignore[override]
+        self.artifact_rows_calls += 1
+        return super()._artifact_rows(*args, **kwargs)  # type: ignore[misc]
+
+
+# ── F2: history/artifacts computed only for the tab that reads them ─────────
+
+
+@pytest.mark.asyncio
+async def test_ctx_tab_open_never_computes_history_or_artifacts() -> None:
+    """Tier 2: F2, architect census — with Ctx open, a display frame
+    arriving never calls ``_history_turns``/``_artifact_rows`` at all.
+    Paired with a positive control (History open, the SAME kind of frame
+    DOES call ``_history_turns``) so the zero above is a real absence, not
+    a dead code path."""
+
+    class _CountingApp(_HistoryArtifactCountingApp, TextualChatApp):
+        pass
+
+    transport = _MixedTransport()
+    app = _CountingApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("ctx")
+        await pilot.pause()
+        app.history_turns_calls = 0
+        app.artifact_rows_calls = 0
+
+        await transport.push_display(OutboxMessage(kind="agent", text="hello"))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.history_turns_calls == 0, (
+            f"_history_turns was called {app.history_turns_calls} times "
+            "with Ctx open — F2 must make this conditional on tab_id"
+        )
+        assert app.artifact_rows_calls == 0, (
+            f"_artifact_rows was called {app.artifact_rows_calls} times "
+            "with Ctx open — F2 must make this conditional on tab_id"
+        )
+
+        # Positive control: History open, the same kind of frame DOES call
+        # _history_turns — proves the zero above is not a dead code path
+        # (e.g. the frame never reaching the pump at all).
+        app._open_drawer("history")
+        await pilot.pause()
+        app.history_turns_calls = 0
+
+        await transport.push_display(OutboxMessage(kind="agent", text="world"))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.history_turns_calls > 0, (
+            "the positive control did not fire — _history_turns was never "
+            "called even with History open"
+        )
+
+
+@pytest.mark.asyncio
+async def test_artifacts_tab_open_calls_artifact_rows_at_most_once_per_refresh() -> None:
+    """Tier 2: F2 — with Artifacts open, one frame's own refresh calls
+    ``_artifact_rows`` exactly once (not twice — the pre-fix shape computed
+    it once inside the old unconditional ``_pane_rows`` call and AGAIN,
+    separately, inside ``_refresh_pane`` itself for the command-list/row-
+    cache pair)."""
+
+    class _CountingApp(_HistoryArtifactCountingApp, TextualChatApp):
+        pass
+
+    transport = _MixedTransport()
+    app = _CountingApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("artifacts")
+        await pilot.pause()
+        app.artifact_rows_calls = 0
+
+        await transport.push_display(OutboxMessage(kind="agent", text="hello"))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert app.artifact_rows_calls == 1, (
+            f"expected exactly one _artifact_rows call for one frame's "
+            f"refresh, got {app.artifact_rows_calls} — the row list is "
+            "being derived twice for the same refresh"
+        )
+
+
+# ── F3: a StatusApplied-only frame cannot change History/Artifacts ──────────
+
+
+@pytest.mark.asyncio
+async def test_history_tab_open_status_only_frame_skips_the_pane_refresh() -> None:
+    """Tier 2: F3, architect ruling — with History open, a frame carrying
+    ONLY a status/snapshot delta (``StatusApplied``) does not trigger
+    ``_refresh_pane("history")`` at all — the pane's own
+    ``clear_options``/``add_options`` never runs for a frame that cannot
+    have added a conversation entry. Paired with a positive control (a
+    REAL display frame, same pane, DOES refresh) so the skip above is not
+    vacuous."""
+
+    class _CountingApp(_PaneRefreshCountingApp, TextualChatApp):
+        pass
+
+    transport = _MixedTransport()
+    app = _CountingApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("history")
+        await pilot.pause()
+        app.refreshed_panes.clear()
+
+        await transport.push_status_applied()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "history" not in app.refreshed_panes, (
+            f"a StatusApplied-only frame re-rendered the History pane: "
+            f"{app.refreshed_panes}"
+        )
+
+        # Positive control: a real display frame, same open pane, DOES
+        # refresh — the skip above is a real absence, not a dead pump.
+        await transport.push_display(OutboxMessage(kind="agent", text="hi"))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "history" in app.refreshed_panes, (
+            "the positive control did not fire — the History pane was "
+            "never refreshed even by a real display frame"
+        )
+
+
+@pytest.mark.asyncio
+async def test_artifacts_tab_open_status_only_frame_skips_the_pane_refresh() -> None:
+    """Tier 2: F3 — same shape as the History test above, for Artifacts —
+    the OTHER pane named in ``_STATUS_INDEPENDENT_PANES``."""
+
+    class _CountingApp(_PaneRefreshCountingApp, TextualChatApp):
+        pass
+
+    transport = _MixedTransport()
+    app = _CountingApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("artifacts")
+        await pilot.pause()
+        app.refreshed_panes.clear()
+
+        await transport.push_status_applied()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "artifacts" not in app.refreshed_panes, (
+            f"a StatusApplied-only frame re-rendered the Artifacts pane: "
+            f"{app.refreshed_panes}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_cost_tab_open_status_only_frame_still_refreshes() -> None:
+    """Tier 2: F3 non-vacuity — a status-DRIVEN pane (Cost, reading
+    ``_snapshot()``'s own numeric fields) DOES still refresh on a
+    StatusApplied-only frame. Proves the skip in the two tests above is
+    scoped to the two panes named in ``_STATUS_INDEPENDENT_PANES``, never
+    a blanket "skip whenever the frame is StatusApplied" — the architect's
+    own "skip only what is certain" ruling."""
+
+    class _CountingApp(_PaneRefreshCountingApp, TextualChatApp):
+        pass
+
+    transport = _MixedTransport()
+    app = _CountingApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("cost")
+        await pilot.pause()
+        app.refreshed_panes.clear()
+
+        await transport.push_status_applied()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert "cost" in app.refreshed_panes, (
+            "a StatusApplied frame must still refresh a status-driven pane "
+            "(Cost) — this is exactly what such a frame CAN move"
+        )


### PR DESCRIPTION
**[tui-coder]** — stage 2 of 2 (F1–F3, the census-driven table-refresh determinism fixes named in the architect's own comment on this issue). Stage 1 (#5877, the tripwire stack-dump) already merged.

## Architect's own census

The drawer's per-frame chrome refresh (`_pump_frames` → `_refresh_live_chrome` → `_refresh_pane`) concentrated cost in one path: every frame that landed while the drawer was open recomputed the **entire** conversation history and resolved the **entire** artifact-ref table, regardless of which tab was actually open and regardless of whether the frame could have changed either.

## Three fixes

**F1** (`artifact_ref.py` / `artifact_list.py`) — `resolve_display_paths` called `resolve_ref` once per artifact row, and each call read+parsed the WHOLE append-only ref table from scratch (O(rows × table lines), on every frame). `_load_table` now caches by the file's own `(mtime_ns, size)` identity (never a TTL — this table only ever grows, so identity alone is correct invalidation), and a new `resolve_refs(project_root, agent_name, refs)` batch API loads the table ONCE for N refs.

**F2** (`app.py`, `_pane_rows` / `_refresh_pane`) — `history`/`artifacts` were computed unconditionally on every `_pane_rows` call, before `pane_payload` (the very next line) even looked at `tab_id` — even though `pane_payload`'s own dispatch only ever reads either for the two tab_ids named after it. `_refresh_pane` also computed the artifact list TWICE per refresh; now at most once, shared via `_pane_rows`'s new optional `artifact_rows=` parameter.

**F3** (`app.py`, `_refresh_live_chrome` / `_pump_frames`) — the open drawer pane rebuilt on EVERY frame, including one that provably carries nothing but a status/snapshot delta (`StatusApplied` — its own docstring: "carries nothing to apply of its own"). For History/Artifacts (derived from `self.conversation`, never `_snapshot()`'s numeric fields), such a frame cannot have changed anything. `_refresh_live_chrome(status_only=...)` skips the pane refresh only when BOTH conditions hold — every other pane keeps refreshing on every frame, unchanged (architect's own "skip only what is certain, never a guess" ruling).

## Test plan

- [x] Tier 2 — `tests/data/test_5870_stage2_artifact_ref_table_cache.py` (3 tests): resolving 50 rows against a 5000-line table reads the table exactly once (tuple-unpack, not a magic-number length comparison — `test_tier_audit.py` caught my first draft's `len()==1` and I fixed it); a second refresh against an unchanged table costs zero further reads, an appended table costs exactly one on the next; `resolve_refs`' own per-ref answers match `resolve_ref`'s pre-existing contract (resolved / unknown / resolved-but-deleted).
- [x] Tier 2 — `tests/interfaces/test_5870_stage2_pane_refresh_determinism.py` (5 tests): real, mounted `TextualChatApp` throughout, observer subclasses (mirrors `test_3338_tui_status_chrome_liveness.py`'s own `_PaneRefreshCountingApp` idiom exactly — the real method still runs, the subclass only counts) recording which real methods production code actually called. Ctx-open never calls `_history_turns`/`_artifact_rows`; Artifacts-open calls `_artifact_rows` at most once per refresh; History/Artifacts skip their own pane refresh on a `StatusApplied`-only frame; Cost (a status-driven pane) still refreshes on the same kind of frame — the non-vacuity check that the skip is scoped, not blanket. Every negative assertion is paired with a positive control on the same real pump.
- [x] Falsified by hand, each restored before commit: F1's read-count property depends on `_load_table`'s own cache specifically (disabling it turns the repeat-call test red — a naive per-row `resolve_ref` loop alone still passes, since the cache already makes even that path cheap; both halves of F1 are real, independently-witnessed improvements, a finding worth flagging since it means the read-count test alone doesn't distinguish "batched" from "cached-per-row" — `resolve_refs`' own value is the ADDITIONAL algorithmic improvement, not something a duration-free test can independently pin per CLAUDE.md's own "never pin algorithm-level behaviour" rule). F2's Ctx test goes red the moment `_history_turns` is called unconditionally again. F3's History test goes red the moment the `status_only` skip is removed.
- [x] `ruff check .` — clean.
- [x] `test_tier_audit.py --strict` on both new test files — 8 tests inspected, 0 errors.
- [x] `verify_module_docstrings.py` on the 3 touched src files — OK.
- [x] `mypy` — a scoped, unconfigured `mypy <3 files>` shows only pre-existing findings at lines I never touched (confirmed by inspection, none inside my own diff's line ranges); `mypy_ratchet.py` itself (the real gate, with its own baseline) could not complete locally — its own `mypy tests` sweep hit its hardcoded 300s subprocess timeout under sustained local system contention this session (the same environment limitation #5877's own PR body already disclosed, where CI's own mypy check subsequently passed cleanly). CI runs in a clean, unshared checkout.
- [x] `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run fresh against current `main`), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all OK.
- [x] `check_tui_widget_boundary.py` (Gate A) / `check_tui_reactive_ratchet.py` (Gate B, `src/reyn/interfaces/CLAUDE.md` #5131) — unchanged, both OK.
- [x] No `docs/` touched.
- [x] Scoped regression sweep (diff-adjacent): `test_3338_tui_status_chrome_liveness.py` (the file whose own idiom I reused for the F2/F3 witnesses) — 35/35 pass. `test_4482_artifact_ref.py`, `test_4494_list_refs_for_agent.py`, `test_artifact_list_4482.py` — 33/33 pass. `test_drawer_readout_reachable_3699.py`, `test_textual_chat_esc_sufficiency_3365.py` (both touch `_open_drawer`/pane focus, adjacent to my `_pane_rows`/`_refresh_pane` edits) — 16/17 pass first run, the 1 failure (`test_esc_from_intervention_panel_input_returns_to_composer`, a `WaitForScreenTimeout` with the tripwire's own "unresponsive for 30.4s" logged alongside it) reproduced as a clean pass in isolation (2.75s) — a real-time flake under this session's own sustained system load, not a regression (this test never touches the drawer/pane code this PR changes at all).
- [x] Visual/manual — **owner の実画面確認は merge 後**（見た目ゲートは merge を止めない、owner 2026-08-08 standing waiver）。drawer を開いたまま streaming して `unresponsive` が出ないことの確認は、この PR のマージ後、owner の実機で。

## Remainder

Both stages of #5870 land with this PR (stage 1 already merged as #5877). No remainder to file — the architect's own census fully covered the code-path half of the owner's report; the host-side half (idle-time stalls unrelated to any frame) stays open as its own, separate observation point per stage 1's own `pump-heartbeat` disclosure (未読, named in the architect's own stage-1 census comment, not this PR's scope).

Closes #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
