### PR TITLE
docs: verification-hazards.md -- add a Misidentification instance (gate text-scan)

### DIFF
--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -1243,6 +1243,35 @@ missing one.
   unexpanded (`matrix.python-version` literal) rather than the real
   values. The rollup's SUCCESS was real; it just
   never named which suite, of the two, it was a rollup of.
+- A census of this repo's own `scripts/check_*.py` gates found 6 of 28 scan
+  raw prose to decide whether a declaration, exemption, or resolution
+  exists — and 5 of those 6 had a concrete false-positive input
+  constructible on the spot. The worst shape: a NEGATED sentence reads as
+  positive evidence. `This PR is not ready for a TESTS-READ note yet —
+  still investigating 9cc1006.` makes the TESTS-READ gate see a note
+  exists; `No RE-READ (head start) needed here, this is a docs-only typo
+  fix.` makes the RE-READ gate see one too — the sentence that SAYS a note
+  is absent is read as the note. A sibling gate's substring match
+  (`_resolves_via_body`) is worse than merely weak: it is **structurally
+  incapable** of the distinction it exists to make, because quoting the
+  checkbox text is the REQUIRED form for a rebuttal comment too — the
+  presence of a quote carries zero bits toward "resolved vs. disputed," at
+  any match strength, string or otherwise. Only one script in the census
+  avoided every false positive, via a double constraint: restrict the
+  scan target to `docstring.splitlines()[0]` (one line, not the whole
+  text) AND use `match` (anchored at the start), not `search` (anywhere).
+  The other five all used unanchored `search` over multi-line or
+  whole-file text. Discriminant for which false positives actually
+  matter: does the misread make the gate answer YES (a declaration,
+  exemption, or resolution exists) — a human reading the same sentence
+  and answering NO, while the gate answers YES, is fail-open regardless of
+  which direction (silent-pass or falsely-satisfied) it takes. The
+  author of the census fell into its own found shape the same day, twice:
+  once writing an ad hoc `jq` query to verify a colleague's enumeration
+  and picking up a mere prose MENTION of a checkbox as the checkbox
+  itself; and once by counting only the silent-pass direction of the
+  gates found and missing the negated-sentence-as-evidence direction
+  until asked the YES/NO discriminant directly (#5919).
 
 **This is where B combines with §16**, not a coincidence: the sessions that
 trusted a stale environment did so *because* their result matched `main`'s


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder-dispatched: 8th instance for `verification-hazards.md`, §18 face B (Misidentification). Primary data: #5919 census (https://github.com/tya5/reyn/issues/5919#issuecomment-5567441928 and the architect/lead-coder exchange following it).

Census of `scripts/check_*.py` (28 scripts): 6 scan raw prose to decide whether a declaration/exemption/resolution exists; 5 of those 6 had a concrete false-positive input constructible on the spot. Worst shape: a NEGATED sentence reads as positive evidence — `This PR is not ready for a TESTS-READ note yet` makes the TESTS-READ gate see a note exists; `No RE-READ (head start) needed here` makes the RE-READ gate see one too. `_resolves_via_body`'s substring match is structurally incapable of the distinction it exists to make, since quoting the checkbox text is the REQUIRED form for a rebuttal comment too — the presence of a quote carries zero bits toward resolved-vs-disputed. The one clean script (`test_tier_audit.py`) used a double constraint: restrict the scan target to one line (`splitlines()[0]`) plus `match` (anchored), not `search`. Discriminant that decides scope: does the misread make the gate answer YES.

The census's own author fell into the same shape twice the same day — an ad hoc `jq` query picked up a prose mention of a checkbox as the checkbox itself; and counted only the silent-pass direction of the found gates, missing the negated-sentence-as-evidence direction until asked the YES/NO discriminant directly.

Classified B (Misidentification), same face/placement as the CI check-suite instance already there — a real text match, real and green, but not the structured declaration the claim is about.

Independent PR per instruction. Doesn't quote CLAUDE.md rule 7 (still open in #5924) — no dependency on that landing first.

## Test plan
- [x] `ruff check .` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds; only pre-existing INFO-level en/ja anchor-parity gaps
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] (skipped — docs-only diff, no `tests/`/`src/` files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
