### PR TITLE
fix(#5886): seed the sent-queue gate from the snapshot, never from a live read

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2779,6 +2779,30 @@ class TextualChatApp(App):
                     self._hydrate_from_history()
                 except Exception:
                     logger.exception("textual chat: on_mount hydrate-from-history failed")
+        # #5886: seed the sent-queue gate ONCE at mount, and let a remote
+        # connection's own STATE_SNAPSHOT re-seed it authoritatively when
+        # the pump reaches one (:meth:`_pump_frames`).
+        #
+        # This exists for the LOCAL (in-process) transport, which never
+        # produces a ``StatusApplied`` at all — ``agui/client.py`` is its
+        # only producer — so after #5886 deleted the lazy first-frame seed
+        # there would otherwise be NOTHING to seed a local client, and a
+        # local attach to a session with items already queued would show an
+        # empty sent-queue region. Caught by asking "what does this change
+        # make false" of the local path, not by a test: the architect's
+        # ruling assumed a mount-time live read already existed here, and
+        # the lazy seed had been quietly serving that role.
+        #
+        # Harmless for remote, deliberately: at mount the read model is
+        # still empty, so this takes a baseline of 0 — the ADMITTING
+        # direction, never the dropping one — and the connect-time snapshot
+        # replaces it with the real hydration value moments later. A local
+        # read at mount IS the hydration value there (no wire, so "now" and
+        # "the snapshot instant" are the same instant).
+        try:
+            self._seed_queue_view()
+        except Exception:
+            logger.exception("textual chat: on_mount queue-view seed failed")
         # The running-blink gutter animates off FlowView's NATIVE animation clock
         # (``animation_fps`` wired in :meth:`compose`), not an app-side timer — so
         # there is nothing to start/pause here. The blink is ADDITIVE: a frozen

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -5995,19 +5995,40 @@ class TextualChatApp(App):
             logger.exception("textual chat: could not start image resolution")
 
     def _seed_queue_view(self) -> None:
-        """Seed :attr:`_queue_view` from a fresh read-model snapshot — called
-        once, on the FIRST frame the pump processes (#3300 P2b).
+        """Seed :attr:`_queue_view` — the sent-queue seq-gate's baseline —
+        from a fresh read-model snapshot (#3300 P2b).
+
+        **WHEN this runs is the whole design (#5886).** It is called from
+        exactly two places, and both are hydration points:
+
+        - remote: the moment a ``StatusApplied(kind="snapshot")`` is
+          processed IN THE STREAM (:meth:`_pump_frames`). A snapshot is the
+          server's own paired, consistent view (#5179's
+          ``_session_backlog_page_and_status``), and reading it at its own
+          position in the stream is what makes the baseline independent of
+          how far ahead the decoder happens to be.
+        - local (in-process): once at mount. No wire exists, so a single
+          live read IS the hydration value.
+
+        It is deliberately NOT called on "the first non-status frame" any
+        more (#5886, architect ruling ④ — deleted, not kept as a fallback,
+        because a fallback is a second source). That older trigger read a
+        LIVE read model at a data-dependent moment, and ``AgUiTransport``'s
+        own ``_pump_sse`` decodes without yielding between frames while
+        ``frames()`` suspends between each — so the read model runs
+        arbitrarily far ahead of the pump's position, and the baseline
+        could be seeded from state the pump had not reached. Measured, not
+        theorised: the operator's own first message after attaching was
+        rejected by its own gate (``seq 1 <= baseline``), leaving no user
+        row and a stranded sent-queue placeholder.
 
         The read-model projects ``queue``/``turn_active``/``queue_seq``
         uniformly for local and remote (``read_model.py``'s
         ``project_remote_snapshot`` mirrors ``interfaces/repl/status.py``'s
-        ``_snapshot()``), so ONE call seeds the seq-gate baseline correctly
-        for either transport: local is always live (no wire delay), and for
-        remote the connect-time ``STATE_SNAPSHOT`` has already reached the
-        transport by the time frame #1 is yielded (emitter.py's "Reconnect
-        snapshots first (A4)"), so this is late-joiner-correct. Any item the
-        snapshot already carries (a submission from BEFORE this client
-        attached) is rendered into the sent-queue region immediately."""
+        ``_snapshot()``), so ONE call seeds correctly for either transport.
+        Any item the snapshot already carries (a submission from BEFORE this
+        client attached) is rendered into the sent-queue region
+        immediately."""
         snap = self._snapshot() or {}
         self._queue_view.apply_snapshot(
             queue=snap.get("queue", []),
@@ -6263,15 +6284,21 @@ class TextualChatApp(App):
                 agent=agent or self._destination.agent,
                 session_id=session_id or self._destination.session_id,
             )
-        # Eager reseed (see the ``_queue_view``/``_queue_seeded`` bullet
-        # above): seed the fresh view from the NEW session's snapshot right
-        # now, rather than deferring to the generic "first frame" check —
-        # which would need ANOTHER frame after this barrier to ever fire.
-        try:
-            self._seed_queue_view()
-        except Exception:
-            logger.exception("textual chat: switch queue-view reseed failed")
-        self._queue_seeded = True
+        # #5886 (architect ruling ④): the eager reseed that used to run
+        # HERE is DELETED, not kept as a fallback. It read the live read
+        # model at the moment this ``session_attached`` frame was
+        # processed — but the emitter yields this barrier frame FIRST and
+        # the new session's own backlog + STATE_SNAPSHOT strictly AFTER it
+        # (``emitter.py``'s ``if etype == "session_attached"`` branch runs
+        # after the frame is encoded). Landing in the same HTTP chunk made
+        # it accidentally correct (``_consume_block`` applies the snapshot
+        # to the read model before the app sees either); across a chunk
+        # boundary it seeded from the OLD session's values — the same class
+        # #5886 fixes on the connect path. The fresh view built above is
+        # now seeded by that new session's own STATE_SNAPSHOT when the pump
+        # reaches it, which is the one moment the value is known to be
+        # this session's.
+        self._queue_seeded = False
         # #5050 ③: SAME reasoning — a switch to an agent that already has
         # a pending intervention gets no live announce (restore.py: an
         # unanswered intervention leaves no history trace, and
@@ -6368,10 +6395,27 @@ class TextualChatApp(App):
             # stale delta is legitimate and stays silent to the operator; it
             # stops being invisible to the LOG, which is the surface an
             # investigation reads.
-            logger.debug(
+            # #5886 (architect ruling ⑥): a rejection whose ``client_ref``
+            # is THIS client's own pending row is the bug's fingerprint,
+            # not routine staleness. This client minted that id moments ago
+            # for a submission it has not seen echoed yet, so "already
+            # reflected" cannot be true of it — the only way the gate says
+            # so is a baseline that is wrong. Loud, with the id, so an
+            # operator's log shows the cause instead of just the silence.
+            # Every OTHER rejection (another client's genuinely stale
+            # delta) stays debug: those are the gate doing its job.
+            _ref = (dict(data.get("meta") or {})).get("client_ref")
+            _is_own_pending = isinstance(_ref, str) and self._sent_queue.has_row(_ref)
+            (logger.warning if _is_own_pending else logger.debug)(
                 "textual chat: sent-queue gate rejected user_submitted "
-                "msg_id=%s seq=%s (already reflected by a prior snapshot/delta)",
-                msg_id, seq,
+                "msg_id=%s seq=%s client_ref=%s (already reflected by a "
+                "prior snapshot/delta)%s",
+                msg_id, seq, _ref,
+                (
+                    " — this is THIS client's own pending submission, so the "
+                    "gate's baseline is wrong (#5886), not the delta stale"
+                    if _is_own_pending else ""
+                ),
             )
 
     def _handle_turn_started_event(self, event) -> None:
@@ -7083,13 +7127,41 @@ class TextualChatApp(App):
                     # delta only" case — StatusApplied's own docstring
                     # already states it carries nothing else to apply.
                     frame_is_status_only = True
-                else:
-                    if not self._queue_seeded:
+                    # #5886 (architect ruling ②): a SNAPSHOT is the seq
+                    # gate's hydration point, and seeding HERE — at the
+                    # snapshot's own position in the stream — is what makes
+                    # the baseline independent of how far ahead the decoder
+                    # ran. Every route that produces one converges here:
+                    # first connect, reconnect, and a mid-stream session
+                    # switch (emitter.py's `_reconnect_snapshot_chunks`
+                    # emits a STATE_SNAPSHOT for all three). A DELTA is
+                    # deliberately NOT a seed point (ruling ③): it is a
+                    # display update, and letting it move the baseline is
+                    # the defect itself.
+                    if frame.kind == "snapshot":
                         try:
                             self._seed_queue_view()
                         except Exception:
                             logger.exception("textual chat: queue-view seed failed")
                         self._queue_seeded = True
+                else:
+                    if not self._queue_seeded:
+                        # #5886 (architect ruling ⑤): an event frame BEFORE
+                        # any snapshot is a protocol violation — the server
+                        # contract is snapshot-first (emitter.py's
+                        # "Reconnect snapshots first (A4)"). Say so, then
+                        # APPLY it anyway: dropping it is the invisible
+                        # failure this whole issue is about, while a
+                        # duplicate row is a visible one an operator can
+                        # report. The gate's baseline stays 0 here, which
+                        # admits the frame — the safe direction.
+                        logger.warning(
+                            "textual chat: %s frame arrived before any "
+                            "STATE_SNAPSHOT (protocol expects snapshot "
+                            "first) — applying it rather than dropping it; "
+                            "the sent-queue gate is still unseeded",
+                            getattr(getattr(frame, "event", None), "type", frame),
+                        )
                     if frame.tag is FrameTag.EVENT:
                         etype = getattr(frame.event, "type", None)
                         if etype == "session_attached":

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -71,7 +71,7 @@ from reyn.interfaces.transport.frames import (
     HYDRATE_PAGE_FRAMES,
     BacklogBatch,
     DisplayFrame,
-    FrameTag,
+    EventFrame,
     StatusApplied,
 )
 
@@ -7168,7 +7168,7 @@ class TextualChatApp(App):
                     # is the announcement OF the seed, not a frame that
                     # arrived before one.
                     _is_barrier = (
-                        frame.tag is FrameTag.EVENT
+                        isinstance(frame, EventFrame)
                         and getattr(frame.event, "type", None) == "session_attached"
                     )
                     if not self._queue_seeded and not _is_barrier:
@@ -7188,7 +7188,7 @@ class TextualChatApp(App):
                             "the sent-queue gate is still unseeded",
                             getattr(getattr(frame, "event", None), "type", frame),
                         )
-                    if frame.tag is FrameTag.EVENT:
+                    if isinstance(frame, EventFrame):
                         etype = getattr(frame.event, "type", None)
                         if etype == "session_attached":
                             try:

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2779,30 +2779,12 @@ class TextualChatApp(App):
                     self._hydrate_from_history()
                 except Exception:
                     logger.exception("textual chat: on_mount hydrate-from-history failed")
-        # #5886: seed the sent-queue gate ONCE at mount, and let a remote
-        # connection's own STATE_SNAPSHOT re-seed it authoritatively when
-        # the pump reaches one (:meth:`_pump_frames`).
-        #
-        # This exists for the LOCAL (in-process) transport, which never
-        # produces a ``StatusApplied`` at all — ``agui/client.py`` is its
-        # only producer — so after #5886 deleted the lazy first-frame seed
-        # there would otherwise be NOTHING to seed a local client, and a
-        # local attach to a session with items already queued would show an
-        # empty sent-queue region. Caught by asking "what does this change
-        # make false" of the local path, not by a test: the architect's
-        # ruling assumed a mount-time live read already existed here, and
-        # the lazy seed had been quietly serving that role.
-        #
-        # Harmless for remote, deliberately: at mount the read model is
-        # still empty, so this takes a baseline of 0 — the ADMITTING
-        # direction, never the dropping one — and the connect-time snapshot
-        # replaces it with the real hydration value moments later. A local
-        # read at mount IS the hydration value there (no wire, so "now" and
-        # "the snapshot instant" are the same instant).
-        try:
-            self._seed_queue_view()
-        except Exception:
-            logger.exception("textual chat: on_mount queue-view seed failed")
+        # #5895: no mount-time seed here. The sent-queue gate is seeded from
+        # a ``StatusApplied(kind="snapshot")`` frame and from nothing else —
+        # the local transport puts one behind every ``session_attached``
+        # barrier (``in_process.py``), the first attach included, and the
+        # remote transport decodes one from every STATE_SNAPSHOT. A live
+        # read here was the #5886 defect in a narrower window.
         # The running-blink gutter animates off FlowView's NATIVE animation clock
         # (``animation_fps`` wired in :meth:`compose`), not an app-side timer — so
         # there is nothing to start/pause here. The blink is ADDITIVE: a frozen
@@ -6018,9 +6000,22 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: could not start image resolution")
 
-    def _seed_queue_view(self) -> None:
+    def _seed_queue_view(self, frame: "StatusApplied") -> None:
         """Seed :attr:`_queue_view` — the sent-queue seq-gate's baseline —
-        from a fresh read-model snapshot (#3300 P2b).
+        from the values a ``StatusApplied(kind="snapshot")`` frame CARRIES
+        (#3300 P2b; #5895 for why the frame and never the read model).
+
+        The parameter type IS the rule (architect ruling, #5895 ③): this
+        method takes the frame and reads ``frame.snapshot`` only. It does
+        not call :meth:`_snapshot`, and must not — the read model is the
+        DISPLAY's source, live and free to move; the gate's baseline is a
+        hydration value that must be exactly what the snapshot said at the
+        instant it was taken. #5886's first fix seeded "at the snapshot
+        frame's position" but still read the read model live, which only
+        narrowed the window: a delta the decoder applied (remote), or a
+        submit that advanced ``queue_seq`` (local), between enqueuing the
+        frame and the pump reaching it, still left the baseline ahead of
+        the frames it must admit.
 
         **WHEN this runs is the whole design (#5886).** It is called from
         exactly two places, and both are hydration points:
@@ -6046,24 +6041,24 @@ class TextualChatApp(App):
         rejected by its own gate (``seq 1 <= baseline``), leaving no user
         row and a stranded sent-queue placeholder.
 
-        The read-model projects ``queue``/``turn_active``/``queue_seq``
-        uniformly for local and remote (``read_model.py``'s
-        ``project_remote_snapshot`` mirrors ``interfaces/repl/status.py``'s
-        ``_snapshot()``), so ONE call seeds correctly for either transport.
-        Any item the snapshot already carries (a submission from BEFORE this
-        client attached) is rendered into the sent-queue region
-        immediately."""
-        snap = self._snapshot() or {}
+        Both producers build the frame's values from the SAME status
+        builder the read model uses (``interfaces/repl/status.py``), so one
+        seed body serves either transport. Any item the snapshot already
+        carries (a submission from BEFORE this client attached) is rendered
+        into the sent-queue region immediately."""
+        if frame.snapshot is None:  # a delta — never a seed point (ruling ③)
+            raise ValueError("_seed_queue_view needs a kind='snapshot' frame")
+        snap = frame.snapshot
         self._queue_view.apply_snapshot(
-            queue=snap.get("queue", []),
-            turn_active=snap.get("turn_active", False),
-            queue_seq=snap.get("queue_seq", 0),
+            queue=[dict(item) for item in snap.queue],
+            turn_active=snap.turn_active,
+            queue_seq=snap.queue_seq,
         )
         # #3693: a client that attached mid-turn knows ``turn_active`` and
         # nothing else — no start instant, no tool, no stream. It says so and
         # shows no clock (``started=False``), rather than timing from the
         # moment it happened to connect.
-        if snap.get("turn_active"):
+        if snap.turn_active:
             self._activity.begin("WORKING", started=False)
             # A mid-turn attach did not see the entries that already landed,
             # so it counts from zero and says so by counting from HERE. It
@@ -6154,22 +6149,19 @@ class TextualChatApp(App):
           the panel is tabbed, #3308) actually closes rather than lingering
           empty.
         - :attr:`_queue_view` / :attr:`_queue_seeded` — a FRESH
-          ``RemoteQueueView()``, immediately re-seeded from the NEW session's
-          OWN snapshot right here (:meth:`_seed_queue_view`) rather than
-          deferred to "whenever the next frame happens to arrive" — the
-          identical PROJECTION the #3305 reconnect-reseed/mount-time seed
-          use, just called eagerly instead of gated on
-          :attr:`_queue_seeded`. ★Found during gate-writing (not in the
-          architect's table): deferring to the generic first-frame gate
-          (leaving ``_queue_seeded = False`` and letting the ordinary
-          "seed on first frame" check in :meth:`_pump_frames` catch it) is
-          NOT equivalent here — that check runs BEFORE a frame is
-          dispatched, so it would need a frame AFTER this barrier to ever
-          fire; a session with an already-queued item but no OTHER pending
-          activity would show an empty sent-queue region until something
-          else happened to arrive. Seeding eagerly here closes that gap;
-          :attr:`_queue_seeded` is still set True (never left False) so the
-          generic check is correctly a no-op for this same barrier frame.
+          ``RemoteQueueView()``, seeded by the NEW session's own
+          ``StatusApplied(kind="snapshot")`` frame when the pump reaches
+          it (#5895) — which both transports guarantee follows this
+          barrier: the local one enqueues it right behind the barrier
+          (``in_process.py``), the remote emitter's reconnect protocol
+          sends a STATE_SNAPSHOT after it. No eager reseed here any more:
+          the one this handler used to do read the read model LIVE at the
+          moment the barrier was processed, and the remote emitter yields
+          the barrier BEFORE the new session's snapshot, so across a chunk
+          boundary it seeded from the OLD session — #5886's class in its
+          switch form. (An earlier version of this bullet argued the
+          generic first-frame seed needed a frame AFTER the barrier to
+          fire; the snapshot frame IS that frame, by construction.)
         - :attr:`_queue_item_meta` — cleared (keyed by msg_id, which is
           per-submission; an old session's entries are meaningless once its
           queue view is gone too).
@@ -7164,12 +7156,22 @@ class TextualChatApp(App):
                     # the defect itself.
                     if frame.kind == "snapshot":
                         try:
-                            self._seed_queue_view()
+                            self._seed_queue_view(frame)
                         except Exception:
                             logger.exception("textual chat: queue-view seed failed")
                         self._queue_seeded = True
                 else:
-                    if not self._queue_seeded:
+                    # #5895: the ``session_attached`` barrier is EXEMPT from
+                    # the pre-seed warning below — by construction it
+                    # precedes its own session's snapshot frame (both
+                    # transports put the snapshot right behind it), so it
+                    # is the announcement OF the seed, not a frame that
+                    # arrived before one.
+                    _is_barrier = (
+                        frame.tag is FrameTag.EVENT
+                        and getattr(frame.event, "type", None) == "session_attached"
+                    )
+                    if not self._queue_seeded and not _is_barrier:
                         # #5886 (architect ruling ⑤): an event frame BEFORE
                         # any snapshot is a protocol violation — the server
                         # contract is snapshot-first (emitter.py's

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -32,7 +32,7 @@ from reyn.interfaces.transport.client_transport import ClientTransport, pending_
 from reyn.interfaces.transport.frames import (
     BacklogBatch,
     DisplayFrame,
-    FrameTag,
+    EventFrame,
     StatusApplied,
 )
 from reyn.runtime.outbox import OutboxMessage
@@ -397,7 +397,7 @@ async def run_output_loop(
         # stream is dispatched by tag at the CONSUMING end so the renderer keeps
         # its two entry points; an outbox-only stream would silently drop these
         # (the A2 WaitingOn bug, designed out by the completeness gate).
-        if frame.tag is FrameTag.EVENT:
+        if isinstance(frame, EventFrame):
             event = frame.event
             if getattr(event, "type", None) == "user_submitted":
                 data = getattr(event, "data", None) or {}

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -67,7 +67,7 @@ from reyn.interfaces.transport.client_transport import ClientTransport
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from reyn.interfaces.transport.frames import Frame
+    from reyn.interfaces.transport.frames import BacklogBatch, Frame
     from reyn.runtime.outbox import OutboxMessage
 
 logger = logging.getLogger(__name__)
@@ -250,7 +250,7 @@ class _ErrorWatchingTransport(ClientTransport):
     def close(self) -> None:
         self._inner.close()
 
-    def frames(self) -> "AsyncIterator[Frame]":
+    def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
         return self._inner.frames()
 
     def has_session(self) -> bool:

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -320,7 +320,20 @@ class AgUiTransport(ClientTransport):
                 # happens to arrive next (the owner-hit: the status bar
                 # stayed on the old agent until the next turn's own
                 # frame). See `StatusApplied`'s own docstring.
-                out.append(StatusApplied())
+                #
+                # #5886 (architect ruling ①): carry WHICH of the two this
+                # was. This branch has always known — the two `if`s right
+                # above are that knowledge — and handed the app one opaque
+                # item for both, which is what left the sent-queue seq-gate
+                # with no way to tell a hydration point from a display
+                # update. A snapshot wins when a block somehow carries
+                # both: hydration is the stronger claim, and seeding from
+                # it is never wrong.
+                out.append(
+                    StatusApplied(
+                        kind="snapshot" if decoded.snapshot is not None else "delta"
+                    )
+                )
             elif isinstance(decoded, MessagesSnapshot):
                 # #5139 (architect FINAL ruling, issuecomment-5383272756):
                 # ONE BacklogBatch item, appended to `out` like any other

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -54,6 +54,7 @@ from reyn.interfaces.transport.frames import (
     DisplayFrame,
     EventFrame,
     Frame,
+    QueueSnapshot,
     StatusApplied,
 )
 
@@ -329,11 +330,19 @@ class AgUiTransport(ClientTransport):
                 # update. A snapshot wins when a block somehow carries
                 # both: hydration is the stronger claim, and seeding from
                 # it is never wrong.
-                out.append(
-                    StatusApplied(
-                        kind="snapshot" if decoded.snapshot is not None else "delta"
-                    )
-                )
+                #
+                # #5895: a snapshot frame CARRIES its own queue values,
+                # captured right here from the decoded snapshot — the seed
+                # reads the frame, never the live `_status` view, which a
+                # later delta in this same pump task can have moved before
+                # the app reaches this frame. A delta carries nothing.
+                if decoded.snapshot is not None:
+                    out.append(StatusApplied(
+                        kind="snapshot",
+                        snapshot=QueueSnapshot.from_status(decoded.snapshot),
+                    ))
+                else:
+                    out.append(StatusApplied(kind="delta"))
             elif isinstance(decoded, MessagesSnapshot):
                 # #5139 (architect FINAL ruling, issuecomment-5383272756):
                 # ONE BacklogBatch item, appended to `out` like any other

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -70,7 +70,18 @@ if TYPE_CHECKING:
 # module-level ``object()`` rather than ``None``: a locally-authored
 # ``put_display`` call could in principle wrap a falsy/None-ish payload,
 # and this must never be confused with one.
-_SSE_DONE = object()
+class _SSEDone:
+    """The pump's end-of-stream sentinel — a class of its own (not a bare
+    ``object()``) so ``frames()`` narrows it by ``isinstance`` and mypy can
+    see the item that is yielded past it IS a stream item (#5895: the type
+    enumerates the consumers, so the queue's element type must be honest).
+    """
+
+    __slots__ = ()
+
+
+_SSE_DONE = _SSEDone()
+
 
 
 class _SSEPumpError:
@@ -158,7 +169,9 @@ class AgUiTransport(ClientTransport):
         # SAME queue :meth:`frames` drains, so a locally-authored message
         # renders through the identical renderer path a server-sent one
         # does, without waiting on the next SSE event to unblock it.
-        self._display_queue: "asyncio.Queue[Frame | BacklogBatch | object]" = asyncio.Queue()
+        self._display_queue: "asyncio.Queue[Frame | BacklogBatch | _SSEPumpError | _SSEDone]" = (
+            asyncio.Queue()
+        )
         self._sse_pump_task: "asyncio.Task[None] | None" = None
         # #5694: set once :meth:`frames` re-raises a genuine ``_SSEPumpError``
         # (the pump died — a real read failure, never a clean end or an
@@ -260,9 +273,17 @@ class AgUiTransport(ClientTransport):
     # -- frame production ---------------------------------------------------
 
     def _reguard_frame(self, frame: Frame) -> Frame:
+        # Only a DisplayFrame carries render-nodes; the other members pass
+        # through untouched (#5895: split so a ``list[DisplayFrame]`` — a
+        # backlog page — stays typed as one after re-guarding).
+        if isinstance(frame, DisplayFrame):
+            return self._reguard_display(frame)
+        return frame
+
+    def _reguard_display(self, frame: DisplayFrame) -> DisplayFrame:
         # Per-connection edge re-guard for presentation render-nodes (A5): inert
         # at construction already, re-neutralized here for a heterogeneous client.
-        if isinstance(frame, DisplayFrame) and frame.message.kind == "presentation":
+        if frame.message.kind == "presentation":
             nodes = frame.message.meta.get("nodes")
             if isinstance(nodes, list):
                 meta = dict(frame.message.meta)
@@ -361,7 +382,7 @@ class AgUiTransport(ClientTransport):
                     BacklogBatch(
                         agent=self._backlog_agent,
                         sid=self._backlog_sid,
-                        frames=[self._reguard_frame(f) for f in decoded.frames],
+                        frames=[self._reguard_display(f) for f in decoded.frames],
                         has_more=decoded.has_more,
                         next_cursor=decoded.next_cursor,
                     )
@@ -513,7 +534,7 @@ class AgUiTransport(ClientTransport):
         finally:
             self._display_queue.put_nowait(_SSE_DONE)
 
-    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch | StatusApplied]":
+    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
         # #5139: widened from ``AsyncIterator[Frame]`` — this transport is
         # the only ``ClientTransport`` implementation that ever yields a
         # ``BacklogBatch`` (see that class's own docstring); every other
@@ -553,7 +574,7 @@ class AgUiTransport(ClientTransport):
                 self._connected = False
                 self._pump_died = True
                 raise frame.exc
-            if frame is _SSE_DONE:
+            if isinstance(frame, _SSEDone):
                 return
             # #3570 gate (test_stream_drain_yield_3570.py's own class gate):
             # ``queue.get()`` suspends only while the queue is EMPTY — a
@@ -731,7 +752,7 @@ class AgUiTransport(ClientTransport):
             BacklogBatch(
                 agent=self._backlog_agent,
                 sid=self._backlog_sid,
-                frames=[self._reguard_frame(f) for f in decoded.frames],
+                frames=[self._reguard_display(f) for f in decoded.frames],
                 has_more=decoded.has_more,
                 next_cursor=decoded.next_cursor,
                 is_older_page=True,

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -209,11 +209,11 @@ class AgUiEmitter:
             # them over the transport stream (real clipboard copy / rewind
             # picker), so they are forwarded as profiled CUSTOM events —
             # filtering them would make remote /copy / /rewind silent no-ops.
-            is_control = (
-                isinstance(frame, DisplayFrame)
-                and frame.message.kind in CONTROL_FILTER_KINDS
-            )
-            if is_control:
+            # (#5895: written as one ``isinstance`` guard, not an
+            # intermediate bool — mypy narrows the frame's type through
+            # the former only, and the type is what enumerates ``Frame``'s
+            # consumers now that ``StatusApplied`` is a declared member.)
+            if isinstance(frame, DisplayFrame) and frame.message.kind in CONTROL_FILTER_KINDS:
                 if frame.message.kind == "__end__":
                     return
                 continue

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -717,7 +717,7 @@ class _SessionFrameSource:
     def __init__(self, session, *, registry=None, agent_name: str = "") -> None:
         self._registry = registry
         self._agent_name = agent_name
-        self._q: "asyncio.Queue[Frame]" = asyncio.Queue()
+        self._q: "asyncio.Queue[Frame | StatusPingFrame]" = asyncio.Queue()
         self._forward = forwarded_frame_kinds()
         self._drain_task: "asyncio.Task | None" = None
         self._sub = None

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -366,6 +366,20 @@ class RemoteQueueView:
         """The current queue view, insertion order."""
         return list(self.items.values())
 
+    def baseline_seq(self) -> int:
+        """The seq-gate's current baseline — the highest ``seq`` this view
+        has applied, i.e. the value every incoming delta is compared
+        against (#5886).
+
+        Public because the invariant that matters is about this number and
+        nothing else: **only a snapshot may move it.** A delta advancing
+        the baseline is exactly the defect #5886 reports (the client's read
+        model runs ahead of the pump, so a delta-derived baseline measures
+        frames the pump has not processed yet), and an invariant nobody can
+        read is an invariant nobody can test — its absence here was itself
+        the finding the architect's own acceptance list named."""
+        return self._last_seq
+
 
 def reguard_nodes(nodes: "list[dict]", *, surface: str = "terminal") -> list[dict]:
     """Re-run the surface neutralizer over every leaf string in render nodes (A5).

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -50,7 +50,7 @@ _logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from reyn.interfaces.transport.frames import Frame
+    from reyn.interfaces.transport.frames import BacklogBatch, Frame
     from reyn.runtime.outbox import OutboxMessage
 
 
@@ -66,8 +66,13 @@ class ClientTransport(ABC):
         """Stop producing frames and release the underlying subscriptions."""
 
     @abstractmethod
-    def frames(self) -> "AsyncIterator[Frame]":
-        """Yield the unified, ordered, tagged frame stream (display + event)."""
+    def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
+        """Yield the unified, ordered frame stream: ``DisplayFrame`` /
+        ``EventFrame`` (tagged, renderable), ``StatusApplied`` (the
+        sent-queue seed / status delta — #5830 remote, #5895 local, no
+        ``.tag``) and, from ``AgUiTransport`` only, ``BacklogBatch``
+        (#5139). Every consumer type-checks before reading ``.tag`` —
+        the union is declared here so mypy names the ones that do not."""
 
     @abstractmethod
     async def submit_user_text(
@@ -675,7 +680,7 @@ class DelegatingClientTransport(ClientTransport):
     def close(self) -> None:
         self._inner.close()
 
-    def frames(self) -> "AsyncIterator[Frame]":
+    def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
         return self._inner.frames()
 
     async def submit_user_text(

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from reyn.interfaces.repl.status import _WAITING_ON_BY_EVENT
 
@@ -238,8 +238,17 @@ class EventFrame:
     agent: "str | None" = None
 
 
-# A client consumes a stream of these; ``frame.tag`` selects the renderer entry.
-Frame = "DisplayFrame | EventFrame"
+# A client consumes a stream of these. ``frame.tag`` selects the renderer
+# entry for the two renderable members; ``StatusApplied`` (#5830 remote,
+# #5895 local too — the seed frame behind every ``session_attached``
+# barrier) is a declared member precisely so that a consumer reading
+# ``.tag`` without an ``isinstance`` check is a mypy error, not a runtime
+# ``AttributeError`` found by whichever configuration happens to run it
+# (architect ruling, #5895: the type enumerates the consumers, not a grep).
+# It carries no ``.tag`` on purpose — a third tag value would turn that
+# loud error into a silent mis-branch in every ``if tag is EVENT: ...
+# else: <display>`` consumer.
+Frame: TypeAlias = "DisplayFrame | EventFrame | StatusApplied"
 
 
 @dataclass(frozen=True)

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -365,15 +365,67 @@ class StatusApplied:
       between frames while ``frames()`` suspends between each, so the read
       model runs arbitrarily far ahead of the pump's position).
 
-    A required field, not a defaulted one: there is exactly one producer,
-    and a default would let a future second producer silently pick the
-    lenient answer — the shape #5818 spent a night removing elsewhere."""
+    A required field, not a defaulted one: a default would let a future
+    producer silently pick the lenient answer — the shape #5818 spent a
+    night removing elsewhere.
+
+    ``snapshot`` (#5895, architect ruling on #5886's fix — the class was
+    only narrowed, not closed, until this): a ``"snapshot"`` CARRIES the
+    three values the sent-queue gate seeds from, captured at the instant
+    the snapshot was taken. The seed reads THIS frame and nothing else —
+    never the live read model. Reading the read model at seed time, even
+    "at the snapshot frame's own position", is the #5886 defect with a
+    narrower window: on the remote side ``_pump_sse`` can apply a later
+    delta onto ``RemoteStatusView`` between enqueuing this frame and the
+    pump reaching it; on the local side a submit can advance ``queue_seq``
+    in the same gap. Both leave a baseline ahead of the frames it must
+    admit. A value captured with the snapshot cannot move.
+
+    Typed, not documented: a ``"snapshot"`` MUST carry one and a
+    ``"delta"`` MUST NOT (``__post_init__``) — the read model stays the
+    display's source, the frame is the seed's, and the two cannot be
+    mixed by accident because the seed's parameter type is this class."""
 
     kind: Literal["snapshot", "delta"]
+    snapshot: "QueueSnapshot | None" = None
+
+    def __post_init__(self) -> None:
+        if (self.kind == "snapshot") != (self.snapshot is not None):
+            raise ValueError(
+                f"StatusApplied(kind={self.kind!r}) must carry a QueueSnapshot "
+                f"iff kind is 'snapshot' (got snapshot={self.snapshot!r})"
+            )
+
+
+@dataclass(frozen=True)
+class QueueSnapshot:
+    """The sent-queue gate's hydration values, as of one snapshot instant
+    (#5895): the undispatched queue, whether a turn is active, and the
+    monotonic ``queue_seq`` that becomes the gate's baseline. Produced by
+    the same status builder the read model uses (``interfaces/repl/status.
+    py``'s ``_snapshot_for_session``, via the remote ``project_status`` or
+    the local ``_snapshot``), captured once, immutable."""
+
+    queue: "tuple[dict, ...]"
+    turn_active: bool
+    queue_seq: int
+
+    @classmethod
+    def from_status(cls, values: "dict | None") -> "QueueSnapshot":
+        """Build from a status dict in the ``_snapshot`` shape — the SAME
+        three keys, read once, defensively typed (a wire dict may carry
+        ``None`` where a fresh session has nothing)."""
+        v = values or {}
+        return cls(
+            queue=tuple(dict(item) for item in (v.get("queue") or ())),
+            turn_active=bool(v.get("turn_active", False)),
+            queue_seq=int(v.get("queue_seq", 0) or 0),
+        )
 
 
 __all__ = [
     "BacklogBatch",
+    "QueueSnapshot",
     "DisplayFrame",
     "EventFrame",
     "StatusApplied",

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from reyn.interfaces.repl.status import _WAITING_ON_BY_EVENT
 
@@ -338,13 +338,38 @@ class StatusApplied:
     to iterate for a snapshot/delta-only SSE block, so the redraw waited
     for whatever frame happened to arrive next.
 
-    Carries no data of its own — the values are already on
+    Carries no VALUES of its own — they are already on
     :class:`~reyn.interfaces.transport.agui.state.RemoteStatusView` by the
     time this item is even constructed (:meth:`_consume_block` applies the
     ``StateUpdate`` first, in the SAME branch, before appending this). Its
     only job is to exist as a stream item so ``_pump_frames``'s trailing
     ``_refresh_live_chrome()`` call fires in wire-arrival order — unlike
-    :class:`BacklogBatch`, the pump does NOT ``continue`` past it."""
+    :class:`BacklogBatch`, the pump does NOT ``continue`` past it.
+
+    ``kind`` (#5886, architect ruling ①) is the ONE thing it does carry, and
+    it exists because this class used to erase it. ``_consume_block``
+    knows perfectly well which it decoded (``decoded.snapshot is not None``
+    / ``decoded.delta is not None``) and handed the app the same opaque item
+    for both — the information-losing point. The two are NOT
+    interchangeable to a consumer:
+
+    - ``"snapshot"`` is a HYDRATION point. It is the paired, server-side
+      consistent view (#5179's ``_session_backlog_page_and_status``) of the
+      queue at one instant, so it — and only it — may seed the sent-queue
+      seq-gate's baseline.
+    - ``"delta"`` is a display update. It moves the live status a viewer
+      reads; it must never move the gate's baseline, because a delta can
+      reach the client's read model long before the pump has processed the
+      frames that baseline is supposed to be measured against (#5886's own
+      measurement: ``AgUiTransport._pump_sse`` decodes without yielding
+      between frames while ``frames()`` suspends between each, so the read
+      model runs arbitrarily far ahead of the pump's position).
+
+    A required field, not a defaulted one: there is exactly one producer,
+    and a default would let a future second producer silently pick the
+    lenient answer — the shape #5818 spent a night removing elsewhere."""
+
+    kind: Literal["snapshot", "delta"]
 
 
 __all__ = [

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -41,6 +41,8 @@ from reyn.interfaces.transport.frames import (
     EventFrame,
     Frame,
     FrameTag,
+    QueueSnapshot,
+    StatusApplied,
     forwarded_frame_kinds,
 )
 
@@ -74,7 +76,7 @@ class InProcessTransport(ClientTransport):
         self._forward_events = (
             forward_events if forward_events is not None else forwarded_frame_kinds()
         )
-        self._frames: "asyncio.Queue[Frame]" = asyncio.Queue()
+        self._frames: "asyncio.Queue[Frame | StatusApplied]" = asyncio.Queue()
         self._pump_task: "asyncio.Task | None" = None
 
     # -- lifecycle ----------------------------------------------------------
@@ -155,17 +157,39 @@ class InProcessTransport(ClientTransport):
         while True:
             item = await outbox.get()
             if isinstance(item, EventFrame):
-                if item.event.type == "session_attached":
+                is_barrier = item.event.type == "session_attached"
+                if is_barrier:
                     current_agent = item.event.data.get("agent", current_agent)
                 if item.agent is None:
                     item = replace(item, agent=current_agent)
                 self._frames.put_nowait(item)
+                if is_barrier:
+                    # #5895 (architect ruling): the LOCAL hydration point.
+                    # Right behind every ``session_attached`` barrier —
+                    # the first attach and every switch alike — one
+                    # ``StatusApplied(kind="snapshot")`` carrying the newly
+                    # attached session's queue values, read from the SAME
+                    # builder the local read model uses (``status.
+                    # _snapshot``), at this instant. The app's sent-queue
+                    # gate seeds from this frame and from nothing else, so
+                    # the seed point is ONE regardless of transport: "the
+                    # pump processed a snapshot frame". This replaced the
+                    # app's own mount-time seed and its switch-time reseed
+                    # (both read the read model live — the #5886 defect
+                    # in a narrower window). A remote connection gets the
+                    # equivalent frame from ``agui/client.py`` at decode.
+                    from reyn.interfaces.repl.status import _snapshot
+
+                    self._frames.put_nowait(StatusApplied(
+                        kind="snapshot",
+                        snapshot=QueueSnapshot.from_status(_snapshot(self._registry)),
+                    ))
                 continue
             self._frames.put_nowait(DisplayFrame(item, agent=current_agent))
             if item.kind == "__end__":
                 return
 
-    async def frames(self) -> "AsyncIterator[Frame]":
+    async def frames(self) -> "AsyncIterator[Frame | StatusApplied]":
         while True:
             frame = await self._frames.get()
             # #3570: an UNCONDITIONAL yield point, once per frame. ``Queue.get()``
@@ -189,6 +213,13 @@ class InProcessTransport(ClientTransport):
             # can ever straddle ``__end__``.
             await suspend_between_frames()
             yield frame
+            # #5895: this stream now also carries ``StatusApplied`` (the
+            # snapshot frame behind every ``session_attached`` barrier),
+            # which has no ``.tag`` — exactly the hazard frames.py's own
+            # module contract names for any new non-``Frame`` item. Check
+            # the type BEFORE touching ``.tag``, as every consumer must.
+            if isinstance(frame, StatusApplied):
+                continue
             if frame.tag is FrameTag.DISPLAY and frame.message.kind == "__end__":
                 return
 

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -40,7 +40,6 @@ from reyn.interfaces.transport.frames import (
     DisplayFrame,
     EventFrame,
     Frame,
-    FrameTag,
     QueueSnapshot,
     StatusApplied,
     forwarded_frame_kinds,
@@ -76,7 +75,7 @@ class InProcessTransport(ClientTransport):
         self._forward_events = (
             forward_events if forward_events is not None else forwarded_frame_kinds()
         )
-        self._frames: "asyncio.Queue[Frame | StatusApplied]" = asyncio.Queue()
+        self._frames: "asyncio.Queue[Frame]" = asyncio.Queue()
         self._pump_task: "asyncio.Task | None" = None
 
     # -- lifecycle ----------------------------------------------------------
@@ -189,7 +188,7 @@ class InProcessTransport(ClientTransport):
             if item.kind == "__end__":
                 return
 
-    async def frames(self) -> "AsyncIterator[Frame | StatusApplied]":
+    async def frames(self) -> "AsyncIterator[Frame]":
         while True:
             frame = await self._frames.get()
             # #3570: an UNCONDITIONAL yield point, once per frame. ``Queue.get()``
@@ -218,9 +217,7 @@ class InProcessTransport(ClientTransport):
             # which has no ``.tag`` — exactly the hazard frames.py's own
             # module contract names for any new non-``Frame`` item. Check
             # the type BEFORE touching ``.tag``, as every consumer must.
-            if isinstance(frame, StatusApplied):
-                continue
-            if frame.tag is FrameTag.DISPLAY and frame.message.kind == "__end__":
+            if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
                 return
 
     # -- send side ----------------------------------------------------------

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -86,7 +86,7 @@ from reyn.interfaces.transport.drain import suspend_between_frames
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+    from reyn.interfaces.transport.frames import BacklogBatch, Frame
     from reyn.runtime.outbox import OutboxMessage
 
 
@@ -201,7 +201,7 @@ class ThreadedTransportProxy(ClientTransport):
         self._thread: "threading.Thread | None" = None
         self._worker_thread_ident: "int | None" = None
         self._caller_loop: "asyncio.AbstractEventLoop | None" = None
-        self._caller_queue: "asyncio.Queue[DisplayFrame | EventFrame] | None" = None
+        self._caller_queue: "asyncio.Queue[Frame | BacklogBatch] | None" = None
         # Single overwriting slot (#4995's own settled design, see module
         # docstring) — a plain attribute, not a queue: only the LATEST
         # snapshot is ever meaningful, so an older one is safe to discard
@@ -279,7 +279,7 @@ class ThreadedTransportProxy(ClientTransport):
         if self._inner is not None:
             self._inner.close()
 
-    async def frames(self) -> "AsyncIterator[DisplayFrame | EventFrame]":
+    async def frames(self) -> "AsyncIterator[Frame | BacklogBatch]":
         assert self._caller_queue is not None
         while True:
             frame = await self._caller_queue.get()

--- a/tests/interfaces/test_3300_p2b_sentqueue_render.py
+++ b/tests/interfaces/test_3300_p2b_sentqueue_render.py
@@ -59,7 +59,7 @@ from reyn.interfaces.inline.textual_chat.sent_queue import ROW_TEXT_COLUMN, Sent
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.agui.state import RemoteQueueView
 from reyn.interfaces.transport.client_transport import ClientTransportStub
-from reyn.interfaces.transport.frames import EventFrame
+from reyn.interfaces.transport.frames import EventFrame, QueueSnapshot, StatusApplied
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
 
@@ -78,6 +78,12 @@ class QueueTransport(ClientTransportStub):
 
     async def push_event(self, event: Event) -> None:
         await self._queue.put(EventFrame(event))
+
+    async def push(self, item: object) -> None:
+        """Any stream item — used for the ``StatusApplied(kind="snapshot")``
+        seed frame (#5895: the sent-queue gate seeds from the values THAT
+        frame carries, never from the read model)."""
+        await self._queue.put(item)
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass
@@ -112,6 +118,25 @@ class QueueTransport(ClientTransportStub):
 
     async def shutdown(self) -> None:  # pragma: no cover - trivial
         pass
+
+
+_PEER_ITEM = {
+    "msg_id": "m1", "chain_id": "c1", "text": "peer's queued line",
+    "meta": {"actor": "alice", "auth_user_id": "alice"},
+}
+
+
+def _snapshot_frame(items: "list[dict]", *, queue_seq: int) -> StatusApplied:
+    """The seed frame (#5895): ``StatusApplied(kind="snapshot")`` carrying
+    the server-authoritative queue as of the snapshot — what the connect
+    STATE_SNAPSHOT (remote) / the frame behind the ``session_attached``
+    barrier (local) put on the stream."""
+    return StatusApplied(
+        kind="snapshot",
+        snapshot=QueueSnapshot(
+            queue=tuple(dict(i) for i in items), turn_active=False, queue_seq=queue_seq,
+        ),
+    )
 
 
 def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
@@ -474,12 +499,12 @@ async def test_snapshot_seeded_item_keeps_attribution_after_promotion() -> None:
     app = TextualChatApp(transport=transport, read_model=read_model)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        # The queue view is seeded on the FIRST frame the pump processes
-        # (:meth:`TextualChatApp._seed_queue_view`) — a harmless, unhandled
-        # event type triggers that seed without mutating any state, so the
-        # snapshot-seeded item's pre-promotion visibility can be observed
-        # before the (separate) turn_started frame promotes it.
-        await transport.push_event(Event(type="__noop__", data={}))
+        # #5895: the queue view is seeded when the pump processes a
+        # ``StatusApplied(kind="snapshot")`` frame, from the values that
+        # frame CARRIES (the connect STATE_SNAPSHOT, remotely; the frame
+        # behind the ``session_attached`` barrier, locally) — never from
+        # the read model. Push that frame with the peer's queued item.
+        await transport.push(_snapshot_frame([_PEER_ITEM], queue_seq=1))
         await pilot.pause()
         sent_queue = app.query_one(SentQueue)
         assert "peer's queued line" in sent_queue.rendered_texts()[0]
@@ -505,12 +530,12 @@ async def test_strip_snapshot_meta_carry_loses_attribution(monkeypatch) -> None:
     attribution is lost, proving the positive test above is not vacuous."""
     from reyn.interfaces.inline.textual_chat import app as app_module
 
-    def _seed_without_meta_carry(self) -> None:
-        snap = self._snapshot() or {}
+    def _seed_without_meta_carry(self, frame) -> None:
+        snap = frame.snapshot
         self._queue_view.apply_snapshot(
-            queue=snap.get("queue", []),
-            turn_active=snap.get("turn_active", False),
-            queue_seq=snap.get("queue_seq", 0),
+            queue=[dict(item) for item in snap.queue],
+            turn_active=snap.turn_active,
+            queue_seq=snap.queue_seq,
         )
         for item in self._queue_view.queue():
             msg_id = item.get("msg_id")
@@ -531,6 +556,8 @@ async def test_strip_snapshot_meta_carry_loses_attribution(monkeypatch) -> None:
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, read_model=read_model)
     async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push(_snapshot_frame([_PEER_ITEM], queue_seq=1))
         await pilot.pause()
         await transport.push_event(_turn_started(chain_id="c1", seq=2))
         await pilot.pause()
@@ -585,12 +612,11 @@ async def test_seed_queue_view_does_not_reshow_a_row_the_delta_path_already_crea
     one frame — neither of which an item that has not actually changed
     should ever cause.
 
-    Driven by calling :meth:`TextualChatApp._seed_queue_view` directly a
-    SECOND time (the same method this test file already names for
-    monkeypatch strip-witnesses above) — production fires it from two
-    call sites (first frame, and session-switch re-seed), and this test
-    needs the intermediate state neither site exposes alone: a row
-    already present for an item the snapshot ALSO reports."""
+    Driven by pushing a SECOND ``StatusApplied(kind="snapshot")`` frame
+    (#5895: the ONE seed point, regardless of transport — a reconnect or
+    switch snapshot in production) whose queue ALSO reports the items this
+    client's own delta path already drew rows for — the intermediate state
+    the issue names."""
     read_model = _MutableQueueReadModel()
     transport = QueueTransport()
     app = TextualChatApp(transport=transport, read_model=read_model)
@@ -602,15 +628,16 @@ async def test_seed_queue_view_does_not_reshow_a_row_the_delta_path_already_crea
         sent_queue = app.query_one(SentQueue)
         assert [t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()] == ["alpha", "beta"]
 
-        # The server's own current truth (what a reconnect snapshot would
-        # report) now ALSO includes both items — the exact input
-        # _seed_queue_view sees when it runs again.
-        read_model.queue_items = [
-            {"msg_id": "m1", "text": "alpha", "meta": {}},
-            {"msg_id": "m2", "text": "beta", "meta": {}},
-        ]
-        read_model.queue_seq = 2
-        app._seed_queue_view()
+        # The server's own current truth (what a reconnect snapshot
+        # reports) now ALSO includes both items — the exact frame the seed
+        # sees when it runs again.
+        await transport.push(_snapshot_frame(
+            [
+                {"msg_id": "m1", "text": "alpha", "meta": {}},
+                {"msg_id": "m2", "text": "beta", "meta": {}},
+            ],
+            queue_seq=2,
+        ))
         await pilot.pause()
 
         assert [t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()] == ["alpha", "beta"], (
@@ -638,12 +665,12 @@ async def test_strip_seed_has_row_guard_reorders_the_already_shown_row(monkeypat
     at all)."""
     from reyn.interfaces.inline.textual_chat import app as app_module
 
-    def _seed_without_has_row_guard(self) -> None:
-        snap = self._snapshot() or {}
+    def _seed_without_has_row_guard(self, frame) -> None:
+        snap = frame.snapshot
         self._queue_view.apply_snapshot(
-            queue=snap.get("queue", []),
-            turn_active=snap.get("turn_active", False),
-            queue_seq=snap.get("queue_seq", 0),
+            queue=[dict(item) for item in snap.queue],
+            turn_active=snap.turn_active,
+            queue_seq=snap.queue_seq,
         )
         for item in self._queue_view.queue():
             msg_id = item.get("msg_id")
@@ -663,12 +690,13 @@ async def test_strip_seed_has_row_guard_reorders_the_already_shown_row(monkeypat
         await pilot.pause()
         sent_queue = app.query_one(SentQueue)
 
-        read_model.queue_items = [
-            {"msg_id": "m2", "text": "beta", "meta": {}},
-            {"msg_id": "m1", "text": "alpha", "meta": {}},
-        ]
-        read_model.queue_seq = 2
-        app._seed_queue_view()
+        await transport.push(_snapshot_frame(
+            [
+                {"msg_id": "m2", "text": "beta", "meta": {}},
+                {"msg_id": "m1", "text": "alpha", "meta": {}},
+            ],
+            queue_seq=2,
+        ))
         await pilot.pause()
 
         assert [t[ROW_TEXT_COLUMN:] for t in sent_queue.rendered_texts()] == ["beta", "alpha"], (

--- a/tests/interfaces/test_3310_n2_reset_hydrate.py
+++ b/tests/interfaces/test_3310_n2_reset_hydrate.py
@@ -67,6 +67,7 @@ from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
 from reyn.interfaces.repl.read_model import RegistryReadModel
 from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -822,24 +823,24 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
     Beta has its OWN item ALREADY queued (behind a held-busy turn, manually
     pumped — the auto-driver is stopped so this test has sole, deterministic
     control over dispatch, exactly like the #3300 P2a late-joiner test) BEFORE
-    this client ever switches to it. If the switch-barrier handler did not
-    eagerly reseed :attr:`_queue_view` from the NEW session's OWN snapshot,
-    beta's already-queued item would never render (there is no OTHER trigger
-    that would show it — nothing else happens on beta in this scenario) —
-    this is the #3305-shaped reconnect-reseed, witnessed here for the SWITCH
-    path specifically.
+    this client ever switches to it. Beta's already-queued item must render
+    once this client switches — there is no OTHER trigger that would show it
+    (nothing else happens on beta in this scenario) — the #3305-shaped
+    reconnect-reseed, witnessed here for the SWITCH path specifically.
 
-    ★Non-vacuity guard (found while strip-falsifying the WHOLE
-    ``session_attached`` handler for #3323 co-vet re-review): the very
-    generic "seed on the first frame the pump EVER processes" check
-    (:meth:`TextualChatApp._pump_frames`) would ALSO explain a green result
-    here if the ``session_attached`` frame below happened to be the first
-    frame this app's pump ever sees — masking the eager-reseed-on-switch
-    behavior this test means to isolate. A harmless benign frame is pushed
-    and settled FIRST so that generic check has already fired (on alpha,
-    where it is a no-op) before the switch — the ONLY remaining path that
-    can populate the queue view for beta is the eager reseed inside
-    :meth:`_handle_session_attached_event` itself."""
+    #5895 (architect ruling on #5886's fix; this test was the CI-red
+    witness that the fix had left the local switch path with NO seed point):
+    the app no longer reseeds inside :meth:`_handle_session_attached_event`
+    (it read the read model live — #5886's own defect in a narrower window).
+    The ONE seed point, for every transport, is the pump processing a
+    ``StatusApplied(kind="snapshot")`` frame that CARRIES the new session's
+    queue values. For the local transport that frame is produced by
+    ``InProcessTransport._pump_outbox`` right behind the ``session_attached``
+    barrier, so this test now drives the REAL local transport off the REAL
+    ``repl_outbox`` — the barrier is put where ``AgentRegistry.
+    _announce_session_attached`` puts it — instead of a scripted queue. Strip
+    (verified): removing that local producer leaves beta's item unrendered
+    and this test red; so does making the seed read the read model again."""
     monkeypatch.chdir(tmp_path)
     reg = _registry_with_wal(tmp_path)
     try:
@@ -860,50 +861,63 @@ async def test_reset_queue_view_reseeds_from_new_sessions_own_queue(
         )
         await reg.attach("alpha")
 
-        transport = QueueTransport()
+        # #5895: the REAL local transport, so the seed frame comes from its
+        # own producer (``_pump_outbox``) and nothing the test scripts.
+        transport = InProcessTransport(reg, intervention_channel="tui")
+        # The runner (``repl.py``), not the app, starts the transport's
+        # outbox pump in production — same here, or ``repl_outbox`` is
+        # never drained and nothing below reaches the app.
+        transport.start()
         app = TextualChatApp(
             transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
         )
-        async with app.run_test(size=(100, 30)) as pilot:
-            await _settle(pilot)
+        try:
+            async with app.run_test(size=(100, 30)) as pilot:
+                await _settle(pilot)
 
-            # Non-vacuity guard (see docstring): a harmless frame on alpha,
-            # settled BEFORE the switch, so the generic "seed on first frame
-            # the pump ever processes" check has already fired here (on
-            # alpha) rather than on the session_attached frame below — the
-            # ONLY remaining seed path for beta is the eager reseed inside
-            # the switch handler itself.
-            transport.push_display(OutboxMessage(kind="user", text="alpha noop"))
-            await _settle(pilot)
+                # A harmless frame on alpha first, so the switch below is not
+                # the very first thing this pump ever sees (the shape the
+                # earlier version of this test guarded for a since-deleted
+                # "seed on first frame" path; kept — it costs nothing and keeps
+                # the switch a genuine mid-stream switch).
+                reg.repl_outbox.put_nowait(OutboxMessage(kind="user", text="alpha noop"))
+                await _settle(pilot)
 
-            # NOTE: flips the registry's connection pointer directly (#3793
-            # stage 1: ``AttachedConnection.switch``) rather than calling
-            # ``reg.attach("beta")`` again — the auto-driver was deliberately
-            # stopped above (so THIS test controls dispatch); a real
-            # ``attach()`` call re-boots a fresh ``session.run()`` background
-            # task (its own ``_tasks[key].done()`` check sees the cancelled
-            # task and reboots), which would race the manually-held-busy
-            # turn for the SAME inbox and silently dispatch the "queued"
-            # fixture item out from under this test. Flipping the pointer
-            # directly is the read-side-only equivalent this test needs —
-            # the app's ``_snapshot()`` only ever reads
-            # ``registry.attached_session()``, never re-derives from a live
-            # ``attach()`` call itself.
-            reg._connection.switch(("beta", _DEFAULT_SID))
-            transport.push_event(
-                "session_attached", {"agent": "beta", "session_id": _DEFAULT_SID}
-            )
-            await _settle(pilot)
+                # NOTE: flips the registry's connection pointer directly (#3793
+                # stage 1: ``AttachedConnection.switch``) rather than calling
+                # ``reg.attach("beta")`` again — the auto-driver was deliberately
+                # stopped above (so THIS test controls dispatch); a real
+                # ``attach()`` call re-boots a fresh ``session.run()`` background
+                # task (its own ``_tasks[key].done()`` check sees the cancelled
+                # task and reboots), which would race the manually-held-busy
+                # turn for the SAME inbox and silently dispatch the "queued"
+                # fixture item out from under this test. Flipping the pointer
+                # directly is the read-side-only equivalent this test needs —
+                # the app's ``_snapshot()`` only ever reads
+                # ``registry.attached_session()``, never re-derives from a live
+                # ``attach()`` call itself.
+                reg._connection.switch(("beta", _DEFAULT_SID))
+                # The barrier, put exactly where the registry's own
+                # ``_announce_session_attached`` puts it (an ``EventFrame`` on
+                # ``repl_outbox``); the transport's producer follows it with
+                # the snapshot frame the seed reads.
+                reg.repl_outbox.put_nowait(EventFrame(Event(
+                    type="session_attached", data={"agent": "beta", "session_id": _DEFAULT_SID},
+                )))
+                await _settle(pilot, n=4)
 
-            sent_queue = app.query_one(SentQueue)
-            assert sent_queue.has_items() is True, (
-                "beta's OWN already-queued item must render once this client "
-                "switches to beta — the switch-barrier reseed must fire"
-            )
-            assert any(
-                "beta queued item" in t for t in sent_queue.rendered_texts()
-            ), sent_queue.rendered_texts()
+                sent_queue = app.query_one(SentQueue)
+                assert sent_queue.has_items() is True, (
+                    "beta's OWN already-queued item must render once this client "
+                    "switches to beta — the local transport's snapshot frame behind "
+                    "the barrier is the one seed path (#5895)"
+                )
+                assert any(
+                    "beta queued item" in t for t in sent_queue.rendered_texts()
+                ), sent_queue.rendered_texts()
 
+        finally:
+            transport.close()
         _llm_stub.release.set()
         await turn_task
 

--- a/tests/interfaces/test_5041_1_frame_agent_attribution.py
+++ b/tests/interfaces/test_5041_1_frame_agent_attribution.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 import pytest
 
-from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, StatusApplied
 from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
@@ -144,6 +144,11 @@ async def test_attribution_follows_a_real_switch_via_the_barrier(tmp_path) -> No
                 frame = await transport.frames().__anext__()
                 if isinstance(frame, EventFrame):
                     seen_agents.append(frame.agent)
+                    continue
+                if isinstance(frame, StatusApplied):
+                    # #5895: the seed frame behind the switch barrier —
+                    # carries no ``.agent``/``.message``; not this test's
+                    # subject.
                     continue
                 display_frame = frame
 

--- a/tests/interfaces/test_5830_remote_attach_status_refresh.py
+++ b/tests/interfaces/test_5830_remote_attach_status_refresh.py
@@ -83,7 +83,8 @@ async def test_state_snapshot_alone_yields_a_status_applied_item() -> None:
     reconnect protocol (empty backlog + one STATE_SNAPSHOT, zero display
     frames) yields a StatusApplied item -- not silently absorbed as a side
     channel. Falsifiable: reverting client.py's own `out.append(
-    StatusApplied())` makes this collect zero StatusApplied items."""
+    StatusApplied(kind=...))` (#5886 gave it a required `kind`) makes this
+    collect zero StatusApplied items."""
     state = {"attached_name": "researcher", "model": "opus"}
     transport = await _build_snapshot_only_transport(state)
 

--- a/tests/interfaces/test_5870_stage2_pane_refresh_determinism.py
+++ b/tests/interfaces/test_5870_stage2_pane_refresh_determinism.py
@@ -40,7 +40,7 @@ from reyn.runtime.outbox import OutboxMessage
 
 class _MixedTransport(ClientTransportStub):
     """A real :class:`ClientTransport` that can push either a real
-    ``DisplayFrame`` (an ``OutboxMessage``) or a raw ``StatusApplied()``
+    ``DisplayFrame`` (an ``OutboxMessage``) or a raw ``StatusApplied(kind="delta")``
     item — mirrors #5830's own ``_EventOnlyTransport``
     (``test_3338_tui_status_chrome_liveness.py``), generalized to cover
     both frame families this file's own F2/F3 tests need to distinguish
@@ -53,7 +53,12 @@ class _MixedTransport(ClientTransportStub):
         await self._queue.put(DisplayFrame(msg))
 
     async def push_status_applied(self) -> None:
-        await self._queue.put(StatusApplied())
+        # #5886: `kind` is required now — these are status DELTAS (the
+        # frame this file is about: a status-only frame the pump must
+        # still fire its chrome refresh on). A "snapshot" here would
+        # additionally seed the sent-queue gate, which is a different
+        # frame's job and not what these tests drive.
+        await self._queue.put(StatusApplied(kind="delta"))
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass

--- a/tests/interfaces/test_5886_first_frame_seed_race.py
+++ b/tests/interfaces/test_5886_first_frame_seed_race.py
@@ -69,12 +69,6 @@ def _make_registry(tmp_path) -> AgentRegistry:
     return AgentRegistry(project_root=tmp_path, session_factory=factory)
 
 
-def _flow_error_seen(app: TextualChatApp) -> bool:
-    """Whether the failed turn's own ``kind="error"`` reply has rendered —
-    this test's FIFO ordering barrier (see its use site)."""
-    return any(e.item.kind == "error" for e in app.query_one(FlowView).entries)
-
-
 def _flow_user_texts(app: TextualChatApp) -> "list[str]":
     return [
         str(e.item.text) for e in app.query_one(FlowView).entries
@@ -157,6 +151,7 @@ async def _wait_until(pilot, condition) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.llm_stub
 async def test_a_message_submitted_after_attach_reaches_the_conversation(
     tmp_path, monkeypatch, caplog,
 ) -> None:
@@ -169,16 +164,11 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
     duplicate stuck in the queue; "not stranded" alone passes a build that
     dropped the placeholder without ever rendering anything.
 
-    The verdict is read only after the failed turn's own ``kind="error"``
-    reply has rendered: delivery on this connection is FIFO and that reply
-    is produced strictly after ``turn_started``, so its arrival proves
-    every earlier frame — the ``user_submitted``/``turn_started`` pair this
-    test is about — was already drained by the pump. An ordering barrier,
-    not a duration.
-    """
-    from fastapi import FastAPI
-    from starlette.requests import Request
-    from starlette.responses import StreamingResponse
+    The verdict is waited for as the observable itself — the operator's own
+    message in the flow — unconditionally (CI's ``--timeout`` is the red
+    when the gate rejects the echo; a hang, disclosed at the wait site).
+    The turn behind it runs against ``@pytest.mark.llm_stub`` so no real
+    network call is on the wire.
 
     from reyn.interfaces.transport.agui import endpoint as endpoint_mod
     from reyn.interfaces.transport.agui.endpoint import router
@@ -276,17 +266,22 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
             # does by default.
             gate.set()
 
-            # The FIFO barrier. The dispatched turn reaches the real
-            # litellm boundary, where this suite's network gate raises;
-            # the session CONTAINS that (``session.py``'s "router loop
-            # caught an exception no inner handler took … queued an error
-            # reply and returning normally") and sends a ``kind="error"``
-            # message. It is produced strictly AFTER ``turn_started``, so
-            # its arrival proves the ``user_submitted``/``turn_started``
-            # pair this test is about was already drained by the pump.
-            # An ordering barrier, not a duration — and one whose arrival
-            # is guaranteed, unlike matching on the error's own wording.
-            await _wait_until(pilot, lambda: _flow_error_seen(app_))
+            # The barrier IS the verdict's own observable, waited for
+            # unconditionally: the operator's message appearing in the flow
+            # (the ``user_submitted`` echo, drained by the pump). Under the
+            # defect the echo is rejected by the gate and this loop never
+            # ends — the red is a HANG that CI's ``--timeout`` kills, not an
+            # assertion; said here because a hang wears no colour of its
+            # own. (Two earlier forms waited for an ordering marker instead
+            # — the turn's ``kind="error"`` reply from a REAL litellm
+            # failure, then ``turn_active`` rising and falling — and both
+            # were timing-shaped: the failure took the retry path in CI and
+            # out-waited ``--timeout``; the flag is up too briefly for a
+            # ``pilot.pause()`` poll to ever see it. The stub turn
+            # (``@pytest.mark.llm_stub``) keeps the wire free of a real
+            # network call either way.) The precondition below is still read
+            # first, so a run that never built the racing state says so.
+            await _wait_until(pilot, lambda: _OWN_TEXT in _flow_user_texts(app_))
 
             # ── Did the run reach the state the bug lives in? ───────────
             # NOT the wire order (measured, and it does NOT invert here:

--- a/tests/interfaces/test_5886_first_frame_seed_race.py
+++ b/tests/interfaces/test_5886_first_frame_seed_race.py
@@ -170,6 +170,10 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
     The turn behind it runs against ``@pytest.mark.llm_stub`` so no real
     network call is on the wire.
     """
+    from fastapi import FastAPI
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse
+
     from reyn.interfaces.transport.agui import endpoint as endpoint_mod
     from reyn.interfaces.transport.agui.endpoint import router
     from reyn.interfaces.web.auth import AuthContext

--- a/tests/interfaces/test_5886_first_frame_seed_race.py
+++ b/tests/interfaces/test_5886_first_frame_seed_race.py
@@ -169,7 +169,7 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
     when the gate rejects the echo; a hang, disclosed at the wait site).
     The turn behind it runs against ``@pytest.mark.llm_stub`` so no real
     network call is on the wire.
-
+    """
     from reyn.interfaces.transport.agui import endpoint as endpoint_mod
     from reyn.interfaces.transport.agui.endpoint import router
     from reyn.interfaces.web.auth import AuthContext

--- a/tests/interfaces/test_5886_first_frame_seed_race.py
+++ b/tests/interfaces/test_5886_first_frame_seed_race.py
@@ -309,9 +309,11 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
             )
             # ruling ⑥, the accept side: with a correct baseline this
             # client's own submission is never rejected, so the WARNING
-            # that names that fingerprint must not appear. (Its RED side —
-            # the warning firing when the baseline IS wrong — is its own
-            # test below.)
+            # that names that fingerprint must not appear. Its RED side —
+            # the warning firing when the baseline IS wrong — is witnessed
+            # in ``test_5886_own_client_ref_rejection_warns.py`` (the
+            # discriminator driven directly), and was also observed live on
+            # the strip run that restored the lazy seed.
             own_ref_warnings = [
                 r.getMessage() for r in caplog.records
                 if r.levelname == "WARNING" and "baseline is wrong" in r.getMessage()

--- a/tests/interfaces/test_5886_first_frame_seed_race.py
+++ b/tests/interfaces/test_5886_first_frame_seed_race.py
@@ -1,0 +1,290 @@
+"""Tier 2: #5886 — in ``--connect`` remote mode, a message submitted AFTER
+attach (the session idle at attach time) can be silently dropped: it never
+appears as a user row, and its sent-queue placeholder is never cleared.
+
+This is the FIRST-FRAME instance of #5179's class. #5179 closed the
+*connect-time* half (``endpoint.py::_session_backlog_page_and_status`` pairs
+the backlog page and the status snapshot in one synchronous tick). The
+*lazy seed* half is untouched: ``TextualChatApp._seed_queue_view`` takes the
+seq-gate baseline from a LIVE read of the read-model at the moment the pump
+processes its FIRST non-status frame — and a ``StatusApplied``
+(STATE_SNAPSHOT/STATE_DELTA) deliberately does NOT trigger that seed
+(``app.py``'s own status-only branch). So a delta that advanced
+``queue_seq`` between attach and the first real frame silently becomes the
+gate's baseline, and the very frames the gate exists to admit
+(``user_submitted`` seq 1, ``turn_started`` seq 2) are rejected as
+"already reflected" — ``logger.debug`` only, invisible in a shipped config.
+
+**Why a status delta can outrun the frames it must not outrun** (architect
+ruling on #5886, 2026-09-06): ``submit_user_text`` emits the
+``user_submitted`` audit-event, whose subscriber chain reaches
+``endpoint._on_status_changed`` → ``_SessionFrameSource.push_status_ping()``
+→ ``_q.put_nowait(StatusPingFrame())`` — **directly onto the connection's
+own ordered queue**. The matching ``EventFrame`` reaches that same queue the
+long way, through the session outbox hub. The emitter answers a ping with a
+LIVE ``_project()`` read, so its ``STATE_DELTA`` can carry a ``queue_seq``
+already past the deltas still behind it in the queue. This test builds that
+sequence out of the production path only — no delivery gate, no injected
+ordering: attach, then submit through the client, then let the session's own
+run loop dispatch.
+
+Harness shape is ``test_5179_remote_own_message_seq_gate_race.py``'s (real
+``agui_events`` route + real ``AgUiTransport`` + a real mounted
+``TextualChatApp`` on a real ``RemoteReadModel``), with the two differences
+#5886 turns on: the submit happens AFTER attach, and it goes through the
+CLIENT (``on_composer_submitted`` → ``_submit`` →
+``transport.submit_user_text(client_ref=…)``, so the local sent-queue
+placeholder is staged the way a real operator's Enter stages it), with
+``_send`` bridging back into the real session exactly as ``endpoint.py``'s
+own ``user_message`` handler does.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import RemoteReadModel
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_OWN_TEXT = "the message the operator typed after attaching"
+_AGENT_NAME = "default"
+
+
+def _make_registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return make_session(agent_name=profile.name, agent_role=profile.role)
+
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
+
+
+def _flow_error_seen(app: TextualChatApp) -> bool:
+    """Whether the failed turn's own ``kind="error"`` reply has rendered —
+    this test's FIFO ordering barrier (see its use site)."""
+    return any(e.item.kind == "error" for e in app.query_one(FlowView).entries)
+
+
+def _flow_user_texts(app: TextualChatApp) -> "list[str]":
+    return [
+        str(e.item.text) for e in app.query_one(FlowView).entries
+        if e.item.kind == "user"
+    ]
+
+
+async def _drain_lines(body_iter, seen: "list[str]") -> AsyncIterator[str]:
+    """Adapts a real ``StreamingResponse.body_iterator`` (whole SSE chunks)
+    into the line-at-a-time shape ``AgUiTransport`` expects — copied from
+    ``test_5179_remote_own_message_seq_gate_race.py``'s own helper, blank
+    lines included (they are the SSE block delimiter that parser relies
+    on).
+
+    ``seen`` records every line in ARRIVAL ORDER. It is a pure observer of
+    the wire (append-only, never gates or reorders), and it is what lets
+    this test tell its two possible greens apart: "the racing order
+    occurred and the client survived it" vs "the racing order never
+    occurred, so this run measured nothing" — question 4 of this repo's
+    own test review, made checkable instead of assumed."""
+    async for chunk in body_iter:
+        for line in chunk.split("\n"):
+            seen.append(line)
+            yield line
+            await asyncio.sleep(0)
+
+
+def _wire_shape(lines: "list[str]") -> "list[str]":
+    """A compact, ordered census of what actually crossed the wire — the
+    SSE ``event:`` names, plus a ``queue_seq=N`` marker for any data line
+    carrying one. Reported by the precondition assertion below so a run
+    that failed to build the racing order says what it built instead,
+    rather than leaving the next reader to re-measure."""
+    out: "list[str]" = []
+    for line in lines:
+        if line.startswith("event:"):
+            out.append(line.split(":", 1)[1].strip())
+        elif "queue_seq" in line:
+            marker = "queue_seq=0" if ('"queue_seq": 0' in line or '"queue_seq":0' in line) else "queue_seq>0"
+            out.append(f"  [{marker}]")
+        elif "user_submitted" in line:
+            out.append("  [user_submitted]")
+        elif "turn_started" in line:
+            out.append("  [turn_started]")
+    return out
+
+
+def _first_index(lines: "list[str]", predicate) -> "int | None":
+    for i, line in enumerate(lines):
+        if predicate(line):
+            return i
+    return None
+
+
+def _advanced_queue_seq(line: str) -> bool:
+    """A wire line carrying a ``queue_seq`` that is NOT 0 — i.e. a status
+    projection that has already seen at least the enqueue bump."""
+    if "queue_seq" not in line:
+        return False
+    return '"queue_seq": 0' not in line and '"queue_seq":0' not in line
+
+
+async def _wait_until(pilot, condition) -> None:
+    """Poll ``pilot.pause()`` unboundedly until ``condition()`` is true —
+    CLAUDE.md's Ceiling rule: wait on the real condition, never a fixed
+    pause count. CI's own ``--timeout`` is the kill switch."""
+    while not condition():
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_message_submitted_after_attach_reaches_the_conversation(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: #5886's acceptance — attach to an IDLE session, then submit
+    through the client. The message must be promoted into the conversation
+    as a user row, and its sent-queue placeholder must be gone.
+
+    Both halves are asserted because either alone is satisfiable by the
+    wrong behaviour: "rendered" alone passes a build that also leaves a
+    duplicate stuck in the queue; "not stranded" alone passes a build that
+    dropped the placeholder without ever rendering anything.
+
+    The verdict is read only after the failed turn's own ``kind="error"``
+    reply has rendered: delivery on this connection is FIFO and that reply
+    is produced strictly after ``turn_started``, so its arrival proves
+    every earlier frame — the ``user_submitted``/``turn_started`` pair this
+    test is about — was already drained by the pump. An ordering barrier,
+    not a duration.
+    """
+    from fastapi import FastAPI
+    from starlette.requests import Request
+    from starlette.responses import StreamingResponse
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    registry = _make_registry(tmp_path)
+    AgentProfile.new(_AGENT_NAME, role="").save(
+        tmp_path / ".reyn" / "agents" / _AGENT_NAME
+    )
+    session = await registry.ensure_running(_AGENT_NAME)
+
+    api = FastAPI()
+    api.include_router(router)
+    api.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: registry)
+
+    scope = {
+        "type": "http", "method": "GET", "path": f"/agui/chat/{_AGENT_NAME}/events",
+        "query_string": b"token=s3cret&connection_id=conn-5886-first-frame-seed",
+        "headers": [], "client": ("127.0.0.1", 12345), "app": api,
+        "path_params": {"agent_name": _AGENT_NAME},
+    }
+    req = Request(scope)
+
+    try:
+        resp = await endpoint_mod.agui_events(req)
+        assert isinstance(resp, StreamingResponse), (
+            f"expected a real StreamingResponse (auth/agent-exists must both "
+            f"pass for this test's own setup); got {resp!r}"
+        )
+
+        async def _send(payload: dict) -> "dict | None":
+            """The client→server half of the real POST route, inlined: the
+            same call ``endpoint.py``'s own ``user_message`` branch makes
+            (``session.submit_user_text(text, client_ref=…)``), the same
+            echoed ``msg_id`` shape."""
+            if payload.get("type") != "user_message":
+                return None
+            client_ref = payload.get("client_ref")
+            msg_id = await session.submit_user_text(
+                str(payload.get("text", "")),
+                client_ref=client_ref if isinstance(client_ref, str) else None,
+            )
+            return {"status": "ok", "msg_id": msg_id}
+
+        wire_lines: "list[str]" = []
+        transport = AgUiTransport(_drain_lines(resp.body_iterator, wire_lines), _send)
+        app_ = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+
+        async with app_.run_test(size=(100, 30)) as pilot:
+            # Attach: the connect-time STATE_SNAPSHOT (queue_seq 0 — this
+            # session is idle) reaches the app. It does NOT seed the
+            # seq-gate (status-only frames never do), which is the standing
+            # precondition this whole class rests on.
+            await _wait_until(pilot, lambda: transport.has_session())
+
+            # The operator's own Enter, through the client path, so the
+            # local placeholder is staged exactly as in production.
+            await app_.on_composer_submitted(Composer.Submitted(_OWN_TEXT))
+
+            # The session's OWN run loop (started by ``ensure_running``,
+            # which the route requires) dispatches the queued message —
+            # nothing here drives it, exactly as in production. Wait on the
+            # SERVER's own counter reaching the dispatch bump, pumping the
+            # app while we wait.
+            # ``Session.queue_seq`` is the public read-only accessor for
+            # the same counter the status projection publishes (#3300 P2a);
+            # 2 = the enqueue bump plus the dispatch bump.
+            await _wait_until(pilot, lambda: session.queue_seq >= 2)
+
+            # The FIFO barrier. The dispatched turn reaches the real
+            # litellm boundary, where this suite's network gate raises;
+            # the session CONTAINS that (``session.py``'s "router loop
+            # caught an exception no inner handler took … queued an error
+            # reply and returning normally") and sends a ``kind="error"``
+            # message. It is produced strictly AFTER ``turn_started``, so
+            # its arrival proves the ``user_submitted``/``turn_started``
+            # pair this test is about was already drained by the pump.
+            # An ordering barrier, not a duration — and one whose arrival
+            # is guaranteed, unlike matching on the error's own wording.
+            await _wait_until(pilot, lambda: _flow_error_seen(app_))
+
+            # ── Did the racing order actually happen on this run? ──────
+            # The whole point of #5886 is a status projection carrying an
+            # ALREADY-ADVANCED queue_seq reaching the pump BEFORE the
+            # `user_submitted` frame it must not outrun. If that order did
+            # not occur here, a green below measures nothing — so the order
+            # is READ off the wire and reported, never assumed.
+            advanced_idx = _first_index(wire_lines, _advanced_queue_seq)
+            submitted_idx = _first_index(
+                wire_lines, lambda ln: "user_submitted" in ln
+            )
+            raced = (
+                advanced_idx is not None
+                and submitted_idx is not None
+                and advanced_idx < submitted_idx
+            )
+            assert raced, (
+                "this run did NOT construct #5886's own order — an advanced "
+                "queue_seq must reach the client BEFORE the user_submitted "
+                f"frame (advanced at line {advanced_idx}, user_submitted at "
+                f"line {submitted_idx}). Whatever the assertions below say, "
+                "they would say it about a sequence the bug does not live in. "
+                f"Wire, in arrival order: {_wire_shape(wire_lines)!r}"
+            )
+
+            user_texts = _flow_user_texts(app_)
+            queued_texts = list(app_.query_one(SentQueue).rendered_texts())
+
+            assert any(_OWN_TEXT in t for t in user_texts), (
+                "#5886: the operator's own message never reached the "
+                f"conversation — flow user rows: {user_texts!r}, sent-queue: "
+                f"{queued_texts!r}"
+            )
+            assert not any(_OWN_TEXT in t for t in queued_texts), (
+                "#5886: the message was left stranded in the sent-queue "
+                f"region — sent-queue: {queued_texts!r}"
+            )
+    finally:
+        await registry.shutdown()

--- a/tests/interfaces/test_5886_first_frame_seed_race.py
+++ b/tests/interfaces/test_5886_first_frame_seed_race.py
@@ -82,7 +82,9 @@ def _flow_user_texts(app: TextualChatApp) -> "list[str]":
     ]
 
 
-async def _drain_lines(body_iter, seen: "list[str]") -> AsyncIterator[str]:
+async def _drain_lines(
+    body_iter, seen: "list[str]", gate: "asyncio.Event | None" = None,
+) -> AsyncIterator[str]:
     """Adapts a real ``StreamingResponse.body_iterator`` (whole SSE chunks)
     into the line-at-a-time shape ``AgUiTransport`` expects — copied from
     ``test_5179_remote_own_message_seq_gate_race.py``'s own helper, blank
@@ -97,9 +99,18 @@ async def _drain_lines(body_iter, seen: "list[str]") -> AsyncIterator[str]:
     own test review, made checkable instead of assumed."""
     async for chunk in body_iter:
         for line in chunk.split("\n"):
+            if gate is not None:
+                await gate.wait()
             seen.append(line)
             yield line
-            await asyncio.sleep(0)
+            # NO `await asyncio.sleep(0)` here (the #5179 helper this was
+            # copied from has one). That yield hands control back to the app
+            # pump between every single line, which keeps the pump level with
+            # its own decoder and makes the state #5886 lives in
+            # unreachable. A real socket delivers many SSE lines in one read;
+            # awaiting an async generator that returns immediately does not
+            # yield to the loop, so `_pump_sse` gets to do what its own
+            # comment says it does — decode a whole burst without yielding.
 
 
 def _wire_shape(lines: "list[str]") -> "list[str]":
@@ -147,7 +158,7 @@ async def _wait_until(pilot, condition) -> None:
 
 @pytest.mark.asyncio
 async def test_a_message_submitted_after_attach_reaches_the_conversation(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, caplog,
 ) -> None:
     """Tier 2: #5886's acceptance — attach to an IDLE session, then submit
     through the client. The message must be promoted into the conversation
@@ -191,6 +202,9 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
         "path_params": {"agent_name": _AGENT_NAME},
     }
     req = Request(scope)
+    caplog.set_level(
+        "DEBUG", logger="reyn.interfaces.inline.textual_chat.app",
+    )
 
     try:
         resp = await endpoint_mod.agui_events(req)
@@ -214,8 +228,13 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
             return {"status": "ok", "msg_id": msg_id}
 
         wire_lines: "list[str]" = []
-        transport = AgUiTransport(_drain_lines(resp.body_iterator, wire_lines), _send)
-        app_ = TextualChatApp(transport=transport, read_model=RemoteReadModel(transport))
+        gate = asyncio.Event()
+        gate.set()  # open: the connect-time snapshot must reach the app
+        transport = AgUiTransport(
+            _drain_lines(resp.body_iterator, wire_lines, gate), _send,
+        )
+        read_model = RemoteReadModel(transport)
+        app_ = TextualChatApp(transport=transport, read_model=read_model)
 
         async with app_.run_test(size=(100, 30)) as pilot:
             # Attach: the connect-time STATE_SNAPSHOT (queue_seq 0 — this
@@ -223,6 +242,13 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
             # seq-gate (status-only frames never do), which is the standing
             # precondition this whole class rests on.
             await _wait_until(pilot, lambda: transport.has_session())
+
+            # Hold DELIVERY (never production): the server keeps running
+            # at full speed; this only decides when bytes it has already
+            # produced reach the client, which is the one variable this race
+            # turns on. Released below, so the whole burst is decoded in one
+            # go.
+            gate.clear()
 
             # The operator's own Enter, through the client path, so the
             # local placeholder is staged exactly as in production.
@@ -238,6 +264,18 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
             # 2 = the enqueue bump plus the dispatch bump.
             await _wait_until(pilot, lambda: session.queue_seq >= 2)
 
+            # Release. `_pump_sse` (AgUiTransport's OWN task, client.py:507)
+            # decodes the whole burst WITHOUT yielding between frames — its
+            # own comment says so — applying every STATE_* to the read-model
+            # as it goes, while `frames()` hands the app one frame at a time
+            # through `suspend_between_frames()`. So by the time the app pump
+            # reaches `user_submitted`, the read-model the lazy seed reads is
+            # ALREADY at the post-dispatch `queue_seq`. That gap is the bug,
+            # and it needs no wire reordering at all — only a pump that lags
+            # its own decoder, which a real TUI doing real rendering work
+            # does by default.
+            gate.set()
+
             # The FIFO barrier. The dispatched turn reaches the real
             # litellm boundary, where this suite's network gate raises;
             # the session CONTAINS that (``session.py``'s "router loop
@@ -250,29 +288,35 @@ async def test_a_message_submitted_after_attach_reaches_the_conversation(
             # is guaranteed, unlike matching on the error's own wording.
             await _wait_until(pilot, lambda: _flow_error_seen(app_))
 
-            # ── Did the racing order actually happen on this run? ──────
-            # The whole point of #5886 is a status projection carrying an
-            # ALREADY-ADVANCED queue_seq reaching the pump BEFORE the
-            # `user_submitted` frame it must not outrun. If that order did
-            # not occur here, a green below measures nothing — so the order
-            # is READ off the wire and reported, never assumed.
-            advanced_idx = _first_index(wire_lines, _advanced_queue_seq)
-            submitted_idx = _first_index(
-                wire_lines, lambda ln: "user_submitted" in ln
+            # ── Did the run reach the state the bug lives in? ───────────
+            # NOT the wire order (measured, and it does NOT invert here:
+            # `user_submitted` precedes the advancing delta on the wire).
+            # The precondition that matters is that the client's READ MODEL
+            # was already carrying the post-dispatch `queue_seq` — that is
+            # what the lazy seed reads. `_pump_sse` decodes the released
+            # burst without yielding, so it is; asserted here rather than
+            # assumed, since a run where the decoder had NOT advanced would
+            # make every verdict below meaningless.
+            # The read model this test itself constructed and handed to
+            # the app — its own public `snapshot()`, never a private
+            # attribute reached back through the app.
+            advanced = (read_model.snapshot() or {}).get("queue_seq", 0)
+            assert advanced >= 2, (
+                "this run never reached #5886's own precondition — the "
+                "client's read model must already carry the post-dispatch "
+                f"queue_seq when the pump seeds (saw {advanced!r}). Wire, in "
+                f"arrival order: {_wire_shape(wire_lines)!r}"
             )
-            raced = (
-                advanced_idx is not None
-                and submitted_idx is not None
-                and advanced_idx < submitted_idx
-            )
-            assert raced, (
-                "this run did NOT construct #5886's own order — an advanced "
-                "queue_seq must reach the client BEFORE the user_submitted "
-                f"frame (advanced at line {advanced_idx}, user_submitted at "
-                f"line {submitted_idx}). Whatever the assertions below say, "
-                "they would say it about a sequence the bug does not live in. "
-                f"Wire, in arrival order: {_wire_shape(wire_lines)!r}"
-            )
+            # ruling ⑥, the accept side: with a correct baseline this
+            # client's own submission is never rejected, so the WARNING
+            # that names that fingerprint must not appear. (Its RED side —
+            # the warning firing when the baseline IS wrong — is its own
+            # test below.)
+            own_ref_warnings = [
+                r.getMessage() for r in caplog.records
+                if r.levelname == "WARNING" and "baseline is wrong" in r.getMessage()
+            ]
+            assert not own_ref_warnings, own_ref_warnings
 
             user_texts = _flow_user_texts(app_)
             queued_texts = list(app_.query_one(SentQueue).rendered_texts())

--- a/tests/interfaces/test_5886_own_client_ref_rejection_warns.py
+++ b/tests/interfaces/test_5886_own_client_ref_rejection_warns.py
@@ -1,0 +1,187 @@
+"""Tier 2: #5886 ruling ⑥ — the seq gate's rejection log is DISCRIMINATING.
+
+A rejection whose ``meta.client_ref`` names a row THIS client is still
+waiting on cannot be "already reflected": the client minted that id moments
+ago for a submission it has not yet seen echoed. The only way the gate says
+so is a baseline that is wrong — the fingerprint of #5886's own defect — so
+it WARNS, naming the id. Every other rejection (another client's genuinely
+stale delta) is the gate doing its job and stays ``debug``.
+
+Both halves are tested, because either alone is satisfiable by the wrong
+build: a build that warned on EVERY rejection passes the first test and
+turns the log into noise; a build that warned on none passes the second and
+keeps the failure invisible — the shape #5886 was reported in.
+
+Driven through a real mounted ``TextualChatApp`` on the SAME two seam
+implementations ``test_3338_tui_status_chrome_liveness.py`` established: a
+real ``ChatReadModel`` subclass whose ``snapshot()`` the test controls (so
+"the read model already carries queue_seq 5" is a fact the seed reads, not a
+private poke), and a real minimal ``ClientTransport`` fed one frame at a
+time. The verdict is read off the logger, the barrier is the rejection's own
+log record — a definite signal in BOTH tests, since the gate rejects in
+both; only the LEVEL differs, which is exactly the property under test.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import EventFrame, StatusApplied
+from reyn.schemas.models import Event
+
+_TEXT = "a submission the gate will reject"
+_LOGGER = "reyn.interfaces.inline.textual_chat.app"
+
+
+class _SeededReadModel(ChatReadModel):
+    """A real ``ChatReadModel`` seam impl (the ``_MutableSnapshotReadModel``
+    shape from ``test_3338``) whose snapshot already carries ``queue_seq 5``
+    — what the seed reads when the snapshot frame below is processed."""
+
+    @property
+    def capabilities(self):
+        return LOCAL_CHAT_READ_CAPABILITIES
+
+    def snapshot(self, config=None):
+        return {"queue": [], "turn_active": False, "queue_seq": 5}
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_5886_history")
+
+    def conversation_history(self, *, limit=None, agent=None, session_id=None):
+        return []
+
+    def load_older_conversation_history(self, *, agent=None, session_id=None):
+        return 0
+
+
+class _FrameTransport(ClientTransportStub):
+    """A real, minimal ``ClientTransport`` fed one item at a time — the
+    ``_EventOnlyTransport`` shape from ``test_3338``, widened to push a
+    ``StatusApplied`` too."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push(self, item: object) -> None:
+        await self._queue.put(item)
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
+        return ""
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        return True
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg) -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _stale_user_submitted(client_ref: str) -> EventFrame:
+    """``seq 1`` against a baseline of 5 — rejected by the gate either way;
+    only WHOSE submission it is should change what gets logged."""
+    return EventFrame(Event(type="user_submitted", data={
+        "msg_id": "m1", "chain_id": "c1", "text": _TEXT, "seq": 1,
+        "meta": {"client_ref": client_ref},
+    }))
+
+
+def _rejections(caplog) -> "list":
+    return [r for r in caplog.records if "gate rejected" in r.getMessage()]
+
+
+async def _drive(app: TextualChatApp, transport: _FrameTransport, client_ref: str, pilot, caplog) -> None:
+    await transport.push(StatusApplied(kind="snapshot"))  # baseline := 5
+    await transport.push(_stale_user_submitted(client_ref))
+    while not _rejections(caplog):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_rejecting_this_clients_own_pending_submission_warns(caplog) -> None:
+    """Tier 2: the fingerprint. The rejected delta's ``client_ref`` names a
+    row THIS client staged and is still waiting on → WARNING, naming it."""
+    caplog.set_level("DEBUG", logger=_LOGGER)
+    transport = _FrameTransport()
+    app = TextualChatApp(transport=transport, read_model=_SeededReadModel())
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        # Staged exactly the way the composer stages one — the widget's
+        # own public API, no private field.
+        app.query_one(SentQueue).show_item("local:mine", _TEXT, sending=True)
+        await _drive(app, transport, "local:mine", pilot, caplog)
+
+        (record,) = _rejections(caplog)
+        assert record.levelname == "WARNING", (record.levelname, record.getMessage())
+        assert "local:mine" in record.getMessage()
+        assert "baseline is wrong" in record.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_rejecting_someone_elses_stale_delta_stays_debug(caplog) -> None:
+    """Tier 2: the control that keeps the log discriminating. The SAME
+    rejection, but the ``client_ref`` is nobody's pending row here (another
+    client's genuinely stale delta) → the gate is doing its job → ``debug``,
+    never a warning."""
+    caplog.set_level("DEBUG", logger=_LOGGER)
+    transport = _FrameTransport()
+    app = TextualChatApp(transport=transport, read_model=_SeededReadModel())
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _drive(app, transport, "local:someone-else", pilot, caplog)
+
+        (record,) = _rejections(caplog)
+        assert record.levelname == "DEBUG", (record.levelname, record.getMessage())
+        assert "baseline is wrong" not in record.getMessage()

--- a/tests/interfaces/test_5886_own_client_ref_rejection_warns.py
+++ b/tests/interfaces/test_5886_own_client_ref_rejection_warns.py
@@ -33,7 +33,7 @@ from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
 from reyn.interfaces.repl.read_model import LOCAL_CHAT_READ_CAPABILITIES, ChatReadModel
 from reyn.interfaces.transport.client_transport import ClientTransportStub
-from reyn.interfaces.transport.frames import EventFrame, StatusApplied
+from reyn.interfaces.transport.frames import EventFrame, QueueSnapshot, StatusApplied
 from reyn.schemas.models import Event
 
 _TEXT = "a submission the gate will reject"
@@ -42,15 +42,19 @@ _LOGGER = "reyn.interfaces.inline.textual_chat.app"
 
 class _SeededReadModel(ChatReadModel):
     """A real ``ChatReadModel`` seam impl (the ``_MutableSnapshotReadModel``
-    shape from ``test_3338``) whose snapshot already carries ``queue_seq 5``
-    — what the seed reads when the snapshot frame below is processed."""
+    shape from ``test_3338``) — the surface the app needs to mount. Its
+    ``snapshot()`` deliberately reports ``queue_seq 0``: #5895 moved the
+    seed's source onto the frame, so if the seed still consulted this read
+    model the baseline would be 0, the stale seq-1 delta below would be
+    ADMITTED, and both tests would fail on "no rejection" — that is the
+    strip."""
 
     @property
     def capabilities(self):
         return LOCAL_CHAT_READ_CAPABILITIES
 
     def snapshot(self, config=None):
-        return {"queue": [], "turn_active": False, "queue_seq": 5}
+        return {"queue": [], "turn_active": False, "queue_seq": 0}
 
     def intervention_head(self):
         return None
@@ -143,7 +147,11 @@ def _rejections(caplog) -> "list":
 
 
 async def _drive(app: TextualChatApp, transport: _FrameTransport, client_ref: str, pilot, caplog) -> None:
-    await transport.push(StatusApplied(kind="snapshot"))  # baseline := 5
+    # #5895: the frame CARRIES the baseline — queue_seq 5 rides here.
+    await transport.push(StatusApplied(
+        kind="snapshot",
+        snapshot=QueueSnapshot(queue=(), turn_active=False, queue_seq=5),
+    ))
     await transport.push(_stale_user_submitted(client_ref))
     while not _rejections(caplog):
         await pilot.pause()

--- a/tests/interfaces/test_5895_seed_from_frame_values.py
+++ b/tests/interfaces/test_5895_seed_from_frame_values.py
@@ -1,0 +1,222 @@
+"""Tier 2: #5895 — the sent-queue gate seeds from the values the snapshot
+frame CARRIES, never from the live read model. The local-shaped witness.
+
+#5886's first fix moved the seed from "the first non-status frame" to "the
+snapshot frame's own position in the stream" but still read the read model
+LIVE at that moment — which only narrowed the window. Between the instant a
+snapshot frame is enqueued and the instant the pump processes it, the live
+value can move: remotely, ``_pump_sse`` applies a later delta onto
+``RemoteStatusView``; locally, a submit advances ``queue_seq``. Either way a
+live read seeds a baseline AHEAD of the submission the gate must admit, and
+the operator's own message is rejected as "already reflected" — the same
+silence #5886 was reported as. Architect ruling: the frame carries the
+values captured at snapshot time; the seed reads the frame and nothing else.
+
+This file constructs that gap deterministically in its LOCAL form: a REAL
+registry and session, a REAL ``RegistryReadModel`` (so "the live value" is
+the real session's own ``queue_seq``), a real submit that advances it, and a
+snapshot frame carrying the value captured BEFORE the submit — exactly the
+state the local producer leaves when a submit lands between its capture and
+the pump. The submit happens before the frame is pushed, so by the time the
+pump seeds, the live counter is already one ahead of what the frame says —
+the gap is a fact this test controls, not a race it hopes for (the producer
+itself is exercised by ``test_3310_n2_reset_hydrate.py``'s switch witness).
+The auto-driver is stopped so nothing else moves the counter.
+
+The sessions here carry NO WAL on purpose: ``Session.queued_user_messages()``
+is journal-backed and stays empty without one, while ``queue_seq`` is
+in-memory and advances regardless. That makes the operator's row reachable
+by exactly ONE path — the ``user_submitted`` echo passing the gate. With a
+WAL, a build that seeds from the live read model would ALSO pick the queued
+item up from the live queue and draw the same row, and the accept-side
+assert could not tell the two apart (that is how this file's first form
+stayed green under its own strip).
+
+Strip (verified): making ``_seed_queue_view`` read ``self._snapshot()``
+instead of ``frame.snapshot`` turns the accept-side test red — the real,
+advanced ``queue_seq`` becomes the baseline and the submission is rejected.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.core.events.events import Event
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import RegistryReadModel
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import EventFrame, QueueSnapshot, StatusApplied
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_MINE = "the operator's own submission after the snapshot was captured"
+
+
+class _FrameTransport(ClientTransportStub):
+    """A real, minimal ``ClientTransport`` fed one item at a time (the
+    ``_EventOnlyTransport`` shape ``test_3338_tui_status_chrome_liveness.py``
+    established)."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push(self, item: object) -> None:
+        await self._queue.put(item)
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
+        return ""
+
+    async def run_slash_command(self, name: str, args: str) -> bool:
+        return True
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg) -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _registry_without_wal(tmp_path: Path) -> AgentRegistry:
+    """A real registry whose sessions carry NO ``StateLog`` — see the module
+    docstring: the live queue must stay empty so the only way a row can
+    appear is the echo passing the gate."""
+
+    def factory(profile: AgentProfile) -> Session:
+        return make_session(agent_name=profile.name, agent_role=profile.role)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("alpha")
+    return reg
+
+
+async def _stop_auto_driver(reg: AgentRegistry, name: str) -> None:
+    """Cancel the background ``session.run()`` ``attach`` booted, so a
+    submission stays QUEUED (its seq is the next after the baseline) and
+    nothing but this test moves the counter."""
+    task = reg._tasks.get((name, _DEFAULT_SID))
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _settle(pilot, n: int = 3) -> None:
+    for _ in range(n):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_submit_between_snapshot_capture_and_seed_is_not_rejected(tmp_path, monkeypatch):
+    """Tier 2: the accept side. The snapshot frame carries ``queue_seq`` as
+    it was when captured; a REAL submit then advances the session's live
+    counter before the pump seeds. The operator's own ``user_submitted``
+    (the very next seq) must be admitted into the sent-queue region."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry_without_wal(tmp_path)
+    try:
+        session = await reg.attach("alpha")
+        await _stop_auto_driver(reg, "alpha")
+        captured_seq = session.queue_seq  # what the producer would have captured
+        # The gap: a real submit advances the LIVE counter after the frame's
+        # values were captured and before the pump seeds (the frame is
+        # pushed below, after this). The live queue itself stays empty (no
+        # WAL) — only ``queue_seq`` moves.
+        msg_id = await session.submit_user_text(_MINE)
+        assert session.queue_seq == captured_seq + 1
+        read_model = RegistryReadModel(reg)
+        assert read_model.snapshot()["queue_seq"] == captured_seq + 1
+        assert not session.queued_user_messages(), "premise: no WAL, no live queue"
+
+        transport = _FrameTransport()
+        app = TextualChatApp(transport=transport, read_model=read_model, agent_name="alpha")
+        async with app.run_test(size=(100, 30)) as pilot:
+            await transport.push(StatusApplied(
+                kind="snapshot",
+                snapshot=QueueSnapshot(queue=(), turn_active=False, queue_seq=captured_seq),
+            ))
+            # The echo the local forwarder would deliver for that submit.
+            await transport.push(EventFrame(Event(type="user_submitted", data={
+                "msg_id": msg_id, "chain_id": None, "text": _MINE, "seq": captured_seq + 1,
+            })))
+            await _settle(pilot)
+
+            rendered = list(app.query_one(SentQueue).rendered_texts())
+            assert any(_MINE in t for t in rendered), (
+                "the operator's own submission was rejected by the gate — the seed "
+                f"read the LIVE queue_seq ({captured_seq + 1}) instead of the frame's "
+                f"captured one ({captured_seq}); sent-queue: {rendered!r}"
+            )
+    finally:
+        await reg.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_delta_older_than_the_captured_snapshot_is_still_rejected(tmp_path, monkeypatch):
+    """Tier 2: the discriminating control — the gate still gates. A delta
+    whose seq is AT the captured baseline (already reflected in the
+    snapshot) is rejected, so "seed from the frame" cannot be satisfied by a
+    build that stopped seeding, or seeded 0, altogether."""
+    monkeypatch.chdir(tmp_path)
+    reg = _registry_without_wal(tmp_path)
+    try:
+        session = await reg.attach("alpha")
+        await _stop_auto_driver(reg, "alpha")
+        await session.submit_user_text("already in the snapshot")
+        captured_seq = session.queue_seq  # >= 1: the snapshot reflects that submit
+
+        transport = _FrameTransport()
+        app = TextualChatApp(
+            transport=transport, read_model=RegistryReadModel(reg), agent_name="alpha",
+        )
+        async with app.run_test(size=(100, 30)) as pilot:
+            await transport.push(StatusApplied(
+                kind="snapshot",
+                snapshot=QueueSnapshot(queue=(), turn_active=False, queue_seq=captured_seq),
+            ))
+            await transport.push(EventFrame(Event(type="user_submitted", data={
+                "msg_id": "stale", "chain_id": None, "text": "a stale replay",
+                "seq": captured_seq,
+            })))
+            await _settle(pilot)
+
+            rendered = list(app.query_one(SentQueue).rendered_texts())
+            assert not any("a stale replay" in t for t in rendered), rendered
+    finally:
+        await reg.shutdown()

--- a/tests/interfaces/test_5895_threaded_proxy_forwards_seed_frame.py
+++ b/tests/interfaces/test_5895_threaded_proxy_forwards_seed_frame.py
@@ -1,0 +1,130 @@
+"""Tier 2: #5895 (architect container ruling) — ``ThreadedTransportProxy``
+forwards a ``StatusApplied(kind="snapshot")`` seed frame UNCHANGED, and an
+app behind the proxy is seeded by it.
+
+The local frame stream now carries ``StatusApplied`` (the sent-queue seed
+behind every ``session_attached`` barrier, ``in_process.py``). The threaded
+proxy sits between that stream and the TUI in the threaded configuration
+(#4995) and is a pass-through consumer: it must forward the seed, not drop
+it — a proxy that dropped it would reproduce the #5886 regression in
+exactly ONE configuration, silently (the architect's own named hazard).
+
+Both tests use a real minimal ``ClientTransport`` (the ``test_5048_
+threaded_proxy_pending_head_not_live_object.py`` shape) whose ``frames()``
+yields one seed frame and then holds, so "the seed reached the caller
+side" is a fact the stream itself shows; the proxy is the REAL
+``ThreadedTransportProxy`` with its real worker thread. No registry is
+built here: the property under test is the proxy's forwarding, not the
+producer (``test_3310_n2_reset_hydrate.py`` covers the producer).
+
+Strip (verified): making ``ThreadedTransportProxy._pump_frames`` skip
+``StatusApplied`` items turns BOTH tests red — as a HANG that CI's
+``--timeout`` kills (the stream yields nothing before the hold, so
+``__anext__`` / the app's pump wait forever), not as an assertion; said
+here because a hang wears no colour of its own.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import QueueSnapshot, StatusApplied
+from reyn.interfaces.transport.threaded import ThreadedTransportProxy
+
+_QUEUED = {"msg_id": "m1", "chain_id": "c1", "text": "seeded through the proxy", "meta": {}}
+
+
+class _SeedThenHoldTransport(ClientTransportStub):
+    """Yields ONE ``StatusApplied(kind="snapshot")`` seed frame, then holds
+    forever — the smallest stream in which "the seed was forwarded" is
+    observable on the caller side."""
+
+    def __init__(self) -> None:
+        self._never: "asyncio.Event | None" = None
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[StatusApplied]":
+        yield StatusApplied(
+            kind="snapshot",
+            snapshot=QueueSnapshot(queue=(dict(_QUEUED),), turn_active=False, queue_seq=1),
+        )
+        # Created lazily ON the worker loop (the proxy runs this generator
+        # there), never on the caller's loop.
+        self._never = asyncio.Event()
+        await self._never.wait()
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    def put_display(self, msg) -> None:
+        pass
+
+    async def cancel_inflight(self) -> str:
+        return ""
+
+    async def shutdown(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_the_proxy_forwards_the_seed_frame_unchanged() -> None:
+    """Tier 2: the first item out of ``proxy.frames()`` IS the inner
+    stream's ``StatusApplied`` seed — same kind, same carried values."""
+    proxy = ThreadedTransportProxy(_SeedThenHoldTransport)
+    proxy.start()
+    try:
+        frame = await proxy.frames().__anext__()
+        assert isinstance(frame, StatusApplied), (
+            f"the proxy did not forward the seed frame as-is: {frame!r}"
+        )
+        assert frame.kind == "snapshot" and frame.snapshot is not None
+        assert frame.snapshot.queue_seq == 1
+        assert [i["msg_id"] for i in frame.snapshot.queue] == ["m1"]
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_an_app_behind_the_proxy_is_seeded_by_the_forwarded_frame() -> None:
+    """Tier 2: one layer up — the TUI fed through the proxy shows the
+    snapshot's queued item in its sent-queue region, i.e. the seed point
+    survives the threaded configuration."""
+    proxy = ThreadedTransportProxy(_SeedThenHoldTransport)
+    proxy.start()  # the runner's act in production (``repl.py``), not the app's
+    app = TextualChatApp(transport=proxy)
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            rendered = list(app.query_one(SentQueue).rendered_texts())
+            assert any("seeded through the proxy" in t for t in rendered), (
+                f"the app behind the proxy was not seeded; sent-queue: {rendered!r}"
+            )
+    finally:
+        await proxy.shutdown()

--- a/tests/interfaces/test_stream_drain_yield_3570.py
+++ b/tests/interfaces/test_stream_drain_yield_3570.py
@@ -41,7 +41,7 @@ from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.transport.agui.client import AgUiTransport
 from reyn.interfaces.transport.agui.endpoint import _SessionFrameSource
 from reyn.interfaces.transport.agui.protocol import encode_frame, to_sse
-from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, FrameTag
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, StatusApplied
 from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.registry import AgentRegistry
@@ -224,14 +224,20 @@ async def test_the_stream_still_terminates_at_the_end_frame(tmp_path) -> None:
         async for frame in transport.frames():
             seen.append(frame)
 
+        # #5895: the local stream also carries ``StatusApplied`` (the seed
+        # frame behind the ``session_attached`` barrier) — it has no
+        # ``.tag``; classify by type, as every consumer must.
         kinds = [
-            f.message.kind if f.tag is FrameTag.DISPLAY else "<event>" for f in seen
+            f.message.kind if isinstance(f, DisplayFrame)
+            else "<status>" if isinstance(f, StatusApplied)
+            else "<event>"
+            for f in seen
         ]
         assert "__end__" in kinds, f"the terminal frame was never delivered: {kinds}"
         assert kinds[-1] == "__end__", (
             f"frames were delivered after the terminal frame: {kinds}"
         )
-        assert isinstance(seen[0], (DisplayFrame, EventFrame))
+        assert isinstance(seen[0], (DisplayFrame, EventFrame, StatusApplied))
     finally:
         await registry.shutdown()
 


### PR DESCRIPTION
**[tui-coder]** — owner が `--connect` で踏んだ「attach 後の最初の送信が会話に出ず、pending 行も消えない」を再現 → 裁定どおり修正しました。

## 機構 — 裁定の想定より広い（実測）

裁定は「ping の STATE_DELTA が `user_submitted` frame を追い越す」順序を想定していますが、**wire 順の逆転は不要**でした。実測の wire 順は最後まで `STATE_SNAPSHOT[queue_seq=0] → user_submitted → STATE_DELTA[queue_seq>0] → turn_started` のままです。効いていたのは:

- `AgUiTransport._pump_sse` は**自前の task**（`client.py:507`）で、decode した `STATE_*` を**即** `RemoteStatusView` に適用し、frame は `_display_queue` に積むだけ。
- その `_pump_sse` は **frame 間で yield しない**（`client.py` 自身のコメント）。一方 `frames()` は **1 frame ごとに `suspend_between_frames()` で譲る**。
- ∴ **read model は app pump の位置より任意に先行し得ます。** lazy seed はその live 値を読んでいたので、**pump が自分の decoder に遅れるだけ**で baseline が上がり、自分の `user_submitted(seq=1)` が `1 <= baseline` で落ちます。

実 TUI は 1 frame ごとに本物の描画をするので遅れるのが常態で、owner の「1 通目だけ」という報告とも整合します（2 通目以降は seed 済み）。

## 修正（裁定 ①〜⑥）

1. `StatusApplied` に **必須** `kind: Literal["snapshot","delta"]`。`_consume_block` は元々どちらか知っていて、app には同じ物を渡していました — そこが情報を落とす地点です。
2. seed は **`StatusApplied(kind="snapshot")` を stream の中で処理した瞬間**。初回 connect / reconnect / switch はすべてここに合流します（3 経路とも snapshot を出すため）。
3. **delta は seed しない。** viewer が読む live `queue_seq` と gate の hydration baseline は別の事実です。
4. **lazy first-frame seed と `session_attached` 時 reseed を削除**（fallback に残さない = 2 source にしない）。switch の方も同じ欠陥の別形でした（emitter は barrier frame を**先に** yield し、新 session の snapshot は**後**なので、chunk 境界を跨ぐと旧 session の値で seed していました）。
5. **seed 前の event frame は WARNING ＋ APPLY**。落とすのが本件の「見えない故障」、重複表示は見える故障。
6. **自分の `client_ref` を持つ拒否は WARNING**（他人の stale は debug のまま）。自分が今 mint した id が「already reflected」であり得ないので、これは baseline が誤っている時だけ出る指紋です。

`RemoteQueueView.baseline_seq()` を公開読み口として追加（裁定の受入が「無ければその不在が finding」と名指ししていたもの）。

## ⚠️ 発見: local transport が seed されなくなる所だった（自己申告）

`agui/client.py` が `StatusApplied` の**唯一の producer**なので、④ で lazy seed を消すと **local（in-process）は誰も seed しない**状態になり、既に queue のある session への local attach で sent-queue が空になるところでした。「この変更は local にとって何を偽にするか」を問い直して気づいたもので、**test が捕まえたのではありません**。`on_mount` で 1 回 seed するようにしています（local ではその read が hydration 値そのもの。remote では mount 時点の read model は空なので baseline 0 =**通す側**に倒れ、直後の connect snapshot が本物に置き換えます）。

## Test plan

- [x] Tier 2 — `tests/interfaces/test_5886_first_frame_seed_race.py`: real `agui_events` route ＋ real `AgUiTransport` ＋ mounted `TextualChatApp`、**attach → idle → client 経由 submit（`client_ref` 付き）**、dispatch は session 自身の run loop。test が持つのは「生産済みの bytes をいつ client に届けるか」の 1 点だけです。
- [x] **strip-falsify（復元済み）**: lazy seed に戻すと ①acceptance が赤 ＋ ⑥ の WARNING が実際に出る（`client_ref=local:661f…` を名指しして「baseline is wrong」）。**1 回の strip で 2 つの主張が同時に噛んでいる**ことを確認しました。
- [x] 回帰: **#5179 の 3 ファイル（4 tests）緑**（server 側 pairing は不変）、`test_5830_remote_attach_status_refresh.py` ＋ `test_5870_stage2_pane_refresh_determinism.py`（`StatusApplied` を触る 2 ファイル）緑。合計 11 + 4。
- [x] `ruff check .` / `test_tier_audit.py --strict` / `verify_module_docstrings.py` / `flat_tests_ratchet` / `check_tests_path_literal_reference`（push 直前に再実行）/ `check_bare_tests_import_reference` / `check_file_depth_reference` / `check_subprocess_reyn_pin` / TUI Gate A・B — すべて OK。
- [x] `mypy` — **CI 判定**（lead-coder 指示、#5882 着地まで local 禁止）。
- [x] `docs/` は未変更。
- [ ] Visual — owner 実機で `--connect` 直後の 1 通目（見た目ゲートは merge を止めない）。

## 🔴 受入のうち、この PR に**無い**もの（誠実な申告）

裁定の受入 6 項のうち、**②switch（別 chunk）／③delta が baseline を動かさない／④seed 前 event の WARNING＋apply／⑤自分の client_ref 拒否 WARNING の単体 witness** は、この PR には**入っていません**。

⑤ は上の strip で「実際に出る」ことを確認済み、③④は実装済みですが、**専用 witness を書こうとして失敗しました**: `ClientTransportStub` ベースの軽量 harness を組んだところ app の pump が動かず（frame が 1 つも描画に届かない）、時間内に安定させられませんでした。**不安定な harness を witness と称して出すより、無いと言う方を選びます。** 実 route harness を使えば書けるはずなので、必要なら follow-up として起票してください（起票は lead の役）。

Closes #5886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
