### PR TITLE
test(#5856): stage2_bang reads the attachment queue through the public accessor

### DIFF
--- a/tests/interfaces/test_5837_exec_slash_stage2_bang.py
+++ b/tests/interfaces/test_5837_exec_slash_stage2_bang.py
@@ -68,8 +68,8 @@ async def test_bang_bang_and_slash_exec_produce_the_same_reply(tmp_path):
     assert reply_kind_bang == reply_kind_slash
     assert any("exit 0" in t and "4" in t for t in slash_texts), slash_texts
 
-    bang_queue = bang_session._pending_user_attachments
-    slash_queue = slash_session._pending_user_attachments
+    bang_queue = bang_session.pending_user_attachments
+    slash_queue = slash_session.pending_user_attachments
     assert not bang_queue
     assert not slash_queue
 
@@ -89,8 +89,8 @@ async def test_bang_and_slash_exec_attach_both_queue_the_same_block(tmp_path):
     slash_ctx_ = slash_ctx(slash_session)
     await maybe_dispatch_slash(slash_ctx_.transport, f"/exec-attach {cmdline}")
 
-    (bang_block,) = bang_session._pending_user_attachments
-    (slash_block,) = slash_session._pending_user_attachments
+    (bang_block,) = bang_session.pending_user_attachments
+    (slash_block,) = slash_session.pending_user_attachments
     assert bang_block["type"] == slash_block["type"] == "text"
     assert "2" in bang_block["text"] and "exit 0" in bang_block["text"]
     assert bang_block["text"] == slash_block["text"], (
@@ -112,7 +112,7 @@ async def test_double_bang_is_not_misrouted_to_exec_attach(tmp_path):
     ctx = slash_ctx(session)
     await maybe_dispatch_slash(ctx.transport, '!!python3 -c "print(3+3)"')
 
-    queue = session._pending_user_attachments
+    queue = session.pending_user_attachments
     assert not queue, "!! must never queue an attachment -- that is /exec-attach's job"
     texts = _texts(ctx)
     assert any("6" in t for t in texts), texts
@@ -135,7 +135,7 @@ async def test_bare_bang_is_an_explicit_error_not_a_submitted_message(tmp_path, 
     assert consumed is True, f"{bare!r} alone must be consumed, not forwarded as a turn"
     kinds = [m.kind for m in ctx.transport.displayed]
     assert "error" in kinds, ctx.transport.displayed
-    queue = session._pending_user_attachments
+    queue = session.pending_user_attachments
     assert not queue
 
 


### PR DESCRIPTION
**[lead-coder-subagent]** — part of #5856

Replaces the 6 private-state reads (`session._pending_user_attachments`) in
`tests/interfaces/test_5837_exec_slash_stage2_bang.py` with the public
`session.pending_user_attachments` property (`src/reyn/runtime/session.py:3969`,
added by #5856). Only this test file was touched — `test_4497_resident_slash.py`
and `test_4497_resident_stats.py` are out of scope (lead-coder ruling: the
accessor is read-only and those files exercise setup writes).

`pending_user_attachments` returns a tuple **copy**, not the live list
`_pending_user_attachments` is. Checked every one of the 6 sites: all 6 read
the queue AFTER the `await maybe_dispatch_slash(...)` that mutates it has
already completed, so no read needed to move relative to the mutation — a
straight substitution keeps each test's original subject unchanged.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_5837_exec_slash_stage2_bang.py` — 6/6 OK, 0 errors
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK (ratchet unchanged)
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (ratchet unchanged)
- [x] `pytest tests/interfaces/test_5837_exec_slash_stage2_bang.py -v` — 7 passed
- [x] Strip-falsify: temporarily made `Session.pending_user_attachments` always return `()`, re-ran the scoped suite — `test_bang_and_slash_exec_attach_both_queue_the_same_block` went RED (`ValueError: not enough values to unpack`), confirming the accessor path is actually exercised; reverted the src edit and confirmed GREEN + clean `git status`/`git diff`.
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LZ2nN392xjGJNJzpCc8T5
