### PR TITLE
ci(#5909): name the killer of a silently-dead xdist worker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,17 @@ jobs:
         # nothing pyproject didn't already declare.
         run: pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]" -c ci-constraints.txt
 
+      # #5909: the host's capacity, on the SAME surface the crash shows up
+      # on. `-n auto` starts one worker per core, and `memory_ceiling.py`
+      # allows each worker 2 GB — whether the SUM fits this runner is the
+      # one arithmetic a silent `node down: Not properly terminated`
+      # (a SIGKILL leaves no Python-side record) needs, and it was not in
+      # any job log during the #5909 triage.
+      - name: Runner capacity (#5909 — cores and memory the workers share)
+        run: |
+          echo "cores: $(nproc)"
+          free -m
+
       - name: Run tests
         # --timeout=120: a per-test wall-clock cap (pytest-timeout). Without it a
         # single hung test (e.g. a stuck subprocess/asyncio test under Linux-3.12)
@@ -192,6 +203,35 @@ jobs:
           else
             echo "no memory-ceiling dump (no worker exceeded its RSS ceiling)"
           fi
+
+      # #5909: name the killer of a worker that died with no Python-side
+      # record. `tests/conftest.py` (`reyn.dev.testing.worker_forensics`)
+      # writes `.reyn-worker-down.log` from xdist's own `pytest_testnodedown`
+      # hook — the dead worker's EXIT CODE (`-9` = SIGKILL: the host's OOM
+      # killer or a reaper, never reyn; `1` = pytest-timeout's thread-method
+      # `os._exit`; `97` = reyn's memory ceiling) and the last tests it ran
+      # (from `.reyn-worker-trace/<gw>.log`, one nodeid per test start).
+      # Every worker's peak RSS lands in its trace at session end — the
+      # figure a host OOM kill judges, which the memory-ceiling log above
+      # never shows for a worker that stayed under reyn's own 2 GB. `dmesg`
+      # is the host's side of the same story (an OOM kill logs there and
+      # nowhere else); `|| true` because a runner that denies dmesg must
+      # not turn this informational step red. `if: always()`: forensics
+      # must print on exactly the runs that failed.
+      - name: Worker forensics (#5909 — only non-empty if a worker died)
+        if: always()
+        run: |
+          if [ -s .reyn-worker-down.log ]; then
+            echo "::warning::#5909 an xdist worker went down — its exit code and last tests:"
+            cat .reyn-worker-down.log
+          else
+            echo "no worker went down"
+          fi
+          echo "--- per-worker peak RSS (MB) ---"
+          grep -H "peak_rss_mb=" .reyn-worker-trace/*.log 2>/dev/null || echo "(no worker traces)"
+          echo "--- host OOM kills (dmesg) ---"
+          (sudo dmesg -T 2>/dev/null || dmesg -T 2>/dev/null) | grep -iE "out of memory|killed process|oom" || echo "no OOM kill in dmesg (or dmesg unavailable)"
+          true
 
       # #4331: what a green run above does NOT say — the skip census (count
       # + reason breakdown) and the collection-error count, on the SAME

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ spike_results/
 scratch/
 .reyn-memory-ceiling.log
 .reyn-ci-stall-trace.log
+.reyn-worker-trace/
+.reyn-worker-down.log

--- a/scripts/check_subprocess_reyn_pin_baseline.json
+++ b/scripts/check_subprocess_reyn_pin_baseline.json
@@ -9,6 +9,7 @@
   "tests/core/test_codeact_proctitle_3869.py",
   "tests/core/test_codeact_runner_harness_python_1663.py",
   "tests/core/test_windows_kill_tree_2292_2715.py",
+  "tests/dev/test_5909_worker_forensics.py",
   "tests/dev/test_stall_dump_4986.py",
   "tests/environment/test_container_backend_1115_stage2.py",
   "tests/environment/test_container_backend_cancel_3862.py",

--- a/src/reyn/dev/testing/memory_ceiling.py
+++ b/src/reyn/dev/testing/memory_ceiling.py
@@ -58,13 +58,18 @@ _config: object | None = None
 LOG_PATH = os.path.join(os.getcwd(), ".reyn-memory-ceiling.log")
 
 
-def _peak_mb() -> float:
+def peak_mb() -> float:
     """This process's high-water RSS.
 
     ``ru_maxrss`` is a peak, not a current reading: it never falls. That is the
     right shape for a ceiling — a run that touched the limit and then freed is
     still a run that touched the limit — but it means this cannot be used to
     watch memory come back down.
+
+    Public since #5909: ``worker_forensics`` records each xdist worker's
+    figure at session end — the number a HOST OOM kill judges (per worker,
+    ``-n auto`` of them at once), which this module's own log never shows
+    for a worker that stayed under reyn's ceiling.
     """
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / _RSS_DIVISOR
 
@@ -81,7 +86,7 @@ def ceiling_mb() -> int:
 
 def _watch(limit_mb: int) -> None:
     while True:
-        peak = _peak_mb()
+        peak = peak_mb()
         if peak > limit_mb:
             # The test's name is the whole value here: "some pytest used 10 GB"
             # is where the 2026-08-09 investigation started, and it cost hours.

--- a/src/reyn/dev/testing/worker_forensics.py
+++ b/src/reyn/dev/testing/worker_forensics.py
@@ -1,0 +1,186 @@
+"""Name the killer of a silently-dead xdist worker (#5909).
+
+WHY THIS EXISTS
+    On 2026-09-07 four CI jobs (one on a docs-only PR) each lost an xdist
+    worker — ``[gwN] node down: Not properly terminated`` — while running the
+    same test, and the job log carried NOTHING else about that worker: no
+    traceback, no ``Fatal Python error``, no memory-ceiling line. Everything a
+    reader could reach for was either ambiguous or missing, and the issue's
+    first hypothesis (a faulthandler dump into an execnet channel) had to be
+    measured and set aside before anyone could say what it was NOT.
+
+    What "nothing" excludes, and what it does not (measured, #5909):
+
+    - pytest's own faulthandler plugin ``enable()``s on a ``dup`` of the
+      ORIGINAL stderr at configure time (``_pytest/faulthandler.py``; global
+      capture is SUSPENDED around ``pytest_configure``, so the dup is the
+      real fd 2). Measured with CI's exact pins (pytest 9.1.1, xdist 3.8.0):
+      a test that ``SIGSEGV``s itself inside an xdist worker under
+      ``--capture=fd`` prints ``Fatal Python error: Segmentation fault`` and
+      every thread's stack on the parent's stderr, and xdist then reports
+      exactly the CI shape (``node down: Not properly terminated`` /
+      ``worker crashed while running``). None of the four CI logs carried
+      that line, so a fatal signal (SIGSEGV/SIGABRT/SIGBUS/SIGFPE/SIGILL)
+      is out.
+    - ``dev/testing/memory_ceiling.py`` writes its log only when REYN'S OWN
+      watcher kills the worker (``os._exit(97)``). A host OOM kill
+      (``SIGKILL``) writes nothing there — its silence does not exclude it.
+    - pytest-timeout's ``thread`` method ends the worker with ``os._exit(1)``
+      after printing its ``~~~ Stack of ... ~~~`` dump (which is NOT a
+      faulthandler dump — same shape, different author) to the item's
+      terminal writer — a worker's ``sys.stdout``, which execnet points at
+      ``/dev/null``: silent in a worker. (The signal method, the default in
+      a main thread, raises ``Failed`` inside the test instead and its dump
+      DOES reach the job log — that is what the CI logs' ``~~~ Stack of``
+      blocks are.)
+
+    So the surviving candidates all end the worker without a Python-side
+    record. The process's EXIT CODE tells them apart (``-9`` SIGKILL, ``1``
+    ``os._exit(1)``, ``97`` reyn's ceiling) — and xdist has it (execnet's
+    ``Popen``), but never prints it. Nor does ``-q`` say which tests that
+    worker ran before dying, so "the same test is named 4/4 times" could be
+    "that test" or "that point in a deterministic ``--dist load`` schedule".
+
+WHAT THIS RECORDS (all under the repo cwd, like ``memory_ceiling``'s log)
+    ``.reyn-worker-trace/<workerid>.log`` — one nodeid per line as each test
+    STARTS in that worker (so a dead worker's last line is the test it died
+    in, and the lines above are what ran before it), plus a final
+    ``peak_rss_mb=<n>`` line at session end (``resource.ru_maxrss``, the same
+    reader the memory ceiling uses).
+
+    ``.reyn-worker-down.log`` — one line per dead worker, written by the
+    CONTROLLER from xdist's ``pytest_testnodedown`` hook: worker id, xdist's
+    own error text, the worker process's exit code (best-effort: execnet's
+    private ``Popen`` handle, ``None`` if the shape ever changes), and the
+    last few nodeids from that worker's trace.
+
+    ``.github/workflows/test.yml`` prints both after every run (with the
+    host's ``dmesg`` OOM lines and ``free -m``/``nproc`` before), so the next
+    crash names its killer in the job log instead of costing another
+    investigation round-trip.
+
+COST
+    One small append per test start (open/append/close — no held fd, so
+    nothing here can be the #5877 fd-reuse hazard it helps diagnose). Off
+    on a non-xdist run (no ``workerinput`` → no worker id → nothing written).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+TRACE_DIR = ".reyn-worker-trace"
+DOWN_LOG = ".reyn-worker-down.log"
+#: How many of the dead worker's most recent tests the down-log line quotes.
+RECENT_TESTS = 5
+
+
+def worker_id(config: object) -> "str | None":
+    """xdist's worker id (``gw0`` ...) inside a worker, ``None`` on the
+    controller or a plain serial run — ``config.workerinput`` is xdist's own
+    discriminator (present only in a worker subprocess), the same one
+    ``stall_dump.py`` already reads."""
+    workerinput = getattr(config, "workerinput", None)
+    if not isinstance(workerinput, dict):
+        return None
+    wid = workerinput.get("workerid")
+    return str(wid) if wid else None
+
+
+def trace_path(wid: str, root: "str | os.PathLike[str] | None" = None) -> Path:
+    return Path(root if root is not None else os.getcwd()) / TRACE_DIR / f"{wid}.log"
+
+
+def _append(path: Path, line: str) -> None:
+    """Best-effort append — a forensics writer that can fail the run it
+    watches is worse than none (same policy as ``memory_ceiling``'s log)."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+
+def record_test_start(wid: str, nodeid: str, root: "str | os.PathLike[str] | None" = None) -> None:
+    _append(trace_path(wid, root), nodeid)
+
+
+def record_peak_rss(wid: str, peak_mb: float, root: "str | os.PathLike[str] | None" = None) -> None:
+    _append(trace_path(wid, root), f"peak_rss_mb={peak_mb:.0f}")
+
+
+def recent_tests(wid: str, root: "str | os.PathLike[str] | None" = None, n: int = RECENT_TESTS) -> "list[str]":
+    """The last *n* nodeids in *wid*'s trace (the ``peak_rss_mb=`` line, if
+    the worker got as far as writing one, is not a test and is skipped)."""
+    try:
+        lines = trace_path(wid, root).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    tests = [ln for ln in lines if ln and not ln.startswith("peak_rss_mb=")]
+    return tests[-n:]
+
+
+def format_node_down(wid: str, error: object, returncode: "int | None", recent: "list[str]") -> str:
+    """The one line a reader needs: who died, what xdist said, how the
+    process ended, and what it was doing. ``returncode`` is the process's
+    own exit status: a negative number is the signal that killed it
+    (``-9`` = SIGKILL — the host's OOM killer or a reaper, never reyn),
+    ``1`` is pytest-timeout's thread-method ``os._exit(1)``, ``97`` is
+    ``memory_ceiling``'s own kill."""
+    signal_note = ""
+    if isinstance(returncode, int) and returncode < 0:
+        signal_note = f" (signal {-returncode}{' SIGKILL' if -returncode == 9 else ''})"
+    last = recent[-1] if recent else "<no test recorded>"
+    before = recent[:-1]
+    return (
+        f"worker={wid} error={error!r} returncode={returncode!r}{signal_note} "
+        f"last_test={last} before_it={before!r}"
+    )
+
+
+def returncode_of(node: object) -> "int | None":
+    """The dead worker process's exit status, read through execnet's own
+    ``Popen`` handle (``node.gateway._io.popen`` — a private shape; every
+    step is ``getattr``-guarded so a future execnet that moves it yields
+    ``None`` here, never an exception in a hook that runs in execnet's
+    receiver thread)."""
+    popen = getattr(getattr(getattr(node, "gateway", None), "_io", None), "popen", None)
+    if popen is None:
+        return None
+    try:
+        rc = popen.poll()
+    except Exception:  # noqa: BLE001 — forensics never raise
+        return None
+    return rc if isinstance(rc, int) else None
+
+
+# ── pytest / xdist hook bodies (called from tests/conftest.py) ───────────────
+
+
+def pytest_runtest_setup(item: object) -> None:
+    """Worker: record the test that is about to run."""
+    wid = worker_id(getattr(item, "config", None))
+    if wid is not None:
+        record_test_start(wid, str(getattr(item, "nodeid", "?")))
+
+
+def pytest_sessionfinish(session: object, exitstatus: int) -> None:
+    """Worker: record this worker's peak RSS — the figure a host OOM kill
+    would have been judging, which ``memory_ceiling``'s own log never shows
+    for a worker that stayed under reyn's ceiling."""
+    wid = worker_id(getattr(session, "config", None))
+    if wid is None:
+        return
+    from reyn.dev.testing.memory_ceiling import peak_mb
+
+    record_peak_rss(wid, peak_mb())
+
+
+def pytest_testnodedown(node: object, error: object) -> None:
+    """Controller: a worker went down — write the one line that names how."""
+    wid = str(getattr(getattr(node, "gateway", None), "id", "?"))
+    _append(
+        Path(os.getcwd()) / DOWN_LOG,
+        format_node_down(wid, error, returncode_of(node), recent_tests(wid)),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -552,7 +552,7 @@ def _clear_find_project_root_cache() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_stall_trace_file_handler_registration() -> Iterator[None]:
+def _isolate_stall_trace_file_handler_registration(request: pytest.FixtureRequest) -> Iterator[None]:
     """Save + restore ``reyn.runtime.stall_trace``'s registered log-handler
     path around every test (#5873 follow-up, #5879 CI finding).
 
@@ -581,12 +581,34 @@ def _isolate_stall_trace_file_handler_registration() -> Iterator[None]:
     ``register_file_handler_path`` anywhere in ``tests/``), matching
     ``_isolate_rich_style_ansi_memo``/``_isolate_budget_limit_context``
     above: process-global state a test can set is this file's own
-    responsibility to isolate, not each individual test's."""
+    responsibility to isolate, not each individual test's.
+
+    #5909: the SAME fixture also cancels any ``faulthandler.dump_traceback_
+    later`` timer a test left pending — the other process-global this
+    module's callers touch. Measured: ``test_3671_stall_trace_startup_
+    wiring.py::test_stall_trace_disarmed_at_first_frame_via_on_mount`` runs
+    the tripwire's REAL ``arm`` (a ``repeat=False`` 0.25 s one-shot against
+    the worker's own fd) with ``disarm`` stubbed, so the worker's
+    ``finally`` closes that fd with the one-shot still pending; a pending
+    dump against a closed fd lands in whatever REUSES the number (measured
+    in isolation: a ``socketpair`` received the 116-byte dump). In the
+    suite that one-shot was NOT observed landing anywhere (it fires inside
+    the app's own shutdown, at a number nobody holds yet) — so this is
+    hygiene closing the class, not the #5909 crash's mechanism, which is
+    what ``worker_forensics`` exists to name. Guarded: under a serial run
+    with ``REYN_STALL_TRACE_CI`` set, the ONE process-wide timer is #4986's
+    session watchdog (``stall_dump.py`` arms it only on the controller,
+    never in an xdist worker) — cancelling it per test would exclude
+    exactly the teardown-hang class that watchdog exists to catch, so the
+    cancel runs only where that watchdog cannot be: inside an xdist worker,
+    or with the CI watchdog unset."""
     from reyn.runtime import stall_trace
 
     saved = stall_trace.find_file_handler_path()
     yield
     stall_trace.register_file_handler_path(saved)
+    if hasattr(request.config, "workerinput") or not os.environ.get("REYN_STALL_TRACE_CI"):
+        stall_trace.disarm()
 
 # ── Marker registration ────────────────────────────────────────────────────────
 
@@ -702,10 +724,11 @@ def pytest_collection_modifyitems(
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:
-    from reyn.dev.testing import memory_ceiling, network_gate
+    from reyn.dev.testing import memory_ceiling, network_gate, worker_forensics
 
     network_gate.pytest_runtest_setup(item)
     memory_ceiling.pytest_runtest_setup(item)
+    worker_forensics.pytest_runtest_setup(item)  # #5909: per-worker test trace
 
 
 def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:
@@ -715,16 +738,33 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> 
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    from reyn.dev.testing import extra_skip_report, network_gate, replay_unconsumed
+    from reyn.dev.testing import (
+        extra_skip_report,
+        network_gate,
+        replay_unconsumed,
+        worker_forensics,
+    )
 
     network_gate.pytest_sessionfinish(session, exitstatus)
     extra_skip_report.pytest_sessionfinish(session, exitstatus)
     replay_unconsumed.pytest_sessionfinish(session, exitstatus)
+    worker_forensics.pytest_sessionfinish(session, exitstatus)  # #5909: per-worker peak RSS
     # #4986 (reyn.dev.testing.stall_dump): deliberately has no
     # pytest_sessionfinish hook — see that module's own "WHY THIS NEVER
     # DISARMS" docstring section (architect finding, PR #5362 review): a
     # cancel here would exclude exactly the interpreter-shutdown/atexit
     # hang class #4986 exists to catch.
+
+
+def pytest_testnodedown(node: object, error: object) -> None:
+    """#5909 (xdist hook, controller side): a worker went down — write the
+    one line that names HOW (its exit code: ``-9`` SIGKILL, ``1``
+    pytest-timeout's ``os._exit``, ``97`` reyn's memory ceiling) and what it
+    was running, to ``.reyn-worker-down.log``; the CI job prints it. Runs
+    in execnet's receiver thread, so it only appends a line."""
+    from reyn.dev.testing import worker_forensics
+
+    worker_forensics.pytest_testnodedown(node, error)
 
 
 # ── Autouse fixture ────────────────────────────────────────────────────────────

--- a/tests/dev/test_5909_worker_forensics.py
+++ b/tests/dev/test_5909_worker_forensics.py
@@ -64,7 +64,17 @@ def test_returncode_of_reads_a_finished_process_through_execnets_popen_shape() -
     signal-killed process reports the negative signal number, which is
     exactly the datum #5909's crashed workers never surfaced. Any missing
     link in the shape yields ``None``, never an exception (the hook runs in
-    execnet's receiver thread)."""
+    execnet's receiver thread).
+
+    ``sys.executable`` spawn, deliberately NOT pinned with #5028's
+    env-identity fixture: the child runs ``-c "os.kill(getpid(), SIGKILL)"``
+    and never imports ``reyn`` — the process only exists to be dead with a
+    known signal. This file is therefore listed in ``scripts/check_
+    subprocess_reyn_pin_baseline.json`` as the gate's own "genuinely never
+    touches reyn" case, with this paragraph as the explanation the gate asks
+    for. (The fixture's name is deliberately not written here: the gate's
+    declared-check is a text scan, and naming it would read as a
+    declaration and hide this file from the baseline it belongs in.)"""
     proc = subprocess.Popen([sys.executable, "-c", "import os, signal; os.kill(os.getpid(), signal.SIGKILL)"])
     proc.wait()
 

--- a/tests/dev/test_5909_worker_forensics.py
+++ b/tests/dev/test_5909_worker_forensics.py
@@ -1,0 +1,126 @@
+"""Tier 2: #5909 — ``reyn.dev.testing.worker_forensics`` names how an xdist
+worker died and what it was running, from the files it leaves behind.
+
+Real files under a tmp cwd, a real finished ``subprocess.Popen`` for the
+exit-code reader, this test's own real ``request.node`` for the setup hook.
+ONE disclosed stand-in: the xdist ``node.gateway._io`` attribute chain the
+exit-code reader walks is a hand-rolled attribute holder around that REAL
+``Popen`` — a live ``WorkerController`` needs a spawned execnet gateway,
+which is not cheaply constructible, and the reader's own contract is
+exactly "follow this shape, never raise". The one thing no real
+collaborator exposes as state (that the isolation fixture cancels a
+pending stall dump only where #4986's controller watchdog cannot be) is
+gated on the fixture's own source, the same ``inspect.getsource`` shape
+``test_5364_media_store_flush_barrier.py`` uses for a timer-driven seam.
+"""
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.dev.testing import worker_forensics as wf
+
+
+def test_node_down_line_names_the_signal_the_last_test_and_what_ran_before() -> None:
+    """Tier 2: the one line a reader needs — a negative exit code is the
+    killing signal (``-9`` named SIGKILL: the host, never reyn); the last
+    recorded test is separated from the ones before it."""
+    line = wf.format_node_down(
+        "gw2", "Not properly terminated", -9, ["suite/a.py::t1", "suite/b.py::t2", "suite/c.py::t3"],
+    )
+    assert "worker=gw2" in line
+    assert "returncode=-9 (signal 9 SIGKILL)" in line
+    assert "last_test=suite/c.py::t3" in line
+    assert "before_it=['suite/a.py::t1', 'suite/b.py::t2']" in line
+
+    quiet = wf.format_node_down("gw0", "Not properly terminated", None, [])
+    assert "returncode=None" in quiet and "last_test=<no test recorded>" in quiet
+    assert "signal" not in quiet
+
+
+def test_trace_records_each_test_start_and_the_peak_rss_and_recent_skips_the_peak_line(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: one nodeid per test start per worker file; the session-end
+    ``peak_rss_mb=`` line is part of the trace but never counted as a
+    test by ``recent_tests``."""
+    for nodeid in ("suite/x.py::t1", "suite/x.py::t2", "suite/y.py::t3"):
+        wf.record_test_start("gw1", nodeid, root=tmp_path)
+    wf.record_peak_rss("gw1", 1234.6, root=tmp_path)
+
+    trace = (tmp_path / wf.TRACE_DIR / "gw1.log").read_text(encoding="utf-8").splitlines()
+    assert trace == ["suite/x.py::t1", "suite/x.py::t2", "suite/y.py::t3", "peak_rss_mb=1235"]
+    assert wf.recent_tests("gw1", root=tmp_path, n=2) == ["suite/x.py::t2", "suite/y.py::t3"]
+    assert wf.recent_tests("gw9", root=tmp_path) == [], "an unknown worker has no trace, not an error"
+
+
+def test_returncode_of_reads_a_finished_process_through_execnets_popen_shape() -> None:
+    """Tier 2: the exit-code reader follows execnet's ``gateway._io.popen``
+    shape to a REAL ``subprocess.Popen`` that has already ended — a
+    signal-killed process reports the negative signal number, which is
+    exactly the datum #5909's crashed workers never surfaced. Any missing
+    link in the shape yields ``None``, never an exception (the hook runs in
+    execnet's receiver thread)."""
+    proc = subprocess.Popen([sys.executable, "-c", "import os, signal; os.kill(os.getpid(), signal.SIGKILL)"])
+    proc.wait()
+
+    class _IO:
+        popen = proc
+
+    class _Gateway:
+        _io = _IO()
+        id = "gw7"
+
+    class _Node:
+        gateway = _Gateway()
+
+    assert wf.returncode_of(_Node()) == -9
+    assert wf.returncode_of(object()) is None
+
+
+def test_the_setup_hook_records_this_very_test_under_its_worker_id(
+    request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: driven with this test's OWN real ``request.node`` — the hook
+    reads the worker id off ``config.workerinput`` (xdist's discriminator)
+    and appends the nodeid under the cwd. Outside xdist (no
+    ``workerinput``) it writes nothing at all."""
+    monkeypatch.chdir(tmp_path)
+    item = request.node
+
+    had_workerinput = hasattr(item.config, "workerinput")
+    if not had_workerinput:
+        monkeypatch.setattr(item.config, "workerinput", {"workerid": "gwX"}, raising=False)
+    wid = wf.worker_id(item.config)
+    assert wid, "test setup sanity: a worker id must resolve"
+
+    wf.pytest_runtest_setup(item)
+
+    assert wf.recent_tests(wid, root=tmp_path) == [item.nodeid]
+
+    if not had_workerinput:
+        monkeypatch.delattr(item.config, "workerinput", raising=False)
+        assert wf.worker_id(item.config) is None
+        wf.pytest_runtest_setup(item)  # serial run: nothing written
+        assert wf.recent_tests(wid, root=tmp_path) == [item.nodeid]
+
+
+def test_the_isolation_fixture_cancels_a_pending_stall_dump_only_where_the_ci_watchdog_cannot_be() -> None:
+    """Tier 2: hygiene gate for the #5909 leak class (a test that runs the
+    real ``stall_trace.arm`` with ``disarm`` stubbed leaves a one-shot
+    pending against an fd its own ``finally`` then closes). A negative
+    timing witness ("nothing arrives") would be a wait the assertion
+    depends on, so this reads the fixture's own source instead: it must
+    ``disarm()`` after the yield, and only inside an xdist worker or with
+    ``REYN_STALL_TRACE_CI`` unset — the one process-wide timer on a serial
+    CI run is #4986's session watchdog, which must survive every test."""
+    import tests.conftest as conftest
+
+    src = inspect.getsource(conftest._isolate_stall_trace_file_handler_registration)
+    after_yield = src.split("yield", 1)[1]
+    assert 'if hasattr(request.config, "workerinput") or not os.environ.get("REYN_STALL_TRACE_CI"):' in after_yield
+    assert "stall_trace.disarm()" in after_yield


### PR DESCRIPTION
**[e2e-coder]** — part of #5909 (the measurement the issue's step 1 asks for; the mechanism claim and its strip come after the next crash names its killer — `Closes` then).

## What was measured (all primary; details on the issue)

| claim in the issue | measurement | result |
|---|---|---|
| "faulthandler dump appears in the job's stdout" | read the four job logs (#5897 `ba17fc94e`, #5902, #5895, #5904) | the `~~~ Stack of …` blocks are **pytest-timeout's signal-method dump** (`timeout_sigalrm` → `dump_stacks`, then `Failed: Timeout (>120.0s)`); `reyn-memory-ceiling` is just one thread in that list. Not faulthandler. The crashed worker itself wrote **nothing** — xdist's only line is `[gwN] node down: Not properly terminated` |
| "a leaked faulthandler one-shot lands in an execnet channel" (#5877 class) | (a) isolated: arm `dump_traceback_later(0.25, repeat=False, file=fd)`, close fd, `socketpair()` reuses the number → 116-byte dump lands on the socket; (b) in the suite: `test_3671::test_stall_trace_disarmed_at_first_frame_via_on_mount` runs the real tripwire `arm` with `disarm` stubbed → a one-shot IS left pending against a closed fd; (c) probe right after that test: 40 pipes (fds 5..84) opened at once, 0.6 s wait → **nothing lands**; execnet's channel fds are `dup(0)/dup(1)` taken at worker start and never closed | mechanism real in isolation, **not reachable as the crash**: the one-shot fires during the app's own shutdown at a number nobody holds; the channel can never be the reuser. Hygiene fix included (below), not claimed as the cause |
| "SIGSEGV/SIGABRT would be invisible under `--capture=fd`" (raised mid-triage) | with CI's exact pins (pytest 9.1.1 / xdist 3.8.0, `ci-constraints.txt:145-149`): a test that `SIGSEGV`s itself inside an `-n1` worker | `Fatal Python error: Segmentation fault` + every thread's stack **on the parent's stderr**, then `[gw0] node down: Not properly terminated` / `worker 'gw0' crashed while running …` — the CI shape verbatim. pytest suspends global capture around `pytest_configure`, so its builtin plugin dups the real fd 2. **Fatal signals are excluded** by the four logs' silence |
| "memory ceiling did not fire ∴ not memory" | read `memory_ceiling.py` | its log is written only by reyn's own `os._exit(97)`; a host `SIGKILL` writes nothing there. Not excluded |
| "the same test is the trigger" | `-q` prints no per-worker order | **not decidable from today's logs** — `--dist load` is a deterministic schedule, so "the same test" may be "the same point"; this PR records the order |

Left standing: **SIGKILL** (the host's OOM killer or a reaper — `ubuntu-latest`, `-n auto` = 4 workers × reyn's 2 GB ceiling) or an `os._exit` with no output (pytest-timeout's *thread* method prints to the worker's stdout, which execnet points at `/dev/null` — but that method needs a non-main thread, so unlikely). Neither can be named from the existing log. So this PR makes the next crash name itself.

## What this adds

- **`reyn.dev.testing.worker_forensics`** (wired from `tests/conftest.py` like `memory_ceiling`/`network_gate`):
  - `.reyn-worker-trace/<gw>.log` — one nodeid per test START in that worker (the dead worker's last line is the test it died in; the lines above are the order lead asked for), plus `peak_rss_mb=` at session end (`ru_maxrss`, the memory ceiling's own reader, now public as `peak_mb()`).
  - `.reyn-worker-down.log` — from xdist's `pytest_testnodedown` on the controller: worker id, xdist's error text, the **process exit code** via execnet's `Popen` (`-9` SIGKILL, `-11` SIGSEGV, `1` pytest-timeout thread `os._exit`, `97` memory ceiling; `getattr`-guarded, `None` if the private shape moves), and the last 5 tests from that worker's trace.
- **`test.yml`**: `Runner capacity` (`nproc`, `free -m`) before pytest; `Worker forensics` (`if: always()`) after the memory-ceiling dump — prints the down-log, every worker's peak RSS, and `dmesg`'s OOM lines (`|| true`).
- **Hygiene** (the #5877 class, measured above, not the cause): the autouse `_isolate_stall_trace_file_handler_registration` fixture also `disarm()`s after each test — only inside an xdist worker or with `REYN_STALL_TRACE_CI` unset, so #4986's controller watchdog is never cancelled.
- `.gitignore`: the two artifacts.

Removed before opening: a faulthandler re-point to capture's saved fd 2 (folded in from a mid-triage proposal, then falsified by the `-n1` SIGSEGV measurement above — the builtin already reaches the job log).

## Tests (`tests/dev/test_5909_worker_forensics.py`, Tier 2)

- `format_node_down` names the signal, the last test, and the ones before it.
- trace/peak/recent with real files under a tmp cwd; the `peak_rss_mb=` line is never counted as a test.
- `returncode_of` follows execnet's `gateway._io.popen` shape to a REAL `subprocess.Popen` killed by SIGKILL → `-9`; a missing link → `None` (disclosed stand-in: the gateway attribute chain around that real `Popen` — a live `WorkerController` needs a spawned gateway).
- the setup hook driven with this test's own real `request.node` + `config.workerinput`; nothing written without a worker id.
- the fixture's guarded cancel, gated on its source (`inspect.getsource`, the flush-barrier precedent) — a negative timing witness would be a wait the assertion depends on.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/dev/test_5909_worker_forensics.py`
- [x] `python scripts/verify_module_docstrings.py` (2 files)
- [x] `python scripts/mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` · `check_tests_path_literal_reference.py` (re-run before push) · `check_bare_tests_import_reference.py` · `check_file_depth_reference.py` · `check_subprocess_reyn_pin.py`
- [x] scoped pytest: the new file + `test_3671_stall_trace_startup_wiring.py` + `test_loop_probe_3539.py` + `test_3233_inprocess_env_identity.py` (45 passed); import identity verified against the worktree `src/`
- [ ] CI: the new `Worker forensics` step prints `no worker went down` + 4 `peak_rss_mb=` lines on a green run (first real run of the step happens on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
