### PR TITLE
fix(#5878): CI -- cat .reyn-memory-ceiling.log when a worker was killed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,32 @@ jobs:
             echo "no stall-trace dump (pytest session finished normally)"
           fi
 
+      # #5878 (architect follow-up, #5877 co-vet): the same visibility gap
+      # #4986 closed for a session-teardown hang, for a DIFFERENT silent
+      # death — `dev/testing/memory_ceiling.py`'s per-worker RSS ceiling
+      # kills a runaway worker with `os._exit(97)` (no pytest traceback,
+      # capture-manager output discarded on the way out) after naming the
+      # offending test in `.reyn-memory-ceiling.log` FIRST. Unlike the
+      # stall-trace file above, this one is never pre-created empty (it is
+      # only opened, in append mode, at the moment the ceiling actually
+      # fires) — `-s` (exists AND non-empty) is still the right test either
+      # way: false on both "never created" and "created but empty", which
+      # is exactly "did not fire" here. `-n auto` runs several workers
+      # sharing this job's one checkout/cwd, so any worker's firing lands
+      # in this SAME file (append mode, never clobbered) — one check
+      # covers all of them. Missing this cat is what cost a full
+      # investigation round-trip during #5877's own CI-hang triage (the
+      # test name that died was invisible in the job log).
+      - name: Memory-ceiling dump (#5878 — only non-empty if a worker was killed)
+        if: always()
+        run: |
+          if [ -s .reyn-memory-ceiling.log ]; then
+            echo "::warning::#5878 memory ceiling fired — a pytest worker exceeded its RSS ceiling and was killed"
+            cat .reyn-memory-ceiling.log
+          else
+            echo "no memory-ceiling dump (no worker exceeded its RSS ceiling)"
+          fi
+
       # #4331: what a green run above does NOT say — the skip census (count
       # + reason breakdown) and the collection-error count, on the SAME
       # surface (this job's own summary page) a human reads the green


### PR DESCRIPTION
**[e2e-coder]** — Closes #5878.

## What

`dev/testing/memory_ceiling.py`'s per-worker RSS ceiling kills a runaway pytest worker with `os._exit(97)` after writing the offending test's name to `.reyn-memory-ceiling.log` — but CI never `cat`s or artifacts that file. The controller then waits on the dead worker until the job's own `timeout 12m` kills it at exit 124, and the test name that actually caused it is gone with the ephemeral runner. This cost a full investigation round-trip during #5877's own CI-hang triage.

Adds a "Memory-ceiling dump" step, `if: always()`, mirroring the existing "Stall-trace dump (#4986)" step's exact shape.

One difference from that step, called out in the new step's own comment: `.reyn-ci-stall-trace.log` is pre-created **empty** at watchdog-arm time (faulthandler needs an already-open file object), so a healthy run leaves an empty file, not a missing one. `.reyn-memory-ceiling.log` is different — it's only opened, in append mode, at the moment the ceiling actually fires, so it may not exist at all on a healthy run. `[ -s ... ]` (exists AND non-empty) is still the correct test either way — false on both "never created" and "created but empty".

`-n auto`'s several workers share this job's one checkout/cwd, so any worker's firing lands in the same file (append mode, never clobbered) — one check covers all of them.

## Gates

No `src/`/`tests/`/`docs/` touched — pure CI workflow YAML, so none of the path-conditional gates apply.

- YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — OK.
- `ruff check .` — clean.
- The one existing test that reads this workflow file (`test_5691_ci_diff_filter_excludes_deletions.py`, targeting the unrelated "Run test-tier audit" step) still passes, unaffected.
- Machine was under swap pressure during this PR (per lead-coder's own directive) — checked for contending `mypy`/`pytest`/`mkdocs` processes before every run here; none of those gates apply to this diff anyway.

## Test plan

- [x] Automated checks above.
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
