### PR TITLE
fix(#5882): mypy_ratchet -- shared cache, changed-files default, repo lock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,8 +277,15 @@ jobs:
       #
       # `timeout 8m` (#3670): see the "Run tests" job's comment for why —
       # converts a would-be `cancelled` job-timeout into a legible `failure`.
+      #
+      # `--full` (#5882): the script's own LOCAL default is now
+      # changed-files mode (only the .py files a branch touched, relative
+      # to origin/main) — a "find out sooner" tool, not the judgment (see
+      # the script's own module docstring). CI is the judgment, so it
+      # always passes `--full` explicitly, checking the whole src/reyn +
+      # tests trees exactly as before this change.
       - name: Run mypy ratchet
-        run: timeout 8m python scripts/mypy_ratchet.py
+        run: timeout 8m python scripts/mypy_ratchet.py --full
 
   docs:
     name: docs build (strict)

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -39,9 +39,10 @@ records.
 scripts/test_tier_audit.py --strict <changed test files>`, `python
 scripts/verify_module_docstrings.py <changed src files>`, `python
 scripts/mypy_ratchet.py` (#5882 — this LOCAL run defaults to changed-files
-mode, only the `.py` files your branch touched relative to `origin/main`:
-a "find out sooner" tool, not the judgment — a signature change breaking
-an UNCHANGED caller elsewhere is invisible to it. CI always passes
+mode: the `.py` files your branch touched relative to `origin/main`'s
+merge-base, committed or not, plus untracked ones. It is a "find out
+sooner" tool, not the judgment — a signature change breaking an UNCHANGED
+caller elsewhere is invisible to it. CI always passes
 `--full`, checking the whole tree, and is the one that actually decides),
 `python scripts/flat_tests_ratchet.py`
 (#3879 Stage 0 — CI runs this unconditionally on every PR, no path

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -38,7 +38,12 @@ records.
 **Before you open a PR, run `ruff check .`, `python
 scripts/test_tier_audit.py --strict <changed test files>`, `python
 scripts/verify_module_docstrings.py <changed src files>`, `python
-scripts/mypy_ratchet.py`, `python scripts/flat_tests_ratchet.py`
+scripts/mypy_ratchet.py` (#5882 — this LOCAL run defaults to changed-files
+mode, only the `.py` files your branch touched relative to `origin/main`:
+a "find out sooner" tool, not the judgment — a signature change breaking
+an UNCHANGED caller elsewhere is invisible to it. CI always passes
+`--full`, checking the whole tree, and is the one that actually decides),
+`python scripts/flat_tests_ratchet.py`
 (#3879 Stage 0 — CI runs this unconditionally on every PR, no path
 filter, `.github/workflows/flat-tests-ratchet.yml`; it only fails when
 a NEW `.py` file lands directly in `tests/`, not in any subdirectory —

--- a/scripts/check_tests_path_literal_reference_baseline.json
+++ b/scripts/check_tests_path_literal_reference_baseline.json
@@ -511,7 +511,22 @@
   },
   {
     "file": "tests/scripts/test_3726_mypy_ratchet.py",
+    "literal": "tests/bar.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_3726_mypy_ratchet.py",
+    "literal": "tests/changed.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_3726_mypy_ratchet.py",
     "literal": "tests/runtime/test_foo.py",
+    "class": "never-existed"
+  },
+  {
+    "file": "tests/scripts/test_3726_mypy_ratchet.py",
+    "literal": "tests/unchanged.py",
     "class": "never-existed"
   },
   {

--- a/scripts/mypy_ratchet.py
+++ b/scripts/mypy_ratchet.py
@@ -120,8 +120,10 @@ Three changes, all from the architect's own ruling (issue #5882):
 
 2. **Local default is changed-files mode, not the whole tree** — see
    :func:`changed_python_files` / :func:`main` below: only the ``.py``
-   files this branch actually touched (relative to ``origin/main``) are
-   passed to mypy, and the baseline comparison is SCOPED to those same
+   files this branch actually touched relative to ``origin/main``'s
+   merge-base — committed, staged, unstaged, or untracked alike, since
+   the gate is usually run BEFORE committing — are passed to mypy, and
+   the baseline comparison is SCOPED to those same
    files. ``--full`` restores the old whole-tree behavior; CI always
    passes it explicitly, and a checkout where ``origin/main`` cannot be
    resolved (no such remote-tracking ref) falls back to it automatically,
@@ -316,24 +318,29 @@ def release_lock(handle: "IO[Any] | None") -> None:
 
 
 def changed_python_files(root: Path = _ROOT, base_ref: str = _BASE_REF) -> "list[str] | None":
-    """The ``.py`` files this checkout's ``HEAD`` changed relative to
-    ``base_ref``, plus untracked ``.py`` files — the population
-    changed-files mode checks (#5882).
+    """Every ``.py`` file this checkout differs from ``base_ref``'s
+    merge-base by — committed, staged, unstaged — plus untracked ``.py``
+    files. The population changed-files mode checks (#5882).
 
     Returns ``None`` when ``base_ref`` cannot be resolved (no such
     remote-tracking ref — a shallow clone, a fork without ``origin/main``
     configured, or CI's own non-PR contexts) so the caller can fall back
     to ``--full`` instead of silently checking nothing.
 
-    Committed changes only (``git diff --name-only --diff-filter=ACMR
-    <base_ref>...HEAD``, three-dot = against the MERGE-BASE, so a branch
-    that has diverged from a moving ``main`` is diffed against where it
-    branched, not against ``main``'s current tip) plus untracked new
-    files — deliberately NOT staged-or-unstaged edits to an already
-    TRACKED file. Architect's own ruling scope; a caller mid-edit with
-    uncommitted changes to a tracked file should commit (or use
-    ``--full``) before relying on this for anything but a quick look —
-    disclosed here and in ``pr-workflow.md``, not silently assumed.
+    ``git diff --name-only --diff-filter=ACMR --merge-base <base_ref>``
+    (no second commit, so the comparison's right-hand side is the WORKING
+    TREE) is the whole tracked side in one command: the question this
+    mode answers is "is there a new finding in what I am about to push",
+    and at the moment a coder actually runs the gate — before committing
+    — the edits in question are usually still uncommitted. An earlier
+    version of this diffed ``<base_ref>...HEAD`` (committed only), which
+    made exactly that moment report "nothing to check": a verdict over a
+    population it had never looked at, the same silently-green shape
+    #5849 closed elsewhere (architect ruling, #5884 review).
+    ``--merge-base`` (rather than a bare ``<base_ref>``) keeps the
+    three-dot semantics that matter here — a branch diverging from a
+    MOVING ``main`` is compared against where it branched, so unrelated
+    commits landing on ``main`` never enter this population.
 
     ``--diff-filter=ACMR`` (Added/Copied/Modified/Renamed) excludes
     Deleted — nothing to type-check in a file that no longer exists."""
@@ -344,7 +351,7 @@ def changed_python_files(root: Path = _ROOT, base_ref: str = _BASE_REF) -> "list
     if resolvable.returncode != 0:
         return None
     diff = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD"],
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "--merge-base", base_ref],
         cwd=root, capture_output=True, text=True, check=True,
     ).stdout.splitlines()
     untracked = subprocess.run(

--- a/scripts/mypy_ratchet.py
+++ b/scripts/mypy_ratchet.py
@@ -92,10 +92,70 @@ a missing module and a normal findings-reported run BOTH exit 1 (measured).
 NOT covered, disclosed rather than silently half-closed: mypy installed but
 crashing mid-run in some shape the ``[syntax]`` guard above doesn't already
 name. That shape has never been observed here; this one had.
+
+#5882 (architect ruling — 2026-09-06 owner-machine swap incident, 8 GB RAM):
+whole-tree ``mypy tests`` (1,711 files) plus ``mypy src/reyn`` (640 files)
+holds a typed AST for the whole population in memory (RSS 1-3 GB, several
+minutes), and this repo's own workflow gives every task a FRESH git
+worktree — mypy's own ``.mypy_cache`` defaults to the invoking process's
+cwd, so every worktree started cold, incremental caching bought nothing
+(measured: 27 separate ``.mypy_cache`` directories, 2.8 GB total, scattered
+under one coder's worktrees). Two coders running this at once on a
+free-12%-RAM machine forced it into swap, ~5x slower, past the 300s
+subprocess timeout, retried — 7 times in one night. CI's own ``mypy
+(ratchet)`` job makes the same judgment on a separate machine regardless, so
+a full local run's only real value was "find out sooner" — not a second,
+independent verdict.
+
+Three changes, all from the architect's own ruling (issue #5882):
+
+1. **One shared cache across every worktree of this repo** —
+   :func:`default_cache_dir` resolves ``--cache-dir`` from ``git
+   rev-parse --git-common-dir`` (OUTSIDE any single worktree's own tree,
+   survives a worktree being removed) rather than mypy's own cwd-relative
+   default. mypy's cache entries are keyed by source hash, so a cache
+   warmed by one worktree's content answering for a DIFFERENT worktree's
+   run cannot produce a wrong answer — a stale entry is simply
+   recomputed, never trusted blind.
+
+2. **Local default is changed-files mode, not the whole tree** — see
+   :func:`changed_python_files` / :func:`main` below: only the ``.py``
+   files this branch actually touched (relative to ``origin/main``) are
+   passed to mypy, and the baseline comparison is SCOPED to those same
+   files. ``--full`` restores the old whole-tree behavior; CI always
+   passes it explicitly, and a checkout where ``origin/main`` cannot be
+   resolved (no such remote-tracking ref) falls back to it automatically,
+   printing why.
+
+   ⚠️ Disclosure (architect's own wording, also in
+   ``docs/deep-dives/contributing/pr-workflow.md``): changed-files mode
+   only sees NEW findings inside the files this branch touched. A
+   signature change that breaks an UNCHANGED caller elsewhere in the tree
+   is invisible to it — that shape is exactly what CI's own ``--full``
+   run exists to catch. Local changed-files mode is a "find out sooner"
+   tool, not a second judgment; CI's ``--full`` run is still the one that
+   decides.
+
+3. **A repo-wide lock, so "two runs at once" cannot happen at all** —
+   :func:`acquire_lock` takes an ``fcntl.flock`` on ``run.lock`` inside
+   the shared cache dir before either mypy subprocess starts. A second
+   concurrent invocation waits (printing that it is waiting) unless
+   ``--no-wait`` is passed, in which case it exits 2 immediately. This is
+   the charter's own "who stops this if it repeats" subject for the
+   swap incident above — 1 and 2 alone shrink each individual run, but
+   without this a machine could still see two shrunk-but-still-real runs
+   overlap on the same night the incident happened.
+
+``dmypy`` (mypy's daemon mode) is deliberately NOT adopted here — the
+ruling defers it to "after 1-3, measured": the three changes above may
+already remove enough of the cost that a daemon's own complexity (a
+long-lived process per repo, its own staleness/restart questions) is not
+worth taking on without first seeing whether it is still needed.
 """
 from __future__ import annotations
 
 import argparse
+import fcntl
 import importlib.util
 import json
 import os
@@ -103,6 +163,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import IO, Any, Callable
 
 _ROOT = Path(__file__).resolve().parent.parent
 _BASELINE_PATH = _ROOT / "scripts" / "mypy_ratchet_baseline.json"
@@ -117,6 +178,17 @@ _TARGET = "src/reyn"
 #: ONLY for the narrow, zero-false-positive shape :func:`none_arg_type_
 #: hits_in_tests` looks for, never for a general tests/ mypy sweep.
 _TESTS_TARGET = "tests"
+#: #5882: the base ref changed-files mode diffs against. A module constant
+#: (not a CLI flag) — the ruling's own scope is "local vs CI", not "diff
+#: against an arbitrary ref"; a future need for the latter can add a flag
+#: without touching this default.
+_BASE_REF = "origin/main"
+#: #5882: the lock file inside the shared cache dir. Its PARENT directory
+#: doubling as both "mypy's own cache" and "this script's own lock" is
+#: deliberate, not a namespace collision — both are per-repo, both must
+#: survive a worktree's own removal, and a caller who deletes the whole
+#: cache dir to force a cold run also correctly drops any stale lock.
+_LOCK_FILENAME = "run.lock"
 
 # Matches mypy's normal-mode error line:
 #   src/reyn/foo/bar.py:123: error: <message>  [error-code]
@@ -160,15 +232,162 @@ _MYPY_MISSING = (
 )
 
 
-def run_mypy(root: Path = _ROOT, target: str = _TARGET) -> str:
-    """Run mypy against ``target`` and return its combined stdout+stderr.
+def default_cache_dir(root: Path = _ROOT) -> Path:
+    """The shared ``--cache-dir`` for every mypy invocation this script
+    makes: ``<git-common-dir>/reyn-mypy-cache`` (#5882).
+
+    ``git rev-parse --git-common-dir`` resolves to the MAIN checkout's
+    ``.git`` for any worktree (worktrees share one common-dir by
+    construction) and to the ordinary ``.git`` for a non-worktree
+    checkout either way — so every worktree of this repo, and the main
+    checkout itself, converge on the SAME cache directory, warmed by
+    whichever of them ran mypy most recently. This is OUTSIDE any single
+    worktree's own working tree, so removing a worktree (the normal way
+    a coder's task-scoped checkout is cleaned up) never touches it.
+
+    mypy's own cache entries are keyed by source content hash, not by
+    which worktree wrote them — a cache entry warmed while looking at one
+    worktree's version of a file is simply a cache MISS (recomputed, not
+    trusted) when a different worktree's version of that file differs, so
+    sharing the cache across worktrees cannot make mypy report a wrong
+    answer, only a slower-than-warm one on the files that actually
+    changed between worktrees.
+
+    Raises ``subprocess.CalledProcessError`` if ``root`` is not inside a
+    git checkout at all — a caller that reaches this function is already
+    inside one (this script itself is), so that failure would mean
+    something is badly wrong with the invocation, not an ordinary
+    "no ref" case (unlike :func:`changed_python_files`'s OWN, expected,
+    "not resolvable" case for ``origin/main``)."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    common_dir = (root / proc.stdout.strip()).resolve()
+    return common_dir / "reyn-mypy-cache"
+
+
+def acquire_lock(cache_dir: Path, *, wait: bool = True, out: "IO[str]" = sys.stderr) -> "IO[Any] | None":
+    """Take an exclusive, repo-wide lock before any mypy subprocess starts
+    (#5882 — the charter's "who stops this if it repeats" subject for the
+    swap incident this module's own docstring describes).
+
+    ``fcntl.flock`` on an open file, not a PID file or a bare "does
+    run.lock exist" check: flock is held per OPEN FILE DESCRIPTION (not
+    per process), auto-releases if the holder dies without cleanup
+    (no stale-lock-from-a-killed-process hazard a PID file would have),
+    and — the property this module's own tests rely on — TWO separate
+    ``open()`` calls on the same path within a SINGLE process still
+    contend with each other, so a test can simulate "another run holds
+    the lock" without a real second process.
+
+    Returns the open, locked file handle (the caller holds it for as
+    long as the lock should be held, then passes it to
+    :func:`release_lock`), or ``None`` if ``wait=False`` and the lock was
+    already held.
+
+    ``wait=True`` (the default) tries non-blocking FIRST so it can print
+    "waiting" exactly once before falling into a real blocking wait —
+    silently blocking with no explanation would look identical to a
+    hang to whoever is watching."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = cache_dir / _LOCK_FILENAME
+    handle = open(lock_path, "a+")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return handle
+    except BlockingIOError:
+        if not wait:
+            handle.close()
+            return None
+        print(f"another mypy run is holding {lock_path}; waiting", file=out)
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)  # blocks until released
+        return handle
+
+
+def release_lock(handle: "IO[Any] | None") -> None:
+    """Release a lock :func:`acquire_lock` returned. A no-op on ``None``
+    (the ``--no-wait`` "did not acquire" case) so a caller's ``finally``
+    never needs its own conditional."""
+    if handle is None:
+        return
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    handle.close()
+
+
+def changed_python_files(root: Path = _ROOT, base_ref: str = _BASE_REF) -> "list[str] | None":
+    """The ``.py`` files this checkout's ``HEAD`` changed relative to
+    ``base_ref``, plus untracked ``.py`` files — the population
+    changed-files mode checks (#5882).
+
+    Returns ``None`` when ``base_ref`` cannot be resolved (no such
+    remote-tracking ref — a shallow clone, a fork without ``origin/main``
+    configured, or CI's own non-PR contexts) so the caller can fall back
+    to ``--full`` instead of silently checking nothing.
+
+    Committed changes only (``git diff --name-only --diff-filter=ACMR
+    <base_ref>...HEAD``, three-dot = against the MERGE-BASE, so a branch
+    that has diverged from a moving ``main`` is diffed against where it
+    branched, not against ``main``'s current tip) plus untracked new
+    files — deliberately NOT staged-or-unstaged edits to an already
+    TRACKED file. Architect's own ruling scope; a caller mid-edit with
+    uncommitted changes to a tracked file should commit (or use
+    ``--full``) before relying on this for anything but a quick look —
+    disclosed here and in ``pr-workflow.md``, not silently assumed.
+
+    ``--diff-filter=ACMR`` (Added/Copied/Modified/Renamed) excludes
+    Deleted — nothing to type-check in a file that no longer exists."""
+    resolvable = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", base_ref],
+        cwd=root, capture_output=True, text=True,
+    )
+    if resolvable.returncode != 0:
+        return None
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD"],
+        cwd=root, capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=root, capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    return sorted({f for f in (*diff, *untracked) if f.endswith(".py")})
+
+
+def split_src_and_tests(files: "list[str]") -> "tuple[list[str], list[str]]":
+    """Partition ``files`` (repo-relative paths) into the (src, tests)
+    populations the two gates below each cover. A file under neither
+    ``src/reyn/`` nor ``tests/`` (e.g. ``scripts/*.py``) is checked by
+    NEITHER gate — the same scope the pre-#5882 whole-tree targets
+    (:data:`_TARGET`, :data:`_TESTS_TARGET`) already had; changed-files
+    mode narrows WHICH files within that scope are checked, not the
+    scope itself."""
+    src = [f for f in files if f.startswith("src/reyn/")]
+    tests = [f for f in files if f.startswith("tests/")]
+    return src, tests
+
+
+def run_mypy(
+    targets: "list[str]",
+    *,
+    cache_dir: Path,
+    root: Path = _ROOT,
+    runner: "Callable[..., subprocess.CompletedProcess[str]]" = subprocess.run,
+) -> str:
+    """Run mypy against ``targets`` (either ``[_TARGET]`` for a whole-tree
+    run, or a specific list of changed files) and return its combined
+    stdout+stderr.
+
+    ``runner`` is injectable (#5882 acceptance ②) so a test can record the
+    exact argv this function builds — including ``--cache-dir`` and the
+    target list — without a real mypy install or a real subprocess.
 
     Never raises on a non-zero exit — mypy exits 1 whenever it reports any
     error, which is the expected, common case this script exists to handle,
     not a failure of the subprocess call itself.
     """
-    proc = subprocess.run(
-        [sys.executable, "-m", "mypy", target],
+    proc = runner(
+        [sys.executable, "-m", "mypy", "--cache-dir", str(cache_dir), *targets],
         cwd=root,
         capture_output=True,
         text=True,
@@ -193,9 +412,16 @@ def parse_mypy_output(text: str) -> "set[tuple[str, str]]":
     return pairs
 
 
-def run_mypy_tests_none_arg_type(root: Path = _ROOT) -> str:
-    """Run mypy against :data:`_TESTS_TARGET` and return combined stdout+stderr
-    (#5739).
+def run_mypy_tests_none_arg_type(
+    targets: "list[str]",
+    *,
+    cache_dir: Path,
+    root: Path = _ROOT,
+    runner: "Callable[..., subprocess.CompletedProcess[str]]" = subprocess.run,
+) -> str:
+    """Run mypy against ``targets`` (either ``[_TESTS_TARGET]`` for a
+    whole-tree run, or a specific list of changed test files) and return
+    combined stdout+stderr (#5739, targets/runner added #5882).
 
     ``MYPYPATH=src`` — unlike the ``src/reyn`` target above, ``tests/``
     itself is not on mypy's default search path, so an ``import reyn.foo``
@@ -213,8 +439,8 @@ def run_mypy_tests_none_arg_type(root: Path = _ROOT) -> str:
     cover.
     """
     env = {**os.environ, "MYPYPATH": str(root / "src")}
-    proc = subprocess.run(
-        [sys.executable, "-m", "mypy", _TESTS_TARGET],
+    proc = runner(
+        [sys.executable, "-m", "mypy", "--cache-dir", str(cache_dir), *targets],
         cwd=root,
         capture_output=True,
         text=True,
@@ -224,7 +450,9 @@ def run_mypy_tests_none_arg_type(root: Path = _ROOT) -> str:
     return proc.stdout + proc.stderr
 
 
-def none_arg_type_hits_in_tests(text: str) -> "set[tuple[str, int, str]]":
+def none_arg_type_hits_in_tests(
+    text: str, *, scope: "set[str] | None" = None,
+) -> "set[tuple[str, int, str]]":
     """Extract every (file, line, message) triple matching the #5739 shape:
     a `tests/` call site passing a `None` literal to an argument mypy
     resolves as non-Optional.
@@ -235,12 +463,20 @@ def none_arg_type_hits_in_tests(text: str) -> "set[tuple[str, int, str]]":
     (file, line, message), not the coarser (file, code) grain
     :func:`parse_mypy_output` uses above — see :data:`_NONE_ARG_TYPE_LINE`'s
     own comment for why the coarser grain does not apply to a baseline-free
-    gate."""
+    gate.
+
+    ``scope`` (#5882): when given (changed-files mode), a hit whose file is
+    outside ``scope`` is dropped — mypy following an import from a changed
+    test file into an UNCHANGED one could otherwise surface a pre-existing
+    hit that changed-files mode has no business reporting on this run
+    (``--full`` still catches it)."""
     hits: set[tuple[str, int, str]] = set()
     for line in text.splitlines():
         m = _NONE_ARG_TYPE_LINE.match(line)
         if m:
             hits.add((m.group("file"), int(m.group("lineno")), m.group("msg").strip()))
+    if scope is not None:
+        hits = {h for h in hits if h[0] in scope}
     return hits
 
 
@@ -255,11 +491,22 @@ def write_baseline(pairs: "set[tuple[str, str]]", path: Path = _BASELINE_PATH) -
 
 
 def new_findings(
-    measured: "set[tuple[str, str]]", baseline: "set[tuple[str, str]]"
+    measured: "set[tuple[str, str]]",
+    baseline: "set[tuple[str, str]]",
+    *,
+    scope: "set[str] | None" = None,
 ) -> "set[tuple[str, str]]":
     """The ratchet check itself: any measured pair the baseline does not
     already declare is new — a pair leaving the measured set (a fix) is not
-    reported here at all, by design (see module docstring)."""
+    reported here at all, by design (see module docstring).
+
+    ``scope`` (#5882): when given (changed-files mode), only pairs whose
+    file is IN ``scope`` are compared at all — an off-baseline pair in an
+    UNCHANGED file (surfaced only because mypy followed an import into it)
+    must stay invisible to changed-files mode; it is exactly the shape
+    ``--full`` exists to still catch."""
+    if scope is not None:
+        measured = {p for p in measured if p[0] in scope}
     return measured - baseline
 
 
@@ -281,7 +528,15 @@ def syntax_pairs_in(pairs: "set[tuple[str, str]]") -> "set[tuple[str, str]]":
     baselined or not, and refuses to bake one into the baseline at all via
     `--write-baseline` — the one operation the module docstring already names
     as "the one way to defeat the ratchet" would otherwise defeat THIS
-    specific check permanently, silently, in one command."""
+    specific check permanently, silently, in one command.
+
+    Deliberately NOT scoped to changed-files mode's own file set (#5882): a
+    truncated run means "trust nothing this run says" regardless of which
+    files were the intended target — the whole point of #3727's own finding
+    is that a `[syntax]` abort makes every OTHER file's silence
+    UNINFORMATIVE, not confirmed clean, so narrowing this check to "only
+    care if the syntax error is in a file I meant to check" would reinstate
+    exactly the misidentification #3727 closed."""
     return {p for p in pairs if p[1] == "syntax"}
 
 
@@ -304,7 +559,29 @@ def main(argv: "list[str] | None" = None) -> int:
             "regenerate the baseline from a fresh mypy run instead of checking "
             "against it. Use ONLY after actually fixing/triaging findings — "
             "regenerating to silence a new failure defeats the ratchet (see "
-            "module docstring)."
+            "module docstring). Always runs against the WHOLE tree (--full is "
+            "implied) — a baseline scoped to changed files would silently "
+            "drop every pair outside them the next time someone runs this."
+        ),
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help=(
+            "check the whole src/reyn + tests trees (#5882) — CI's own "
+            "mode, always passed explicitly there. Local runs default to "
+            "changed-files mode instead (only .py files this branch "
+            "touched relative to origin/main); a checkout where "
+            "origin/main cannot be resolved falls back to this "
+            "automatically."
+        ),
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help=(
+            "if another mypy_ratchet.py run already holds the repo-wide "
+            "lock, exit 2 immediately instead of waiting for it (#5882)."
         ),
     )
     args = parser.parse_args(argv)
@@ -318,84 +595,148 @@ def main(argv: "list[str] | None" = None) -> int:
         print(_MYPY_MISSING.format(exe=sys.executable), file=sys.stderr)
         return 1
 
-    # #5739: the tests/-scoped, baseline-free gate — checked in EVERY mode
-    # (including --write-baseline, which only ever regenerates the OTHER
-    # gate's baseline and has no bearing on this one). Any hit is
-    # unconditionally a failure; there is nothing here to grandfather.
-    none_arg_hits = none_arg_type_hits_in_tests(run_mypy_tests_none_arg_type())
+    # #5882: --write-baseline always operates on the whole tree — a
+    # baseline is a claim about the WHOLE population's current findings,
+    # and writing one scoped to a diff would silently drop every pair
+    # outside it the next time someone regenerates.
+    full = args.full or args.write_baseline
 
-    output = run_mypy()
-    measured = parse_mypy_output(output)
-    syntax_pairs = syntax_pairs_in(measured)
-
-    def _report_none_arg_hits() -> None:
-        print(
-            f"\n#5739 gate FAILED: {len(none_arg_hits)} tests/ site(s) pass a "
-            f"None literal to a non-Optional argument (no baseline — fix "
-            f"each site; see the finding's own message for whether the TEST "
-            f"or the production signature is wrong):",
-            file=sys.stderr,
-        )
-        for file, lineno, msg in sorted(none_arg_hits):
-            print(f"  {file}:{lineno}: {msg}", file=sys.stderr)
-
-    if args.write_baseline:
-        if syntax_pairs:
+    src_scope: "set[str] | None" = None
+    tests_scope: "set[str] | None" = None
+    if full:
+        src_targets = [_TARGET]
+        tests_targets = [_TESTS_TARGET]
+    else:
+        changed = changed_python_files()
+        if changed is None:
             print(
-                "REFUSING to write baseline: this measurement contains a "
-                "[syntax] finding, which means mypy aborted before checking "
-                "most of the tree. Baselining it would bake in a "
-                "permanently-degraded run that reports \"OK\" forever while "
-                "only ever checking one file. Fix the [syntax] finding(s) "
-                "first, then regenerate.\n",
+                f"{_BASE_REF} is not resolvable in this checkout — falling "
+                "back to --full (changed-files mode needs a base ref to "
+                "diff against).",
                 file=sys.stderr,
             )
-            for file, code in sorted(syntax_pairs):
-                print(f"  {file}  [{code}]", file=sys.stderr)
-            return 1
-        write_baseline(measured)
-        print(f"Wrote {len(measured)} (file, code) pairs to {_BASELINE_PATH}")
-        if none_arg_hits:
-            # #5739 has no baseline to write — surfaced here too so
-            # --write-baseline never reads as "everything is clean".
-            _report_none_arg_hits()
-            return 1
-        return 0
+            full = True
+            src_targets = [_TARGET]
+            tests_targets = [_TESTS_TARGET]
+        else:
+            src_files, tests_files = split_src_and_tests(changed)
+            src_scope, tests_scope = set(src_files), set(tests_files)
+            src_targets, tests_targets = src_files, tests_files
+            if not src_targets and not tests_targets:
+                print(
+                    "mypy ratchet: no changed .py file under src/reyn/ or "
+                    "tests/ relative to origin/main — nothing to check "
+                    "locally. This is a \"find out sooner\" tool, not the "
+                    "judgment (see module docstring) — CI's own --full run "
+                    "is still the gate."
+                )
+                return 0
 
-    baseline = load_baseline()
-    new = new_findings(measured, baseline)
-
-    if not new and not syntax_pairs and not none_arg_hits:
-        print(f"mypy ratchet OK: {len(measured)} findings, all baselined ({len(baseline)} declared).")
-        return 0
-
-    print("mypy ratchet FAILED:\n", file=sys.stderr)
-    if new:
+    cache_dir = default_cache_dir()
+    lock_handle = acquire_lock(cache_dir, wait=not args.no_wait)
+    if lock_handle is None:
         print(
-            f"{len(new)} new (file, error-code) pair(s) not in the baseline "
-            f"({_BASELINE_PATH.relative_to(_ROOT)}):",
+            f"another mypy_ratchet.py run is holding the lock at "
+            f"{cache_dir / _LOCK_FILENAME}; refusing to wait (--no-wait).",
             file=sys.stderr,
         )
-        for file, code in sorted(new):
-            print(f"  {file}  [{code}]", file=sys.stderr)
-    if syntax_pairs:
-        # Fires even when every syntax_pairs entry is already baselined (so
-        # absent from `new`) — a baselined [syntax] is never "known debt",
-        # see syntax_pairs_in()'s own docstring.
-        print(f"\n{_SYNTAX_ABORT_WARNING}", file=sys.stderr)
-        for file, code in sorted(syntax_pairs):
-            note = "" if (file, code) in new else "  (already \"baselined\" — still fatal, see above)"
-            print(f"  {file}  [{code}]{note}", file=sys.stderr)
-    if none_arg_hits:
-        _report_none_arg_hits()
-    print(
-        "\nEither fix the new finding(s), or if this is a deliberate, understood "
-        "addition, add the (file, code) pair to the baseline explicitly — do "
-        "NOT regenerate the whole baseline with --write-baseline to silence this. "
-        "(The #5739 gate above has no baseline at all — fix those sites directly.)",
-        file=sys.stderr,
-    )
-    return 1
+        return 2
+
+    try:
+        # #5739: the tests/-scoped, baseline-free gate — checked in EVERY
+        # mode (including --write-baseline, which only ever regenerates the
+        # OTHER gate's baseline and has no bearing on this one). Any hit is
+        # unconditionally a failure; there is nothing here to grandfather.
+        # Skipped entirely (no subprocess) when changed-files mode found no
+        # changed tests/ file — the whole point of #5882 is not spending a
+        # multi-minute run when there is nothing in scope to check.
+        none_arg_hits: "set[tuple[str, int, str]]" = set()
+        if tests_targets:
+            none_arg_hits = none_arg_type_hits_in_tests(
+                run_mypy_tests_none_arg_type(tests_targets, cache_dir=cache_dir),
+                scope=tests_scope,
+            )
+
+        measured: "set[tuple[str, str]]" = set()
+        if src_targets:
+            output = run_mypy(src_targets, cache_dir=cache_dir)
+            measured = parse_mypy_output(output)
+        syntax_pairs = syntax_pairs_in(measured)
+
+        def _report_none_arg_hits() -> None:
+            print(
+                f"\n#5739 gate FAILED: {len(none_arg_hits)} tests/ site(s) pass a "
+                f"None literal to a non-Optional argument (no baseline — fix "
+                f"each site; see the finding's own message for whether the TEST "
+                f"or the production signature is wrong):",
+                file=sys.stderr,
+            )
+            for file, lineno, msg in sorted(none_arg_hits):
+                print(f"  {file}:{lineno}: {msg}", file=sys.stderr)
+
+        if args.write_baseline:
+            if syntax_pairs:
+                print(
+                    "REFUSING to write baseline: this measurement contains a "
+                    "[syntax] finding, which means mypy aborted before checking "
+                    "most of the tree. Baselining it would bake in a "
+                    "permanently-degraded run that reports \"OK\" forever while "
+                    "only ever checking one file. Fix the [syntax] finding(s) "
+                    "first, then regenerate.\n",
+                    file=sys.stderr,
+                )
+                for file, code in sorted(syntax_pairs):
+                    print(f"  {file}  [{code}]", file=sys.stderr)
+                return 1
+            write_baseline(measured)
+            print(f"Wrote {len(measured)} (file, code) pairs to {_BASELINE_PATH}")
+            if none_arg_hits:
+                # #5739 has no baseline to write — surfaced here too so
+                # --write-baseline never reads as "everything is clean".
+                _report_none_arg_hits()
+                return 1
+            return 0
+
+        baseline = load_baseline()
+        new = new_findings(measured, baseline, scope=src_scope)
+
+        if not new and not syntax_pairs and not none_arg_hits:
+            mode = "--full" if full else "changed-files"
+            print(
+                f"mypy ratchet OK ({mode}): {len(measured)} findings, all "
+                f"baselined ({len(baseline)} declared)."
+            )
+            return 0
+
+        print("mypy ratchet FAILED:\n", file=sys.stderr)
+        if new:
+            print(
+                f"{len(new)} new (file, error-code) pair(s) not in the baseline "
+                f"({_BASELINE_PATH.relative_to(_ROOT)}):",
+                file=sys.stderr,
+            )
+            for file, code in sorted(new):
+                print(f"  {file}  [{code}]", file=sys.stderr)
+        if syntax_pairs:
+            # Fires even when every syntax_pairs entry is already baselined (so
+            # absent from `new`) — a baselined [syntax] is never "known debt",
+            # see syntax_pairs_in()'s own docstring.
+            print(f"\n{_SYNTAX_ABORT_WARNING}", file=sys.stderr)
+            for file, code in sorted(syntax_pairs):
+                note = "" if (file, code) in new else "  (already \"baselined\" — still fatal, see above)"
+                print(f"  {file}  [{code}]{note}", file=sys.stderr)
+        if none_arg_hits:
+            _report_none_arg_hits()
+        print(
+            "\nEither fix the new finding(s), or if this is a deliberate, understood "
+            "addition, add the (file, code) pair to the baseline explicitly — do "
+            "NOT regenerate the whole baseline with --write-baseline to silence this. "
+            "(The #5739 gate above has no baseline at all — fix those sites directly.)",
+            file=sys.stderr,
+        )
+        return 1
+    finally:
+        release_lock(lock_handle)
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_3726_mypy_ratchet.py
+++ b/tests/scripts/test_3726_mypy_ratchet.py
@@ -49,16 +49,6 @@ def _load():
     return module
 
 
-class _FakeCompleted:
-    """A real, minimal stand-in for `subprocess.CompletedProcess` — not a
-    mock, just the two attributes `run_mypy`/`run_mypy_tests_none_arg_type`
-    read off whatever `runner` returns."""
-
-    def __init__(self, stdout: str = "", stderr: str = "") -> None:
-        self.stdout = stdout
-        self.stderr = stderr
-
-
 # ── parse_mypy_output ───────────────────────────────────────────────────────
 
 
@@ -299,13 +289,17 @@ def test_changed_files_mode_passes_only_the_changed_files_to_mypy() -> None:
     """Tier 1: #5882 accept ② — the exact argv `run_mypy` builds for a
     changed-files call is just those files (plus `--cache-dir`); a
     `--full`-shaped call (`["src/reyn"]`) still gets the WHOLE target.
-    `runner` is injected so this needs no real mypy install or subprocess."""
+    `runner` is injected so this needs no real mypy install or subprocess —
+    and what it returns is a REAL `subprocess.CompletedProcess` (cheaply
+    constructible, and its own `.stdout`/`.stderr` are exactly the two
+    attributes the function under test reads), never a hand-rolled
+    stand-in."""
     module = _load()
     recorded: list[list[str]] = []
 
-    def _runner(argv: list[str], **kwargs: object) -> _FakeCompleted:
+    def _runner(argv: list[str], **kwargs: object) -> "subprocess.CompletedProcess[str]":
         recorded.append(argv)
-        return _FakeCompleted()
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
 
     module.run_mypy(["src/reyn/foo.py"], cache_dir=Path("/tmp/cache"), runner=_runner)
     assert recorded[-1][-1] == "src/reyn/foo.py"
@@ -320,9 +314,9 @@ def test_changed_files_mode_passes_only_the_changed_test_files_to_mypy() -> None
     module = _load()
     recorded: list[list[str]] = []
 
-    def _runner(argv: list[str], **kwargs: object) -> _FakeCompleted:
+    def _runner(argv: list[str], **kwargs: object) -> "subprocess.CompletedProcess[str]":
         recorded.append(argv)
-        return _FakeCompleted()
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
 
     module.run_mypy_tests_none_arg_type(
         ["tests/runtime/test_foo.py"], cache_dir=Path("/tmp/cache"), runner=_runner,

--- a/tests/scripts/test_3726_mypy_ratchet.py
+++ b/tests/scripts/test_3726_mypy_ratchet.py
@@ -12,11 +12,24 @@ Public surface only: `parse_mypy_output` / `new_findings` / `load_baseline` /
 `write_baseline` are called directly against real strings/files (no mocks —
 there is nothing to fake here, the whole point is these are pure functions
 over text/sets).
+
+#5882 additions (cache-dir sharing / changed-files mode / the repo-wide
+lock): every `main()`-driving test below now forces `--full` and points
+`default_cache_dir` at a throwaway `tmp_path` — `main([])`'s new DEFAULT is
+changed-files mode, which would otherwise run a real `git diff` against
+THIS checkout's actual working-tree state and make these tests' own
+target/scope non-deterministic; `--full` restores the old, deterministic
+whole-tree semantics these tests were written against. Pointing
+`default_cache_dir` at `tmp_path` keeps every test from touching (or
+contending on) the real, shared `<git-common-dir>/reyn-mypy-cache` a
+genuine concurrent mypy_ratchet.py run elsewhere on the machine might be
+holding.
 """
 from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -34,6 +47,16 @@ def _load():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+class _FakeCompleted:
+    """A real, minimal stand-in for `subprocess.CompletedProcess` — not a
+    mock, just the two attributes `run_mypy`/`run_mypy_tests_none_arg_type`
+    read off whatever `runner` returns."""
+
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        self.stdout = stdout
+        self.stderr = stderr
 
 
 # ── parse_mypy_output ───────────────────────────────────────────────────────
@@ -103,6 +126,31 @@ def test_measured_set_equal_to_baseline_is_clean() -> None:
     module = _load()
     pairs = {("src/reyn/foo.py", "attr-defined"), ("src/reyn/bar.py", "arg-type")}
     assert module.new_findings(pairs, pairs) == set()
+
+
+def test_changed_files_mode_hides_an_off_baseline_pair_in_an_unchanged_file() -> None:
+    """Tier 1: #5882 accept ③ — positive control. An off-baseline pair in a
+    file OUTSIDE changed-files mode's `scope` stays invisible (mypy
+    following an import into an unchanged file must not resurrect a
+    pre-existing finding on THIS run) — the SAME pair surfaces the moment
+    `scope` is removed (`--full`), proving the hiding is `scope`-driven,
+    not a bug that would hide it everywhere."""
+    module = _load()
+    measured = {
+        ("src/reyn/changed.py", "arg-type"),
+        ("src/reyn/unchanged.py", "attr-defined"),
+    }
+    baseline = {("src/reyn/changed.py", "arg-type")}  # unchanged.py's pair is NOT baselined
+
+    scoped = module.new_findings(measured, baseline, scope={"src/reyn/changed.py"})
+    assert scoped == set(), (
+        "an off-baseline pair OUTSIDE changed-files mode's scope must stay green"
+    )
+
+    full = module.new_findings(measured, baseline, scope=None)
+    assert full == {("src/reyn/unchanged.py", "attr-defined")}, (
+        "the SAME off-baseline pair must surface once scope is removed (--full)"
+    )
 
 
 # ── syntax_pairs_in (#3727, verification-hazards.md §18 "B. Misidentification") ──
@@ -188,11 +236,218 @@ def test_the_committed_baseline_is_reachable_through_the_registered_target() -> 
     assert len(baseline) > 0
 
 
+# ── #5882: split_src_and_tests ──────────────────────────────────────────────
+
+
+def test_split_src_and_tests_partitions_by_top_level_directory() -> None:
+    """Tier 1: a changed-files population splits into exactly the two
+    populations the src ratchet / #5739 tests gate each cover; a file under
+    neither (e.g. scripts/) is in NEITHER output list — same scope the old
+    whole-tree targets already had."""
+    module = _load()
+    src, tests = module.split_src_and_tests(
+        ["src/reyn/foo.py", "tests/bar.py", "scripts/baz.py", "docs/readme.md"]
+    )
+    assert src == ["src/reyn/foo.py"]
+    assert tests == ["tests/bar.py"]
+
+
+# ── #5882: default_cache_dir — shared across worktrees ──────────────────────
+
+
+def test_cache_dir_resolves_to_the_git_common_dir_not_the_worktree(tmp_path: Path) -> None:
+    """Tier 1: #5882 accept ① — from a REAL git worktree, `default_cache_dir`
+    resolves under the MAIN checkout's `.git` (shared across every
+    worktree of this repo), never the worktree's own directory. strip: the
+    naive cwd-relative default this fix replaces would resolve to a path
+    INSIDE the worktree instead — verified directly by asserting the
+    resolved path is NOT under the worktree and IS under the main repo."""
+    module = _load()
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    _run_git = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=main_repo, check=True, capture_output=True, text=True,
+    )
+    _run_git("init", "-q")
+    _run_git("config", "user.email", "t@example.com")
+    _run_git("config", "user.name", "t")
+    (main_repo / "f.txt").write_text("x")
+    _run_git("add", ".")
+    _run_git("commit", "-q", "-m", "init")
+    _run_git("branch", "wt-branch")
+
+    worktree = tmp_path / "worktree"
+    _run_git("worktree", "add", str(worktree), "wt-branch")
+
+    resolved = module.default_cache_dir(root=worktree)
+
+    assert resolved.name == "reyn-mypy-cache"
+    assert not str(resolved).startswith(str(worktree)), (
+        "cache dir resolved INSIDE the worktree — the shared-across-worktrees "
+        "fix regressed to a naive per-worktree default"
+    )
+    assert str(resolved).startswith(str(main_repo)), (
+        "cache dir did not resolve under the MAIN checkout — worktrees no "
+        "longer share a warm cache"
+    )
+
+
+# ── #5882: run_mypy / run_mypy_tests_none_arg_type — injectable argv ────────
+
+
+def test_changed_files_mode_passes_only_the_changed_files_to_mypy() -> None:
+    """Tier 1: #5882 accept ② — the exact argv `run_mypy` builds for a
+    changed-files call is just those files (plus `--cache-dir`); a
+    `--full`-shaped call (`["src/reyn"]`) still gets the WHOLE target.
+    `runner` is injected so this needs no real mypy install or subprocess."""
+    module = _load()
+    recorded: list[list[str]] = []
+
+    def _runner(argv: list[str], **kwargs: object) -> _FakeCompleted:
+        recorded.append(argv)
+        return _FakeCompleted()
+
+    module.run_mypy(["src/reyn/foo.py"], cache_dir=Path("/tmp/cache"), runner=_runner)
+    assert recorded[-1][-1] == "src/reyn/foo.py"
+    assert "--cache-dir" in recorded[-1] and "/tmp/cache" in recorded[-1]
+
+    module.run_mypy(["src/reyn"], cache_dir=Path("/tmp/cache"), runner=_runner)
+    assert recorded[-1][-1] == "src/reyn"
+
+
+def test_changed_files_mode_passes_only_the_changed_test_files_to_mypy() -> None:
+    """Tier 1: same as above, for the #5739 tests/-scoped invocation."""
+    module = _load()
+    recorded: list[list[str]] = []
+
+    def _runner(argv: list[str], **kwargs: object) -> _FakeCompleted:
+        recorded.append(argv)
+        return _FakeCompleted()
+
+    module.run_mypy_tests_none_arg_type(
+        ["tests/runtime/test_foo.py"], cache_dir=Path("/tmp/cache"), runner=_runner,
+    )
+    assert recorded[-1][-1] == "tests/runtime/test_foo.py"
+
+    module.run_mypy_tests_none_arg_type(["tests"], cache_dir=Path("/tmp/cache"), runner=_runner)
+    assert recorded[-1][-1] == "tests"
+
+
+# ── #5882: acquire_lock / release_lock — repo-wide, single-run ──────────────
+
+
+def test_no_wait_returns_none_immediately_when_the_lock_is_already_held(tmp_path: Path) -> None:
+    """Tier 1: #5882 accept ④ — a SECOND, independent open-file-description
+    on the same lock path contends via `flock` even within one process
+    (`acquire_lock`'s own docstring on why this is testable without a real
+    second process). `wait=False` must fail IMMEDIATELY — no sleep, no
+    duration — while the first holder has it, and succeed the moment it is
+    released."""
+    module = _load()
+    cache_dir = tmp_path / "cache"
+
+    holder = module.acquire_lock(cache_dir, wait=True)
+    assert holder is not None
+
+    second = module.acquire_lock(cache_dir, wait=False)
+    assert second is None, (
+        "a second, non-waiting acquire must fail immediately while the first is held"
+    )
+
+    module.release_lock(holder)
+
+    third = module.acquire_lock(cache_dir, wait=False)
+    assert third is not None, "once released, a non-waiting acquire must succeed"
+    module.release_lock(third)
+
+
+def test_main_no_wait_exits_2_when_the_lock_is_held(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 1: #5882 accept ④, wired through `main()` — `--no-wait` against
+    an already-held lock is exit code 2, distinct from the ratchet's own
+    0/1 verdicts, and never reaches either mypy invocation."""
+    module = _load()
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(module, "default_cache_dir", lambda: cache_dir)
+    calls: list[str] = []
+    monkeypatch.setattr(module, "run_mypy", lambda *a, **kw: calls.append("src") or "")
+    monkeypatch.setattr(
+        module, "run_mypy_tests_none_arg_type", lambda *a, **kw: calls.append("tests") or "",
+    )
+
+    holder = module.acquire_lock(cache_dir, wait=True)
+    try:
+        rc = module.main(["--full", "--no-wait"])
+    finally:
+        module.release_lock(holder)
+
+    assert rc == 2
+    assert calls == [], "a lock refusal must never reach either mypy invocation"
+
+
+# ── #5882: main() — changed-files mode selection ────────────────────────────
+
+
+def test_main_changed_files_mode_skips_mypy_entirely_when_nothing_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: #5882 — with zero changed `.py` files, `main()` spends no
+    subprocess call on either gate at all (the whole point of the fix), and
+    never touches the cache dir / lock either."""
+    module = _load()
+    monkeypatch.setattr(module, "changed_python_files", lambda: [])
+    calls: list[str] = []
+    monkeypatch.setattr(module, "run_mypy", lambda *a, **kw: calls.append("src") or "")
+    monkeypatch.setattr(
+        module, "run_mypy_tests_none_arg_type", lambda *a, **kw: calls.append("tests") or "",
+    )
+    monkeypatch.setattr(
+        module, "default_cache_dir",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("cache dir must not be resolved when there is nothing to check")
+        ),
+    )
+
+    rc = module.main([])
+
+    assert rc == 0
+    assert calls == []
+
+
+def test_main_falls_back_to_full_when_origin_main_is_unresolvable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 1: #5882 — a checkout where `origin/main` cannot be resolved
+    (`changed_python_files` returns ``None``) falls back to the WHOLE
+    `src/reyn` / `tests` targets, same as an explicit `--full`."""
+    module = _load()
+    monkeypatch.setattr(module, "changed_python_files", lambda: None)
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
+    monkeypatch.setattr(module, "load_baseline", lambda: set())
+    recorded_src_targets: list[list[str]] = []
+    recorded_tests_targets: list[list[str]] = []
+    monkeypatch.setattr(
+        module, "run_mypy",
+        lambda targets, **kw: recorded_src_targets.append(list(targets)) or "",
+    )
+    monkeypatch.setattr(
+        module, "run_mypy_tests_none_arg_type",
+        lambda targets, **kw: recorded_tests_targets.append(list(targets)) or "",
+    )
+
+    rc = module.main([])
+
+    assert rc == 0
+    assert recorded_src_targets == [["src/reyn"]]
+    assert recorded_tests_targets == [["tests"]]
+
+
 # ── main() wiring (#3727 review: the bug lived in main(), not in a pure fn) ──
 
 
 def test_main_fails_even_when_the_only_measured_pair_is_a_baselined_syntax_one(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
     """Tier 1: FALSIFY the exact gap lead-coder's review found — the ORIGINAL
     wiring checked `new_findings()` only, so a `[syntax]` pair already in the
@@ -202,38 +457,40 @@ def test_main_fails_even_when_the_only_measured_pair_is_a_baselined_syntax_one(
     already bound into their default-argument at module-def time) so the
     test drives `main()`'s real control flow without touching disk."""
     module = _load()
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(module, "load_baseline", lambda: {("src/reyn/foo.py", "syntax")})
     monkeypatch.setattr(
         module, "run_mypy",
-        lambda: "src/reyn/foo.py:1: error: Invalid syntax  [syntax]\n"
+        lambda *a, **kw: "src/reyn/foo.py:1: error: Invalid syntax  [syntax]\n"
                 "Found 1 error in 1 file (errors prevented further checking)\n",
     )
-    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda: "")
+    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda *a, **kw: "")
 
-    rc = module.main([])
+    rc = module.main(["--full"])
 
     assert rc == 1
     assert "not confirmed clean" in capsys.readouterr().err
 
 
 def test_main_ok_when_measured_matches_baseline_with_no_syntax(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """Tier 1: the ordinary green path is unaffected by the syntax check —
     only actually-present [syntax] pairs change the verdict."""
     module = _load()
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(module, "load_baseline", lambda: {("src/reyn/foo.py", "attr-defined")})
     monkeypatch.setattr(
         module, "run_mypy",
-        lambda: "src/reyn/foo.py:1: error: msg  [attr-defined]\n",
+        lambda *a, **kw: "src/reyn/foo.py:1: error: msg  [attr-defined]\n",
     )
-    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda: "")
+    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda *a, **kw: "")
 
-    assert module.main([]) == 0
+    assert module.main(["--full"]) == 0
 
 
 def test_main_write_baseline_refuses_when_a_syntax_pair_is_measured(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
     """Tier 1: FALSIFY — `--write-baseline` is the module docstring's own
     named "one way to defeat the ratchet"; baking in a `[syntax]` pair would
@@ -241,14 +498,15 @@ def test_main_write_baseline_refuses_when_a_syntax_pair_is_measured(
     adds. `main()` must refuse to write at all — `write_baseline` must never
     even be called."""
     module = _load()
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
     calls: list[object] = []
     monkeypatch.setattr(module, "write_baseline", lambda pairs, path=None: calls.append(pairs))
     monkeypatch.setattr(
         module, "run_mypy",
-        lambda: "src/reyn/foo.py:1: error: Invalid syntax  [syntax]\n"
+        lambda *a, **kw: "src/reyn/foo.py:1: error: Invalid syntax  [syntax]\n"
                 "Found 1 error in 1 file (errors prevented further checking)\n",
     )
-    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda: "")
+    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda *a, **kw: "")
 
     rc = module.main(["--write-baseline"])
 
@@ -268,13 +526,14 @@ def test_main_refuses_when_mypy_is_not_importable(
 ) -> None:
     """Tier 1: FALSIFY the #4576 shape — with mypy absent, `main()` must
     fail LOUDLY (not print "0 findings" and exit 0) and must never even
-    reach either mypy invocation."""
+    reach either mypy invocation — nor the changed-files/cache-dir/lock
+    machinery below the guard."""
     module = _load()
     monkeypatch.setattr(module, "mypy_is_importable", lambda: False)
     calls: list[str] = []
-    monkeypatch.setattr(module, "run_mypy", lambda: calls.append("src") or "")
+    monkeypatch.setattr(module, "run_mypy", lambda *a, **kw: calls.append("src") or "")
     monkeypatch.setattr(
-        module, "run_mypy_tests_none_arg_type", lambda: calls.append("tests") or "",
+        module, "run_mypy_tests_none_arg_type", lambda *a, **kw: calls.append("tests") or "",
     )
 
     rc = module.main([])
@@ -369,22 +628,46 @@ def test_two_none_hits_on_the_same_line_are_kept_distinct() -> None:
     }
 
 
+def test_scope_hides_a_none_arg_hit_in_an_unchanged_test_file() -> None:
+    """Tier 1: #5882 — same shape as `new_findings`'s own `scope` above,
+    for the #5739 gate: a hit outside changed-files mode's tests/ scope
+    (mypy following an import into an unchanged test helper) stays
+    invisible on THIS run; unscoped (`--full`) still catches it."""
+    module = _load()
+    text = (
+        'tests/changed.py:1: error: Argument "x" to "Y" has incompatible '
+        'type "None"; expected "Z"  [arg-type]\n'
+        'tests/unchanged.py:2: error: Argument "a" to "B" has incompatible '
+        'type "None"; expected "C"  [arg-type]\n'
+    )
+    scoped = module.none_arg_type_hits_in_tests(text, scope={"tests/changed.py"})
+    assert scoped == {
+        ("tests/changed.py", 1, 'Argument "x" to "Y" has incompatible type "None"; expected "Z"'),
+    }
+    unscoped = module.none_arg_type_hits_in_tests(text, scope=None)
+    assert unscoped == {
+        ("tests/changed.py", 1, 'Argument "x" to "Y" has incompatible type "None"; expected "Z"'),
+        ("tests/unchanged.py", 2, 'Argument "a" to "B" has incompatible type "None"; expected "C"'),
+    }
+
+
 def test_main_fails_on_a_none_arg_type_hit_even_when_the_baselined_ratchet_is_clean(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
     """Tier 1: FALSIFY — #5739's own gate has NO baseline, so it must fail
     `main()` independently of the src/reyn ratchet's own verdict (a clean
     baselined run must not mask a real #5739 hit)."""
     module = _load()
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(module, "load_baseline", lambda: {("src/reyn/foo.py", "attr-defined")})
-    monkeypatch.setattr(module, "run_mypy", lambda: "src/reyn/foo.py:1: error: msg  [attr-defined]\n")
+    monkeypatch.setattr(module, "run_mypy", lambda *a, **kw: "src/reyn/foo.py:1: error: msg  [attr-defined]\n")
     monkeypatch.setattr(
         module, "run_mypy_tests_none_arg_type",
-        lambda: 'tests/runtime/test_foo.py:1: error: Argument "x" to "Y" has '
+        lambda *a, **kw: 'tests/runtime/test_foo.py:1: error: Argument "x" to "Y" has '
                 'incompatible type "None"; expected "Z"  [arg-type]\n',
     )
 
-    rc = module.main([])
+    rc = module.main(["--full"])
 
     err = capsys.readouterr().err
     assert rc == 1
@@ -393,20 +676,21 @@ def test_main_fails_on_a_none_arg_type_hit_even_when_the_baselined_ratchet_is_cl
 
 
 def test_main_ok_when_both_the_ratchet_and_the_5739_gate_are_clean(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """Tier 1: the ordinary green path — neither gate has anything to
     report."""
     module = _load()
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(module, "load_baseline", lambda: {("src/reyn/foo.py", "attr-defined")})
-    monkeypatch.setattr(module, "run_mypy", lambda: "src/reyn/foo.py:1: error: msg  [attr-defined]\n")
-    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda: "")
+    monkeypatch.setattr(module, "run_mypy", lambda *a, **kw: "src/reyn/foo.py:1: error: msg  [attr-defined]\n")
+    monkeypatch.setattr(module, "run_mypy_tests_none_arg_type", lambda *a, **kw: "")
 
-    assert module.main([]) == 0
+    assert module.main(["--full"]) == 0
 
 
 def test_main_write_baseline_still_surfaces_a_5739_hit(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path,
 ) -> None:
     """Tier 1: FALSIFY — #5739 has no baseline to write, so
     `--write-baseline` must not read as "everything is clean" while a real
@@ -415,11 +699,12 @@ def test_main_write_baseline_still_surfaces_a_5739_hit(
     unrelated, legitimate baseline regeneration), but main() still exits
     nonzero and reports the hit."""
     module = _load()
+    monkeypatch.setattr(module, "default_cache_dir", lambda: tmp_path / "cache")
     monkeypatch.setattr(module, "write_baseline", lambda pairs, path=None: None)
-    monkeypatch.setattr(module, "run_mypy", lambda: "src/reyn/foo.py:1: error: msg  [attr-defined]\n")
+    monkeypatch.setattr(module, "run_mypy", lambda *a, **kw: "src/reyn/foo.py:1: error: msg  [attr-defined]\n")
     monkeypatch.setattr(
         module, "run_mypy_tests_none_arg_type",
-        lambda: 'tests/runtime/test_foo.py:1: error: Argument "x" to "Y" has '
+        lambda *a, **kw: 'tests/runtime/test_foo.py:1: error: Argument "x" to "Y" has '
                 'incompatible type "None"; expected "Z"  [arg-type]\n',
     )
 

--- a/tests/scripts/test_3726_mypy_ratchet.py
+++ b/tests/scripts/test_3726_mypy_ratchet.py
@@ -282,6 +282,80 @@ def test_cache_dir_resolves_to_the_git_common_dir_not_the_worktree(tmp_path: Pat
     )
 
 
+# ── #5882: changed_python_files — the population changed-files mode checks ──
+
+
+def test_an_uncommitted_edit_to_a_tracked_file_is_in_the_population(tmp_path: Path) -> None:
+    """Tier 1: #5882 accept (architect's widened scope, #5884 review) — a
+    tracked `.py` file EDITED BUT NOT COMMITTED is in changed-files mode's
+    population, because that is the state a coder is actually in at the
+    moment they run this gate (before committing). An earlier version
+    diffed `origin/main...HEAD` (committed only) and reported "nothing to
+    check" there — a verdict over a population it had never looked at.
+
+    strip: reverting the diff to `f"{base_ref}...HEAD"` drops `edited.py`
+    from the returned list (verified directly during this fix), leaving
+    only the untracked file — this test goes red on exactly that revert.
+
+    Real git throughout: a repo with a real `refs/remotes/origin/main`,
+    a real commit, a real uncommitted edit, and a real untracked file —
+    the only way to witness what `git diff` actually reports."""
+    module = _load()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True,
+    )
+    _run_git("init", "-q")
+    _run_git("config", "user.email", "t@example.com")
+    _run_git("config", "user.name", "t")
+    (repo / "tracked.py").write_text("x = 1\n")
+    (repo / "edited.py").write_text("y = 1\n")
+    _run_git("add", ".")
+    _run_git("commit", "-q", "-m", "init")
+    # A real remote-tracking ref at this commit — `changed_python_files`
+    # resolves `origin/main` and diffs against its merge-base with HEAD.
+    _run_git("update-ref", "refs/remotes/origin/main", "HEAD")
+
+    # The three states the widened population must cover, minus the
+    # committed one (which the merge-base makes trivially empty here).
+    (repo / "edited.py").write_text("y = 2  # uncommitted edit\n")   # tracked, unstaged
+    (repo / "brand_new.py").write_text("z = 3\n")                    # untracked
+    (repo / "notes.md").write_text("not python\n")                   # untracked, not .py
+
+    changed = module.changed_python_files(root=repo)
+
+    assert changed is not None, "origin/main resolves here — this must not be the fallback"
+    assert changed == ["brand_new.py", "edited.py"], (
+        "an uncommitted edit to a TRACKED file must be in the population "
+        f"(and a non-.py file must not); got: {changed!r}"
+    )
+
+
+def test_changed_python_files_returns_none_when_the_base_ref_is_unresolvable(
+    tmp_path: Path,
+) -> None:
+    """Tier 1: #5882 — a checkout with no `origin/main` (a shallow clone, a
+    fork, CI's own non-PR contexts) returns `None` so `main()` can fall
+    back to `--full` and say why, rather than diffing against nothing and
+    silently reporting an empty population as "nothing to check"."""
+    module = _load()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True,
+    )
+    _run_git("init", "-q")
+    _run_git("config", "user.email", "t@example.com")
+    _run_git("config", "user.name", "t")
+    (repo / "a.py").write_text("x = 1\n")
+    _run_git("add", ".")
+    _run_git("commit", "-q", "-m", "init")
+    # deliberately NO refs/remotes/origin/main
+
+    assert module.changed_python_files(root=repo) is None
+
+
 # ── #5882: run_mypy / run_mypy_tests_none_arg_type — injectable argv ────────
 
 


### PR DESCRIPTION
**[e2e-coder]** — Closes #5882.

## What

2026-09-06 night: `mypy_ratchet.py`'s whole-tree `mypy tests` (1,711 files) + `mypy src/reyn` (640 files) holds a typed AST for the whole population in memory (RSS 1-3 GB, minutes) — and every coder task gets a FRESH git worktree, so mypy's own cwd-relative `.mypy_cache` started cold every time (measured: 27 separate cache dirs, 2.8 GB, scattered under one coder's worktrees, zero incremental benefit). Two coders running this at once on a free-12%-RAM 8 GB machine forced it into swap, ~5x slower, past the 300s subprocess timeout, retried — 7 times in one night. CI's own mypy job makes the same judgment on a separate machine regardless, so a full local run's only real value was "find out sooner."

Three changes, all from the architect's own ruling (issue #5882):

1. `default_cache_dir()` resolves `--cache-dir` from `git rev-parse --git-common-dir` (outside any single worktree, survives its removal) instead of mypy's cwd-relative default — shared across every worktree of this repo. mypy's cache is keyed by source hash, so a cache warmed by a different worktree's content is a cache MISS (recomputed), never a wrong answer.
2. Local default is now changed-files mode: the `.py` files a branch touched relative to `origin/main`'s **merge-base — committed, staged, unstaged, plus untracked** (`changed_python_files`; scope widened by the architect's own #5884 review, since a coder runs this gate *before* committing and the earlier committed-only shape reported "nothing to check" over a population it had never looked at) are passed to mypy, and the baseline comparison (`new_findings`'s new `scope` param, same for the #5739 None-arg-type gate) is scoped to those same files. `--full` restores the old whole-tree behavior; CI always passes it explicitly, and an unresolvable `origin/main` falls back to it automatically. Disclosed in both the script's own module docstring and `pr-workflow.md`: changed-files mode only sees NEW findings inside touched files — a signature change breaking an UNCHANGED caller elsewhere is invisible to it; CI's `--full` run is still the judgment.
3. `acquire_lock`/`release_lock`: an `fcntl.flock` on `run.lock` inside the shared cache dir, held for the whole of either mypy invocation. A second concurrent run waits (printing that it's waiting) unless `--no-wait`, which exits 2 immediately. This is the charter's own "who stops this if it repeats" subject for the swap incident — 1 and 2 alone shrink each run, but without this two shrunk runs could still overlap on the same night it happened.

`dmypy` (daemon mode) is deliberately deferred — ruling: measure whether 1-3 already remove enough of the cost before taking on a long-lived per-repo process.

## Acceptance (from the issue's ruling comment)

- [x] From a REAL git worktree, `default_cache_dir` resolves to `<common-dir>/reyn-mypy-cache` (strip-verified: a naive cwd-relative default resolves inside the worktree instead — confirmed red, restored).
- [x] A tracked `.py` file edited but NOT committed is in the population, an untracked `.py` is too, an untracked non-`.py` is not (architect's widened-scope acceptance item; strip-verified: reverting the diff to `origin/main...HEAD` drops the edited file — confirmed red, restored).
- [x] With a single changed file, the mypy argv is exactly that file (injectable `runner`, no real subprocess needed); `--full` still passes the whole `src/reyn`/`tests` target.
- [x] Baseline comparison is scoped to changed files: an off-baseline pair in an unchanged file stays green in changed-files mode, red in `--full` (positive control).
- [x] Lock: held → `--no-wait` returns/exits immediately (no duration, verified via two independent open-file-descriptions on the same lock file within one process — `flock` still contends); released → passes through (strip-verified: a no-op lock makes both lock tests red — confirmed, restored).
- [x] CI's `mypy (ratchet)` step now passes `--full` explicitly (`test.yml` diff).
- [x] `pr-workflow.md` gained the local-changed-files-vs-CI-`--full` distinction.

## Gates

- `ruff check .` — clean.
- `python scripts/test_tier_audit.py --strict tests/scripts/test_3726_mypy_ratchet.py` — 36/36 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py scripts/mypy_ratchet.py` — OK.
- `python scripts/check_tests_path_literal_reference.py` — OK (3 new illustrative literal filenames in the test file classified `never-existed`, matching this file's own established convention for fake example paths — `--write-baseline`'d, re-verified clean, re-ran again right before push per the doc's own staleness warning).
- `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `flat_tests_ratchet.py` — OK.
- docs/-path gates (`mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py`) — all exit 0.
- Scoped `pytest tests/scripts/test_3726_mypy_ratchet.py` — 36/36 passed, 0.5s (no real mypy subprocess in any test — everything drives pure functions or an injected `runner`).
- **`mypy_ratchet.py` itself was NOT run locally this round**, per lead-coder's own temporary directive (the owner's machine is still under swap pressure) — this PR's self-verification relies on the unit-test witnesses above; CI's own `--full` run is the judgment, exactly as the new local-mode's own disclosure says it should be.

## Test plan

- [x] Automated tests above.
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S

