### PR TITLE
docs: mypy_ratchet's local default drifted false after #5882

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,8 @@ sessions apart. Full rationale and the measured instances behind each rule:
 **Before you open a PR** — `ruff check .` (the same command CI runs, not a
 narrower one), `python scripts/test_tier_audit.py --strict <changed test
 files>`, `python scripts/verify_module_docstrings.py <changed src files>`,
-`python scripts/mypy_ratchet.py`, `python scripts/flat_tests_ratchet.py`,
+`python scripts/mypy_ratchet.py` (changed-files by default, #5882 — see
+pr-workflow.md), `python scripts/flat_tests_ratchet.py`,
 `python scripts/check_tests_path_literal_reference.py` (re-run right before
 pushing — its baseline goes stale when `main` moves), and `pytest` **scoped to
 your diff**. Do NOT run the full suite locally — CI does that in a clean

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1278,6 +1278,13 @@ set (CI's own full run) or `REYN_FULL_SUITE_OK=1` is passed explicitly.
    ```bash
    python scripts/mypy_ratchet.py
    ```
+   This bare invocation is now changed-files mode by default (#5882 —
+   the `.py` files your branch touched relative to `origin/main`'s
+   merge-base, committed or not, plus untracked ones; shared cache dir,
+   repo-wide lock). CI always passes `--full` and is the one that
+   actually decides — see [PR workflow](pr-workflow.md) for what that
+   split means and why.
+
    ⚠️ It also fails when `mypy` is not importable by the interpreter running it
    (#4576) — that is a *precondition* failure, not a finding. Before the guard,
    a missing mypy produced `OK: 0 findings, all baselined (215 declared)` and

--- a/scripts/claude_md_word_count_baseline.json
+++ b/scripts/claude_md_word_count_baseline.json
@@ -1,5 +1,5 @@
 {
-  "CLAUDE.md": 2614,
+  "CLAUDE.md": 2621,
   "src/reyn/core/events/CLAUDE.md": 74,
   "src/reyn/interfaces/CLAUDE.md": 396,
   "src/reyn/mcp/CLAUDE.md": 22,


### PR DESCRIPTION
**[docs-maintainer]** — `mypy_ratchet.py`'s local-default change (#5882/#5884) went unreflected in two describing docs: `testing.md:1273-1284` and `CLAUDE.md:121` both still showed the bare `python scripts/mypy_ratchet.py` line with no note that local runs now default to changed-files mode (vs `origin/main`'s merge-base, committed or not, plus untracked), that CI passes `--full` and is the one that decides, or the shared cache dir / repo lock. `pr-workflow.md:41` already carries this in-PR (checked, correct) — both spots here now point to it rather than duplicate the explanation.

`CLAUDE.md`'s own word count grew +7; `scripts/claude_md_word_count_baseline.json` updated in this same commit (#4872).

Also drift-checked the other four PRs merged since 06:05 today: #5879 (logs rotation — `reyn-yaml.md`/`reyn-dir-layout.md` already updated in-PR), #5881 (CI workflow only, no docs), #5883 (pipeline `tool:` step → `dispatch_tool` — `permission-model.md`/`.ja.md`, `events.md`, `pipeline-dsl.md` already updated in-PR), #5893 (`/compact` wording — `chat.md`/`events.md` already updated in-PR). Nothing further needed on any of the four.

Not touched: #5364's body, `chat-compaction.md`'s invariants, ADR-0042/0044/0045 — those are *deciding* docs; #5896 tracks the implementation gap (#5364 §1.1 A), not a doc error.

## Test plan
- [x] `ruff check .` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds; only pre-existing INFO-level en/ja anchor-parity gaps unrelated to this diff
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] `python scripts/claude_md_word_count_ratchet.py` — passes for `CLAUDE.md` itself (baseline updated); two stale, gitignored subagent-worktree `CLAUDE.md` files under `.claude/worktrees/` also fail this locally, confirmed pre-existing on unmodified `main` too (unrelated to this PR, not fixed here)
- [x] (skipped — docs-only diff, no `tests/`/`src/` files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
