### PR TITLE
docs: verification-hazards.md -- add a Misidentification instance (CI check-suite mismatch)

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1206,19 +1206,28 @@ missing one.
   .../merge` call: `"2 of 7 required status checks are expected."`
   `expected` means "no report under that name exists yet" — not "pending,"
   not "failed," and nothing in the rollup or `gh pr checks` distinguishes
-  it from either. The cause: the SAME workflow produced TWO check suites on
-  one head, and the newer one was skipped by a path filter before its
-  matrix ever expanded — so it reported a single job still literally named
-  `pytest (Python ${{ matrix.python-version }})`, never the two expanded
-  names (`pytest (Python 3.11)` / `(Python 3.12)`) branch protection
-  actually requires. Those two names existed and were green — under the
-  OLDER suite, the one that had actually run — but branch protection
-  consults the LATEST suite per workflow, where the names were never
-  written at all: a genuine absence at the exact (name, suite) pair branch
-  protection reads, invisible to every aggregate view that blends across
-  suites instead of asking "does THIS suite's report for THIS name exist"
-  (#5912). The rollup's SUCCESS was real; it just never named which suite,
-  of the two, it was a rollup of.
+  it from either. **Two check suites on one head is the NORMAL case, not
+  the hazard** — of five heads measured the same night, three carried two
+  suites, and two of those three were perfectly healthy (including the PR
+  this very instance was added by). The hazard is specifically WHICH suite
+  is newer getting reversed: branch protection consults the LATEST suite
+  per workflow, and here the suite that had actually run the full matrix
+  (with the two expanded names, `pytest (Python 3.11)` / `(Python 3.12)`,
+  branch protection requires) was an OLDER attempt — a re-run of a prior
+  run, which reuses its existing suite rather than creating a new one — so
+  a later, path-filter-skipped `pull_request` run became the newer suite,
+  and reported a single job still literally named `pytest (Python ${{
+  matrix.python-version }})`, never the two expanded names. Branch
+  protection then read the newer, skipped suite and saw a genuine absence
+  at the exact (name, suite) pair it checks, invisible to every aggregate
+  view that blends across suites instead of asking "does THIS suite's
+  report for THIS name exist" (#5912). The discriminant a reader can pull
+  directly: `gh api repos/<org>/<repo>/commits/<sha>/check-runs --jq
+  '.check_runs[]|"\(.name)|\(.check_suite.id)"'` and check whether the
+  suite id carrying the required names is the MAXIMUM id present — if a
+  newer, empty-of-those-names suite exists, that is the blocked shape,
+  not merely having two suites. The rollup's SUCCESS was real; it just
+  never named which suite, of the two, it was a rollup of.
 
 **This is where B combines with §16**, not a coincidence: the sessions that
 trusted a stale environment did so *because* their result matched `main`'s

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1199,6 +1199,27 @@ missing one.
   they share its age. Here that was 5 claims re-run against
   `origin/main`, of which 4 held and only the reported one fell.
 
+- A PR sat `mergeStateStatus=BLOCKED` for hours with every visible signal
+  reading green: `gh pr checks` SUCCESS, the GitHub UI's own rollup SUCCESS,
+  no required review, no ruleset shown. The only place the real reason
+  surfaced was the literal rejection text of a direct `gh api -X PUT
+  .../merge` call: `"2 of 7 required status checks are expected."`
+  `expected` means "no report under that name exists yet" — not "pending,"
+  not "failed," and nothing in the rollup or `gh pr checks` distinguishes
+  it from either. The cause: the SAME workflow produced TWO check suites on
+  one head, and the newer one was skipped by a path filter before its
+  matrix ever expanded — so it reported a single job still literally named
+  `pytest (Python ${{ matrix.python-version }})`, never the two expanded
+  names (`pytest (Python 3.11)` / `(Python 3.12)`) branch protection
+  actually requires. Those two names existed and were green — under the
+  OLDER suite, the one that had actually run — but branch protection
+  consults the LATEST suite per workflow, where the names were never
+  written at all: a genuine absence at the exact (name, suite) pair branch
+  protection reads, invisible to every aggregate view that blends across
+  suites instead of asking "does THIS suite's report for THIS name exist"
+  (#5912). The rollup's SUCCESS was real; it just never named which suite,
+  of the two, it was a rollup of.
+
 **This is where B combines with §16**, not a coincidence: the sessions that
 trusted a stale environment did so *because* their result matched `main`'s
 — an equality read as confirmation, when both sides were victims of the

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1222,11 +1222,26 @@ missing one.
   at the exact (name, suite) pair it checks, invisible to every aggregate
   view that blends across suites instead of asking "does THIS suite's
   report for THIS name exist" (#5912). The discriminant a reader can pull
-  directly: `gh api repos/<org>/<repo>/commits/<sha>/check-runs --jq
-  '.check_runs[]|"\(.name)|\(.check_suite.id)"'` and check whether the
-  suite id carrying the required names is the MAXIMUM id present — if a
-  newer, empty-of-those-names suite exists, that is the blocked shape,
-  not merely having two suites. The rollup's SUCCESS was real; it just
+  directly must scope the "which is newer" comparison to suites of the
+  SAME workflow, not every suite on the head — a head carries one suite
+  per workflow, so the head-wide maximum id is almost always a different
+  workflow's, and comparing against it false-positives on every healthy
+  PR (measured directly against this instance's own head: false-positive
+  confirmed, then fixed and re-measured 4/4 against known-good and the
+  one known-BLOCKED head):
+
+  ```sh
+  gh api "repos/<org>/<repo>/commits/<sha>/check-runs?per_page=100" --jq '
+    [.check_runs[] | select(.name | test("^pytest \\(Python"))]
+    | (map(.check_suite.id) | max) as $newest
+    | map(select(.check_suite.id == $newest) | .name)
+    | if any(.[]; test("matrix")) then "BLOCKED shape" else "OK" end'
+  ```
+
+  — find the newest suite among only the ones reporting a name in the
+  required family, and check whether THAT suite's names are still
+  unexpanded (`matrix.python-version` literal) rather than the real
+  values. The rollup's SUCCESS was real; it just
   never named which suite, of the two, it was a rollup of.
 
 **This is where B combines with §16**, not a coincidence: the sessions that


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder-dispatched: 7th instance for `verification-hazards.md`, §18 face B (Misidentification). Primary data is lead-coder's own #5912 comment: https://github.com/tya5/reyn/pull/5912#issuecomment-5565922248

#5912 (merged) sat `mergeStateStatus=BLOCKED` for hours with every visible signal reading green — `gh pr checks` SUCCESS, GitHub's own rollup SUCCESS, no required review, no ruleset. The only place the real reason surfaced was the literal rejection text of a direct `gh api -X PUT .../merge` call: `"2 of 7 required status checks are expected."` Root cause: the same workflow produced two check suites on one head; the newer one was skipped by a path filter before its matrix expanded, so it reported one job still literally named `pytest (Python ${{ matrix.python-version }})` instead of the two expanded names (`pytest (Python 3.11)` / `(3.12)`) branch protection actually requires — green under the OLDER suite, but branch protection reads the LATEST suite per workflow, where the names were never written at all.

Classified as B (Misidentification), not A (Absence): the rollup/`gh pr checks` aggregate is real and green, it just never names which suite it's a rollup of — matches this face's existing instances (a stale pin, a wrong command) one layer up, in the CI/branch-protection substrate instead of a local environment.

Independent PR, not `part of #5895`, per instruction — this instance's own referent (#5912) is separate from #5895's.

## Test plan
- [x] `ruff check .` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds; only pre-existing INFO-level en/ja anchor-parity gaps
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] (skipped — docs-only diff, no `tests/`/`src/` files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
