### PR TITLE
fix(#5265 recurrence): detect a required context missing by name, matrix-family newest-suite comparison

### DIFF
--- a/scripts/detect_5265_missing_required_context.py
+++ b/scripts/detect_5265_missing_required_context.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""#5265 (recurrence, 2026-09-07, PR #5912) -- detect a PR head sha whose
+required branch-protection context will NEVER be reported under its own
+NAME, even though nothing on the PR looks red.
+
+## The failure this detects (measured, not guessed -- #5265 issue,
+2026-09-07 comment, lead-coder's own direct-execution finding)
+
+`detect_5265_startup_failure_blocked_prs.py` (the original #5265 script)
+answers one question: did ANY workflow run start at all for this head?
+The 2026-09-07 recurrence (PR #5912) is a DIFFERENT mechanism producing
+the SAME terminal symptom -- a required context permanently ABSENT,
+never failing -- so a whole-run-absence check does not catch it:
+
+  A CI check suite re-ran on the same head (the `mypy_ratchet` #5882
+  matrix-collapse landed the same day and re-triggered CI). The re-run's
+  own `pytest` job never expanded its version matrix -- GitHub recorded
+  it under the literal, UNEXPANDED template string (`pytest (Python
+  ${{ matrix.python-version }})`) instead of concrete per-version names.
+  An OLDER run on the SAME head DOES have a real `pytest (Python
+  3.11)`/`(3.12)` success -- but GitHub's required-check resolution
+  treats the newer run as authoritative for that workflow and never
+  falls back to the stale one. Branch protection reported "2 of 7
+  required status checks are expected" forever; nothing on the PR's own
+  page was red (`gh pr checks` / `statusCheckRollup` / combined status
+  were all uniformly SUCCESS -- the FAILURE rows a naive read sees there
+  belong to same-named-but-different WORKFLOW JOB rows, not the required
+  CONTEXT itself; see this module's own sibling finding in
+  ``feedback_statuscheckrollup_mixes_required_context_with_similarly_
+  named_workflow_rows`` -- do not repeat that misread here).
+
+## Two required-by-lead-coder detection rules (2026-09-07 comment, verbatim)
+
+  ① Compare branch protection's required-context list against everything
+     this head has ANY report under (commit status ∪ check-run), BY
+     NAME. A required name with zero reports anywhere is flagged.
+
+  ② A matrix-family required name's staleness is judged by comparing
+     ONLY within that family's OWN check-runs (same job-name prefix),
+     never against the single highest check_suite id on the WHOLE head.
+     Comparing against the head's global max false-positives on every
+     healthy PR that happens to have OTHER, unrelated workflows whose
+     suites were created later (BLOCKING re-read note, sandbox gates,
+     ...) -- lead-coder's own same-day mistake, corrected before this
+     script was written.
+
+## Judgement is read-only, always
+
+`gh api -X PUT .../merge` is what actually SURFACED the "2 of 7 required
+status checks are expected" text this script's own family-shape check
+reproduces read-only -- that PUT call must never be the detection
+mechanism: if the PR genuinely IS mergeable the instant you check, it
+real-merges it. This script never calls it.
+
+## Verified against real heads (2026-09-07, lead-coder-supplied, 4/4)
+
+  positive: `0ee0072...` (PR #5912, pre-rebase -- WAS permanently blocked
+    this way)
+  negative: `9c05527...` (#5911), `676e794...` (#5912, post-rebase),
+    `37cb926...` (#5921) -- all three healthy.
+
+See ``tests/scripts/test_detect_5265_missing_required_context.py`` for
+the fixture-driven 4/4 (captured from these same 4 real heads' `gh api`
+output, not synthesized).
+
+⚠️ The OTHER #5265 mechanism (`startup_failure`/`jobs==0`, no workflow
+run at all) has NOT been re-verified against a real head by this PR --
+lead-coder does not have a saved head sha for it (that branch's own
+script, `detect_5265_startup_failure_blocked_prs.py`, was already
+verified against ITS OWN real heads when it landed, #5666/#5665; this
+new script does not touch that code path).
+
+## Placement
+
+Same ruling as the original #5265 script (architect, 2026-08-30):
+detection only, no automatic recovery; not a GitHub Actions cron
+(self-referential silence on exactly the days it is needed); invoked
+from OUTSIDE Actions (a peer session's own sweep, or reyn-broker's
+`github_pr_watcher.py` plugin -- a different repo, not touched here).
+
+Usage:
+    python scripts/detect_5265_missing_required_context.py --pr 5912
+    python scripts/detect_5265_missing_required_context.py --head-sha <sha>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+_REPO = "tya5/reyn"
+
+# The literal, unexpanded GitHub Actions matrix-strategy template marker
+# (e.g. `pytest (Python ${{ matrix.python-version }})`) -- present in a
+# job name only when the matrix strategy never got to expand it.
+_MATRIX_TEMPLATE_MARKER = "${{"
+
+# A required context that is one member of a Python-version matrix looks
+# like "<job> (Python 3.11)"; its family key is the "<job> (Python "
+# prefix shared with its siblings AND with the unexpanded template name.
+_MATRIX_FAMILY_RE = re.compile(r"^(?P<prefix>.+ \(Python )\d+\.\d+\)$")
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic -- no gh, no network, no duration.
+# ---------------------------------------------------------------------------
+
+
+def reported_context_names(status_contexts: "list[dict]", check_runs: "list[dict]") -> "set[str]":
+    """Every name this head has ANY report under. StatusContext entries
+    (``{"context": ...}``, the legacy commit-status API) cover names set
+    directly via the status API (``open-blocking-checkbox``,
+    ``tests-read-names-its-tree`` in this repo); CheckRun entries
+    (``{"name": ...}``) cover Actions-produced names (``pytest (Python
+    3.11)``, ``ruff``, ...). Neither source alone is complete for this
+    repo's actual required-context list -- #5265's 2026-09-07 requirement
+    ① is explicitly "commit status ∪ check-run"."""
+    names = {s["context"] for s in status_contexts}
+    names |= {c["name"] for c in check_runs}
+    return names
+
+
+def find_never_reported(
+    required: "list[str]", status_contexts: "list[dict]", check_runs: "list[dict]",
+) -> "list[str]":
+    """Required-context names with ZERO report anywhere on this head --
+    #5265 requirement ①, name-matched against the union of both report
+    sources."""
+    reported = reported_context_names(status_contexts, check_runs)
+    return sorted(r for r in required if r not in reported)
+
+
+def find_matrix_family_blocked(required: "list[str]", check_runs: "list[dict]") -> "list[str]":
+    """Required matrix-family names (``pytest (Python 3.11)``, ...) whose
+    OWN family's NEWEST check-run on this head is the unexpanded
+    template (``pytest (Python ${{ matrix.python-version }})``) instead
+    of a concrete per-version name -- #5265 requirement ②, 2026-09-07
+    recurrence. The "newest" comparison is scoped to the family's OWN
+    check-runs (same job-name prefix) only -- comparing against the
+    head's global max suite id false-positives on any healthy PR with
+    unrelated later workflows (accept-side deny case, see the test
+    file's own ``deny`` tests)."""
+    blocked: "list[str]" = []
+    for name in required:
+        m = _MATRIX_FAMILY_RE.match(name)
+        if not m:
+            continue
+        prefix = m.group("prefix")
+        family_runs = [c for c in check_runs if c["name"].startswith(prefix)]
+        if not family_runs:
+            continue  # zero reports at all -- find_never_reported's job, not this one
+        newest = max(family_runs, key=lambda c: c["suite"])
+        if _MATRIX_TEMPLATE_MARKER in newest["name"]:
+            blocked.append(name)
+    return sorted(set(blocked))
+
+
+def find_permanently_blocked_required_contexts(
+    required: "list[str]", status_contexts: "list[dict]", check_runs: "list[dict]",
+) -> "list[str]":
+    """The union #5265's 2026-09-07 comment asks for: every required
+    context this head will never satisfy under its own name, by either
+    mechanism (①: never reported at all; ②: matrix family reversed onto
+    an unexpanded newer run)."""
+    return sorted(
+        set(find_never_reported(required, status_contexts, check_runs))
+        | set(find_matrix_family_blocked(required, check_runs)),
+    )
+
+
+def format_notification(pr_number: "str | int", head_sha: str, blocked_names: "list[str]") -> str:
+    """Names the PR/head AND the specific required-context names stuck --
+    a reader must not have to re-run the query themselves to know which
+    of the 7 required contexts are the problem."""
+    names_text = ", ".join(blocked_names)
+    return (
+        f"RED #5265 -- PR #{pr_number} (head {head_sha[:12]}) is silently "
+        f"BLOCKED: required context(s) will never report under their own "
+        f"name: {names_text}. Not visible as red anywhere on the PR (`gh "
+        "pr checks` / combined status / statusCheckRollup all read clean "
+        "-- the FAILURE rows a naive read sees there are same-named "
+        "WORKFLOW JOB rows, not the required CONTEXT). Detection is "
+        "read-only; do not use `gh api -X PUT .../merge` to check this."
+    )
+
+
+# ---------------------------------------------------------------------------
+# gh wrapper -- kept separate from the pure logic above. Deliberately
+# self-contained (not imported from the sibling #5265 script) so this
+# file stays runnable as a plain script path (this repo's own convention,
+# see the sibling's own Usage line) without needing `scripts` on
+# sys.path as a package.
+# ---------------------------------------------------------------------------
+
+
+def _parse_paginated_json(stdout: str) -> "list[dict]":
+    """Split ``gh api``'s stdout into its individual page objects. For an
+    OBJECT-shaped response, ``gh api --paginate`` concatenates one
+    complete JSON object per page back-to-back on stdout (NOT a JSON
+    array) -- see the sibling #5265 script's own #5666 finding, same
+    endpoint family. A bare ``json.loads`` only survives a single page."""
+    decoder = json.JSONDecoder()
+    stdout = stdout.strip()
+    pages: "list[dict]" = []
+    idx = 0
+    while idx < len(stdout):
+        obj, end = decoder.raw_decode(stdout, idx)
+        pages.append(obj)
+        idx = end
+        while idx < len(stdout) and stdout[idx].isspace():
+            idx += 1
+    return pages
+
+
+def _merge_paginated_pages(pages: "list[dict]", array_key: str) -> dict:
+    """Merge *pages* into one dict, cross-checking the server's own
+    ``total_count`` against the merged length rather than trusting
+    ``--paginate`` finished (#5666 accept ②, same reasoning as the
+    sibling script)."""
+    merged: "list[dict]" = []
+    total_count = None
+    for page in pages:
+        merged.extend(page.get(array_key, []))
+        if "total_count" in page:
+            total_count = page["total_count"]
+    if total_count is not None and total_count != len(merged):
+        raise ValueError(
+            f"gh api --paginate returned {len(merged)} {array_key!r} "
+            f"entries but total_count={total_count} -- incomplete merge, "
+            "refusing to treat this as the full population (#5666)",
+        )
+    result = dict(pages[0]) if pages else {}
+    result[array_key] = merged
+    if total_count is not None:
+        result["total_count"] = total_count
+    return result
+
+
+def _gh_json(args: "list[str]") -> "list[dict]":
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return _parse_paginated_json(result.stdout)
+
+
+def _fetch_head_sha_for_pr(pr_number: str) -> str:
+    pages = _gh_json(["pr", "view", pr_number, "--repo", _REPO, "--json", "headRefOid"])
+    return pages[0]["headRefOid"]
+
+
+def _fetch_required_contexts() -> "list[str]":
+    pages = _gh_json(["api", f"repos/{_REPO}/branches/main/protection/required_status_checks"])
+    return pages[0]["contexts"]
+
+
+def _fetch_status_contexts(head_sha: str) -> "list[dict]":
+    pages = _gh_json(["api", f"repos/{_REPO}/commits/{head_sha}/status", "--paginate"])
+    return _merge_paginated_pages(pages, "statuses")["statuses"]
+
+
+def _fetch_check_runs(head_sha: str) -> "list[dict]":
+    pages = _gh_json([
+        "api", f"repos/{_REPO}/commits/{head_sha}/check-runs?per_page=100", "--paginate",
+    ])
+    merged = _merge_paginated_pages(pages, "check_runs")["check_runs"]
+    return [{"name": c["name"], "suite": c["check_suite"]["id"]} for c in merged]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect a PR head sha with a required context that will never report by name (#5265, 2026-09-07 recurrence).",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--pr", metavar="N", help="PR number -- head sha resolved via `gh pr view`.")
+    group.add_argument("--head-sha", metavar="SHA", help="A commit sha directly (no PR lookup).")
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    pr_label: "str | int" = "?"
+    try:
+        if args.pr is not None:
+            pr_label = args.pr
+            head_sha = _fetch_head_sha_for_pr(args.pr)
+        else:
+            head_sha = args.head_sha
+        required = _fetch_required_contexts()
+        status_contexts = _fetch_status_contexts(head_sha)
+        check_runs = _fetch_check_runs(head_sha)
+    except subprocess.CalledProcessError as exc:
+        print(f"gh call failed: {exc.stderr}", file=sys.stderr)
+        return 2
+
+    blocked = find_permanently_blocked_required_contexts(required, status_contexts, check_runs)
+    if blocked:
+        print(format_notification(pr_label, head_sha, blocked))
+        return 1
+
+    print(f"OK -- head {head_sha[:12]} has a report (or a live path to one) for all {len(required)} required contexts.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_detect_5265_missing_required_context.py
+++ b/tests/scripts/test_detect_5265_missing_required_context.py
@@ -1,0 +1,256 @@
+"""Tier 1: #5265 (2026-09-07 recurrence, PR #5912) -- the by-NAME
+missing-required-context detector's own decision contract (lead-coder's
+own verbatim requirements, issue #5265 comment 2026-09-07).
+
+Two rules, each with its own accept/deny pair:
+
+  ① a required context with zero reports anywhere on the head (commit
+    status ∪ check-run, matched by name) is flagged.
+  ② a matrix-family required context (``pytest (Python 3.11)``) whose
+    OWN family's newest check-run is the unexpanded template
+    (``pytest (Python ${{ matrix.python-version }})``) is flagged --
+    but ONLY when that unexpanded run is the family's own newest; an
+    OLDER unexpanded run (a stale artifact from an earlier, superseded
+    workflow attempt) must NOT flag a family whose current newest run is
+    a real, expanded success. This deny case is the whole point of ②
+    scoping "newest" to the family, not the head's global max suite id
+    (lead-coder's own same-day mistake, corrected before this script was
+    written) -- without it, an implementation that flags any family with
+    ANY unexpanded run anywhere in its history would still pass every
+    other test here.
+
+The 4 fixtures below (``PYTEST_POSITIVE``/``PYTEST_NEGATIVE_*``) are
+``check_runs`` arrays captured verbatim via ``gh api
+repos/tya5/reyn/commits/<sha>/check-runs?per_page=100`` against the 4
+real heads lead-coder supplied (issue #5265, 2026-09-07 comment) --
+trimmed to ``{"name", "suite"}`` (the only fields the pure logic reads),
+not synthesized. ``REQUIRED`` is this repo's own real branch-protection
+``required_status_checks.contexts`` (captured the same day, `gh api
+repos/tya5/reyn/branches/main/protection/required_status_checks`).
+
+Strip-falsify (performed during review): with
+``find_matrix_family_blocked`` reduced to "flag every family with ANY
+unexpanded-template run in its check_runs, regardless of suite
+recency", the accept-side positive test stays green (it has an
+unexpanded run) but ``test_an_older_stale_unexpanded_run_does_not_block_a_family_whose_newest_run_is_real``
+(the real #9c05527 shape) goes RED -- that deny test is what proves this
+detector reads suite recency, not mere presence.
+"""
+from __future__ import annotations
+
+from scripts.detect_5265_missing_required_context import (
+    find_matrix_family_blocked,
+    find_never_reported,
+    find_permanently_blocked_required_contexts,
+    format_notification,
+    reported_context_names,
+)
+
+REQUIRED = [
+    "pytest (Python 3.11)",
+    "pytest (Python 3.12)",
+    "ruff",
+    "test-tier audit",
+    "docs build (strict)",
+    "open-blocking-checkbox",
+    "tests-read-names-its-tree",
+]
+
+STATUS_CONTEXTS = [
+    {"context": "tests-read-names-its-tree", "state": "success"},
+    {"context": "open-blocking-checkbox", "state": "success"},
+    {"context": "blocking-has-reread-note", "state": "success"},
+]
+
+# PR #5912 pre-rebase (head 0ee0072...) -- real incident: a second CI
+# check suite (92325567209) reran on the same head with the pytest job's
+# matrix template unexpanded, newer than the real matrix suite
+# (92325567037) that has genuine 3.11/3.12 successes.
+PYTEST_POSITIVE = [
+    {"name": "pytest (Python 3.11)", "suite": 92325567037},
+    {"name": "pytest (Python 3.12)", "suite": 92325567037},
+    {"name": "ruff", "suite": 92325567037},
+    {"name": "test-tier audit", "suite": 92325567037},
+    {"name": "docs build (strict)", "suite": 92325567037},
+    {"name": "ruff", "suite": 92325567209},
+    {"name": "docs build (strict)", "suite": 92325567209},
+    {"name": "test-tier audit", "suite": 92325567209},
+    {"name": "pytest (Python ${{ matrix.python-version }})", "suite": 92325567209},
+]
+
+# PR #5911 (head 9c05527...) -- the DENY shape for ②: this head ALSO has
+# an unexpanded-template run (suite 92304802767), but it is OLDER than
+# the real matrix suite (92304973971) -- a stale run from an earlier
+# attempt, superseded by a real one. Must NOT be flagged.
+PYTEST_NEGATIVE_STALE_UNEXPANDED = [
+    {"name": "ruff", "suite": 92304973971},
+    {"name": "pytest (Python 3.12)", "suite": 92304973971},
+    {"name": "pytest (Python 3.11)", "suite": 92304973971},
+    {"name": "test-tier audit", "suite": 92304973971},
+    {"name": "docs build (strict)", "suite": 92304973971},
+    {"name": "test-tier audit", "suite": 92304802767},
+    {"name": "docs build (strict)", "suite": 92304802767},
+    {"name": "pytest (Python ${{ matrix.python-version }})", "suite": 92304802767},
+    {"name": "ruff", "suite": 92304802767},
+]
+
+# PR #5912 post-rebase (head 676e794...) -- the simple healthy shape:
+# a single suite, no reruns at all.
+PYTEST_NEGATIVE_SINGLE_SUITE = [
+    {"name": "pytest (Python 3.11)", "suite": 92351273634},
+    {"name": "pytest (Python 3.12)", "suite": 92351273634},
+    {"name": "ruff", "suite": 92351273634},
+    {"name": "docs build (strict)", "suite": 92351273634},
+    {"name": "test-tier audit", "suite": 92351273634},
+    {"name": "BLOCKING PR carries a re-read note naming its tree", "suite": 92351273635},
+]
+
+# PR #5921 (head 37cb926...) -- single suite, plus OTHER unrelated
+# workflows on the head with HIGHER suite ids than the pytest suite
+# (92353647224 < 92353647708/92353647590/...). This is the exact shape
+# that false-positives if "newest" is read as the head's global max
+# suite instead of the family's own -- lead-coder's own same-day
+# mistake this fixture guards against.
+PYTEST_NEGATIVE_LATER_UNRELATED_WORKFLOWS = [
+    {"name": "ruff", "suite": 92353647224},
+    {"name": "test-tier audit", "suite": 92353647224},
+    {"name": "docs build (strict)", "suite": 92353647224},
+    {"name": "pytest (Python 3.11)", "suite": 92353647224},
+    {"name": "pytest (Python 3.12)", "suite": 92353647224},
+    {"name": "sandbox boundary is load-method independent (ld-linux + mmap-load,", "suite": 92353647708},
+    {"name": "file-depth-reference gate", "suite": 92353647590},
+    {"name": "TESTS-READ note names the tree it read", "suite": 92353647380},
+]
+
+
+# ── ① find_never_reported -- name-matched, commit status ∪ check-run ──
+
+
+def test_a_required_name_with_zero_reports_anywhere_is_flagged():
+    """Tier 1: ① accept -- a required name absent from both status
+    contexts and check-runs must be flagged."""
+    missing = find_never_reported(
+        ["a-context-that-was-never-reported"], STATUS_CONTEXTS, PYTEST_NEGATIVE_SINGLE_SUITE,
+    )
+    assert missing == ["a-context-that-was-never-reported"]
+
+
+def test_a_required_name_reported_via_status_api_is_not_flagged():
+    """Tier 1: ① deny -- StatusContext-sourced names (set directly via
+    the commit-status API, not a workflow job) must count as reported;
+    without this, a repo whose required checks include any StatusContext
+    (this repo's own ``open-blocking-checkbox``) would always false-RED."""
+    missing = find_never_reported(["open-blocking-checkbox"], STATUS_CONTEXTS, [])
+    assert missing == []
+
+
+def test_a_required_name_reported_via_check_run_is_not_flagged():
+    """Tier 1: ① deny sibling -- CheckRun-sourced names (Actions jobs)
+    must also count; without this, every Actions-produced required
+    context would always false-RED."""
+    missing = find_never_reported(["ruff"], [], PYTEST_NEGATIVE_SINGLE_SUITE)
+    assert missing == []
+
+
+def test_reported_context_names_is_the_union_of_both_sources():
+    """Tier 1: ``reported_context_names`` itself -- #5265's own 2026-09-07
+    requirement is explicitly "commit status ∪ check-run"; a union that
+    silently dropped one source would only surface as spurious flags on
+    whichever required name happens to come from the dropped source."""
+    names = reported_context_names(STATUS_CONTEXTS, PYTEST_NEGATIVE_SINGLE_SUITE)
+    assert "open-blocking-checkbox" in names  # from status
+    assert "ruff" in names  # from check-runs
+
+
+# ── ② find_matrix_family_blocked -- same-family newest-suite comparison ──
+
+
+def test_the_real_5912_positive_head_is_flagged():
+    """Tier 1: ② accept -- the real #5265 2026-09-07 incident shape
+    (verified against the actual head, issue #5265 comment): the
+    family's own newest suite is the unexpanded template -> both
+    pytest required names flagged."""
+    blocked = find_matrix_family_blocked(REQUIRED, PYTEST_POSITIVE)
+    assert blocked == ["pytest (Python 3.11)", "pytest (Python 3.12)"]
+
+
+def test_an_older_stale_unexpanded_run_does_not_block_a_family_whose_newest_run_is_real():
+    """Tier 1: ② deny -- THE test that proves this detector reads suite
+    RECENCY within the family, not mere presence of an unexpanded run
+    anywhere in the family's history (real #9c05527/#5911 shape: an
+    older stale unexpanded run coexists with a newer real success).
+    Without this test, an implementation that flags any family
+    containing ANY unexpanded-template run at all would still pass the
+    accept-side test above."""
+    blocked = find_matrix_family_blocked(REQUIRED, PYTEST_NEGATIVE_STALE_UNEXPANDED)
+    assert blocked == []
+
+
+def test_a_single_clean_suite_is_not_blocked():
+    """Tier 1: ② deny sibling -- the simplest healthy shape (no rerun at
+    all, real #676e794/#5912-post-rebase)."""
+    blocked = find_matrix_family_blocked(REQUIRED, PYTEST_NEGATIVE_SINGLE_SUITE)
+    assert blocked == []
+
+
+def test_unrelated_later_workflows_on_the_same_head_do_not_false_positive():
+    """Tier 1: ② deny -- THE regression guard for lead-coder's own
+    same-day mistake (comparing against the head's global max suite id
+    instead of the family's own). Real #37cb926/#5921 shape: other,
+    unrelated workflows on this head have HIGHER suite ids than the
+    pytest family's own suite. A "global max" implementation would read
+    the pytest family as stale relative to those unrelated suites and
+    false-positive on this healthy head."""
+    blocked = find_matrix_family_blocked(REQUIRED, PYTEST_NEGATIVE_LATER_UNRELATED_WORKFLOWS)
+    assert blocked == []
+
+
+def test_a_required_name_not_shaped_like_a_matrix_family_is_never_considered():
+    """Tier 1: ② scope -- a required name that doesn't match the
+    ``<job> (Python X.Y)`` shape (``ruff``, ``open-blocking-checkbox``)
+    is never evaluated by this rule at all (①'s job, not ②'s)."""
+    blocked = find_matrix_family_blocked(["ruff", "open-blocking-checkbox"], PYTEST_POSITIVE)
+    assert blocked == []
+
+
+def test_a_family_with_zero_reports_at_all_is_left_to_find_never_reported():
+    """Tier 1: ② boundary -- a matrix-family required name with NO
+    check-runs under its family prefix at all (not even a template) must
+    not be claimed by this rule (it has nothing to compare "newest"
+    against) -- that case belongs to ① instead."""
+    blocked = find_matrix_family_blocked(REQUIRED, [])
+    assert blocked == []
+    assert find_never_reported(REQUIRED, [], []) == sorted(REQUIRED)
+
+
+# ── combined union, against the real 4 heads (4/4) ──
+
+
+def test_the_real_positive_head_is_flagged_end_to_end():
+    """Tier 1: the real #5265 2026-09-07 positive, through the combined
+    ``find_permanently_blocked_required_contexts`` entry point."""
+    blocked = find_permanently_blocked_required_contexts(REQUIRED, STATUS_CONTEXTS, PYTEST_POSITIVE)
+    assert blocked == ["pytest (Python 3.11)", "pytest (Python 3.12)"]
+
+
+def test_all_three_real_negative_heads_are_clean_end_to_end():
+    """Tier 1: the 3 real negative heads lead-coder supplied, through the
+    combined entry point -- 3/3 clean, completing the 4/4 lead-coder's
+    own dispatch required before opening the PR."""
+    for check_runs in (
+        PYTEST_NEGATIVE_STALE_UNEXPANDED,
+        PYTEST_NEGATIVE_SINGLE_SUITE,
+        PYTEST_NEGATIVE_LATER_UNRELATED_WORKFLOWS,
+    ):
+        assert find_permanently_blocked_required_contexts(REQUIRED, STATUS_CONTEXTS, check_runs) == []
+
+
+def test_notification_names_the_pr_the_head_and_the_specific_blocked_names():
+    """Tier 1: the notification must name which of the required contexts
+    are stuck, not just that "something" is -- a reader must not have to
+    re-run the query themselves."""
+    text = format_notification(5912, "0ee007268fe1bfb366f40b3d598cd74525d5d937", ["pytest (Python 3.11)"])
+    assert "#5912" in text
+    assert "0ee007268fe1" in text
+    assert "pytest (Python 3.11)" in text
+    assert "read-only" in text.lower()


### PR DESCRIPTION
**[backlog-watcher]** — part of #5265 (2026-09-07 recurrence, PR #5912)

## What

A second #5265 mechanism, distinct from `detect_5265_startup_failure_blocked_prs.py`'s own (`startup_failure`/`jobs==0`, no workflow run at all): a required matrix-family context (`pytest (Python 3.11)`/`(3.12)`) permanently absent because the family's **newest** check-suite carries the unexpanded GitHub Actions template name (`pytest (Python ${{ matrix.python-version }})`) instead of concrete per-version names, while an OLDER suite on the same head has a real success under the real name. GitHub's required-check resolution never falls back to the stale suite — branch protection reports the required context as permanently "expected", with nothing red anywhere on the PR (`gh pr checks` / combined status / `statusCheckRollup` all read clean).

New script: `scripts/detect_5265_missing_required_context.py`. Two rules, both from lead-coder's verbatim requirements (issue #5265, 2026-09-07 comment):

1. **①** — branch protection's required-context list vs everything the head has ANY report under (commit status ∪ check-run), matched by name. Zero reports anywhere → flagged.
2. **②** — matrix-family staleness judged **within the family's own check-runs only** (same job-name prefix), never against the head's global max suite id — comparing against the global max false-positives on any healthy PR with unrelated later workflows (lead-coder's own same-day mistake, corrected before this script was written; see the module docstring and the test file's own regression-guard test).

Detection is read-only throughout. Never calls `gh api -X PUT .../merge` (the call that originally surfaced the underlying GitHub error text) — a real merge attempt real-merges the PR if conditions happen to be met.

## Verification (required: 4/4 on lead-coder's supplied heads)

Ran live (`gh api`, not fixtures) against the 4 real heads lead-coder supplied on the issue:

```
0ee007268fe1... (PR #5912 pre-rebase) → RED (pytest 3.11/3.12 flagged)   -- the positive
9c0552793e9f... (#5911)                → OK                              -- negative
676e794d5a16... (#5912 post-rebase)    → OK                              -- negative
37cb926d2467... (#5921)                → OK                              -- negative
```

4/4 matches ground truth. The 3rd negative (#5921) is the specific regression guard for the "global max suite" mistake — it has unrelated later workflows on the same head with higher suite ids than pytest's own family.

⚠️ **The OTHER #5265 mechanism (`startup_failure`/`jobs==0`, no workflow run at all) is NOT re-verified against a real head by this PR** — lead-coder has no saved head sha for it. That branch's own script (`detect_5265_startup_failure_blocked_prs.py`) was already verified at its own landing (#5665/#5666, real-machine) and is untouched here.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_detect_5265_missing_required_context.py` — 13/13 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py scripts/detect_5265_missing_required_context.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, 0 findings
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK
- [x] `pytest tests/scripts/test_detect_5265_missing_required_context.py -v` — 13 passed
- [x] Live 4/4 against lead-coder's supplied real heads (see Verification above)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
