### PR TITLE
test(#5914): read the on-disk snapshot only after the journal's durability barrier

### DIFF
--- a/tests/core/test_1800_c_staging.py
+++ b/tests/core/test_1800_c_staging.py
@@ -385,6 +385,7 @@ async def test_c_staging_cleared_durably_after_injection(
     )
 
     # Snapshot must have empty next_turn_context.
+    await session.journal.flush()  # #5914: the clear is a queued snapshot save (save_nowait)
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     n_ntc = len(snapshot.next_turn_context)
     assert n_ntc == 0, (
@@ -461,6 +462,7 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
         f"returns (in run_one_iteration), so the WAL would still be empty here."
     )
 
+    await session.journal.flush()  # #5914: the staging is a queued snapshot save (save_nowait)
     snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     n_snap = len(snap.next_turn_context)
     assert n_snap == 1, (
@@ -485,6 +487,11 @@ async def test_c_staging_durable_during_drain_wait(tmp_path) -> None:
         state_log=StateLog(tmp_path / "state2.wal"),
         snapshot_path=session._snapshot_path,
     )
+    # #5914: the staged entry's snapshot save was queued by the (now cancelled)
+    # drain task; the WAL worker still lands it — "crash" here means the
+    # drain task died, not the durability worker — so wait for it before
+    # reading what a real restore would find on disk.
+    await session.journal.flush()
     recovered_snap = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     session2.restore_state(recovered_snap)
 

--- a/tests/core/test_1800_wake_drain.py
+++ b/tests/core/test_1800_wake_drain.py
@@ -141,6 +141,7 @@ async def test_wake_drain_equivalence_single_message(tmp_path, monkeypatch) -> N
     )
 
     # Snapshot inbox must be empty: message was consumed.
+    await session.journal.flush()  # #5914: consume_inbox persists via save_nowait (queued)
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     assert snapshot.inbox == [], (
         f"Snapshot inbox must be empty after consumption; got {snapshot.inbox}"
@@ -333,6 +334,7 @@ async def test_drain_to_wake_inbox_consume_per_message(tmp_path) -> None:
     )
 
     # Snapshot inbox must be empty: both messages consumed.
+    await session.journal.flush()  # #5914: consume_inbox persists via save_nowait (queued)
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     assert snapshot.inbox == [], (
         f"Snapshot inbox must be empty after drain; got {snapshot.inbox}"

--- a/tests/runtime/test_session_invariants.py
+++ b/tests/runtime/test_session_invariants.py
@@ -271,6 +271,7 @@ async def test_chain_register_emits_wal_event(tmp_path, monkeypatch):
     assert "waiting_on" in ev, f"Missing 'waiting_on' in WAL event: {ev}"
 
     # Snapshot must reflect the chain as pending.
+    await session.journal.flush()  # #5914: the register's snapshot save is queued (save_nowait)
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     assert "chain-reg-001" in snapshot.pending_chains, (
         f"chain-reg-001 not found in snapshot.pending_chains: {snapshot.pending_chains}"
@@ -325,6 +326,13 @@ async def test_chain_resolve_clears_snapshot_and_emits_resolve(tmp_path, monkeyp
     })
 
     # Snapshot must NOT contain the chain after resolve.
+    # #5914: the resolve persists its snapshot with ``save_nowait`` (#2259
+    # PR-2b — a queued durable write, the hot path never awaits it), so the
+    # on-disk file is only guaranteed current after the journal's barrier.
+    # Measured on main: the chain was still on disk right after the await
+    # and gone 2.6 ms later — a late write, not a lost one — which read as
+    # a 1-in-3 red on unrelated PRs.
+    await session.journal.flush()
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     assert "chain-res-001" not in snapshot.pending_chains, (
         f"chain-res-001 still present in snapshot after resolve: {snapshot.pending_chains}"
@@ -694,6 +702,7 @@ async def test_inbox_put_consume_emits_wal_events_with_monotonic_seq(tmp_path, m
 
     # Snapshot applied_seq must equal the highest seq in the WAL.
     max_seq = max(all_seqs)
+    await session.journal.flush()  # #5914: applied_seq is stamped by the queued snapshot job
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     assert snapshot.applied_seq == max_seq, (
         f"snapshot.applied_seq {snapshot.applied_seq} != max WAL seq {max_seq}"
@@ -987,6 +996,7 @@ async def test_p6_chain_state_changes_emit_events(tmp_path, monkeypatch):
         )
 
     # External snapshot read — verify pending_chains is empty post-resolve.
+    await session.journal.flush()  # #5914: same queued save as the resolve test above
     snapshot = AgentSnapshot.load(session.agent_name, session._snapshot_path)
     assert snapshot.pending_chains == {}, (
         f"pending_chains must be empty after resolve, got: {snapshot.pending_chains!r}"


### PR DESCRIPTION
**[e2e-coder]** — Closes #5914.

## Mechanism (one sentence) and its strip

`ChainManager` resolves a chain through `SnapshotJournal.record_chain_resolve`, which persists the snapshot with **`save_nowait()`** — a durable write *queued* on the WAL worker (#2259 PR-2b: "the hot path NEVER awaits durability") — and the test read the on-disk snapshot synchronously right after the `await` returned, so it saw whichever of the two happened first.

Measured on `main` (a probe that re-reads the file until the chain is gone): on the red run the chain was **present right after the await and gone 2.6 ms later**; on green runs it was already gone at the first read (~0.05 ms). A **late** write, not a lost one — the production contract is intact, the test read too early. The first run after a cold start is the slow one (lead's 2/6 were runs 1–2; mine was run 1 of 12), which is why this bites a fresh CI worker and not a warm laptop.

Strip: remove `await session.journal.flush()` from the resolve test → **2 red / 20** (measured, this branch); with it → **0 red / 20**.

## Fix (tests only, `src/` untouched)

`await session.journal.flush()` — the journal's own barrier ("drain every enqueued durable write … so a caller (or test) can observe a fire-and-forget mutation's durable effect"), already used with the exact #2259 comment at `test_1800_c_staging.py:300` — immediately before the on-disk read.

## Census — every on-disk snapshot read after a queued write (acceptance ③)

`grep -rn "AgentSnapshot.load(" tests/` = 22 files. Classified by what precedes each read:

| class | sites | action |
|---|---|---|
| **same shape — read right after a `save_nowait` path, no barrier** | `test_session_invariants.py` `:274` (register), `:328` (the flaky one, resolve), `:697` (`applied_seq` after turns), `:990` (resolve); `test_1800_wake_drain.py` `:144`, `:336` (inbox consume); `test_1800_c_staging.py` `:388` (context cleared), `:464` (staged during drain), `:488` (staged, then the drain *task* cancelled — the worker still lands the write) | `await session.journal.flush()` before the read — 9 sites, same PR |
| already behind a barrier | `test_1800_c_staging.py:319` (behind the `:300` flush); `test_2242:281`, `test_5647:306`, `test_5654:337`, `test_1765:128`, `test_3792:610`, `test_3300:224`, `test_2839:167` (all behind `state_log.aclose()`, a drain) | none |
| self-settling poll | `test_1800_c_staging.py:448` (`while not …load()…`) | none |
| the test wrote the file itself / no session worker | `test_session_invariants.py:601` (`snap.save()`), `test_agent_snapshot.py`, `test_snapshot_applied_seq_coerce.py`, `test_durable_answer_buffer.py`, `test_5786`, `test_5769_*`, `test_registry_*`, `test_live_*`, `test_concurrent_multiagent_rewind_1580.py`, `test_agent_archive_delete_1954.py` (registry ops that `await` their own saves, or files the test writes) | none |

## Test plan

- [x] the flaky test 20× consecutively on this branch: 0 red (acceptance ②)
- [x] strip executed (barrier removed, restored after): 2 red / 20
- [x] the three edited files whole (32 passed) · `ruff check .` · `test_tier_audit.py --strict` on the 3 files · `mypy_ratchet.py` · `flat_tests_ratchet` · `check_tests_path_literal_reference` (re-run before push) · `check_bare_tests_import_reference` · `check_file_depth_reference` · `check_subprocess_reyn_pin`
- [x] import identity verified against the worktree `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
