### PR TITLE
test(#5909): the stall-trace tests stop assuming they are the only writer of process-global state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ the tree I am measuring" is not something a test may assume.
 """
 from __future__ import annotations
 
+import faulthandler
 import importlib.util
 import os
 import sys
@@ -609,6 +610,91 @@ def _isolate_stall_trace_file_handler_registration(request: pytest.FixtureReques
     stall_trace.register_file_handler_path(saved)
     if hasattr(request.config, "workerinput") or not os.environ.get("REYN_STALL_TRACE_CI"):
         stall_trace.disarm()
+
+
+#: #5909 (architect prescription 1) — public witness counter for
+#: :func:`_cancel_any_pending_faulthandler_dump` below. ``faulthandler``'s
+#: own public API (``enable``/``disable``/``is_enabled``/``dump_traceback``/
+#: ``dump_traceback_later``/``cancel_dump_traceback_later``/``register``/
+#: ``unregister`` — confirmed by reading the stdlib module, no other names
+#: exist) exposes no getter for "is a ``dump_traceback_later`` timer
+#: currently armed", so there is no way to observe the fixture's effect by
+#: reading ``faulthandler`` state after the fact. This counter is the
+#: public face this module offers instead: incremented from INSIDE the
+#: fixture's own teardown, once per test, unconditionally — a test can
+#: read it via :func:`faulthandler_safety_net_call_count` to witness the
+#: fixture actually ran, without reaching into any private state.
+_faulthandler_safety_net_calls = 0
+
+
+def faulthandler_safety_net_call_count() -> int:
+    """Public accessor for the counter above — see its own comment."""
+    return _faulthandler_safety_net_calls
+
+
+@pytest.fixture(autouse=True)
+def _cancel_any_pending_faulthandler_dump() -> Iterator[None]:
+    """#5909 (architect prescription 1, real-machine measurement): a
+    process-global safety net for ``faulthandler.dump_traceback_later`` —
+    the OTHER process-global ``tests/interfaces/test_3671_stall_trace_
+    startup_wiring.py`` touches, independent of the file-handler
+    registration :func:`_isolate_stall_trace_file_handler_registration`
+    (above) already isolates.
+
+    ``faulthandler.dump_traceback_later`` captures the armed destination's
+    FILE-DESCRIPTOR NUMBER at arm time, not a live object reference
+    (``reyn.runtime.stall_trace.find_file_handler_path``'s own docstring
+    has the reproduced mechanism, #5877). A test that arms the REAL
+    tripwire with ``stall_trace.disarm`` stubbed out — exactly what
+    ``test_3671_stall_trace_startup_wiring.py::test_the_tripwire_arms_
+    its_own_fd_when_a_file_handler_exists`` does, deliberately, to observe
+    the real ``arm()`` call without letting production's own disarm
+    interfere — leaves a pending one-shot dump when the app's own
+    ``finally`` closes that fd for real at shutdown. Production closes this
+    hole for ITSELF (``app.py``'s own ``_watch_loop_responsiveness``
+    worker: "#5877: disarm BEFORE closing this worker's own fd" — see that
+    method's ``finally`` block) but nothing analogous existed on the test
+    side before this fixture (confirmed by reading this file: no fixture
+    here called ``faulthandler.cancel_dump_traceback_later()``
+    unconditionally).
+
+    Calls ``faulthandler.cancel_dump_traceback_later()`` BY NAME, directly
+    — deliberately never ``stall_trace.disarm()`` (which
+    :func:`_isolate_stall_trace_file_handler_registration` above already
+    calls, conditionally). Several tests in this suite monkeypatch
+    ``stall_trace.disarm`` itself (``monkeypatch.setattr(stall_trace,
+    "disarm", ...)``) to observe wiring without letting the real disarm
+    run — going through that same name here would make this safety net's
+    own effect depend on fixture-teardown ORDERING relative to
+    ``monkeypatch``'s own undo (an implicit assumption, not a guarantee).
+    ``faulthandler.cancel_dump_traceback_later`` is stdlib and never
+    monkeypatched anywhere in this suite (confirmed: ``grep -rn
+    'faulthandler\\.' tests/`` has no ``setattr``/``patch`` hit on it), so
+    calling it by this name is unconditional by CONSTRUCTION — "a test
+    that leaves something armed" cannot exist structurally, regardless of
+    what any given test does to ``stall_trace``'s own names.
+
+    Deliberately function-scoped, not session-scoped, and deliberately NOT
+    gated the way :func:`_isolate_stall_trace_file_handler_registration`'s
+    own ``stall_trace.disarm()`` call is: that gate exists ONLY to protect
+    ``stall_dump.py``'s session-scoped #4986 CONTROLLER watchdog from a
+    per-test cancel (armed once, for the whole session, only on the xdist
+    controller — never inside a worker, that module's own docstring). This
+    repo's CI always runs pytest under xdist WHEN ``REYN_STALL_TRACE_CI``
+    is set (``.github/workflows/test.yml``: ``REYN_STALL_TRACE_CI=600
+    ... pytest -q -n auto`` — same shell invocation, always together), so
+    every process that ever runs a test ITEM body in CI is a worker, never
+    the controller — the one case an unconditional cancel here WOULD
+    defeat (``REYN_STALL_TRACE_CI`` set on a genuinely serial, no ``-n``,
+    invocation) is not this repo's CI shape today. Documented here as the
+    known, accepted narrowing per the architect's #5909 ruling (structural
+    safety net over per-test discipline), not silently assumed away — a
+    future CI shape that runs a serial job WITH ``REYN_STALL_TRACE_CI``
+    set would need to revisit this."""
+    global _faulthandler_safety_net_calls
+    yield
+    faulthandler.cancel_dump_traceback_later()
+    _faulthandler_safety_net_calls += 1
 
 # ── Marker registration ────────────────────────────────────────────────────────
 

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -26,7 +26,6 @@ you touch either call site.
 """
 from __future__ import annotations
 
-import faulthandler
 import logging
 import os
 import sys
@@ -434,41 +433,41 @@ def test_log_stream_falls_back_to_the_original_stderr_not_the_reassignable_name(
     )
 
 
-#: Shared between the two witness tests below — must live in THIS module
-#: (not tests/conftest.py) so both halves read/write the SAME process's
-#: state; xdist_group below is what guarantees they land on that same
-#: process in the first place.
-_faulthandler_safety_net_witness_baseline: "list[int]" = []
+pytest_plugins = ["pytester"]
 
+#: Inner conftest for the witness below — puts the repo root AND its own
+#: ``src`` on ``sys.path`` (a subprocess gets none of this outer session's
+#: own ``pyproject.toml`` ``pythonpath`` favour — ``out_of_process_reyn``'s
+#: own docstring in tests/conftest.py has the full reasoning) then imports
+#: the REAL fixture under test from the REAL tests/conftest.py, never a
+#: reimplementation — pytest activates any ``@pytest.fixture``-decorated
+#: callable present in a conftest module's namespace, imported or not.
+_INNER_CONFTEST = """
+import sys
+sys.path.insert(0, {repo_root!r})
+sys.path.insert(0, {src_root!r})
+from tests.conftest import _cancel_any_pending_faulthandler_dump  # noqa: F401
+"""
 
-@pytest.mark.xdist_group(name="test_3671_faulthandler_safety_net_witness")
-def test_a_leaves_a_faulthandler_dump_armed_without_disarming(tmp_path: Path) -> None:
-    """Tier 2: #5909 (architect prescription 1) witness, half 1 of 2 —
-    paired with the very next test below via the SAME ``xdist_group``
-    (pytest-xdist's own scheduling guarantee: same-group items land on
-    the SAME worker process — required here since what's being witnessed
-    is THIS PROCESS's own module-level state, invisible to any other
-    worker). Deliberately arms a REAL ``faulthandler.dump_traceback_
-    later`` one-shot and returns WITHOUT disarming it — the exact shape
-    ``test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists``
-    (above, this file) leaves behind when its own ``stall_trace.disarm``
-    stub lets the app's real shutdown close the armed fd out from under a
-    still-pending timer.
+#: The inner test pair itself — same shape as the removed xdist_group
+#: version, but ordering and same-process-ness now come from pytest's own
+#: normal (non-distributed) collection order inside ONE real inner
+#: session, not from an xdist scheduling guarantee this repo's CI
+#: invocation does not actually provide (lead-coder finding, #5926:
+#: ``pytest -n auto`` with no ``--dist`` defaults xdist's own ``load``
+#: scheduler, which ignores ``xdist_group`` entirely — only ``loadgroup``
+#: honors it, and this repo's CI passes neither).
+_INNER_TEST = """
+import faulthandler
+import os
+from pathlib import Path
 
-    Records ``tests/conftest.py``'s own public
-    ``faulthandler_safety_net_call_count()`` BEFORE this test's own
-    teardown runs, so the paired test below can assert it moved after —
-    the only public signal available (``faulthandler``'s own API has no
-    "is a timer currently armed" getter — see ``tests/conftest.py``'s
-    ``_cancel_any_pending_faulthandler_dump`` fixture docstring for the
-    confirmed absence). 9999 seconds and a throwaway ``tmp_path``
-    destination fd, closed immediately after arming: even if the safety
-    net this test exists to witness were itself broken, this dump could
-    never fire within any real test run's lifetime, and would land only
-    in a file nothing else ever reads."""
-    from tests.conftest import faulthandler_safety_net_call_count
+from tests.conftest import faulthandler_safety_net_call_count
 
-    _faulthandler_safety_net_witness_baseline.append(faulthandler_safety_net_call_count())
+_baseline = []
+
+def test_a_leaves_a_faulthandler_dump_armed_without_disarming(tmp_path):
+    _baseline.append(faulthandler_safety_net_call_count())
     sink = tmp_path / "leaked_dump.txt"
     fd = os.open(str(sink), os.O_WRONLY | os.O_CREAT)
     try:
@@ -476,29 +475,56 @@ def test_a_leaves_a_faulthandler_dump_armed_without_disarming(tmp_path: Path) ->
     finally:
         os.close(fd)
 
+def test_b_the_conftest_safety_net_cancelled_it():
+    assert _baseline, "setup: test_a must run first, in this same process"
+    assert faulthandler_safety_net_call_count() > _baseline[-1]
+"""
 
-@pytest.mark.xdist_group(name="test_3671_faulthandler_safety_net_witness")
-def test_b_the_conftest_safety_net_cancelled_it() -> None:
-    """Tier 2: #5909 (architect prescription 1) witness, half 2 of 2 — see
-    ``test_a_leaves_a_faulthandler_dump_armed_without_disarming`` (right
-    above) for the setup. Asserts ``tests/conftest.py``'s
-    ``_cancel_any_pending_faulthandler_dump`` autouse fixture's own public
-    call counter advanced across test A's own teardown — evidence the
-    fixture actually RAN and reached its own
-    ``faulthandler.cancel_dump_traceback_later()`` call, not merely that
-    this suite stayed green (a timer left armed for 9999s would ALSO
-    leave this suite green, since nothing in it runs anywhere near that
-    long — the counter, not "did the run finish", is this witness's real
-    evidence)."""
-    from tests.conftest import faulthandler_safety_net_call_count
 
-    assert _faulthandler_safety_net_witness_baseline, (
-        "setup: test_a_leaves_a_faulthandler_dump_armed_without_disarming "
-        "must have run first (same xdist_group => same worker, collection "
-        "order preserved) and recorded its own baseline"
-    )
-    assert faulthandler_safety_net_call_count() > _faulthandler_safety_net_witness_baseline[-1], (
-        "tests/conftest.py's own safety-net call counter did not advance "
-        "across test A's teardown -- either the autouse fixture did not "
-        "run, or it ran but never reached its own increment"
-    )
+def test_the_conftest_safety_net_cancels_a_dump_a_test_left_armed(
+    pytester: pytest.Pytester,
+) -> None:
+    """Tier 2: #5909 (architect prescription 1) witness — a REAL, isolated
+    inner pytest session (pytester's own subprocess seam, same technique
+    ``tests/dev/test_stall_dump_4986.py`` already uses for a real
+    ``faulthandler`` timer) runs two tests that could only observe each
+    other if they land in the SAME process, in order: the first arms a
+    REAL ``faulthandler.dump_traceback_later`` one-shot and returns
+    WITHOUT disarming it — the exact shape ``test_the_tripwire_arms_its_
+    own_fd_when_a_file_handler_exists`` (above, this same outer file)
+    leaves behind when its own ``stall_trace.disarm`` stub lets the app's
+    real shutdown close the armed fd out from under a still-pending
+    timer; the second asserts ``tests/conftest.py``'s own public
+    ``faulthandler_safety_net_call_count()`` counter advanced across the
+    first test's own teardown.
+
+    Subprocess (not pytester's in-process ``runpytest()``): this outer
+    test's own ``faulthandler`` state must never interact with the inner
+    session's — same reasoning ``test_stall_dump_4986.py``'s own module
+    docstring states for its own inner runs.
+
+    The counter, not "the inner session exited 0", is this witness's real
+    evidence — ``faulthandler``'s own public API (``enable``/``disable``/
+    ``is_enabled``/``dump_traceback``/``dump_traceback_later``/
+    ``cancel_dump_traceback_later``/``register``/``unregister`` — the
+    complete list, confirmed by reading the stdlib module) exposes no
+    getter for "is a timer currently armed", so a green inner session
+    alone cannot distinguish "the safety net fired" from "nothing ever
+    checked" (a dump left armed for 9999s would ALSO exit 0, since
+    nothing in the inner session runs anywhere near that long).
+
+    Strip-falsifier: comment out this fixture's own
+    ``faulthandler.cancel_dump_traceback_later()`` call in
+    ``tests/conftest.py`` and ``test_b`` inside the inner session goes
+    red (the counter never advances) — this test's own assertion below
+    then reports that inner failure via ``result.assert_outcomes``."""
+    import reyn
+
+    repo_root = Path(reyn.__file__).resolve().parents[2]
+    src_root = str(repo_root / "src")
+
+    pytester.makeconftest(_INNER_CONFTEST.format(repo_root=str(repo_root), src_root=src_root))
+    pytester.makepyfile(test_inner=_INNER_TEST)
+
+    result = pytester.runpytest_subprocess("test_inner.py")
+    result.assert_outcomes(passed=2)

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -26,6 +26,7 @@ you touch either call site.
 """
 from __future__ import annotations
 
+import faulthandler
 import logging
 import os
 import sys
@@ -291,7 +292,28 @@ async def test_the_tripwire_reopens_its_fd_after_a_log_rotation(monkeypatch, tmp
     # and reopens the SAME path with no rename, which keeps the SAME
     # inode — no rotation for this test to detect at all.
     handler = RotatingFileHandler(str(log_path), maxBytes=1, backupCount=2)
-    logging.getLogger().addHandler(handler)
+    # #5909 (architect prescription 2, #5922 CI finding): a DEDICATED,
+    # non-propagating logger — never ``logging.getLogger()`` (root) — owns
+    # this handler. Root is a process-wide SHARED sink: any unrelated
+    # ``logging.warning(...)`` reaching it (this test's own real,
+    # headless ``TextualChatApp`` runs live below) is one record through
+    # this handler, and with ``maxBytes=1`` ANY record rolls it over —
+    # replacing ``log_path``'s inode BEFORE this test's own controlled
+    # ``handler.doRollover()`` call below, falsifying the setup premise at
+    # ``pre_ino == log_path.stat().st_ino``. The subject under test here
+    # is ``_watch_loop_responsiveness``'s own fd/inode-reopen logic keyed
+    # on the PATH ``stall_trace.register_file_handler_path`` declares
+    # (below) — never which logger owns the handler feeding that path
+    # (``find_file_handler_path`` is a plain declared-path lookup since
+    # #5873, not a root-logger handler scan — see its own docstring), so
+    # this narrows WHO can write through this handler without changing
+    # what the test proves. ``maxBytes=1`` stays as small as it was
+    # (that's what makes ``doRollover()`` a real rollover to detect, not
+    # the bug) — the fix is limiting the WRITER, never loosening the
+    # threshold.
+    private_logger = logging.getLogger(f"{__name__}.log_rotation_witness")
+    private_logger.propagate = False
+    private_logger.addHandler(handler)
     # Registration restore is tests/conftest.py's own autouse
     # _isolate_stall_trace_file_handler_registration fixture's job — see
     # installed_file_handler's own docstring above for why this file no
@@ -331,7 +353,8 @@ async def test_the_tripwire_reopens_its_fd_after_a_log_rotation(monkeypatch, tmp
             while os.fstat(calls[-1][1]).st_ino != post_ino:  # type: ignore[arg-type]
                 await pilot.pause()
     finally:
-        logging.getLogger().removeHandler(handler)
+        private_logger.removeHandler(handler)
+        private_logger.propagate = True
         handler.close()
 
 
@@ -408,4 +431,74 @@ def test_log_stream_falls_back_to_the_original_stderr_not_the_reassignable_name(
     assert stall_trace.default_log_stream() is sys.__stderr__, (
         "expected the fallback to be sys.__stderr__, unaffected by "
         "reassigning sys.stderr"
+    )
+
+
+#: Shared between the two witness tests below — must live in THIS module
+#: (not tests/conftest.py) so both halves read/write the SAME process's
+#: state; xdist_group below is what guarantees they land on that same
+#: process in the first place.
+_faulthandler_safety_net_witness_baseline: "list[int]" = []
+
+
+@pytest.mark.xdist_group(name="test_3671_faulthandler_safety_net_witness")
+def test_a_leaves_a_faulthandler_dump_armed_without_disarming(tmp_path: Path) -> None:
+    """Tier 2: #5909 (architect prescription 1) witness, half 1 of 2 —
+    paired with the very next test below via the SAME ``xdist_group``
+    (pytest-xdist's own scheduling guarantee: same-group items land on
+    the SAME worker process — required here since what's being witnessed
+    is THIS PROCESS's own module-level state, invisible to any other
+    worker). Deliberately arms a REAL ``faulthandler.dump_traceback_
+    later`` one-shot and returns WITHOUT disarming it — the exact shape
+    ``test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists``
+    (above, this file) leaves behind when its own ``stall_trace.disarm``
+    stub lets the app's real shutdown close the armed fd out from under a
+    still-pending timer.
+
+    Records ``tests/conftest.py``'s own public
+    ``faulthandler_safety_net_call_count()`` BEFORE this test's own
+    teardown runs, so the paired test below can assert it moved after —
+    the only public signal available (``faulthandler``'s own API has no
+    "is a timer currently armed" getter — see ``tests/conftest.py``'s
+    ``_cancel_any_pending_faulthandler_dump`` fixture docstring for the
+    confirmed absence). 9999 seconds and a throwaway ``tmp_path``
+    destination fd, closed immediately after arming: even if the safety
+    net this test exists to witness were itself broken, this dump could
+    never fire within any real test run's lifetime, and would land only
+    in a file nothing else ever reads."""
+    from tests.conftest import faulthandler_safety_net_call_count
+
+    _faulthandler_safety_net_witness_baseline.append(faulthandler_safety_net_call_count())
+    sink = tmp_path / "leaked_dump.txt"
+    fd = os.open(str(sink), os.O_WRONLY | os.O_CREAT)
+    try:
+        faulthandler.dump_traceback_later(9999, file=fd, repeat=False)
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.xdist_group(name="test_3671_faulthandler_safety_net_witness")
+def test_b_the_conftest_safety_net_cancelled_it() -> None:
+    """Tier 2: #5909 (architect prescription 1) witness, half 2 of 2 — see
+    ``test_a_leaves_a_faulthandler_dump_armed_without_disarming`` (right
+    above) for the setup. Asserts ``tests/conftest.py``'s
+    ``_cancel_any_pending_faulthandler_dump`` autouse fixture's own public
+    call counter advanced across test A's own teardown — evidence the
+    fixture actually RAN and reached its own
+    ``faulthandler.cancel_dump_traceback_later()`` call, not merely that
+    this suite stayed green (a timer left armed for 9999s would ALSO
+    leave this suite green, since nothing in it runs anywhere near that
+    long — the counter, not "did the run finish", is this witness's real
+    evidence)."""
+    from tests.conftest import faulthandler_safety_net_call_count
+
+    assert _faulthandler_safety_net_witness_baseline, (
+        "setup: test_a_leaves_a_faulthandler_dump_armed_without_disarming "
+        "must have run first (same xdist_group => same worker, collection "
+        "order preserved) and recorded its own baseline"
+    )
+    assert faulthandler_safety_net_call_count() > _faulthandler_safety_net_witness_baseline[-1], (
+        "tests/conftest.py's own safety-net call counter did not advance "
+        "across test A's teardown -- either the autouse fixture did not "
+        "run, or it ran but never reached its own increment"
     )


### PR DESCRIPTION
**[lead-coder-subagent]** — part of #5909

architect ruling（issue #5909、2026-09-07 コメント）の処方 2 つを、どちらも test 側で閉じます。`src/` は無変更です。

## 処方 1 — process 大域の安全網（`tests/conftest.py`）

新しい **function 幅 autouse fixture** `_cancel_any_pending_faulthandler_dump`（`tests/conftest.py:614` 付近、`_isolate_stall_trace_file_handler_registration` の直後）が、各 test の teardown で `faulthandler.cancel_dump_traceback_later()` を **無条件に、名指しで直接** 呼びます。

既存の `_isolate_stall_trace_file_handler_registration`（`tests/conftest.py:555`）は `stall_trace.disarm()` を条件付きで呼んでいますが、`test_3671_stall_trace_startup_wiring.py` の複数の test が `monkeypatch.setattr(stall_trace, "disarm", ...)` でその名前自体をスタブしています。その名前を経由する限り、安全網の実効性は「fixture teardown の順序が monkeypatch の undo より後に来る」という暗黙の前提に依存します。新 fixture は `faulthandler.cancel_dump_traceback_later` を **stdlib のまま直接** 呼ぶので、`stall_trace` 側の何がスタブされていようと無関係です（`grep -rn "faulthandler\." tests/` で確認: 他に monkeypatch されている箇所は無し）。

**#4986 watchdog との関係（既知の絞り込み、隠していません）**: 既存の guard は `REYN_STALL_TRACE_CI` が立った **serial**（非 xdist）実行での controller 上の session watchdog を保護するためのものです。CI は常に `REYN_STALL_TRACE_CI=600 ... pytest -n auto` を同じシェル呼び出しで渡している（`.github/workflows/test.yml:160`）ため、CI で test item を実際に実行するプロセスは常に xdist worker であり、controller が test を直接走らせることはありません。∴ 今回の無条件 cancel は **現在の CI 形状では #4986 watchdog を退行させません**。ただし「serial + REYN_STALL_TRACE_CI」というローカルな組み合わせでは watchdog を消してしまう、という絞り込みは fixture 自身の docstring に明記しました。architect の裁定通り無条件を優先しましたが、この一点は認識の上での判断です。

**witness**: `test_a_leaves_a_faulthandler_dump_armed_without_disarming` / `test_b_the_conftest_safety_net_cancelled_it`（`tests/interfaces/test_3671_stall_trace_startup_wiring.py` 末尾、`xdist_group` で同一 worker に固定）。`faulthandler` の public API に「armed かどうか」の getter が無いことを確認した上で（列挙: `enable`/`disable`/`is_enabled`/`dump_traceback`/`dump_traceback_later`/`cancel_dump_traceback_later`/`register`/`unregister` のみ）、代わりに新 fixture 自身の呼び出し回数を数える public カウンタ `faulthandler_safety_net_call_count()`（`tests/conftest.py`）を witness の観測点にしました — private state を覗いていません。

## 処方 2 — 共有 sink を assert から外す（同 file、`test_the_tripwire_reopens_its_fd_after_a_log_rotation`）

`RotatingFileHandler`（`maxBytes=1`、変更なし — rollover を確実に起こすための値なので縮めていません）の attach 先を root logger から **専用の非 propagate logger**（`logging.getLogger(f"{__name__}.log_rotation_witness")`、`propagate=False`）に変更しました。

根拠: `stall_trace.find_file_handler_path()`（#5873 以降）はロガー構造を一切見ない、単なる宣言済みパスの読み出しです（`src/reyn/runtime/stall_trace.py` の `register_file_handler_path`/`find_file_handler_path` docstring で確認）。∴ この test の主語（`_watch_loop_responsiveness` の fd/inode 追跡ロジック）はどのロガーが handler を持つかに一切依存せず、変えたのは「誰がこの handler へ書けるか」だけです。root のままだと、この test が real headless app を走らせている間に無関係な WARNING が root へ伝播 → `maxBytes=1` で即rollover → `pre_ino == log_path.stat().st_ino` という setup 前提（`test_3671_stall_trace_startup_wiring.py:318` 相当）が偽になり得ます（#5922 の実測ログの症状と一致）。

## Test plan

- [x] `ruff check tests/conftest.py tests/interfaces/test_3671_stall_trace_startup_wiring.py`
- [x] `python scripts/test_tier_audit.py --strict tests/conftest.py tests/interfaces/test_3671_stall_trace_startup_wiring.py` — 9/9 OK
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `python scripts/check_collect_events_settle.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `pytest tests/interfaces/test_3671_stall_trace_startup_wiring.py -v` — 9 passed（serial のみ; xdist 下の再現性は元々環境依存なので、このスコープでは witness の観測面のみを検証しています）
- [ ] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LZ2nN392xjGJNJzpCc8T5
