### PR TITLE
docs: add #5895 instance to verification-hazards.md (rebuilt onto #5911)

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -78,7 +78,9 @@ before trusting a fixture that produces the expected result, check whether
 an OLDER, already-existing rule (sort order, priority, eviction policy)
 would produce the identical result with the new code deleted — a
 construction is only a witness once the new rule is the SOLE explanation
-left standing (#5399).
+left standing (#5399). The same shape recurs whenever a second,
+un-stripped path can independently produce the observable under test
+(#5895).
 
 **The same question binds the PRESCRIBER, not only the writer.** The face
 above reads as advice to whoever writes the assert — but "the observation
@@ -151,6 +153,19 @@ at all (#5399).
 Two of these five were prescribed by the same reviewer who later named the
 face — "the observation point has a name" was mistaken for "the observation
 point measures the claim," on both sides of the exchange.
+
+A sixth instance (2026-09-07), about two independently-sufficient producers
+rather than a mismeasured quantity: a sent-queue seed strip-falsify asserted
+"the operator's own submitted row appears" with the seed-from-frame path
+stripped (reading the live read model instead) — and STAYED GREEN, because
+the row also renders whenever the live, WAL-backed queue is non-empty, a
+second, un-stripped path to the identical observable that the test session
+happened to satisfy. The strip measured "does the row appear," not "did THIS
+path produce it" — the same gap as the first instance above, one layer up:
+an observable with two producers is not falsified by disabling only one.
+Fixed by removing the second path from the test session (an empty WAL
+queue, so only the seed-from-frame path can draw the row) and re-stripping
+(#5895).
 
 #### Instances: Record is a lie
 


### PR DESCRIPTION
**[docs-maintainer]** — supersedes #5903 (closed): the sixth instance rebuilt onto the new `#1 Instances` structure landed in #5911 (this branch is stacked on `docs/verification-hazards-restructure`'s tip, not yet merged to main — the diff will shrink to just this instance once #5911 lands).

Adds #5895's sent-queue seed strip-blind-spot as a sixth instance under `#### Instances: Measures a different quantity`, plus the one-line cross-reference in the detection-technique paragraph — same content as the original #5903, relocated into the new subsection instead of the old table cell.

**Holding as draft**: #5895 is still open. This doc's own opening line requires a real, merged instance before an entry belongs here — ready once lead-coder confirms #5895 has landed.

## Test plan
- [x] `ruff check .` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds; only pre-existing INFO-level en/ja anchor-parity gaps
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] (skipped — docs-only diff, no `tests/`/`src/` files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
