### PR TITLE
feat(#5907 ② + ①): typed control outcome + shared failure renderer; dispatcher run unit on a single-in-flight FIFO

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -458,9 +458,16 @@ cancel, the heartbeat) is a bounded round-trip and gets its own read timeout,
 place — `remote_client.post_control`). A control POST the server does not
 answer within it is a **non-delivery**, not a wait: `cancel_inflight` returns
 the empty summary the `ClientTransport` contract reserves for "not
-delivered", and the Textual TUI draws it as `interrupt: the server did not
-acknowledge the cancel (not responding)` under the `cancel requested…` row it
-drew the instant the key was pressed. The TUI's message pump never awaits
+confirmed", and the Textual TUI draws a row under the `cancel requested…` row
+it drew the instant the key was pressed. Which failure it was is TYPED
+(#5907 ②): `post_control` returns a `ControlOutcome` — `delivered` /
+`refused` (the server's own reason) / `not_delivered` (no answer within T;
+the request may not have reached the server) — the transport records the
+latest one (`ClientTransport.last_control_outcome`), and ONE describer
+(`describe_control_failure`) words it for every surface: the slash layer's
+`reply_error` and the dispatcher's error lines append it, so a refusal and a
+timeout never read the same on any of the 27 wire-touching commands, without
+any handler being edited. The TUI's message pump never awaits
 the wire for any of these — the handler draws what it requested and returns,
 and the round-trip runs on a Textual worker — so a server that has stopped
 answering cannot hold the keyboard (the owner-hit shape: Ctrl-C's cancel POST

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -472,7 +472,16 @@ the wire for any of these — the handler draws what it requested and returns,
 and the round-trip runs on a Textual worker — so a server that has stopped
 answering cannot hold the keyboard (the owner-hit shape: Ctrl-C's cancel POST
 waiting forever, and Ctrl-Q, which touches no wire at all, never delivered
-behind it). While one `cancel_inflight` POST is pending, a second is
+behind it). The slash layer's own wire calls go the same way (#5907 ①): the
+dispatcher (`maybe_dispatch_slash`) hands its run unit — one `run_slash_
+command` POST for a session-locus command, the handler's own transport call
+for a connection-locus one — to a `runner` the TUI supplies, and returns at
+once; the TUI's runner is a **single-in-flight FIFO** (one Textual worker),
+which every submit round-trip joins too, so `/model X` → message and
+`/session switch` → `/compact` keep the effect order the serial pump used to
+give. A stuck unit delays the next one visibly; the control timeout is its
+backstop. The plain CUI passes no runner and awaits inline (its input loop
+is not a pump). While one `cancel_inflight` POST is pending, a second is
 coalesced (`cancel already requested`), so a held Ctrl-C does not open one
 POST per key repeat.
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -38,7 +38,7 @@ import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine
 
 from textual import events
 from textual.app import App, ComposeResult
@@ -1547,6 +1547,13 @@ class TextualChatApp(App):
         #: unreachable dead code for the actual failure mode it would
         #: exist to fix.
         self._loop_tripwire = LoopTripwire()
+        #: #5907 ①: the single-in-flight FIFO every wire-touching unit
+        #: (a slash command's run unit, a submit round-trip) goes through,
+        #: and its one worker — see :meth:`_enqueue_wire`.
+        import asyncio as _asyncio
+
+        self._wire_fifo: "_asyncio.Queue[Coroutine[Any, Any, None]]" = _asyncio.Queue()
+        self._wire_fifo_worker: "object | None" = None
         #: #4761 ②: the App's own message-pump heartbeat — incremented by
         #: :meth:`on_timer` ONLY for :attr:`_pump_heartbeat_timer`'s own
         #: ticks, which (no ``callback=`` given to ``set_interval``) post an
@@ -7880,34 +7887,29 @@ class TextualChatApp(App):
             sent_queue.remove_item(msg_id)
 
     async def _submit(self, text: str, *, local_id: str) -> None:
-        """Route one submitted line: the client-side slash layer FIRST,
-        synchronously on this handler; only a real turn's wire round-trip
-        goes to a worker (#5894 ①-2, lead-coder's BLOCKING on PR #5902).
+        """Route one submitted line onto this app's single-in-flight wire
+        FIFO (#5907 ①, architect ruling): the slash dispatcher hands its run
+        unit to :meth:`_enqueue_wire` and returns at once; a non-command
+        line's ``submit_user_text`` round-trip is enqueued the same way.
+        This handler therefore never awaits the wire — the pump stays
+        alive whatever the server does — while the FIFO keeps the EFFECT
+        order the pump's serial delivery used to guarantee (``/model X``
+        then a message; ``/session switch`` then ``/compact``): one unit
+        in flight at a time, the next waits for it. A stuck unit delays
+        the next, visibly (the UI is alive, the operator can see and
+        judge); the control read timeout (#5894 ①-1) is its backstop.
 
-        ``maybe_dispatch_slash`` is local work — ``/help``, a typo's "unknown
-        command", the picker commands — and the operator expects its answer
-        the instant Enter lands, exactly as the CUI gives it (the shared
-        layer is the point of #3595 S5: one implementation, one answer).
-        Running it on the worker deferred that answer past the handler's
-        return, which is what CI caught (``shown=[]``). The ruling's line is
-        "the pump never awaits the WIRE": a dispatched command that itself
-        touches the wire (``/cancel`` → ``cancel_inflight``) does so through
-        the transport's own bounded control timeout (#5894 ①-1), not the
-        unbounded read that held the pump — a residual named in the PR, not
-        a hole this method hides.
-
-        A non-command line returns as soon as the worker is scheduled: every
-        caller's own local work (the placeholder row, clearing the composer)
-        already happened synchronously before it, and the placeholder
-        resolves off the ``user_submitted`` echo, never off this call's
-        return. An Enter against a server that has stopped answering
-        therefore no longer holds the pump — the same class as Ctrl-C's
-        (see :meth:`action_cancel_turn`): "server が塞がれば Enter でも同じ症状".
+        Everything local that must be on screen the instant Enter lands
+        already is: the echo and the "unknown command" line are drawn by
+        the dispatcher BEFORE it hands the unit over, the sent-queue
+        placeholder by the composer handler before this method, and the
+        placeholder resolves off the ``user_submitted`` echo, never off
+        this call's return.
         """
         try:
             from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
 
-            if await maybe_dispatch_slash(self._transport, text):
+            if await maybe_dispatch_slash(self._transport, text, runner=self._enqueue_wire):
                 # A dispatched command is never queued (#3595 S5) — drop the
                 # placeholder row the composer handler already showed.
                 self._maybe_sent_queue_remove(local_id)
@@ -7915,9 +7917,31 @@ class TextualChatApp(App):
         except Exception as exc:
             self._submit_failed(local_id, exc)
             return
-        self.run_worker(
-            self._submit_over_wire(text, local_id=local_id), name="submit", exclusive=False,
-        )
+        self._enqueue_wire(self._submit_over_wire(text, local_id=local_id))
+
+    def _enqueue_wire(self, unit: "Coroutine[Any, Any, None]") -> None:
+        """Append one wire-touching unit to the single-in-flight FIFO
+        (#5907 ①) and make sure its one worker is running. The worker is
+        a Textual worker (never the pump); ``exclusive=False`` because an
+        exclusive worker would cancel the frames pump."""
+        self._wire_fifo.put_nowait(unit)
+        worker = self._wire_fifo_worker
+        if worker is None or worker.is_finished:
+            self._wire_fifo_worker = self.run_worker(
+                self._drain_wire_fifo(), name="wire-fifo", exclusive=False,
+            )
+
+    async def _drain_wire_fifo(self) -> None:
+        """The FIFO's one consumer: units run strictly one after another, in
+        arrival order. A unit's own failure is its own to report (the
+        dispatcher and :meth:`_submit_over_wire` both catch and draw);
+        this loop only guards against one escaping and stopping the rest."""
+        while True:
+            unit = await self._wire_fifo.get()
+            try:
+                await unit
+            except Exception:
+                logger.exception("textual chat: wire FIFO unit failed")
 
     def _submit_failed(self, local_id: str, exc: BaseException) -> None:
         """Shared failure path of :meth:`_submit` (slash) and

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -4201,13 +4201,16 @@ class TextualChatApp(App):
             )
             return
         if not summary:
+            # #5907 ②: the typed outcome says whether the server refused
+            # or never answered — one describer, shared with the slash layer.
+            from reyn.interfaces.transport.control_outcome import describe_control_failure
+
+            detail = describe_control_failure(self._transport.last_control_outcome())
+            why = detail or "the server did not acknowledge the cancel"
             self._ingest_frame(
                 OutboxMessage(
                     kind="error",
-                    text=(
-                        "interrupt: the server did not acknowledge the cancel "
-                        "(not responding) — the turn may still be running"
-                    ),
+                    text=f"interrupt: {why} — the turn may still be running",
                 )
             )
 

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -24,6 +24,8 @@ import time
 import uuid
 from typing import AsyncIterator
 
+from reyn.interfaces.transport.control_outcome import ControlOutcome
+
 logger = logging.getLogger(__name__)
 
 
@@ -63,19 +65,20 @@ _CONTROL_TIMEOUT_S = _env_float("REYN_AGUI_CONTROL_TIMEOUT_S", 10.0)
 async def post_control(
     client, url: str, *, params: dict, payload: dict,
     timeout_s: "float | None" = None,
-) -> "dict | None":
+) -> "ControlOutcome":
     """POST one client→server control message with the CONTROL timeout
-    policy (#5894 ①-1) and return the parsed JSON body on a 2xx accept,
-    ``None`` on a non-delivery.
+    policy (#5894 ①-1) and return the TYPED outcome (#5907 ②):
+    :class:`ControlOutcome` — ``delivered(payload)`` on a 2xx, ``refused``
+    on ≥300 (the server's own reason), ``not_delivered`` when the request
+    raised (the control read timeout, a connect error …).
 
     This is the whole policy in one place: ``timeout_s`` (default
     :data:`_CONTROL_TIMEOUT_S`) bounds the read; the ``client`` passed in
     keeps its OWN default (``read=None``, the SSE stream's) untouched — one
-    client, two request kinds, two policies. A non-delivery is any of: the
-    request raised (timeout, connect error, ...), or the server answered
-    ≥300. A 2xx whose body is empty / not JSON is still an accept and reads
-    as a truthy ``{"status": "ok"}``, so every ``if accepted:`` caller keeps
-    the old bool contract.
+    client, two request kinds, two policies. A 2xx whose body is empty /
+    not JSON is still delivered, with a truthy ``{"status": "ok"}`` payload,
+    so every ``if accepted:`` caller keeps the old bool contract — the
+    outcome itself is truthy iff delivered.
 
     ``timeout_s`` is a parameter so a test can supply T — it is the subject
     there, never a wait the test sits out.
@@ -88,15 +91,21 @@ async def post_control(
             url, params=params, json=payload,
             timeout=httpx.Timeout(read_timeout, connect=10.0),
         )
-    except Exception:  # noqa: BLE001 — a transport error is a non-delivery
-        logger.warning("remote send failed for %r", payload.get("type"))
-        return None
+    except Exception as exc:  # noqa: BLE001 — a transport error is a non-delivery
+        logger.warning("remote send failed for %r: %s", payload.get("type"), type(exc).__name__)
+        return ControlOutcome.not_delivered(type(exc).__name__, read_timeout)
     if resp.status_code >= 300:
-        return None
+        reason: "str | None"
+        try:
+            body = resp.json()
+            reason = str(body.get("detail") or body.get("error") or body) if isinstance(body, dict) else str(body)
+        except Exception:  # noqa: BLE001 — a non-JSON refusal still has a status
+            reason = (resp.text or "").strip() or None
+        return ControlOutcome.refused(resp.status_code, reason)
     try:
-        return resp.json()
+        return ControlOutcome.delivered(resp.json())
     except Exception:  # noqa: BLE001 — an empty/non-JSON 2xx body is still an accept
-        return {"status": "ok"}
+        return ControlOutcome.delivered({"status": "ok"})
 
 
 def _heartbeat_due(last_send: float, now: float, interval: float = _HEARTBEAT_INTERVAL) -> bool:
@@ -179,7 +188,7 @@ async def run_remote_repl(
         # refreshes it for every accepted POST, not just ``type: heartbeat``).
         last_send = [0.0]
 
-        async def send(payload: dict) -> "dict | None":
+        async def send(payload: dict) -> "ControlOutcome":
             """POST one client→server message; the parsed JSON response body on
             a 2xx accept (always a truthy dict, even if the body itself parsed
             empty — see below), ``None`` if the server rejected it (403/409/…)

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -332,8 +332,16 @@ async def reply(ctx: SlashContext, text: str, *, kind: str = "system") -> None:
 
 
 async def reply_error(ctx: SlashContext, text: str) -> None:
-    """Emit an error message (red ✗ in the TUI)."""
-    await reply(ctx, text, kind="error")
+    """Emit an error message (red ✗ in the TUI).
+
+    #5907 ②: the shared failure renderer — when the transport's latest
+    control POST was refused or not delivered, the typed outcome's own
+    wording is appended here (``dispatch.with_control_failure``), so every
+    handler's ``if not ok: reply_error(...)`` says which it was without
+    being edited."""
+    from reyn.interfaces.slash.dispatch import with_control_failure
+
+    await reply(ctx, with_control_failure(ctx.transport, text), kind="error")
 
 
 # ── trigger registration of built-in commands ─────────────────────────────

--- a/src/reyn/interfaces/slash/cancel.py
+++ b/src/reyn/interfaces/slash/cancel.py
@@ -13,7 +13,7 @@ posture Esc/Ctrl+C already take without asking.
 """
 from __future__ import annotations
 
-from reyn.interfaces.slash import SlashContext, reply, slash
+from reyn.interfaces.slash import SlashContext, reply, reply_error, slash
 
 
 @slash(
@@ -33,5 +33,7 @@ async def cancel_cmd(ctx: "SlashContext", args: str) -> None:
     # #5894: the ABC reserves "" for "not delivered" (control timeout / send
     # failure) — say so instead of printing an empty summary.
     if not summary:
-        summary = "cancel not delivered — the server did not respond"
+        # #5907 ②: refused vs not delivered — the shared renderer words it.
+        await reply_error(ctx, "⏹ cancel not confirmed")
+        return
     await reply(ctx, f"⏹ {summary}")

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -75,7 +75,23 @@ logger = logging.getLogger(__name__)
 
 def _display(transport: "ClientTransport", kind: str, text: str, **meta) -> None:
     from reyn.runtime.outbox import OutboxMessage
+    if kind == "error":
+        text = with_control_failure(transport, text)
     transport.put_display(OutboxMessage(kind=kind, text=text, meta=dict(meta)))
+
+
+def with_control_failure(transport: "ClientTransport", text: str) -> str:
+    """#5907 ②: the ONE place a failure line learns why. Appends the typed
+    outcome's own wording (``describe_control_failure``) when the
+    transport's latest control POST was refused or not delivered — so the
+    27 handlers that write ``if not ok: reply_error(...)`` say the right
+    thing without being edited, and a timeout and a refusal can never read
+    the same. Nothing is appended for a delivered / untyped / wire-less
+    transport."""
+    from reyn.interfaces.transport.control_outcome import describe_control_failure
+
+    detail = describe_control_failure(transport.last_control_outcome())
+    return f"{text} — {detail}" if detail else text
 
 
 async def maybe_dispatch_slash(
@@ -258,6 +274,9 @@ class _ErrorWatchingTransport(ClientTransport):
 
     def attach_failed(self) -> bool:
         return self._inner.attach_failed()
+
+    def last_control_outcome(self):
+        return self._inner.last_control_outcome()
 
     def pending_intervention_head(self) -> "object | None":
         return self._inner.pending_intervention_head()

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -59,7 +59,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Coroutine
 
 from reyn.interfaces.slash import REGISTRY, SlashContext, suggest_for_unknown
 from reyn.interfaces.transport.client_transport import ClientTransport
@@ -96,6 +96,7 @@ def with_control_failure(transport: "ClientTransport", text: str) -> str:
 
 async def maybe_dispatch_slash(
     transport: "ClientTransport", text: str, *, echo: bool = True,
+    runner: "Callable[[Coroutine[Any, Any, None]], None] | None" = None,
 ) -> bool:
     """Interpret ``text`` as a slash command; ``True`` iff it was consumed.
 
@@ -212,16 +213,29 @@ async def maybe_dispatch_slash(
     # answer "attach a different agent") instead of ever reaching
     # AgUiTransport's own correctly-implemented request_attach.
     locus = cmd.locus(args) if callable(cmd.locus) else cmd.locus
-    if locus == "session":
-        ran = await transport.run_slash_command(name, args)
-    else:
-        ctx = SlashContext(transport=transport, session=None)
-        ran = await execute_slash_command(ctx, name, args)
-    if not ran:
-        _display(
-            transport, "error",
-            f"/{name} could not run: this client has no session to run it on.",
-        )
+
+    async def _run() -> None:
+        # #5907 ①: the run UNIT — the one place a command touches the wire
+        # (a session-locus command is one control POST; a connection-locus
+        # / client-locus handler awaits its own transport call inside).
+        # Handed to ``runner`` when the caller has one, so a UI's message
+        # pump never awaits it; awaited inline otherwise (the plain CUI's
+        # input loop is not a pump).
+        if locus == "session":
+            ran = await transport.run_slash_command(name, args)
+        else:
+            ctx = SlashContext(transport=transport, session=None)
+            ran = await execute_slash_command(ctx, name, args)
+        if not ran:
+            _display(
+                transport, "error",
+                f"/{name} could not run: this client has no session to run it on.",
+            )
+
+    if runner is not None:
+        runner(_run())
+        return True
+    await _run()
     return True
 
 

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -48,6 +48,7 @@ from reyn.interfaces.transport.agui.protocol import (
 )
 from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
 from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.control_outcome import ControlOutcome
 from reyn.interfaces.transport.drain import suspend_between_frames
 from reyn.interfaces.transport.frames import (
     BacklogBatch,
@@ -113,7 +114,7 @@ class AgUiTransport(ClientTransport):
     def __init__(
         self,
         sse_lines: "AsyncIterator[str]",
-        send: "Callable[[dict], Awaitable[dict | None]]",
+        send: "Callable[[dict], Awaitable[ControlOutcome | dict | None]]",
         *,
         agent_name: str = "",
         status_view: "RemoteStatusView | None" = None,
@@ -121,7 +122,26 @@ class AgUiTransport(ClientTransport):
         connected: bool = True,
     ) -> None:
         self._sse_lines = sse_lines
-        self._send = send
+        # #5907 ②: every control POST goes through ``_send``; the wrapper
+        # records the TYPED outcome (``ControlOutcome``) of the latest one
+        # and hands the call sites the same ``dict | None`` they always got
+        # — so no site changes, and ``last_control_outcome()`` lets the
+        # shared failure renderer say "refused" or "not delivered" instead
+        # of one line for both. An untyped sender (a test stub returning a
+        # dict / None) records a delivered outcome or nothing.
+        self._last_control_outcome: "ControlOutcome | None" = None
+
+        async def _recording_send(payload: dict) -> "dict | None":
+            self._last_control_outcome = None
+            result = await send(payload)
+            if isinstance(result, ControlOutcome):
+                self._last_control_outcome = result
+                return result.payload if result else None
+            if isinstance(result, dict):
+                self._last_control_outcome = ControlOutcome.delivered(result)
+            return result
+
+        self._send = _recording_send
         # #5894 (architect ruling ①-3): at most one cancel_inflight POST in
         # flight per connection — the SAME coalesce shape endpoint.py's
         # ``_status_ping_pending`` uses. Once the TUI stops awaiting the
@@ -603,6 +623,9 @@ class AgUiTransport(ClientTransport):
 
     def has_session(self) -> bool:
         return self._connected
+
+    def last_control_outcome(self) -> "ControlOutcome | None":
+        return self._last_control_outcome
 
     def attach_failed(self) -> bool:
         # #5096 review finding (lead-coder): EXPLICITLY implemented, not

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -50,6 +50,7 @@ _logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from reyn.interfaces.transport.control_outcome import ControlOutcome
     from reyn.interfaces.transport.frames import BacklogBatch, Frame
     from reyn.runtime.outbox import OutboxMessage
 
@@ -147,6 +148,15 @@ class ClientTransport(ABC):
     @abstractmethod
     def has_session(self) -> bool:
         """Whether a session is currently attached (client input guard)."""
+
+    def last_control_outcome(self) -> "ControlOutcome | None":
+        """#5907 ②: the typed outcome of the most recent control POST this
+        transport made (``ControlOutcome``), or ``None`` when there is no
+        wire (the local transports) or no typed record. Read by the shared
+        failure renderers (``slash.reply_error`` / ``dispatch._display``)
+        so a refusal and a non-delivery never share a line. Not abstract:
+        a transport without a wire has nothing to report."""
+        return None
 
     @abstractmethod
     def attach_failed(self) -> bool:
@@ -708,6 +718,9 @@ class DelegatingClientTransport(ClientTransport):
 
     def has_session(self) -> bool:
         return self._inner.has_session()
+
+    def last_control_outcome(self) -> "ControlOutcome | None":
+        return self._inner.last_control_outcome()
 
     def attach_failed(self) -> bool:
         return self._inner.attach_failed()

--- a/src/reyn/interfaces/transport/control_outcome.py
+++ b/src/reyn/interfaces/transport/control_outcome.py
@@ -1,0 +1,74 @@
+"""#5907 ②: the typed outcome of one client→server control POST.
+
+A control request (a turn submit, an intervention answer, a cancel, a
+session switch …) can end three ways, and a client must say which:
+
+- ``delivered`` — the server accepted it (a 2xx); ``payload`` is the body.
+- ``refused`` — the server answered and said no (≥300); ``reason`` is what
+  it said, verbatim where there was a body.
+- ``not_delivered`` — the server never answered: the control read timeout
+  (#5894 ①-1) elapsed, or the request itself failed; ``cause`` names the
+  exception class. **The request may or may not have reached the server**
+  — the one thing a non-idempotent request's operator most needs to hear.
+
+Before this, ``post_control`` collapsed the last two into ``None`` and
+every handler rendered one line for both (architect, #5907: a falsy
+carrying two facts is the fail-open class; the fix is a type, not a
+check). Handlers keep their ``if not ok:`` — the transport records the
+last outcome (``ClientTransport.last_control_outcome``) and the shared
+renderers (``reply_error`` / ``dispatch._display``) append the outcome's
+own wording, so 27 handlers say the right thing without being edited.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Kind = Literal["delivered", "refused", "not_delivered"]
+
+
+@dataclass(frozen=True)
+class ControlOutcome:
+    kind: Kind
+    payload: "dict | None" = None
+    status: "int | None" = None
+    reason: "str | None" = None
+    cause: "str | None" = None
+    timeout_s: "float | None" = None
+
+    def __bool__(self) -> bool:
+        # Truthy iff delivered — so an ``if not outcome:`` reads as before.
+        return self.kind == "delivered"
+
+    @classmethod
+    def delivered(cls, payload: dict) -> "ControlOutcome":
+        return cls(kind="delivered", payload=payload)
+
+    @classmethod
+    def refused(cls, status: int, reason: "str | None") -> "ControlOutcome":
+        return cls(kind="refused", status=status, reason=reason)
+
+    @classmethod
+    def not_delivered(cls, cause: str, timeout_s: "float | None") -> "ControlOutcome":
+        return cls(kind="not_delivered", cause=cause, timeout_s=timeout_s)
+
+
+def describe_control_failure(outcome: "ControlOutcome | None") -> "str | None":
+    """The outcome's own wording for a failure line, or ``None`` when there
+    is nothing to add (delivered, or no typed outcome recorded — an
+    untyped sender, the local transport). One function, so a refusal and a
+    non-delivery can never read the same on any surface."""
+    if outcome is None or outcome.kind == "delivered":
+        return None
+    if outcome.kind == "refused":
+        detail = f" ({outcome.status}: {outcome.reason})" if outcome.reason else f" ({outcome.status})"
+        return f"the server refused it{detail}"
+    within = f" within {outcome.timeout_s:g}s" if outcome.timeout_s is not None else ""
+    cause = f" [{outcome.cause}]" if outcome.cause else ""
+    return (
+        f"the server did not respond{within}{cause} — the request may not have "
+        "reached it"
+    )
+
+
+__all__ = ["ControlOutcome", "Kind", "describe_control_failure"]

--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -301,6 +301,12 @@ class ThreadedTransportProxy(ClientTransport):
     def attach_failed(self) -> bool:
         return self._latest.attach_failed
 
+    def last_control_outcome(self):
+        # #5907 ②: an immutable record set by the worker's own last POST —
+        # a cross-thread read of one attribute, no live object crosses.
+        inner = self._inner
+        return inner.last_control_outcome() if inner is not None else None
+
     def pending_intervention_head(self) -> "str | None":
         return self._latest.pending_intervention_head
 

--- a/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
+++ b/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
@@ -339,12 +339,11 @@ async def test_the_tui_runs_a_command_without_submitting_it_as_a_turn(
     (the Composer's production entry) over a real ``ClientTransport``. Paired
     with the same negative: bare text still goes to ``submit_user_text``.
 
-    #5894 ①-2: the slash layer runs synchronously on the handler (its answer
-    is on screen when ``_submit`` returns — asserted right after the call),
-    while a bare line's ``submit_user_text`` round-trip runs on a Textual
-    worker — so the app must be running, and the inbox is waited on as a
-    CONDITION (unbounded; CI's ``--timeout`` is the kill switch), never
-    asserted at the instant ``_submit`` returns.
+    #5907 ①: both a command's run unit and a bare line's ``submit_user_
+    text`` round-trip go through the app's single-in-flight wire FIFO (a
+    Textual worker) — so the app must be running, and each effect is waited
+    on as a CONDITION (unbounded; CI's ``--timeout`` is the kill switch),
+    never asserted at the instant ``_submit`` returns.
     """
     import asyncio
 
@@ -370,6 +369,10 @@ async def test_the_tui_runs_a_command_without_submitting_it_as_a_turn(
 
     async with app.run_test(size=(100, 30)) as pilot:
         await app._submit("/help", local_id="local:test-help")
+        # #5907 ①: the run unit goes through the app's wire FIFO worker —
+        # its output is waited for as a condition (CI's --timeout is the red).
+        while "Slash commands:" not in transport.system_text():
+            await pilot.pause()
         assert "Slash commands:" in transport.system_text(), (
             "the TUI did not run /help as a command; _submit is not going through "
             f"the shared client-side slash layer. shown={transport.texts()!r}"

--- a/tests/interfaces/test_5894_control_timeout_and_coalesce.py
+++ b/tests/interfaces/test_5894_control_timeout_and_coalesce.py
@@ -77,8 +77,8 @@ def _url(server) -> str:
 @pytest.mark.asyncio
 async def test_a_control_post_against_a_silent_server_is_a_non_delivery_after_t():
     """Tier 2: the accept side of ①-1. With T supplied, a POST the server
-    never answers returns ``None`` (non-delivery) instead of waiting
-    forever — and the client it went through still carries the stream's
+    never answers returns a falsy ``not_delivered`` outcome (#5907 ②)
+    instead of waiting forever — and the client it went through still carries the stream's
     ``read=None``, so the stream's policy was not the one that ended it."""
     hold = asyncio.Event()
     server = await _silent_server(hold)
@@ -88,7 +88,10 @@ async def test_a_control_post_against_a_silent_server_is_a_non_delivery_after_t(
                 client, _url(server), params={}, payload={"type": "cancel_inflight"},
                 timeout_s=_T,
             )
-            assert result is None, f"a silent server was read as an accept: {result!r}"
+            # #5907 ②: typed — a non-delivery, falsy, naming its cause and T.
+            assert not result and result.kind == "not_delivered", (
+                f"a silent server was read as an accept: {result!r}"
+            )
             assert client.timeout.read is None, (
                 "the control timeout leaked into the client's default — the SSE "
                 f"stream would now time out too: {client.timeout!r}"
@@ -102,9 +105,9 @@ async def test_a_control_post_against_a_silent_server_is_a_non_delivery_after_t(
 @pytest.mark.asyncio
 async def test_a_control_post_the_server_answers_is_an_accept():
     """Tier 2: the discriminating control — the same call against a server
-    that answers returns the parsed body, so the ``None`` above is the
-    timeout's doing and not ``post_control`` returning ``None`` for
-    everything."""
+    that answers returns a delivered outcome carrying the parsed body, so
+    the non-delivery above is the timeout's doing and not ``post_control``
+    failing everything."""
     server = await _answering_server(b'{"msg_id": "m1"}')
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(None, connect=10.0)) as client:
@@ -112,7 +115,7 @@ async def test_a_control_post_the_server_answers_is_an_accept():
                 client, _url(server), params={}, payload={"type": "cancel_inflight"},
                 timeout_s=_T,
             )
-            assert result == {"msg_id": "m1"}
+            assert result and result.kind == "delivered" and result.payload == {"msg_id": "m1"}
     finally:
         server.close()
         await server.wait_closed()

--- a/tests/interfaces/test_5894_pump_never_awaits_wire.py
+++ b/tests/interfaces/test_5894_pump_never_awaits_wire.py
@@ -25,8 +25,9 @@ What each proves, and what its red looks like:
   says so here because a hang wears no colour of its own.
 - The "cancel requested…" row is on the pane BEFORE the wire answers.
 - A cancel the transport could not deliver (the EMPTY summary the ABC
-  reserves for it, #5894) is named on the pane as "not responding" — the
-  silence this issue was reported as gets a row.
+  reserves for it, #5894) is named on the pane — the silence this issue
+  was reported as gets a row (its exact wording comes from the typed
+  outcome when the transport records one, #5907 ②).
 - Ctrl-Q needs no wire at all: not this file's subject (Textual's binding,
   a one-line ``shutdown``), stated so nobody looks for it here.
 """
@@ -165,7 +166,8 @@ async def test_cancel_requested_is_drawn_before_the_wire_answers() -> None:
 @pytest.mark.asyncio
 async def test_an_undelivered_cancel_is_named_not_responding() -> None:
     """Tier 2b: the transport's EMPTY summary (a control timeout / send
-    failure) reaches the operator as a row — and the app stays up."""
+    failure) reaches the operator as a row — and the app stays up. This
+    stub records no typed outcome, so the row is the fallback wording."""
     transport = _UnacknowledgedCancelTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
@@ -174,7 +176,10 @@ async def test_an_undelivered_cancel_is_named_not_responding() -> None:
         await pilot.pause()
         await pilot.pause()
         texts = _pane_texts(app)
-        assert any("not responding" in t for t in texts), (
+        # #5907 ②: this stub records no typed outcome, so the row carries the
+        # honest fallback ("did not acknowledge") — the refused / not-delivered
+        # wording is the typed transport's (test_5907_typed_control_outcome.py).
+        assert any("did not acknowledge the cancel" in t for t in texts), (
             f"an undelivered cancel left only 'requested' on the pane: {texts!r}"
         )
         assert app.is_running, "a non-delivery tore the app down"

--- a/tests/interfaces/test_5907_dispatcher_fifo.py
+++ b/tests/interfaces/test_5907_dispatcher_fifo.py
@@ -1,0 +1,164 @@
+"""Tier 2b: #5907 ① — the TUI's pump never awaits a slash command's wire
+round-trip, and the round-trips run one at a time, in typed order.
+
+Owner-hit class (#5894): with the server not answering, a command that
+touched the wire held the message pump for the whole wait, and every later
+key — Ctrl-Q included — queued behind it. #5902 closed that for Enter and
+Ctrl-C; the slash layer's own wire calls (27 of 32 commands, #5907 census)
+still ran on the handler, bounded only by the control timeout T. The
+architect's ruling ①: T is one round-trip's bound, not the operator's (N
+presses → N×T), and the only exit lives in the pump that is stuck — so the
+dispatcher hands its run unit to a worker, and the app keeps a SINGLE
+in-flight FIFO so effects keep the order the serial pump used to give.
+
+Real keypresses on a real ``TextualChatApp`` over a real minimal
+``ClientTransport`` whose ``request_session_list`` HOLDS on an
+``asyncio.Event`` the test controls — "the server has not answered" as a
+state, never a duration. The plain CUI is untouched (no ``runner``).
+
+What each proves, and its red:
+
+- While ``/session list`` is held, Ctrl-Q still exits. Strip: run the
+  dispatcher's unit inline (``runner=None`` in ``_submit``) — the Ctrl-Q
+  press is never delivered; the red is a HANG CI's ``--timeout`` kills,
+  disclosed here because a hang wears no colour.
+- FIFO: ``/help`` typed behind the held ``/session list`` draws NOTHING
+  until the list is released, then both draw, list first. Strip: run each
+  unit on its own worker — ``/help``'s rows appear while the list is still
+  held → red, deterministically (the first unit never returns until the
+  test says so).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _HeldListTransport(ClientTransportStub):
+    """A real minimal transport: ``request_session_list`` holds until
+    released; everything it is told to display is recorded on the app's
+    own frame path (so the pane shows it) — ``put_display`` re-enters the
+    stream the app pumps, exactly as ``InProcessTransport`` does."""
+
+    def __init__(self) -> None:
+        self.release = asyncio.Event()
+        self.list_calls = 0
+        self._frames: "asyncio.Queue[DisplayFrame]" = asyncio.Queue()
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            yield await self._frames.get()
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._frames.put_nowait(DisplayFrame(msg))
+
+    async def request_session_list(self) -> "list[dict]":
+        self.list_calls += 1
+        await self.release.wait()
+        return [{"sid": "main", "attached": True}]
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None,
+    ) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self):
+        return None
+
+    async def cancel_inflight(self) -> str:
+        return "cancelled"
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _pane_texts(app: TextualChatApp) -> list[str]:
+    return [entry.item.text for entry in app.conversation]
+
+
+async def _type_command(pilot, app: TextualChatApp, text: str) -> None:
+    app.query_one(Composer).focus()
+    await pilot.pause()
+    await pilot.press(*text)
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_ctrl_q_exits_while_session_list_is_held_on_the_wire() -> None:
+    """Tier 2b: the owner-hit shape, for a slash command. The list's
+    round-trip is in flight and held; Ctrl-Q must still be delivered."""
+    transport = _HeldListTransport()
+    app = TextualChatApp(transport=transport)
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await _type_command(pilot, app, "/session list")
+            assert transport.list_calls == 1, "setup: /session list never reached the wire"
+            assert not transport.release.is_set(), "setup: the list must still be held"
+            assert app.is_running
+
+            await pilot.press("ctrl+q")
+            await pilot.pause()
+            assert not app.is_running, (
+                "ctrl+q was not delivered while /session list was unanswered — "
+                "the dispatcher's unit is awaited on the pump again (#5907 ①)"
+            )
+    finally:
+        transport.release.set()
+
+
+@pytest.mark.asyncio
+async def test_units_run_one_at_a_time_in_typed_order() -> None:
+    """Tier 2b: single in-flight FIFO. ``/help`` typed behind a held
+    ``/session list`` draws nothing until the list is released; then the
+    list's result precedes ``/help``'s."""
+    transport = _HeldListTransport()
+    app = TextualChatApp(transport=transport)
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await _type_command(pilot, app, "/session list")
+            await _type_command(pilot, app, "/help")
+            await pilot.pause()
+            assert transport.list_calls == 1, "setup: the list unit never started"
+            held_texts = _pane_texts(app)
+            assert not any("Slash commands:" in t for t in held_texts), (
+                "/help ran while /session list was still in flight — units are "
+                f"concurrent, not a FIFO; pane: {held_texts!r}"
+            )
+
+            transport.release.set()
+            while not any("Slash commands:" in t for t in _pane_texts(app)):
+                await pilot.pause()
+            texts = _pane_texts(app)
+            list_idx = next(i for i, t in enumerate(texts) if "main" in t and "session" in t.lower())
+            help_idx = next(i for i, t in enumerate(texts) if "Slash commands:" in t)
+            assert list_idx < help_idx, f"results out of typed order: {texts!r}"
+    finally:
+        transport.release.set()

--- a/tests/interfaces/test_5907_typed_control_outcome.py
+++ b/tests/interfaces/test_5907_typed_control_outcome.py
@@ -1,0 +1,189 @@
+"""Tier 2: #5907 ② — a control POST's outcome is TYPED, and a refusal and a
+non-delivery never read the same on any surface.
+
+Before: ``post_control`` returned ``None`` for "the server said no" and for
+"the server never answered", and every slash handler's ``if not ok:`` drew
+one line for both — so an operator whose ``/session switch`` timed out
+(the request possibly delivered) read the same words as one whose switch
+was refused. Architect (#5907): a falsy carrying two facts is the fail-open
+class; make the two unrepresentable together with a type, and render the
+failure line in ONE place so the 27 handlers say the right thing unedited.
+
+Everything here is real: real TCP listeners (one silent, one refusing with
+a 403 body, one accepting), a real ``httpx.AsyncClient``, the real
+``post_control`` with T supplied as an INPUT, a real ``AgUiTransport``
+whose ``send`` IS ``post_control``, and the real client-side slash layer
+(``maybe_dispatch_slash``) drawing its line through the real
+``reply_error``. The line is read off the transport's own ``put_display``
+(the slash layer's display seam), captured by a real subclass.
+
+Strip (verified): making ``post_control`` return ``None`` for both failures
+(the pre-#5907 shape) makes ``test_a_refusal_and_a_non_delivery_draw_
+different_lines`` red — the two ``/session switch`` lines become identical.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import httpx
+import pytest
+
+from reyn.interfaces.repl.remote_client import post_control
+from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.control_outcome import ControlOutcome, describe_control_failure
+
+_T = 0.05  # the injected control timeout — the subject, not a wait
+
+
+async def _silent_server(hold: asyncio.Event):
+    async def handler(reader, writer) -> None:
+        try:
+            await reader.read(65536)
+            await hold.wait()
+        finally:
+            writer.close()
+
+    return await asyncio.start_server(handler, "127.0.0.1", 0)
+
+
+async def _answering_server(status_line: bytes, body: bytes):
+    async def handler(reader, writer) -> None:
+        try:
+            await reader.read(65536)
+            writer.write(
+                status_line + b"\r\nContent-Type: application/json\r\n"
+                + f"Content-Length: {len(body)}\r\n".encode()
+                + b"Connection: close\r\n\r\n" + body
+            )
+            await writer.drain()
+        finally:
+            writer.close()
+
+    return await asyncio.start_server(handler, "127.0.0.1", 0)
+
+
+def _url(server) -> str:
+    return f"http://127.0.0.1:{server.sockets[0].getsockname()[1]}/agui/chat/alpha"
+
+
+# ── post_control: three outcomes, three kinds ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_control_names_the_three_outcomes():
+    """Tier 2: delivered / refused / not_delivered are distinct, typed, and
+    the outcome is truthy iff delivered (the old ``if accepted:`` contract)."""
+    hold = asyncio.Event()
+    silent = await _silent_server(hold)
+    refusing = await _answering_server(b"HTTP/1.1 403 Forbidden", b'{"detail": "bad token"}')
+    accepting = await _answering_server(b"HTTP/1.1 200 OK", b'{"msg_id": "m1"}')
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(None, connect=10.0)) as client:
+            nd = await post_control(client, _url(silent), params={}, payload={"type": "x"}, timeout_s=_T)
+            rf = await post_control(client, _url(refusing), params={}, payload={"type": "x"}, timeout_s=_T)
+            ok = await post_control(client, _url(accepting), params={}, payload={"type": "x"}, timeout_s=_T)
+    finally:
+        hold.set()
+        for s in (silent, refusing, accepting):
+            s.close()
+            await s.wait_closed()
+
+    assert nd.kind == "not_delivered" and not nd and nd.timeout_s == _T and nd.cause, nd
+    assert rf.kind == "refused" and not rf and rf.status == 403 and "bad token" in (rf.reason or ""), rf
+    assert ok.kind == "delivered" and ok and ok.payload == {"msg_id": "m1"}, ok
+
+
+def test_the_describer_never_words_a_refusal_like_a_non_delivery():
+    """Tier 1: the ONE wording function — a refusal names the server's
+    reason; a non-delivery says the request may not have reached it (the
+    non-idempotent operator's question); delivered / untyped add nothing."""
+    refused = describe_control_failure(ControlOutcome.refused(403, "bad token"))
+    lost = describe_control_failure(ControlOutcome.not_delivered("ReadTimeout", 10.0))
+    assert refused and "refused" in refused and "bad token" in refused
+    assert lost and "may not have reached" in lost and "10" in lost
+    assert refused != lost
+    assert describe_control_failure(ControlOutcome.delivered({})) is None
+    assert describe_control_failure(None) is None
+
+
+# ── end to end: the slash layer's line, through the real renderer ──────────
+
+
+class _DisplayCapturingTransport(AgUiTransport):
+    """The real ``AgUiTransport`` with its display seam captured — the
+    slash layer's ``reply_error`` lands here."""
+
+    def __init__(self, send) -> None:
+        super().__init__(_no_lines(), send)
+        self.shown: "list[tuple[str, str]]" = []
+
+    def put_display(self, msg) -> None:
+        self.shown.append((msg.kind, msg.text))
+
+
+async def _no_lines() -> AsyncIterator[str]:
+    if False:  # pragma: no cover
+        yield ""
+
+
+def _sender(client, server):
+    """The real ``post_control`` bound to one listener, with T supplied —
+    the ``send`` callable ``remote_client.py`` hands ``AgUiTransport``."""
+    async def send(payload: dict):
+        return await post_control(client, _url(server), params={}, payload=payload, timeout_s=_T)
+    return send
+
+
+async def _switch_line_against(server, client) -> str:
+    transport = _DisplayCapturingTransport(_sender(client, server))
+    handled = await maybe_dispatch_slash(transport, "/session switch other", echo=False)
+    assert handled, "setup: /session switch was not dispatched"
+    errors = [t for k, t in transport.shown if k == "error"]
+    assert errors, f"setup: no error line was drawn; shown={transport.shown!r}"
+    return errors[-1]
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_and_a_non_delivery_draw_different_lines():
+    """Tier 2: the accept side, end to end. The SAME command, unedited
+    handler, against a server that refuses and one that never answers:
+    the two error lines differ, and each says which it was."""
+    hold = asyncio.Event()
+    silent = await _silent_server(hold)
+    refusing = await _answering_server(b"HTTP/1.1 409 Conflict", b'{"detail": "no such session"}')
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(None, connect=10.0)) as client:
+            lost_line = await _switch_line_against(silent, client)
+            refused_line = await _switch_line_against(refusing, client)
+    finally:
+        hold.set()
+        for s in (silent, refusing):
+            s.close()
+            await s.wait_closed()
+
+    assert lost_line != refused_line, (
+        f"a timeout and a refusal read the same: {lost_line!r}"
+    )
+    assert "may not have reached" in lost_line, lost_line
+    assert "refused" in refused_line and "no such session" in refused_line, refused_line
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_control_adds_nothing_to_a_later_error_line():
+    """Tier 2: the discriminating control — after a DELIVERED POST, an
+    unrelated error line (a typo) is drawn plain: the renderer decorates
+    only a recorded failure, never the last success."""
+    accepting = await _answering_server(b"HTTP/1.1 200 OK", b'{"switched": true}')
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(None, connect=10.0)) as client:
+            transport = _DisplayCapturingTransport(_sender(client, accepting))
+            assert await transport.request_session_switch("s2") is True
+            await maybe_dispatch_slash(transport, "/halp", echo=False)
+            errors = [t for k, t in transport.shown if k == "error"]
+    finally:
+        accepting.close()
+        await accepting.wait_closed()
+    assert errors and "unknown command" in errors[-1]
+    assert "refused" not in errors[-1] and "may not have reached" not in errors[-1], errors[-1]


### PR DESCRIPTION
**[tui-coder]** — #5907 の裁定 **②**（typed outcome ＋ 共有 renderer、1 commit 目）と **①**（dispatcher の run unit を runner へ、TUI は単一 in-flight FIFO、2 commit 目）。裁定順どおり ② が先。base は `main`（lead 指摘: `delete_branch_on_merge` のため stack しない）— #5902 の commit を含むので、#5902 着地までは diff にそれも見えます。

part of #5907

## 機構（handler は 1 つも触らない）

- `transport/control_outcome.py`（新）: `ControlOutcome(kind ∈ delivered | refused | not_delivered, payload, status, reason, cause, timeout_s)`。**truthy ⇔ delivered** なので既存の `if not ok:` はそのまま。`describe_control_failure()` が**唯一の文言関数**: refused は server の理由をそのまま、not_delivered は「T 秒応答なし — 要求は届いていない可能性」（冪等でない要求ほど言うべきこと）。
- `remote_client.post_control()` が typed outcome を返す（≥300 は body の `detail`/`error` を理由に、raise は例外 class を cause に）。
- `AgUiTransport`: 構築時に `send` を **記録する wrapper** で包む — 最新 outcome を保持し、10 箇所の call site には従来どおり `dict | None` を渡す（**site 無変更**）。`last_control_outcome()` で読める。ABC に default `None` の読みを足し（wire の無い transport は報告するものが無い）、`DelegatingClientTransport` / `_ErrorWatchingTransport` / `ThreadedTransportProxy` が転送。
- 共有 renderer: `slash.reply_error` と `dispatch._display(kind="error")` が `dispatch.with_control_failure()` で outcome の文言を末尾に付ける ∴ census の **27 command** が編集なしに「拒否」と「無応答」を言い分ける。`/cancel` と TUI の interrupt 行（#5902 の "not responding"）も同じ describer に上げた — untyped の fallback は「did not acknowledge」（事実として言えるのはそこまで）。

## 裁定の witness

- [x] **server が明示的に拒否した場合と無応答の場合で行の文言が異なる** — `tests/interfaces/test_5907_typed_control_outcome.py::test_a_refusal_and_a_non_delivery_draw_different_lines`: 実 TCP listener（409 + body／黙る）、実 `httpx`、実 `post_control`（T 注入）、実 `AgUiTransport`（`send` = `post_control`）、実 slash 層経由の **同じ** `/session switch` → 2 行が異なり、各々が理由を言う。**strip 済**: `post_control` を両失敗で `None` に戻す → 2 行同文言 → 赤（2 failed）。
- [x] `post_control` の 3 outcome（`::test_post_control_names_the_three_outcomes`）、describer の非同文言（`::test_the_describer_never_words_a_refusal_like_a_non_delivery`）、delivered 後の無関係 error 行に何も付かない（`::test_a_delivered_control_adds_nothing_to_a_later_error_line`、判別子）。
## ①（2 commit 目）

- `dispatch.maybe_dispatch_slash(..., runner=None)`: run unit（session-locus は `run_slash_command` の POST 1 本、connection/client-locus は handler 実行そのもの — handler 内の transport await はこの unit に乗る ∴ **handler 無編集**）を `runner` に渡して即 return。CUI は runner 無し（inline、input loop は pump でない）。
- `TextualChatApp._submit` → `_enqueue_wire`: **単一 in-flight FIFO**（`asyncio.Queue` ＋ Textual worker 1 本、`exclusive=False`）。通常 submit の往復も同じ FIFO ∴ `/model X` → message、`/session switch` → `/compact` の効果順序は pump 直列時代のまま。詰まった unit は次を待たせる（UI は生きている）、T が backstop。`/cancel` の連打 coalesce は #5902 の transport 側。
- witness（`tests/interfaces/test_5907_dispatcher_fifo.py`、実 keypress、`request_session_list` を Event で保留する実 minimal transport）:
  - [x] server が応答しない構成で `/session list` → **Ctrl-Q が即効く**（strip: `_submit` を inline dispatch に戻す → hang → `--timeout` で赤、2 failed）
  - [x] 連打（`/session list` 保留中に `/help`）で pump は止まらず、`/help` の結果は list 解放まで出ず、解放後は **打った順**（strip: unit ごとに worker → `/help` が保留中に出る → 赤、決定的）
  - [x] `/cancel` 連打の coalesce — `test_5894_control_timeout_and_coalesce.py::test_a_second_cancel_while_one_is_pending_sends_nothing`（既存）
- `test_3595` の TUI `/help` assert は FIFO の効果を条件待ちに（#5902 で「同期」にした形を裁定①で置き換え）。

## 追従

- `test_5894_control_timeout_and_coalesce.py` の `post_control` の assert を typed に、`test_5894_pump_never_awaits_wire.py` の untyped stub 行を fallback 文言に。`docs/reference/runtime/agui-transport.md` の #5894 段落を typed outcome の記述に。

## Test plan

- [x] scoped pytest: ② 16 file **112 passed**、① 24 file（rewind picker／quit／sent-queue／composer completion／remote rewind／transport 系）**188 passed**
- [x] ruff / tier audit --strict / verify_module_docstrings / mypy_ratchet / flat / path-literal / tests 系 3 本 / mkdocs --strict → anchors → retired keys すべて OK
- [ ] Visual: 拒否 vs 無応答の 2 行（standing waiver）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
