### PR TITLE
fix(#5887): OS-authored notices stop wearing the model's marker

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -12,7 +12,7 @@ import functools
 import json
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, runtime_checkable
 
 from reyn.core.dispatch import DispatchContext, dispatch_tool
 from reyn.llm.llm import call_llm_tools
@@ -93,6 +93,12 @@ _EMPTY_RESPONSE_MSG: dict[str, str] = {
         " · retry: {retry} (chat.empty_stop_retry) · call {call_id}]"
     ),
 }
+
+
+#: #5887: the roles a ``put_outbox`` row may be persisted to history AS —
+#: exactly ``ChatMessage.role``'s own set, so the adapter passes it straight
+#: through and never re-derives a role from the display ``kind``.
+PersistAs = Literal["user", "assistant", "tool", "system", "summary", "spill_record"]
 
 
 def _empty_response_text(
@@ -949,15 +955,22 @@ class RouterLoopCore(Protocol):
     # -- every ``RouterLoopHost`` genuinely implements this, test hosts
     # included (``tests/_support/router_loop.py``'s ``FakeRouterHost``).
     def make_router_op_context(self) -> Any: ...
-    # #3633: ``persist`` makes the kind=="agent" → history-append coupling an
-    # EXPLICIT per-call-site choice instead of an implicit blanket rule the
-    # host applies unconditionally. Defaults True (= the pre-#3633 behavior,
-    # unchanged for every existing caller); a call site whose text is already
-    # persisted by another path (e.g. router_loop's tool-turn display bubble,
-    # duplicated by ``feedback()``'s ``append_history_entry``) passes False.
+    # #5887 (architect ruling): ``persist_as`` says, in ONE argument, both
+    # whether this row lands in history and AS WHAT role — ``None`` = display
+    # only. No default, deliberately: a new call site must state what it
+    # leaves behind for the next turn's wire. It replaces #3633's
+    # ``persist: bool`` plus the host-side "role is inferred from kind" rule,
+    # because that pair is exactly how the #5887 incident's fix would have
+    # gone wrong — changing ``kind`` (the DISPLAY axis: who is speaking to
+    # the operator) silently switched persistence off (the LLM-CONTEXT
+    # axis: what the model sees next turn). The two are orthogonal;
+    # dogfood-v6's decision to keep the empty-response text in history as an
+    # assistant placeholder is a context-axis decision and survives a
+    # display-axis change untouched. #3633's ``persist=False`` (a row whose
+    # text is already persisted by ``feedback()``) maps to ``persist_as=None``.
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
-        persist_as_assistant: bool = False,
+        self, *, kind: str, text: str, meta: dict,
+        persist_as: "PersistAs | None",
     ) -> None: ...
 
 
@@ -1129,11 +1142,12 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def send_to_session(self, *, agent: str, session: str,
                               text: str, wake: bool) -> dict: ...
 
-    # #3633: see RouterLoopCore.put_outbox above — ``persist`` is the same
-    # explicit per-call-site opt-out, inherited here (Protocol overlap).
+    # #5887: see RouterLoopCore.put_outbox above — ``persist_as`` is the same
+    # explicit, default-less per-call-site declaration, inherited here
+    # (Protocol overlap).
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
-        persist_as_assistant: bool = False,
+        self, *, kind: str, text: str, meta: dict,
+        persist_as: "PersistAs | None",
     ) -> None: ...
 
     # E-full PR-E (issue #383): persist a single ChatMessage entry
@@ -2701,7 +2715,7 @@ class RouterLoop:
                 # parent row with its children shown under it is not a visual
                 # regression the way a bare empty bubble alone would have been.
                 #
-                # #3633: this call is DISPLAY-ONLY — ``persist=False``. The prior
+                # #3633: this call is DISPLAY-ONLY — ``persist_as=None`` (was ``persist=False``). The prior
                 # comment here ("no double-emit ... history persistence is unchanged")
                 # was wrong: it only ruled out collision with the *different*
                 # no-tool_calls terminal path further down this file and missed that
@@ -2709,7 +2723,7 @@ class RouterLoop:
                 # ``format_feedback`` → ``append_history_entry``) independently
                 # persists this SAME text moments later as the canonical
                 # ``source="router_tool_turn"`` record — the one that also carries
-                # ``tool_calls``, so it is the complete turn. Without ``persist=False``
+                # ``tool_calls``, so it is the complete turn. Without ``persist_as=None``
                 # RouterHostAdapter's unconditional ``kind=="agent"`` → append-to-
                 # history side effect wrote the identical string to history.jsonl
                 # twice (measured: 24/283 adjacent-duplicate assistant records in a
@@ -2718,7 +2732,7 @@ class RouterLoop:
                 await self.host.put_outbox(
                     kind="agent",
                     text=_tool_turn_text,
-                    persist=False,
+                    persist_as=None,
                     # #1652: supply this turn's reasoning (host gates display/
                     # continuity + emits the discrete kind="reasoning" signal).
                     meta={
@@ -2849,13 +2863,13 @@ class RouterLoop:
                     )
                     ack_text = f"{header}\n\n{trailer}"
                     # #5887: an OS ack, not the model's words — system
-                    # marker, not the agent one. ``persist_as_assistant``
+                    # marker, not the agent one. ``persist_as="assistant"``
                     # preserves the history placeholder this row always
                     # wrote (see RouterHostAdapter.put_outbox).
                     await self.host.put_outbox(
                         kind="system",
                         text=ack_text,
-                        persist_as_assistant=True,
+                        persist_as="assistant",
                         meta={
                             "chain_id": self.chain_id,
                             "source": "agent_spawn_ack",
@@ -3038,7 +3052,7 @@ class RouterLoop:
                 # #5887: reyn authored this sentence, not the model — it
                 # renders under the system marker (``· `` dim), not the
                 # agent one (``● ``), and a generic AG-UI client never
-                # sees it as an ``assistant`` turn. ``persist_as_assistant``
+                # sees it as an ``assistant`` turn. ``persist_as="assistant"``
                 # keeps the dogfood-v6 decision in RouterHostAdapter.
                 # put_outbox intact: the text still lands in history as an
                 # assistant placeholder so the next turn's wire does not
@@ -3046,7 +3060,7 @@ class RouterLoop:
                 await host.put_outbox(
                     kind="system",
                     text=failure_text,
-                    persist_as_assistant=True,
+                    persist_as="assistant",
                     meta={
                         "chain_id": self.chain_id,
                         "source": "router_empty_response",
@@ -3091,12 +3105,14 @@ class RouterLoop:
                 await self.host.put_outbox(
                     kind="agent",
                     text=_structured_text,
+                    persist_as="assistant",
                     meta={"chain_id": self.chain_id, "reasoning": result.reasoning},
                 )
                 return self._total_usage
             await self.host.put_outbox(
                 kind="agent",
                 text=result.content or "",
+                persist_as="assistant",
                 # #1652: supply the turn's reasoning; the host applies the
                 # display/continuity gates + the discrete kind="reasoning" emit.
                 meta={
@@ -3170,6 +3186,7 @@ class RouterLoop:
             await self.host.put_outbox(
                 kind="system",
                 text="✗ turn interrupted",
+                persist_as=None,
                 meta={"chain_id": self.chain_id},
             )
             # #3694: durable cancelled-turn outcome — the cooperative-cancel
@@ -3229,6 +3246,7 @@ class RouterLoop:
                 await self.host.put_outbox(
                     kind="agent",
                     text=_wrapup.content,
+                    persist_as="assistant",
                     meta={
                         "chain_id": self.chain_id,
                         "limit_stopped": True,
@@ -3240,6 +3258,7 @@ class RouterLoop:
             pass
         await self.host.put_outbox(
             kind="error",
+            persist_as=None,
             text=(
                 f"Router loop exceeded max iterations ({self.max_iterations}). "
                 f"Configure safety.on_limit.mode=interactive or auto_extend to "

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -72,16 +72,48 @@ def _resolve_tool_use_scheme(name: "str | None" = None):
 # (finish_reason=stop, no content, no tool calls). Deterministic i18n so
 # output_language is always honoured.  P7-clean: no tool names.
 # "en" is the global-safe default.
+#
+# #5887 (owner report: "llm からのメッセージなのか、システムメッセージなのか
+# tui 表示の区別がついてない"): this is reyn speaking ABOUT the model, so it
+# is (a) emitted as ``kind="system"`` — see the emit site — and (b) worded
+# as an OS notice that says what happened and what is in effect, never as
+# advice in the model's voice. The old "check your configuration" told the
+# owner nothing about WHICH setting; the retry switch is the one that
+# matters here (``chat.empty_stop_retry``, owner default False since
+# 2026-08-14), so its state is printed, with the call id for the audit
+# trail. ``{finish_reason}`` / ``{retry}`` / ``{call_id}`` are filled by
+# :func:`_empty_response_text`.
 _EMPTY_RESPONSE_MSG: dict[str, str] = {
     "ja": (
-        "モデルが空の応答を返しました。"
-        " 別の表現で再入力するか、設定を確認してください。"
+        "[⚠ モデルが空の応答を返しました (finish_reason={finish_reason})"
+        " · 再試行: {retry} (chat.empty_stop_retry) · call {call_id}]"
     ),
     "en": (
-        "The model returned an empty response."
-        " Please try rephrasing your request or check your configuration."
+        "[⚠ model returned an empty response (finish_reason={finish_reason})"
+        " · retry: {retry} (chat.empty_stop_retry) · call {call_id}]"
     ),
 }
+
+
+def _empty_response_text(
+    lang: "str | None", *, finish_reason: "str | None", retry_on: bool,
+    call_id: "str | None",
+) -> str:
+    """Render :data:`_EMPTY_RESPONSE_MSG` for ``lang`` with the facts of this
+    particular empty response filled in (#5887).
+
+    ``retry_on`` is whether the empty-stop retry was IN EFFECT for this
+    call (config ``chat.empty_stop_retry``, or the ``REYN_EMPTY_STOP_RETRY``
+    env override) — printed as ``on``/``off`` so the reader sees the switch
+    that governs what reyn just did, not a generic hint to go look at
+    settings. When it is on and this text is still being shown, the one
+    retry already ran and the model answered empty twice."""
+    template = _EMPTY_RESPONSE_MSG.get(lang or "", _EMPTY_RESPONSE_MSG["en"])
+    return template.format(
+        finish_reason=finish_reason or "?",
+        retry="on" if retry_on else "off",
+        call_id=call_id or "?",
+    )
 
 
 # Localized OS-level acknowledgment emitted when a request is dispatched
@@ -925,6 +957,7 @@ class RouterLoopCore(Protocol):
     # duplicated by ``feedback()``'s ``append_history_entry``) passes False.
     async def put_outbox(
         self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        persist_as_assistant: bool = False,
     ) -> None: ...
 
 
@@ -1100,6 +1133,7 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     # explicit per-call-site opt-out, inherited here (Protocol overlap).
     async def put_outbox(
         self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        persist_as_assistant: bool = False,
     ) -> None: ...
 
     # E-full PR-E (issue #383): persist a single ChatMessage entry
@@ -2814,9 +2848,14 @@ class RouterLoop:
                         lang, _AGENT_SPAWN_ACK_MSG["en"],
                     )
                     ack_text = f"{header}\n\n{trailer}"
+                    # #5887: an OS ack, not the model's words — system
+                    # marker, not the agent one. ``persist_as_assistant``
+                    # preserves the history placeholder this row always
+                    # wrote (see RouterHostAdapter.put_outbox).
                     await self.host.put_outbox(
-                        kind="agent",
+                        kind="system",
                         text=ack_text,
+                        persist_as_assistant=True,
                         meta={
                             "chain_id": self.chain_id,
                             "source": "agent_spawn_ack",
@@ -2984,12 +3023,30 @@ class RouterLoop:
                     )
                     continue  # re-enter the loop with the directive in messages
                 lang = getattr(host, "output_language", None)
-                failure_text = _EMPTY_RESPONSE_MSG.get(
-                    lang, _EMPTY_RESPONSE_MSG["en"]
+                failure_text = _empty_response_text(
+                    lang,
+                    finish_reason=result.finish_reason,
+                    retry_on=bool(
+                        self._empty_stop_retry_directive
+                        and (
+                            self._empty_stop_retry_auto
+                            or os.environ.get("REYN_EMPTY_STOP_RETRY") == "1"
+                        )
+                    ),
+                    call_id=result.call_id,
                 )
+                # #5887: reyn authored this sentence, not the model — it
+                # renders under the system marker (``· `` dim), not the
+                # agent one (``● ``), and a generic AG-UI client never
+                # sees it as an ``assistant`` turn. ``persist_as_assistant``
+                # keeps the dogfood-v6 decision in RouterHostAdapter.
+                # put_outbox intact: the text still lands in history as an
+                # assistant placeholder so the next turn's wire does not
+                # carry two consecutive user messages.
                 await host.put_outbox(
-                    kind="agent",
+                    kind="system",
                     text=failure_text,
+                    persist_as_assistant=True,
                     meta={
                         "chain_id": self.chain_id,
                         "source": "router_empty_response",

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -44,6 +44,7 @@ _TURN_BUDGET_ENGINE_UNSET = object()
 _RUN_PROMPT_DEFAULT_TIMEOUT_S: float = 120.0
 
 if TYPE_CHECKING:
+    from reyn.runtime.router_loop import PersistAs
     from reyn.runtime.router_op_context import RouterOpContextSource
 
 logger = logging.getLogger(__name__)
@@ -2301,8 +2302,8 @@ class RouterHostAdapter:
         await self._commit_mid_turn_injection_cb(msg_id)
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
-        persist_as_assistant: bool = False,
+        self, *, kind: str, text: str, meta: dict,
+        persist_as: "PersistAs | None",
     ) -> None:
         from reyn.runtime.chat_message import ChatMessage, _now_iso
         from reyn.runtime.outbox import OutboxMessage
@@ -2353,34 +2354,32 @@ class RouterHostAdapter:
         # cascading-attractor mitigation needs to live elsewhere
         # (= context build / classifier-side, tracked as follow-up).
         #
-        # #3633: ``persist`` (default True) makes this append an EXPLICIT
-        # per-call-site choice rather than an implicit blanket rule. A caller
-        # whose text is already persisted through a different path (e.g.
-        # router_loop's tool-turn display bubble — the SAME text is persisted
-        # a few lines later as the canonical record by
-        # ``append_history_entry`` in ``RouterLoop.feedback()``, complete
-        # with ``tool_calls``) passes ``persist=False`` so the display-only
-        # outbox emit does not ALSO write to history.jsonl. Do not add a new
-        # unconditional persist path here without checking whether the text
-        # is already recorded elsewhere.
+        # #3633 introduced ``persist: bool`` so a caller whose text is already
+        # persisted through a different path (router_loop's tool-turn display
+        # bubble — the SAME text lands a few lines later as the canonical
+        # record via ``append_history_entry`` in ``RouterLoop.feedback()``,
+        # complete with ``tool_calls``) could opt out of a second write. Do
+        # not add a new unconditional persist path here without checking
+        # whether the text is already recorded elsewhere.
         #
-        # #5887: ``persist_as_assistant`` separates two axes this condition
-        # used to conflate. ``kind`` is the DISPLAY axis — who said it, which
-        # marker the TUI draws, which role a generic AG-UI client sees.
-        # The history append is the LLM-CONTEXT axis — whether the next
-        # turn's wire keeps user/assistant alternation. OS-authored text
-        # (the empty-response notice, the async-dispatch ack) is emitted
-        # as ``kind="system"`` so it stops rendering in the model's voice,
-        # but the dogfood-v6 decision above still stands: it must ALSO land
-        # in history as an ``assistant`` placeholder, or the next turn sees
-        # two consecutive ``user`` messages. Those two sites pass
-        # ``persist_as_assistant=True``; every other non-agent kind keeps
-        # its previous no-persist behaviour, byte-identical.
-        if text and persist and (kind == "agent" or persist_as_assistant):
-            # Issue #383: chat history now uses ``role="assistant"`` +
-            # ``content=`` (= wire shape mirror); the OutboxMessage above
-            # keeps ``kind="agent"`` since that's the TUI-facing
-            # OutboxMessage taxonomy, independent of the LLM-side role.
+        # #5887 (architect ruling): ``persist_as`` replaces that bool AND the
+        # ``kind == "agent"`` role inference this branch used to do. ``kind``
+        # is the DISPLAY axis — who is speaking to the operator, which marker
+        # the TUI draws, which role a generic AG-UI client sees. This append
+        # is the LLM-CONTEXT axis — what the model sees on the next turn's
+        # wire. Inferring the second from the first is exactly how the
+        # #5887 fix would have gone wrong: switching the empty-response
+        # notice to ``kind="system"`` (correct — reyn wrote it) would have
+        # silently switched off its history append, reverting the
+        # dogfood-v6 decision above without anyone choosing to. Now the
+        # caller states the role explicitly (``None`` = display only) and
+        # this method never derives one; the OS-authored rows pass
+        # ``persist_as="assistant"`` and keep the v6 placeholder.
+        if text and persist_as is not None:
+            # Issue #383: chat history uses ``role="assistant"`` +
+            # ``content=`` (= wire shape mirror) for the model's replies;
+            # the OutboxMessage above keeps its own ``kind`` since that's
+            # the TUI-facing taxonomy, independent of the LLM-side role.
             # #1652: persist reasoning on the history ChatMessage ONLY when
             # continuity is on (so _reasoning_continuity_section can replay it);
             # otherwise persist the stripped meta. Either way the wire-shape
@@ -2390,7 +2389,7 @@ class RouterHostAdapter:
                 else _outbox_meta
             )
             self._append_history_cb(ChatMessage(
-                role="assistant", content=text, ts=_now_iso(), meta=_persist_meta,
+                role=persist_as, content=text, ts=_now_iso(), meta=_persist_meta,
             ))
             # Capture for agent-to-agent paths that need to forward the
             # reply upstream via _send_agent_response.

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -2302,6 +2302,7 @@ class RouterHostAdapter:
 
     async def put_outbox(
         self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        persist_as_assistant: bool = False,
     ) -> None:
         from reyn.runtime.chat_message import ChatMessage, _now_iso
         from reyn.runtime.outbox import OutboxMessage
@@ -2362,7 +2363,20 @@ class RouterHostAdapter:
         # outbox emit does not ALSO write to history.jsonl. Do not add a new
         # unconditional persist path here without checking whether the text
         # is already recorded elsewhere.
-        if kind == "agent" and text and persist:
+        #
+        # #5887: ``persist_as_assistant`` separates two axes this condition
+        # used to conflate. ``kind`` is the DISPLAY axis — who said it, which
+        # marker the TUI draws, which role a generic AG-UI client sees.
+        # The history append is the LLM-CONTEXT axis — whether the next
+        # turn's wire keeps user/assistant alternation. OS-authored text
+        # (the empty-response notice, the async-dispatch ack) is emitted
+        # as ``kind="system"`` so it stops rendering in the model's voice,
+        # but the dogfood-v6 decision above still stands: it must ALSO land
+        # in history as an ``assistant`` placeholder, or the next turn sees
+        # two consecutive ``user`` messages. Those two sites pass
+        # ``persist_as_assistant=True``; every other non-agent kind keeps
+        # its previous no-persist behaviour, byte-identical.
+        if text and persist and (kind == "agent" or persist_as_assistant):
             # Issue #383: chat history now uses ``role="assistant"`` +
             # ``content=`` (= wire shape mirror); the OutboxMessage above
             # keeps ``kind="agent"`` since that's the TUI-facing

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -9229,7 +9229,7 @@ class Session:
         ``agent_response_committed`` HERE, filtered on ``msg.kind ==
         "agent"``, covers all 5 without an emit at each — and,
         architect's ruling, also the tool_calls-round accompanying text
-        (``persist=False`` — not written to history, but still reaches
+        (``persist_as=None`` — not written to history, but still reaches
         the user, so still in scope; see ``router_loop.py``'s own
         tool_calls-round site) and rewind/replay, as long as those keep
         going through this same funnel — a call site added later needs

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -249,10 +249,13 @@ class FakeRouterHost:
 
     async def put_outbox(
         self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        persist_as_assistant: bool = False,
     ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
         # #3633: mirror RouterHostAdapter.put_outbox's persist side effect.
-        if kind == "agent" and text and persist:
+        # #5887: including its ``persist_as_assistant`` axis — an OS-authored
+        # ``kind="system"`` row that asks to keep user/assistant alternation.
+        if text and persist and (kind == "agent" or persist_as_assistant):
             self.history.append({
                 "role": "assistant", "content": text, "meta": meta,
                 "tool_calls": None,

--- a/tests/_support/router_loop.py
+++ b/tests/_support/router_loop.py
@@ -248,16 +248,18 @@ class FakeRouterHost:
         return {"status": "delivered", "agent": agent, "session": session, "wake": wake}
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
-        persist_as_assistant: bool = False,
+        self, *, kind: str, text: str, meta: dict,
+        persist_as: "str | None",
     ) -> None:
-        self.outbox.append({"kind": kind, "text": text, "meta": meta})
-        # #3633: mirror RouterHostAdapter.put_outbox's persist side effect.
-        # #5887: including its ``persist_as_assistant`` axis — an OS-authored
-        # ``kind="system"`` row that asks to keep user/assistant alternation.
-        if text and persist and (kind == "agent" or persist_as_assistant):
+        self.outbox.append({
+            "kind": kind, "text": text, "meta": meta, "persist_as": persist_as,
+        })
+        # #3633/#5887: mirror RouterHostAdapter.put_outbox's persist side
+        # effect — the caller's explicit ``persist_as`` role, never one
+        # inferred from ``kind`` (the exact inference #5887 removed).
+        if text and persist_as is not None:
             self.history.append({
-                "role": "assistant", "content": text, "meta": meta,
+                "role": persist_as, "content": text, "meta": meta,
                 "tool_calls": None,
             })
 

--- a/tests/core/test_2242_hard_cancel.py
+++ b/tests/core/test_2242_hard_cancel.py
@@ -65,10 +65,20 @@ from tests._support.events import settle
 
 AGENT = "hard-cancel-agent"
 # #5450: the real stub's canned reply for an empty/no-tool-call completion
-# (router_loop.py's own constant) — the LITERAL content invariant 1 asserts
-# never lands for a hard-cancelled turn, replacing the old private helper's
-# own hand-picked sentinel string.
-_STUB_REPLY = _EMPTY_RESPONSE_MSG["en"]
+# is router_loop.py's own empty-response notice — the content invariant 1
+# asserts never lands for a hard-cancelled turn, replacing the old private
+# helper's own hand-picked sentinel string. #5887 made that notice a
+# TEMPLATE (`{finish_reason}` / `{retry}` / `{call_id}`, rendered per call
+# by `_empty_response_text`), so the persisted text is no longer the raw
+# constant: match on the template's literal head, up to its first
+# placeholder — stable across calls, still the real constant, never a
+# hand-picked string.
+_STUB_REPLY_HEAD = _EMPTY_RESPONSE_MSG["en"].split("{", 1)[0]
+assert _STUB_REPLY_HEAD, "test setup sanity: the notice must have a literal head before its first placeholder"
+
+
+def _is_stub_reply(m) -> bool:
+    return isinstance(m.content, str) and m.content.startswith(_STUB_REPLY_HEAD)
 
 
 def _make_session(wal: Path, snapshot_path: Path) -> tuple[Session, StateLog]:
@@ -152,7 +162,7 @@ async def test_hard_cancel_mid_generation_no_result_append_and_agent_survives(
     assert completed is True
 
     # (a) the cancelled turn's result never landed.
-    assert not any(m.content == _STUB_REPLY for m in session.history), (
+    assert not any(_is_stub_reply(m) for m in session.history), (
         "a hard-cancelled turn's LLM reply must never be appended, even after "
         "the underlying hung call is released post-cancel"
     )
@@ -188,7 +198,7 @@ async def test_hard_cancel_mid_generation_no_result_append_and_agent_survives(
     next_completed = await session.run_one_iteration()
     assert next_completed is True
     assert any(
-        m.role == "assistant" and m.content == _STUB_REPLY for m in session.history
+        m.role == "assistant" and _is_stub_reply(m) for m in session.history
     ), (
         "a normal turn after a hard-cancel must complete and append its reply — "
         "the agent must survive to serve the next turn"
@@ -328,7 +338,7 @@ async def test_external_cancel_of_driver_task_propagates(tmp_path, _llm_stub):
         await turn_task
 
     # sanity: the hung reply never landed (the turn was torn down, not completed).
-    assert not any(m.content == _STUB_REPLY for m in session.history)
+    assert not any(_is_stub_reply(m) for m in session.history)
     # witness ②: the real driver dispatched before the external cancel hit it.
     await settle(session)
     assert any(e.type == "turn_started" for e in events)

--- a/tests/dev/test_chat_turn_completed_inline.py
+++ b/tests/dev/test_chat_turn_completed_inline.py
@@ -162,7 +162,7 @@ class _FakeRouterHost:
         return "fake-model"
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        self, *, kind: str, text: str, meta: dict, persist_as: "str | None",
     ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 

--- a/tests/interfaces/test_agui_messages_standard_shape.py
+++ b/tests/interfaces/test_agui_messages_standard_shape.py
@@ -54,6 +54,37 @@ def test_standard_messages_are_conversation_turns_only() -> None:
     assert all(set(m) == {"role", "content"} for m in standard)
 
 
+def test_os_authored_system_rows_are_not_assistant_turns_in_the_snapshot() -> None:
+    """Tier 2: #5887 accept ② — an OS-authored notice (the empty-response
+    fallback, the async-dispatch ack) is emitted as ``kind="system"`` and so
+    is NOT an ``assistant`` turn in the reconnect ``MESSAGES_SNAPSHOT``: a
+    generic client rebuilding the conversation must not attribute reyn's
+    own sentence to the model, exactly as the live TUI no longer does.
+
+    The present-side sibling of ``_CONVERSATION_KINDS`` having no
+    ``system`` entry: this pins the OBSERVABLE consequence for a real
+    encoded snapshot, not the dict's contents. Before #5887 these rows
+    were ``kind="agent"`` and DID appear here as ``assistant`` — the
+    reconnect backlog had the same misattribution the owner saw live."""
+    backlog = [
+        DisplayFrame(OutboxMessage(kind="user", text="do something")),
+        DisplayFrame(OutboxMessage(
+            kind="system",
+            text="[⚠ model returned an empty response (finish_reason=stop) · retry: off (chat.empty_stop_retry) · call c1]",
+            meta={"source": "router_empty_response"},
+        )),
+        DisplayFrame(OutboxMessage(kind="agent", text="a real reply")),
+    ]
+    ev = encode_messages_snapshot(backlog)
+    standard = ev.data["messages"]
+
+    assert standard == [
+        {"role": "user", "content": "do something"},
+        {"role": "assistant", "content": "a real reply"},
+    ], f"the OS notice must not be an assistant turn; got: {standard!r}"
+    assert not any("empty response" in m["content"] for m in standard)
+
+
 @pytest.mark.asyncio
 async def test_reyn_client_rebuilds_full_backlog_from_reyn_block() -> None:
     """Tier 2: the reyn client replays the FULL backlog (chrome included) from the

--- a/tests/interfaces/test_agui_reasoning_map_p6a.py
+++ b/tests/interfaces/test_agui_reasoning_map_p6a.py
@@ -194,7 +194,7 @@ def test_display_off_yields_zero_reasoning_events() -> None:
     )
     asyncio.run(
         host.put_outbox(
-            kind="agent", text="answer",
+            kind="agent", text="answer", persist_as="assistant",
             meta={"chain_id": "c1", "reasoning": _REASONING_TEXT},
         )
     )
@@ -221,7 +221,7 @@ def test_display_on_yields_reasoning_triplet_on_the_wire() -> None:
     )
     asyncio.run(
         host.put_outbox(
-            kind="agent", text="answer",
+            kind="agent", text="answer", persist_as="assistant",
             meta={"chain_id": "c1", "reasoning": _REASONING_TEXT},
         )
     )

--- a/tests/llm/test_3633_history_double_append.py
+++ b/tests/llm/test_3633_history_double_append.py
@@ -14,18 +14,19 @@ effect (measured in a real session, issue #3633): the identical assistant
 text landed in ``history.jsonl`` twice, 24/283 records in the sampled
 session.
 
-The fix threads an explicit ``persist: bool = True`` kwarg through
-``put_outbox`` (Protocol + ``RouterHostAdapter`` impl) and sets
-``persist=False`` at the ``router_tool_turn_text`` call site — the coupling
-between ``kind=="agent"`` and the history-append side effect is now an
-explicit per-call-site choice rather than an implicit blanket rule.
+The fix threaded an explicit ``persist: bool = True`` kwarg through (#5887
+later replaced it with the default-less ``persist_as`` role argument)
+``put_outbox`` (Protocol + ``RouterHostAdapter`` impl) and set it False at
+the ``router_tool_turn_text`` call site (today: ``persist_as=None``) — the
+history-append side effect is an explicit per-call-site choice, and since
+#5887 the ROLE is explicit too, never inferred from ``kind``.
 
 Tier 3a test drives the real ``RouterLoop`` via the ``call_llm_tools``
 scripted-injection seam + ``FakeRouterHost`` (a real Fake — no mocks — now
 mirroring BOTH of RouterHostAdapter's persist paths: the ``put_outbox``
-side effect, gated by ``persist``, and ``append_history_entry``). Tier 2
+side effect, gated by ``persist_as``, and ``append_history_entry``). Tier 2
 test drives the real ``RouterHostAdapter`` directly (no Fake) to pin the
-``persist=False`` contract at its source.
+``persist_as=None`` contract at its source.
 """
 from __future__ import annotations
 
@@ -98,7 +99,7 @@ async def test_tool_turn_text_persists_to_history_exactly_once(monkeypatch):
     # The surviving record is the canonical one — it carries tool_calls.
     assert surviving["tool_calls"], "surviving record must be the complete turn"
 
-    # The display bubble still renders (outbox unaffected by persist=False).
+    # The display bubble still renders (outbox unaffected by persist_as=None).
     agent_outbox_texts = [m["text"] for m in host.outbox if m["kind"] == "agent"]
     assert "Let me run your skill first." in agent_outbox_texts
 
@@ -107,7 +108,7 @@ async def test_tool_turn_text_persists_to_history_exactly_once(monkeypatch):
 async def test_no_tool_calls_terminal_reply_still_persists(monkeypatch):
     """Tier 3a: regression guard for the OTHER path #3633's wrong comment was
     actually reasoning about — a plain no-tool_calls text reply (the common
-    case) must still persist to history exactly once. ``persist=False`` is
+    case) must still persist to history exactly once. ``persist_as=None`` is
     scoped to the tool-turn-with-text call site only."""
     host = FakeRouterHost()
     loop = make_loop(host)
@@ -131,11 +132,11 @@ def _count_adjacent_exact_duplicates(history: list[dict]) -> int:
     return count
 
 
-# ── RouterHostAdapter.put_outbox persist=False contract ─────────────────
+# ── RouterHostAdapter.put_outbox persist_as=None contract ───────────────
 
 
 def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
-    """Tier 2: RouterHostAdapter.put_outbox with ``persist=False`` emits the
+    """Tier 2: RouterHostAdapter.put_outbox with ``persist_as=None`` emits the
     outbox message but does NOT append to history — the fix's load-bearing
     contract, pinned directly against the real adapter (no Fake)."""
     from reyn.core.events.events import EventLog
@@ -203,16 +204,155 @@ def test_adapter_put_outbox_persist_false_skips_history_append(tmp_path):
     )
 
     asyncio.run(adapter.put_outbox(
-        kind="agent", text="display only", meta={"chain_id": "c1"}, persist=False,
+        kind="agent", text="display only", meta={"chain_id": "c1"}, persist_as=None,
     ))
     assert [m["text"] for m in outbox] == ["display only"]
-    assert history == [], "persist=False must not append to history"
+    assert history == [], "persist_as=None must not append to history"
 
     asyncio.run(adapter.put_outbox(
-        kind="agent", text="final reply", meta={"chain_id": "c1"},
+        kind="agent", text="final reply", meta={"chain_id": "c1"}, persist_as="assistant",
     ))
     assert [m["text"] for m in outbox] == ["display only", "final reply"]
-    # Tuple-unpack: default persist=True must append EXACTLY the new entry —
+    # Tuple-unpack: persist_as="assistant" must append EXACTLY the new entry —
     # not zero (regression) and not a second copy of "display only".
     (only_entry,) = history
     assert only_entry.content == "final reply"
+    assert only_entry.role == "assistant"
+
+
+# ── #5887: persist_as carries the v6 decision explicitly ──────────────────
+
+
+def _make_adapter(tmp_path):
+    """The real RouterHostAdapter with recording outbox/history callbacks —
+    lifted from the #3633 test above so the #5887 witnesses pin the SAME
+    real adapter, not a Fake."""
+    from reyn.core.events.events import EventLog
+    from reyn.llm.model_resolver import ModelResolver
+    from reyn.runtime.services import (
+        LiveSessionIdInputs,
+        McpGatewayInputs,
+        MemoryService,
+        PutOutboxInputs,
+        RouterHostAdapter,
+    )
+    from tests._support.router_host_adapter import (
+        make_op_context_source,
+        null_file_delete,
+        null_file_read,
+        null_file_regen,
+        null_file_write,
+        null_mcp_call_tool,
+    )
+
+    outbox: list[dict] = []
+    history: list = []
+
+    async def _put_outbox(msg) -> None:
+        outbox.append({"kind": msg.kind, "text": msg.text})
+
+    def _append_history(msg) -> None:
+        history.append(msg)
+
+    events = EventLog(subscribers=[])
+    workspace = tmp_path / "agents" / "alpha"
+    adapter = RouterHostAdapter(
+        agent_name="alpha",
+        agent_role="role",
+        output_language=None,
+        op_context_source=make_op_context_source(events=events),
+        permission_resolver=None,
+        mcp_servers=None,
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=MemoryService(
+            agent_workspace_dir=workspace,
+            events=events,
+            file_write=null_file_write,
+            file_read=null_file_read,
+            file_delete=null_file_delete,
+            file_regenerate_index=null_file_regen,
+        ),
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        mcp_call_tool=null_mcp_call_tool,
+        mcp_gateway_inputs=McpGatewayInputs(
+            mcp_connection_service=None, mcp_agent_id=None, ephemeral_fn=None,
+        ),
+        put_outbox_inputs=PutOutboxInputs(
+            put_outbox=_put_outbox, agent_replies_tracker=lambda: None,
+        ),
+        append_history=_append_history,
+        live_session_id_inputs=LiveSessionIdInputs(
+            session_id=None, live_session_id_fn=None,
+        ),
+        universal_wrappers_enabled=False,
+    )
+    return adapter, outbox, history
+
+
+_CANNED = "[⚠ model returned an empty response (finish_reason=stop) · retry: off (chat.empty_stop_retry) · call c1]"
+
+
+def test_system_kind_row_with_persist_as_assistant_lands_in_history_as_assistant(tmp_path):
+    """Tier 2: #5887 witness ② — the dogfood-v6 decision, as a test: the
+    empty-response canned text, now emitted as ``kind="system"`` (reyn's
+    own voice on the display axis), STILL lands in history as a
+    ``role="assistant"`` row, because the caller says so with
+    ``persist_as="assistant"``. Before #5887 this was true only by the
+    accident that the row was ``kind="agent"``; the v6 comment in the
+    adapter recorded the reason but no test pinned it. strip: passing
+    ``persist_as=None`` here appends nothing (see the next test), so the
+    placeholder's survival is decided by this argument alone, not by
+    ``kind``."""
+    adapter, outbox, history = _make_adapter(tmp_path)
+
+    asyncio.run(adapter.put_outbox(
+        kind="system", text=_CANNED, meta={"chain_id": "c1"}, persist_as="assistant",
+    ))
+
+    assert [m["kind"] for m in outbox] == ["system"], "display axis: reyn's marker"
+    (row,) = history
+    assert row.role == "assistant" and row.content == _CANNED, (
+        f"context axis: the v6 assistant placeholder must survive; got {history!r}"
+    )
+
+
+def test_persist_as_none_on_a_system_row_appends_nothing(tmp_path):
+    """Tier 2: #5887 — ``persist_as=None`` is the ONLY thing that means
+    display-only; a ``kind="system"`` row with it never touches history
+    (every pre-#5887 non-agent kind behaved this way, byte-identical)."""
+    adapter, outbox, history = _make_adapter(tmp_path)
+
+    asyncio.run(adapter.put_outbox(
+        kind="system", text="✗ turn interrupted", meta={"chain_id": "c1"}, persist_as=None,
+    ))
+
+    assert [m["kind"] for m in outbox] == ["system"]
+    assert history == []
+
+
+def test_next_turn_never_sees_two_consecutive_user_messages(tmp_path):
+    """Tier 2: #5887 witness ③ — the v6 REASON itself. A user turn, an
+    empty model response (its OS notice), then the next user turn: the
+    history the next request is built from must read user / assistant /
+    user — never user / user. With ``persist_as=None`` on the notice the
+    middle row vanishes and the two user rows become adjacent, which is
+    the attractor dogfood-v6 measured; ``persist_as="assistant"`` is what
+    keeps them apart, independent of the notice's display ``kind``."""
+    from reyn.runtime.chat_message import ChatMessage, _now_iso
+
+    adapter, _outbox, history = _make_adapter(tmp_path)
+    history.append(ChatMessage(role="user", content="first", ts=_now_iso()))
+    asyncio.run(adapter.put_outbox(
+        kind="system", text=_CANNED, meta={"chain_id": "c1"}, persist_as="assistant",
+    ))
+    history.append(ChatMessage(role="user", content="second", ts=_now_iso()))
+
+    roles = [m.role for m in history]
+    assert roles == ["user", "assistant", "user"], roles
+    assert all(a != "user" or b != "user" for a, b in zip(roles, roles[1:])), (
+        f"two consecutive user messages — the v6 attractor: {roles!r}"
+    )

--- a/tests/llm/test_codeact_coexistence_1593.py
+++ b/tests/llm/test_codeact_coexistence_1593.py
@@ -86,7 +86,7 @@ class _FakeHost:
         return "fake-model"
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        self, *, kind: str, text: str, meta: dict, persist_as: "str | None",
     ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -30,7 +30,12 @@ import pytest
 
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
-from reyn.runtime.router_loop import _EMPTY_RESPONSE_MSG, RouterLoop, _is_empty_router_response
+from reyn.runtime.router_loop import (
+    _EMPTY_RESPONSE_MSG,
+    RouterLoop,
+    _empty_response_text,
+    _is_empty_router_response,
+)
 
 # ---------------------------------------------------------------------------
 # Test doubles (copied from test_router_loop.py — shared infrastructure kept
@@ -142,8 +147,12 @@ class FakeRouterHost:
 
     async def put_outbox(
         self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        persist_as_assistant: bool = False,
     ) -> None:
-        self.outbox.append({"kind": kind, "text": text, "meta": meta})
+        self.outbox.append({
+            "kind": kind, "text": text, "meta": meta,
+            "persist_as_assistant": persist_as_assistant,
+        })
 
     async def file_read(self, path: str) -> str:
         if path not in self._files:
@@ -356,7 +365,18 @@ async def test_empty_response_event_has_expected_fields(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_empty_response_puts_failure_message_in_outbox(monkeypatch):
-    """Tier 2: empty-stop response causes a user-visible failure message in outbox with kind=agent."""
+    """Tier 2: #5887 accept ① — the empty-stop notice reaches the outbox as
+    ``kind="system"``: reyn authored it, so it must not wear the model's
+    marker (owner report: "llm からのメッセージなのか、システムメッセージなのか
+    tui 表示の区別がついてない"). strip: reverting the emit site to
+    ``kind="agent"`` turns this red.
+
+    ``persist_as_assistant`` is asserted alongside: the display axis moved
+    to "system", but the dogfood-v6 decision in ``RouterHostAdapter.
+    put_outbox`` (keep an assistant placeholder in history so the next
+    turn's wire does not carry two consecutive user messages) is carried
+    by that explicit flag now, not by ``kind`` — see that method's own
+    comment. Dropping the flag would silently re-open the v6 attractor."""
     host = FakeRouterHost()
     loop = make_loop(host)
     scripted = _ScriptedLLM([empty_stop_result()])
@@ -365,7 +385,13 @@ async def test_empty_response_puts_failure_message_in_outbox(monkeypatch):
     await loop.run("do something", [])
 
     (msg,) = host.outbox
-    assert msg["kind"] == "agent"
+    assert msg["kind"] == "system", (
+        f"an OS-authored notice must not render in the model's voice; got kind={msg['kind']!r}"
+    )
+    assert msg["persist_as_assistant"] is True, (
+        "the notice must still ask for its assistant placeholder in history "
+        "(dogfood-v6 alternation decision)"
+    )
     assert len(msg["text"]) > 0, "Failure text must be non-empty"
     assert msg["meta"].get("source") == "router_empty_response"
 
@@ -447,9 +473,16 @@ async def test_empty_response_ja_i18n(monkeypatch):
 
     (msg,) = host.outbox
     failure_text = msg["text"]
-    assert failure_text == _EMPTY_RESPONSE_MSG["ja"], (
-        f"Expected Japanese message, got: {failure_text!r}"
+    # #5887: the text is now rendered from the ja TEMPLATE with this call's
+    # own facts filled in; compare against the same renderer fed the same
+    # facts the emit site put in meta, so the check is self-consistent
+    # rather than pinning a default for call_id it does not own.
+    expected = _empty_response_text(
+        "ja", finish_reason=msg["meta"]["finish_reason"], retry_on=False,
+        call_id=msg["meta"]["call_id"],
     )
+    assert failure_text == expected, f"Expected Japanese message, got: {failure_text!r}"
+    assert "モデルが空の応答を返しました" in failure_text
 
 
 @pytest.mark.asyncio
@@ -464,7 +497,11 @@ async def test_empty_response_en_i18n(monkeypatch):
 
     (msg,) = host.outbox
     failure_text = msg["text"]
-    assert failure_text == _EMPTY_RESPONSE_MSG["en"]
+    assert failure_text == _empty_response_text(
+        "en", finish_reason=msg["meta"]["finish_reason"], retry_on=False,
+        call_id=msg["meta"]["call_id"],
+    )
+    assert "model returned an empty response" in failure_text
 
 
 @pytest.mark.asyncio
@@ -479,7 +516,71 @@ async def test_empty_response_unknown_language_falls_back_to_en(monkeypatch):
 
     (msg,) = host.outbox
     failure_text = msg["text"]
-    assert failure_text == _EMPTY_RESPONSE_MSG["en"]
+    assert failure_text == _empty_response_text(
+        "en", finish_reason=msg["meta"]["finish_reason"], retry_on=False,
+        call_id=msg["meta"]["call_id"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# #5887 accept ④: the notice says what happened and what was in effect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_response_notice_names_finish_reason_and_retry_off(monkeypatch):
+    """Tier 2: #5887 accept ④ — with the retry at its owner default (off),
+    the notice carries the model's ``finish_reason`` and says the retry was
+    ``off``, naming the switch (``chat.empty_stop_retry``) so the owner
+    knows WHICH setting governs what reyn just did. The pre-#5887 text
+    ("check your configuration") named nothing, which is what the owner
+    reported. strip: reverting the template drops every one of these
+    substrings."""
+    host = FakeRouterHost()
+    loop = make_loop(host)
+    scripted = _ScriptedLLM([empty_stop_result()])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", scripted)
+
+    await loop.run("do something", [])
+
+    (msg,) = host.outbox
+    text = msg["text"]
+    assert "finish_reason=stop" in text, f"finish_reason missing: {text!r}"
+    assert "retry: off" in text, f"retry state missing: {text!r}"
+    assert "chat.empty_stop_retry" in text, f"the governing switch is not named: {text!r}"
+    assert "check your configuration" not in text.lower(), (
+        f"the old advice-in-the-model's-voice wording must be gone: {text!r}"
+    )
+    for lang_key in ("ja", "en"):
+        assert "{finish_reason}" in _EMPTY_RESPONSE_MSG[lang_key], (
+            "both templates must carry the finish_reason placeholder"
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_response_notice_says_retry_on_when_the_retry_already_ran(monkeypatch):
+    """Tier 2: #5887 accept ④ (positive control for the retry field) — with
+    ``chat.empty_stop_retry`` in effect, the first empty stop is retried
+    silently and only a SECOND empty stop produces the notice, which must
+    then read ``retry: on`` — telling the owner the retry already happened
+    and still came back empty, not that it was never attempted."""
+    from reyn.prompt.loop_control import EMPTY_STOP_RETRY_DIRECTIVE
+
+    host = FakeRouterHost()
+    loop = RouterLoop(
+        host=host, chain_id="chain-test", max_iterations=5,
+        empty_stop_retry_directive=EMPTY_STOP_RETRY_DIRECTIVE,
+        empty_stop_retry_auto=True,
+    )
+    scripted = _ScriptedLLM([empty_stop_result(), empty_stop_result()])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", scripted)
+
+    await loop.run("do something", [])
+
+    assert scripted.call_count == 2, "the one retry must have run before the notice"
+    (msg,) = host.outbox
+    assert msg["kind"] == "system"
+    assert "retry: on" in msg["text"], f"expected retry: on after the retry ran; got: {msg['text']!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/llm/test_router_empty_response.py
+++ b/tests/llm/test_router_empty_response.py
@@ -146,12 +146,10 @@ class FakeRouterHost:
         pass
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
-        persist_as_assistant: bool = False,
+        self, *, kind: str, text: str, meta: dict, persist_as: "str | None",
     ) -> None:
         self.outbox.append({
-            "kind": kind, "text": text, "meta": meta,
-            "persist_as_assistant": persist_as_assistant,
+            "kind": kind, "text": text, "meta": meta, "persist_as": persist_as,
         })
 
     async def file_read(self, path: str) -> str:
@@ -371,12 +369,13 @@ async def test_empty_response_puts_failure_message_in_outbox(monkeypatch):
     tui 表示の区別がついてない"). strip: reverting the emit site to
     ``kind="agent"`` turns this red.
 
-    ``persist_as_assistant`` is asserted alongside: the display axis moved
+    ``persist_as="assistant"`` is asserted alongside: the display axis moved
     to "system", but the dogfood-v6 decision in ``RouterHostAdapter.
     put_outbox`` (keep an assistant placeholder in history so the next
     turn's wire does not carry two consecutive user messages) is carried
-    by that explicit flag now, not by ``kind`` — see that method's own
-    comment. Dropping the flag would silently re-open the v6 attractor."""
+    by that explicit argument now, not inferred from ``kind`` — see that
+    method's own comment. ``persist_as=None`` here would silently re-open
+    the v6 attractor."""
     host = FakeRouterHost()
     loop = make_loop(host)
     scripted = _ScriptedLLM([empty_stop_result()])
@@ -388,9 +387,9 @@ async def test_empty_response_puts_failure_message_in_outbox(monkeypatch):
     assert msg["kind"] == "system", (
         f"an OS-authored notice must not render in the model's voice; got kind={msg['kind']!r}"
     )
-    assert msg["persist_as_assistant"] is True, (
+    assert msg["persist_as"] == "assistant", (
         "the notice must still ask for its assistant placeholder in history "
-        "(dogfood-v6 alternation decision)"
+        f"(dogfood-v6 alternation decision); got persist_as={msg['persist_as']!r}"
     )
     assert len(msg["text"]) > 0, "Failure text must be non-empty"
     assert msg["meta"].get("source") == "router_empty_response"

--- a/tests/llm/test_router_loop_non_interactive_live_1443.py
+++ b/tests/llm/test_router_loop_non_interactive_live_1443.py
@@ -114,7 +114,7 @@ class _FakeRouterHost:
         return "fake-model"
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        self, *, kind: str, text: str, meta: dict, persist_as: "str | None",
     ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 

--- a/tests/llm/test_router_loop_routing_decided.py
+++ b/tests/llm/test_router_loop_routing_decided.py
@@ -157,7 +157,7 @@ class _FakeRouterHost:
         return "fake-model"
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        self, *, kind: str, text: str, meta: dict, persist_as: "str | None",
     ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 

--- a/tests/runtime/test_4564_search_actions_scheme_independent.py
+++ b/tests/runtime/test_4564_search_actions_scheme_independent.py
@@ -166,7 +166,7 @@ class _WrappersOffSearchOnHost:
         return "fake-model"
 
     async def put_outbox(
-        self, *, kind: str, text: str, meta: dict, persist: bool = True,
+        self, *, kind: str, text: str, meta: dict, persist_as: "str | None",
     ) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 

--- a/tests/runtime/test_reasoning_integration_1652.py
+++ b/tests/runtime/test_reasoning_integration_1652.py
@@ -84,7 +84,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
 
 def _put(host, *, text="answer", reasoning=_REASONING):
     outbox_async = host.put_outbox(
-        kind="agent", text=text,
+        kind="agent", text=text, persist_as="assistant",
         meta={"chain_id": "c1", "reasoning": reasoning},
     )
     asyncio.run(outbox_async)

--- a/tests/runtime/test_router_cap.py
+++ b/tests/runtime/test_router_cap.py
@@ -179,7 +179,7 @@ def test_router_succeeds_within_cap(tmp_path, monkeypatch):
         # Mirror what real RouterLoop does on a chitchat reply: put a text
         # outbox via the host callback.
         await self.host.put_outbox(
-            kind="agent", text="stub-reply",
+            kind="agent", text="stub-reply", persist_as="assistant",
             meta={"chain_id": self.chain_id},
         )
 

--- a/tests/runtime/test_router_loop.py
+++ b/tests/runtime/test_router_loop.py
@@ -207,14 +207,25 @@ async def test_async_tool_dispatch_exits_the_loop(monkeypatch):
     # structured spawn_ack (= parity with skill / plan spawn_ack),
     # not a generic "awaiting peer reply" status row. (proposal 0067 P4,
     # #3978, architect ruling 2026-08-10: kind=agent -> kind=prompt —
-    # `m["kind"]` below is the UNRELATED outbox-display-frame axis, byte-
-    # identical, not touched by this migration.)
+    # `m["kind"]` below is the UNRELATED outbox-display-frame axis.)
+    # #5887: that display axis is now ``"system"`` — the ack is reyn's
+    # own sentence about a dispatch, not the model's words, so it must
+    # not wear the model's marker. strip: reverting the emit site to
+    # ``kind="agent"`` turns this red.
     assert any(
-        m["kind"] == "agent"
+        m["kind"] == "system"
         and m.get("meta", {}).get("source") == "agent_spawn_ack"
         and "[task_spawned] kind=prompt" in m["text"]
         for m in host.outbox
-    ), f"Expected agent_spawn_ack; got: {host.outbox}"
+    ), f"Expected a system-kind agent_spawn_ack; got: {host.outbox}"
+    # #5887 (dogfood-v6 decision preserved, see RouterHostAdapter.
+    # put_outbox): the ack still lands in history as an assistant
+    # placeholder so the next turn's wire keeps user/assistant
+    # alternation — the DISPLAY kind changed, the LLM-context axis did not.
+    assert any(
+        h["role"] == "assistant" and "[task_spawned] kind=prompt" in h["content"]
+        for h in host.history
+    ), f"spawn ack must still persist as an assistant placeholder; got: {host.history}"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_router_loop.py
+++ b/tests/runtime/test_router_loop.py
@@ -228,6 +228,52 @@ async def test_async_tool_dispatch_exits_the_loop(monkeypatch):
     ), f"spawn ack must still persist as an assistant placeholder; got: {host.history}"
 
 
+def test_every_host_put_outbox_call_site_declares_persist_as() -> None:
+    """Tier 2: #5887 witness ④ — every call to the host's ``put_outbox(``
+    in ``src/`` states ``persist_as=`` explicitly. The argument has no
+    default on purpose (architect ruling): a new call site must say what
+    it leaves in history for the next turn, so the display ``kind`` can
+    never again be the thing that silently decides persistence. Removing
+    the inference only closes the hole if it is closed at EVERY site,
+    which is why this is a census, not a sample.
+
+    Matches the host method (``host.put_outbox(`` / ``self.host.put_outbox(``
+    — keyword ``kind=``/``text=`` form). ``_put_outbox(OutboxMessage(...))``
+    is a different method (the display channel, takes a built
+    ``OutboxMessage``, has no persistence axis) and is not in scope."""
+    import re
+
+    from tests._support.paths import REPO_ROOT
+
+    src = REPO_ROOT / "src"
+    pattern = re.compile(r"(?<![_\w])host\.put_outbox\(", re.MULTILINE)
+    offenders: list[str] = []
+    checked = 0
+    for path in sorted(src.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for m in pattern.finditer(text):
+            # Walk to the matching close paren of THIS call.
+            depth, i = 0, m.end() - 1
+            while i < len(text):
+                if text[i] == "(":
+                    depth += 1
+                elif text[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                i += 1
+            call = text[m.start():i + 1]
+            checked += 1
+            if "persist_as=" not in call:
+                line = text.count("\n", 0, m.start()) + 1
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line}")
+    assert checked >= 8, f"expected the router_loop call sites to be found; saw {checked}"
+    assert offenders == [], (
+        "put_outbox( call sites without an explicit persist_as= "
+        f"(no default — say what the row leaves in history): {offenders}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_async_tool_does_not_redispatch_in_same_turn(monkeypatch):
     """Tier 2: OS invariant — RouterLoop.run() exits after first async

--- a/tests/runtime/test_session_cost_accumulation.py
+++ b/tests/runtime/test_session_cost_accumulation.py
@@ -122,7 +122,7 @@ class _FakeHost:
     async def send_to_agent(self, *, to, request, depth, chain_id) -> None:
         pass
 
-    async def put_outbox(self, *, kind, text, meta, persist: bool = True) -> None:
+    async def put_outbox(self, *, kind, text, meta, persist_as=None) -> None:
         self.outbox.append({"kind": kind, "text": text, "meta": meta})
 
     async def file_read(self, path: str) -> str:


### PR DESCRIPTION
**[e2e-coder]** — Closes #5887.

## What

Owner report (2026-09-07): *"llm からのメッセージなのか、システムメッセージなのか tui 表示の区別がついてない"* — about `The model returned an empty response. Please try rephrasing your request or check your configuration.`, a sentence **reyn** wrote, drawn under the **model's** marker.

Two OS-authored rows now emit `kind="system"` (the existing lifecycle marker, `· ` dim vs `● ` for the model), `meta.source` kept. `_CONVERSATION_KINDS` has no `system` entry, so the reconnect `MESSAGES_SNAPSHOT` no longer presents either as an `assistant` turn.

**Wording** — an OS statement of what happened and what was in effect (owner sees it on the real screen post-merge):

```
[⚠ model returned an empty response (finish_reason=stop) · retry: off (chat.empty_stop_retry) · call <id>]
[⚠ モデルが空の応答を返しました (finish_reason=stop) · 再試行: off (chat.empty_stop_retry) · call <id>]
```

## Two premises in the original ruling were the reverse of the code — corrected by the architect on census, implemented per the revised ruling

1. **Sites are 2, not 3.** `_REPRESENT_ACK` is a synthetic *tool response* appended to the LLM's wire `messages` — never an outbox row, no `kind`. Untouched.
2. **The texts WERE in history.** `RouterHostAdapter.put_outbox` persisted every `kind="agent"` row as `role="assistant"`, and the comment above that branch records a **dogfood-v6 measurement**: filtering the empty-stop text out leaves the next wire with two consecutive `user` messages — an attractor — so it is kept **deliberately**.

Flipping `kind` alone would have silently reverted v6, because persistence was *inferred from kind*. The architect ruled the two axes orthogonal and named the shape:

## `persist_as: PersistAs | None` — no default, no inference

`put_outbox(kind=..., text=..., meta=..., persist_as=...)` says in **one** argument whether the row lands in history and **as what role** (`PersistAs` = `ChatMessage.role`'s own `Literal`; `None` = display only). The adapter does `ChatMessage(role=persist_as, …)` straight through and never derives a role from `kind`. A new call site **must** state what it leaves behind — that is the whole point.

### Census — every `host.put_outbox(` call site in `src/` (8, all in `router_loop.py`)

| line (main) | text | `kind` | before | now `persist_as` |
|---|---|---|---|---|
| 2712 | tool-turn text (model) | `agent` | `persist=False` (#3633: `feedback()` persists it) | `None` |
| 2849 | **spawn ack** (`_AGENT_SPAWN_ACK_MSG`) | agent → **`system`** | persisted as assistant (inferred) | `"assistant"` |
| 3022 | **empty-response notice** (`_EMPTY_RESPONSE_MSG`) | agent → **`system`** | persisted as assistant (inferred) | `"assistant"` |
| 3067 | structured answer (model) | `agent` | persisted as assistant (inferred) | `"assistant"` |
| 3073 | terminal reply (model) | `agent` | persisted as assistant (inferred) | `"assistant"` |
| 3146 | `✗ turn interrupted` | `system` | not persisted | `None` |
| 3205 | wrap-up content (model) | `agent` | persisted as assistant (inferred) | `"assistant"` |
| 3217 | max-iterations error | `error` | not persisted | `None` |

Behaviour per row is byte-identical to before except the two bold rows' **display** kind. **Boundary of the census**: `self._put_outbox(OutboxMessage(...))` (`session.py`, `intervention_handler.py`, `inter_agent_messaging.py`, `chain_timeout_glue.py`) is a *different* method — the display channel that takes a built `OutboxMessage` and has no persistence axis — so it is outside the population by construction, not omitted.

## Witnesses (the architect's 4)

- [x] The empty-response row reaches the outbox as `kind="system"` with `persist_as="assistant"` (strip: `persist_as=None` at the site → red — run, confirmed, restored). Spawn ack likewise.
- [x] **v6 as a test, against the real `RouterHostAdapter`**: a `kind="system"` row with `persist_as="assistant"` lands in history as `role="assistant"`; with `persist_as=None` it appends nothing (`test_3633_history_double_append.py`).
- [x] **The v6 reason itself**: user → notice → user history never reads `user`/`user`.
- [x] **Gate**: a test walks every `host.put_outbox(` call in `src/` and fails on any without `persist_as=` (strip: dropping it from one site → red — run, confirmed, restored).
- [x] `MESSAGES_SNAPSHOT` does not present the OS row as `assistant`; wording carries `finish_reason` + retry state, with a `retry: on` positive control.
- [ ] Owner's real screen — post-merge (Visual, standing waiver).

## Gates

- `ruff check .` — clean. `test_tier_audit.py --strict` on the 4 changed test files — 51/51, 0 Tier-4. `verify_module_docstrings.py` on the 3 changed src files — OK.
- tests-path gates (bare-import, file-depth, subprocess-pin, flat-tests, path-literal) — OK.
- `mypy_ratchet.py` (changed-files) — `OK: 195 findings, all baselined`.
- Scoped `pytest`: the changed files + every test defining a `put_outbox` double or calling the host method directly (15 files) — **105 passed**.
- No `docs/` touched: the marker legend lives in code (`renderer._KIND_LINE`); no doc describes these rows as model text.

## Test plan

- [x] Automated tests above.
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
