### PR TITLE
docs: mark 13 ACCEPTED ADRs SUPERSEDED (retired mechanisms) + 2 status-note fixes

### DIFF
--- a/docs/deep-dives/decisions/0003-op-purity-classification.md
+++ b/docs/deep-dives/decisions/0003-op-purity-classification.md
@@ -1,6 +1,6 @@
 # ADR-0003: Op purity classification for step events
 
-**Status**: Accepted (2026-05-02)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03)
 **Track**: PR-step-events, PR-state-foundation
 
 ## Context

--- a/docs/deep-dives/decisions/0004-memoization-key-design.md
+++ b/docs/deep-dives/decisions/0004-memoization-key-design.md
@@ -1,6 +1,6 @@
 # ADR-0004: Memoization key — (op_invocation_id, phase, args_hash)
 
-**Status**: Accepted (2026-05-02)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03)
 **Track**: D-track (D3b-1), PR-llm-memo (R-D2)
 
 ## Context

--- a/docs/deep-dives/decisions/0009-visit-count-decrement-on-resume.md
+++ b/docs/deep-dives/decisions/0009-visit-count-decrement-on-resume.md
@@ -1,6 +1,6 @@
 # ADR-0009: Pre-decrement visit_count on resume
 
-**Status**: Accepted (2026-05-03)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03)
 **Track**: PR-llm-memo (R-D2) — surfaced during e2e
 
 ## Context

--- a/docs/deep-dives/decisions/0011-world-purity-memo-invalidation.md
+++ b/docs/deep-dives/decisions/0011-world-purity-memo-invalidation.md
@@ -1,6 +1,6 @@
 # ADR-0011: World-purity memo invalidation on resume
 
-**Status**: Accepted (2026-05-04)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03)
 **Track**: PR-memo-purity-fix (commit `7e764ce`)
 
 ## Context

--- a/docs/deep-dives/decisions/0012-auto-resume-default.md
+++ b/docs/deep-dives/decisions/0012-auto-resume-default.md
@@ -1,6 +1,6 @@
 # ADR-0012: Auto-resume default + retry policy
 
-**Status**: Accepted (2026-05-04). Supersedes [ADR-0007](0007-bulk-resume-prompt-ux.md).
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03). Supersedes [ADR-0007](0007-bulk-resume-prompt-ux.md).
 **Track**: PR-resume-auto (commit `2177f55`)
 
 ## Context

--- a/docs/deep-dives/decisions/0013-exception-aware-crash-lifecycle.md
+++ b/docs/deep-dives/decisions/0013-exception-aware-crash-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-0013: Exception-aware skill completion in finally clause
 
-**Status**: Accepted (2026-05-04)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03)
 **Track**: R-D1 (commit `c12c5b9`)
 
 ## Context

--- a/docs/deep-dives/decisions/0015-llm-result-workspace-ref.md
+++ b/docs/deep-dives/decisions/0015-llm-result-workspace-ref.md
@@ -1,6 +1,6 @@
 # ADR-0015: LLM result workspace ref threshold
 
-**Status**: Accepted (2026-05-04)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03)
 **Track**: R-D10 (commit `20bf16d`)
 
 ## Context

--- a/docs/deep-dives/decisions/0020-skill-only-permissions.md
+++ b/docs/deep-dives/decisions/0020-skill-only-permissions.md
@@ -1,6 +1,6 @@
 # ADR-0020: Skill-only permissions — Phase.permissions field removed
 
-**Status**: Accepted (2026-05-04)
+**Status**: SUPERSEDED — the mechanism was removed by #2434 (PR #2438, 2026-07-03). The decision (permissions unify onto skill.md) was satisfied at the time; the skill concept it applied to was later deleted whole — not an unmet decision.
 **Track**: Wave 2 of postprocessor follow-up; supersedes implicit phase-level permission semantics
 
 ## Context

--- a/docs/deep-dives/decisions/0022-plan-mode-crash-fail-safe.md
+++ b/docs/deep-dives/decisions/0022-plan-mode-crash-fail-safe.md
@@ -1,6 +1,6 @@
 # ADR-0022: Plan-Mode Crash Resilience — Phase 1 (Fail-Safe + Observability)
 
-**Status**: Accepted (2026-05-07)
+**Status**: SUPERSEDED — the mechanism was removed by #1953 (PR #2018, 2026-06-21)
 **Track**: Plan-mode crash recovery (= step toward Phase 2 forward replay,
 ADR-future)
 

--- a/docs/deep-dives/decisions/0023-plan-mode-forward-replay.md
+++ b/docs/deep-dives/decisions/0023-plan-mode-forward-replay.md
@@ -1,6 +1,6 @@
 # ADR-0023: Plan-Mode Crash Resilience — Phase 2 (Forward Replay)
 
-**Status**: Accepted + Implemented (2026-05-07);
+**Status**: SUPERSEDED — the mechanism was removed by #1953 (PR #2018, 2026-06-21). Was: Accepted + Implemented (2026-05-07);
 **amended 2026-05-08** (Phase 2.1 — async dispatch + multi-plan).
 **Track**: Plan-mode crash recovery — successor to ADR-0022 Phase 1.
 **Synthesized from**: 4 parallel design proposals (snapshot / analyzer / policy

--- a/docs/deep-dives/decisions/0024-plan-step-result-spill.md
+++ b/docs/deep-dives/decisions/0024-plan-step-result-spill.md
@@ -1,6 +1,6 @@
 # ADR-0024: Plan step result spill-to-file (R-D10 mirror)
 
-**Status**: Accepted (2026-05-08)
+**Status**: SUPERSEDED — the mechanism was removed by #1953 (PR #2018, 2026-06-21)
 **Track**: Plan-mode persistence — closes ADR-0023 "Open issues:
 Step result size cap" deferred item.
 

--- a/docs/deep-dives/decisions/0025-plan-step-llm-memoization.md
+++ b/docs/deep-dives/decisions/0025-plan-step-llm-memoization.md
@@ -1,6 +1,6 @@
 # ADR-0025: Plan-step sub-loop LLM call memoization (R-D2 mirror)
 
-**Status**: Accepted (2026-05-08)
+**Status**: SUPERSEDED — the mechanism was removed by #1953 (PR #2018, 2026-06-21)
 **Track**: Plan-mode persistence — closes ADR-0023 §3.4 "Sub-loop work
 re-paid" deferred trade-off (LLM-cost subset).
 

--- a/docs/deep-dives/decisions/0033-rag-extensible-os.md
+++ b/docs/deep-dives/decisions/0033-rag-extensible-os.md
@@ -11,6 +11,13 @@
 > decision record, not a living doc); see
 > [Concepts: RAG — Local and offline embedding models](../../concepts/data-retrieval/rag.md#local-and-offline-embedding-models)
 > for the current mechanism.
+
+> **Superseding note (#2434, 2026-07-03; found in a 2026-09-07 ADR witness audit)**: the
+> `index_docs` stdlib **skill** this record's narrative is built on ("your RAG, written in
+> skill.md") was deleted whole by #2434 (PR #2438), the skill/phase-engine bulk-delete. The
+> op layer (`embed`/`index_write`/`index_query`/`recall`/`index_drop`, `IndexBackend`) is
+> unaffected and still live (`src/reyn/data/index/`) — this note concerns only the
+> Consequence-level narrative, not a Decision item.
 **Track**: Architecture — RAG infrastructure (= 1.0 release narrative core)
 **Implementation commits**: `d2db332` (foundational) → `1e6f153` (Wave 2b CLI/Tools); 12 commits total, 2073 → 2204 passed (+131 net new tests). Full chain: schemas + registry → IndexBackend (sqlite) + EmbeddingProvider (LiteLLM) + SourceManifest + embedding config → 5 op handlers + permission gate → router Indexed sources section + empty state hint → index_docs stdlib skill + chunkers + cost preflight → recall/drop_source ToolDefinition + reyn source CLI → user-facing docs (concepts/rag + reference/cli/source).
 

--- a/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
+++ b/docs/deep-dives/decisions/0036-history-compaction-force-close-unification.md
@@ -1,6 +1,7 @@
 # ADR-0036 (#1092) — chat/plan/phase within-unit history + compaction + force-close unification (Fork 1: RouterLoop convergence)
 
 **Status**: ACCEPTED — **"Implementation note: PR-F2b force-close handoff cap" superseded by [ADR-0042](0042-force-close-layer2-removal.md)** (2026-08-12); every other part stands unchanged. (user GO 2026-06-02 "懸念点なし、進められるなら進めて"; e2e technical review APPROVE, 3 precisions folded).
+**Status correction** (2026-09-07, ADR witness audit): FD1's phase-side convergence target — `control_ir_executor` / a `PhaseRouterLoopHost` — was removed whole by #2434 (PR #2438, 2026-07-03), the same skill/phase-engine bulk-delete that superseded ADR-0003/0004/0009/0011/0012/0013/0015/0020. The `RouterLoopCore` extraction FD1 introduced (`runtime/router_loop.py:886`) survives and is still satisfied by chat's `RouterHostAdapter` — infrastructure MET, but the decision's primary aim (phase converging onto it) has no remaining consumer.
 **Track**: #1092 (umbrella). **Canonical contract / staging**: GitHub issue **#1234** (FD1–FD7 + staging PR-A..E + test discipline + scope boundary).
 **Builds on**: **ADR-0035** (#1212 — phase op-loop / separate-decide / frame-fed; a landed file at `docs/deep-dives/decisions/0035-phase-tool-calls-unification.md`). This ADR **PRESERVES** #1212's separate-decide and converges only the within-unit act-loop history representation (frame-fed → RouterLoop message-history).
 **Recon foundation**: e2e DEEP_DIVE.md / DEEP_DIVE_2.md / DEEP_DIVE_3.md (primary-evidence flow-trace on main).

--- a/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
+++ b/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
@@ -20,14 +20,17 @@ the WAL/generation GC already runs correctly on the default live-only floor (thr
 every chat-turn boundary — `session.py`'s `maybe_truncate_for_size`), with no
 unbounded-disk-growth risk; the only thing config wiring would have added is a *deeper*
 undo window than live, a capability nobody had asked for while it sat unconfigurable.
-`from_config` removed rather than left dead. **2b's tree-layout UI remains OPEN,
-substrate-only**: the underlying branch-topology data (`list_branches`,
-`list_rewind_points(include_abandoned=True)`) is real and load-bearing for other
-production paths (`checkout`'s fork-switch, the 2c edit flow's lineage lookup), but
-`build_branch_tree_rows` — the function that would render it as a picker tree — has
-no production caller; `/rewind`'s actual picker shows only the active branch's flat
-checkpoint list. Decision on whether to build that UI is owner-pending, tracked
-in #3987.
+`from_config` removed rather than left dead. **2b's tree-layout UI was OPEN,
+substrate-only** at this correction's own time (2026-08-11): the underlying
+branch-topology data (`list_branches`, `list_rewind_points(include_abandoned=True)`)
+was real and load-bearing for other production paths (`checkout`'s fork-switch,
+the 2c edit flow's lineage lookup), but `build_branch_tree_rows` — the function
+that would render it as a picker tree — had no production caller.
+**Status correction, resolved** (2026-09-07, ADR witness audit): #3987 was
+subsequently closed — `61135c9cf` ("feat(#3987): wire the branch tree into the
+`/rewind` picker (#5655)") gave `build_branch_tree_rows` a real production
+caller, `rewind_picker.py:250`. This correction note had itself gone stale;
+the 2b gap it flagged no longer exists on `origin/main`.
 **Track**: Core state-model — successor seam to ADR-0001 (WAL+snapshot),
 ADR-0002 (forward-replay), ADR-0023 (PlanSnapshot).
 **Owner status**: design judgments co-designed + confirmed with owner (issue

--- a/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
+++ b/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
@@ -28,11 +28,11 @@ production paths (`checkout`'s fork-switch, the 2c edit flow's lineage lookup), 
 no production caller; `/rewind`'s actual picker shows only the active branch's flat
 checkpoint list. Decision on whether to build that UI is owner-pending, tracked
 in #3987.
-**Status correction, resolved** (2026-09-07, lead-coder 発注の ADR witness audit, #5900):
-上の 2026-08-11 の correction が指す 2b の gap は、その後 `61135c9cf`
-（"feat(#3987): wire the branch tree into the `/rewind` picker (#5655)"）で
-`build_branch_tree_rows` に production caller（`rewind_picker.py:250`）が付き、
-解消しました。**上の note 自体が古くなっていた**、というのがこの監査の finding です。
+**Status correction, resolved** (2026-09-07, ADR witness audit, #5900): the 2b gap the
+2026-08-11 correction above flagged has since closed — `61135c9cf` ("feat(#3987): wire the
+branch tree into the `/rewind` picker (#5655)") gave `build_branch_tree_rows` a real
+production caller, `rewind_picker.py:250`. **The correction note above had itself gone
+stale**, which is what this audit found.
 **Track**: Core state-model — successor seam to ADR-0001 (WAL+snapshot),
 ADR-0002 (forward-replay), ADR-0023 (PlanSnapshot).
 **Owner status**: design judgments co-designed + confirmed with owner (issue

--- a/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
+++ b/docs/deep-dives/decisions/0038-user-facing-time-travel-rewind.md
@@ -20,17 +20,19 @@ the WAL/generation GC already runs correctly on the default live-only floor (thr
 every chat-turn boundary — `session.py`'s `maybe_truncate_for_size`), with no
 unbounded-disk-growth risk; the only thing config wiring would have added is a *deeper*
 undo window than live, a capability nobody had asked for while it sat unconfigurable.
-`from_config` removed rather than left dead. **2b's tree-layout UI was OPEN,
-substrate-only** at this correction's own time (2026-08-11): the underlying
-branch-topology data (`list_branches`, `list_rewind_points(include_abandoned=True)`)
-was real and load-bearing for other production paths (`checkout`'s fork-switch,
-the 2c edit flow's lineage lookup), but `build_branch_tree_rows` — the function
-that would render it as a picker tree — had no production caller.
-**Status correction, resolved** (2026-09-07, ADR witness audit): #3987 was
-subsequently closed — `61135c9cf` ("feat(#3987): wire the branch tree into the
-`/rewind` picker (#5655)") gave `build_branch_tree_rows` a real production
-caller, `rewind_picker.py:250`. This correction note had itself gone stale;
-the 2b gap it flagged no longer exists on `origin/main`.
+`from_config` removed rather than left dead. **2b's tree-layout UI remains OPEN,
+substrate-only**: the underlying branch-topology data (`list_branches`,
+`list_rewind_points(include_abandoned=True)`) is real and load-bearing for other
+production paths (`checkout`'s fork-switch, the 2c edit flow's lineage lookup), but
+`build_branch_tree_rows` — the function that would render it as a picker tree — has
+no production caller; `/rewind`'s actual picker shows only the active branch's flat
+checkpoint list. Decision on whether to build that UI is owner-pending, tracked
+in #3987.
+**Status correction, resolved** (2026-09-07, lead-coder 発注の ADR witness audit, #5900):
+上の 2026-08-11 の correction が指す 2b の gap は、その後 `61135c9cf`
+（"feat(#3987): wire the branch tree into the `/rewind` picker (#5655)"）で
+`build_branch_tree_rows` に production caller（`rewind_picker.py:250`）が付き、
+解消しました。**上の note 自体が古くなっていた**、というのがこの監査の finding です。
 **Track**: Core state-model — successor seam to ADR-0001 (WAL+snapshot),
 ADR-0002 (forward-replay), ADR-0023 (PlanSnapshot).
 **Owner status**: design judgments co-designed + confirmed with owner (issue


### PR DESCRIPTION
**[docs-maintainer]** — part of #5900 (ADR witness audit). Updates the Status header line only on 15 ADRs; no ADR body text touched (deciding docs aren't rewritten to match code — this records a retire that already happened, not a new decision).

**cluster A** — skill/phase engine bulk-delete, `#2434` (PR `#2438`, 2026-07-03): 0003, 0004, 0009, 0011, 0012, 0013, 0015, 0020, 0036
**cluster B** — planner clean-break delete, `#1953` (PR `#2018`, 2026-06-21): 0022, 0023, 0024, 0025

- 0020: one extra line — the decision (permissions unify onto skill.md) was satisfied before the skill concept it applied to was deleted whole; not an unmet decision.
- 0036: one extra line — `RouterLoopCore` extraction (`runtime/router_loop.py:886`) survives independently and is still satisfied by chat's `RouterHostAdapter`; only the decision's phase-side consumer (`control_ir_executor`/`PhaseRouterLoopHost`) is gone.
- 0033: second superseding note — the `index_docs` stdlib skill the RAG narrative was built on is gone (same #2434); the op layer itself (`embed`/`index_write`/`index_query`/`recall`/`index_drop`, `data/index/`) is unaffected. Consequence-level narrative drift, not an unmet Decision — same shape as the ADR's existing #3128 note.
- 0038: its own 2026-08-11 status-correction note (2b tree-layout UI had no production caller) is itself now stale — `61135c9cf` (#3987/PR #5655) gave `build_branch_tree_rows` a real caller, `rewind_picker.py:250`. Noted as resolved.

**Not in this PR** (per #5900's own checklist, separate judgment): 0006's witness gap (no dedicated test found for `SchemaVersionError`).

## Test plan
- [x] `ruff check .` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds; only pre-existing INFO-level en/ja anchor-parity gaps, unrelated to this diff
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors into published pages
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] (skipped — docs-only diff, no `tests/`/`src/` files touched, no `CLAUDE.md` touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
