### PR TITLE
fix(#5919): declaration gates require a fixed marker syntax prose cannot write by accident

### DIFF
--- a/scripts/_markers.py
+++ b/scripts/_markers.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Shared marker-detection primitives for declaration/exemption/closing-note
+gates (#5919 stage 1).
+
+## The class this closes
+
+Five `scripts/` gates each read prose (a PR comment, a PR body, a source
+comment) looking for a human's *declaration* — "TESTS-READ", "RE-READ",
+"BLOCKING-CLEARED", "this file is exempt", "this PR closes #N". Four of
+them (the ones this module serves; the fifth, `check_open_blocking_
+checkboxes.py`'s `_resolves_via_body`, is a separate PR — house-rule
+change, architect's call) used to detect a declaration by `.search()`-ing
+free text for a keyword, unanchored. #5919's census found the shared
+defect: **a sentence saying the declaration does NOT apply still contains
+the keyword**, so "no TESTS-READ note yet" and "No RE-READ needed here"
+both read as the note they deny. Each gate had grown its own regex to do
+this, so each gate could independently reopen the same hole — a
+per-gate discipline problem CLAUDE.md itself names ("A rule with no
+trigger is not a rule"): the fix has to be a shared BOUNDARY a sixth gate
+cannot avoid, not five separate reminders.
+
+## Why a marker (not smarter prose-reading)
+
+A human declaration and a human *discussion* of that declaration use the
+same words — no keyword search, however placed, can tell them apart from
+content alone (the discussing PR comment "This PR is not ready for a
+TESTS-READ note yet" is not distinguishable from a real one by which
+words it contains). What DOES distinguish them is a fixed, deliberate
+syntax — something nobody produces while writing an ordinary sentence
+about the same topic. Every primitive here compiles a pattern matched
+with `re.Pattern.match()` against a single, pre-isolated line (never
+`.search()` over a whole multi-line comment/body) so the marker's position
+is part of the contract, not a coincidence of where a keyword happened to
+land.
+
+Three shapes cover the four gates:
+
+* **line-start, optional role-prefix** (`role_prefixed_marker`) — the
+  marker keyword must OPEN the comment's first line, either bare
+  (``TESTS-READ (head <sha>)``, the form most existing notes in this repo
+  already use) or immediately after the CLAUDE.md rule-2 role prefix
+  (``**[role]** — TESTS-READ (head <sha>)``) — both anchored at column 0,
+  never merely present somewhere on the line. A sentence that merely
+  DISCUSSES the marker never opens a line this way: "This PR is not ready
+  for a TESTS-READ note yet" does not start with the keyword (something
+  else — "This") and does not start with a role prefix immediately
+  followed by it either. The same anchor also excludes a backtick- or
+  quote-wrapped marker (`` `TESTS-READ (head x)` ``, ``> TESTS-READ
+  ...``) — those do not open the line with the literal keyword or role
+  prefix either, a backtick or `>` character does. Used by TESTS-READ
+  (`check_tests_read_names_its_tree.py`) and RE-READ
+  (`check_blocking_has_reread_note.py`).
+* **HTML comment** (`html_comment_marker`) — invisible when rendered,
+  explicit and greppable in source; nobody writes `<!-- tag: ... -->`
+  by accident mid-sentence. Used by the `closing-check: discussing #N`
+  exemption in `check_pr_closing_intent.py`.
+* **fixed-prefix source comment** (`fixed_comment_marker`) — a Python
+  comment line whose first token, at column 0, is the exact directive
+  word, e.g. `# EXEMPT: out_of_process_reyn`. A prose comment
+  *mentioning* the same fixture name mid-sentence does not start there.
+  Used by `check_subprocess_reyn_pin.py`'s exemption declaration.
+
+## What this module deliberately does NOT do
+
+It does not decide what counts as a declaration for any one gate — each
+gate still owns its own vocabulary (which keyword, which marker body) and
+still owns matching that vocabulary against whatever it reads (a first
+line, a whole comment, a whole file). This module only supplies the
+SHAPE that keeps that matching from being satisfiable by ordinary prose.
+It is not itself a gate and has no `main`.
+
+stdlib-only (`re`), so every importing gate stays dep-free.
+"""
+from __future__ import annotations
+
+import re
+
+#: CLAUDE.md rule 2's required opening of every PR comment/issue body:
+#: ``**[role]** — ``. A marker anchored immediately after this prefix
+#: cannot be produced by a sentence that merely discusses the marker's
+#: keyword, because ordinary prose does not open a comment's first line
+#: with a role prefix followed directly by that keyword.
+ROLE_PREFIX = r"\*\*\[[^\]]+\]\*\*\s+—\s+"
+
+
+def role_prefixed_marker(keyword_pattern: str, *, flags: int = re.IGNORECASE) -> "re.Pattern[str]":
+    """Compile a marker regex matching only a line that OPENS with
+    *keyword_pattern* — bare, or immediately after the role prefix
+    (:data:`ROLE_PREFIX`). Both alternatives are anchored at column 0;
+    neither matches the keyword appearing later on the line, inside
+    backticks/a quote block, or merely discussed in a longer sentence.
+
+    Match the result with ``.match()`` (or ``.search()`` — the leading
+    ``^`` makes them equivalent here) against a single, already-isolated
+    line — never a whole multi-line comment, or the anchor is
+    meaningless."""
+    return re.compile(rf"^(?:{ROLE_PREFIX})?{keyword_pattern}", flags)
+
+
+def first_line(text: str) -> str:
+    """*text*'s first line, newline-delimited, no trailing newline — the
+    single line every marker in this module is matched against. A
+    document's line 2 onward (grounds, discussion, prior history) is
+    never handed to a marker pattern; the exclusion is syntactic, not a
+    matter of where a keyword happens to be more or less likely."""
+    return text.split("\n", 1)[0]
+
+
+def html_comment_marker(tag: str, payload_pattern: str, *, flags: int = re.IGNORECASE) -> "re.Pattern[str]":
+    """Compile an HTML-comment marker regex: ``<!-- tag: <payload> -->``.
+
+    *payload_pattern* is inserted as-is (own capture groups included) so
+    a caller that needs the payload back (e.g. the issue numbers a
+    ``discussing`` marker names) gets the same group numbering it would
+    from a hand-written pattern. Invisible when a PR body/comment is
+    rendered, but explicit and greppable in the raw source — nobody
+    writes an HTML comment by accident in the middle of an ordinary
+    sentence, which is what makes this a declaration rather than a
+    coincidence of wording."""
+    return re.compile(rf"<!--\s*{re.escape(tag)}:\s*{payload_pattern}\s*-->", flags)
+
+
+def fixed_comment_marker(directive: str, *, flags: int = 0) -> "re.Pattern[str]":
+    """Compile a ``# DIRECTIVE: <name>`` marker anchored to a Python
+    comment's OWN start.
+
+    Match the result with ``.match()`` against ONE physical line at a
+    time (e.g. ``for line in text.splitlines(): fixed_comment_marker(...)
+    .match(line)``), never ``.search()`` over the whole file — a prose
+    comment that merely *mentions* the directive word or the exempted
+    name mid-sentence (``# this subprocess call never touches
+    out_of_process_reyn``) does not start a line with ``# DIRECTIVE:``,
+    so it does not match; only a line deliberately opening with the
+    exact directive does."""
+    return re.compile(rf"^#\s*{re.escape(directive)}:\s*(\S+)", flags)

--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -84,7 +84,6 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -106,6 +105,7 @@ def _load(module_name: str, filename: str):
 
 _tests_read = _load("_check_blocking_reread_tests_read", "check_tests_read_names_its_tree.py")
 _blocking = _load("_check_blocking_reread_blocking", "check_open_blocking_checkboxes.py")
+_markers = _load("_check_blocking_reread_markers", "_markers.py")
 
 #: architect's non-blocking recommendation on #5453 (quoted verbatim below,
 #: `evaluate`'s docstring) — reusing ONLY `_tests_read._NOTE_MARKER`
@@ -115,7 +115,12 @@ _blocking = _load("_check_blocking_reread_blocking", "check_open_blocking_checkb
 #: THIS gate, so a PR that also touches `tests/` (and so already needs
 #: `TESTS-READ` for house rule 8) still clears both gates with ONE
 #: comment, while a `src`-only PR can post the accurate one.
-_RE_READ_MARKER = re.compile(r"RE-READ\s*\(\s*head\s", re.IGNORECASE)
+#:
+#: #5919: like `_tests_read._NOTE_MARKER`, now anchored to the CLAUDE.md
+#: rule-2 role prefix via `_markers.role_prefixed_marker` — a bare
+#: `.search()` used to let a line DENYING a re-read ("No RE-READ (head
+#: start) needed here, this is a docs-only typo fix.") read as one.
+_RE_READ_MARKER = _markers.role_prefixed_marker(r"RE-READ\s*\(\s*head\s")
 
 
 def _is_reread_note(first_line: str) -> bool:

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -315,6 +315,10 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _markers  # noqa: E402 -- sibling module, see _markers.py's own docstring
 
 # ---------------------------------------------------------------------------
 # Declaring-phrase vocabulary (OUR vocabulary — deliberately small and NOT a
@@ -452,9 +456,12 @@ def _window_has_negation(window: str) -> bool:
 # PR both declares `Closes #3007` and discusses #2620/#2972/#2827 as
 # examples — a body-wide marker would silently drop check-1 protection from
 # the real declaration, turning the escape hatch into a bypass).
-_DISCUSSING_MARKER_RE = re.compile(
-    r"<!--\s*closing-check:\s*discussing\s+((?:#\d+[\s,]*)+?)\s*-->",
-    re.IGNORECASE,
+#: #5919 stage 1: built via the shared `_markers.html_comment_marker`
+#: primitive (same regex as before this refactor — behaviour unchanged,
+#: only the construction moved into the one place a future gate reaches
+#: for this shape instead of hand-rolling its own).
+_DISCUSSING_MARKER_RE = _markers.html_comment_marker(
+    "closing-check", r"discussing\s+((?:#\d+[\s,]*)+?)",
 )
 _ISSUE_NUM_RE = re.compile(r"#(\d+)")
 

--- a/scripts/check_subprocess_reyn_pin.py
+++ b/scripts/check_subprocess_reyn_pin.py
@@ -58,6 +58,19 @@ demanding that judgment be resolved BEFORE adoption would defer the gate
 indefinitely — same reasoning as that script's own ratchet, and
 `mypy_ratchet.py`'s.
 
+For the over-count case — a spawn that genuinely never touches `reyn` —
+write ``# EXEMPT: <short reason>`` as its own comment line, starting at
+that line's own first character (``_markers.fixed_comment_marker``).
+Before #5919 the declaration check was a plain substring search over the
+WHOLE file, so a comment merely *mentioning* a fixture name anywhere —
+including one explaining that the file does NOT need it, e.g. ``# this
+subprocess call never touches out_of_process_reyn — plain smoke check``
+— satisfied it, silently and permanently. The genuine declaration (a real
+fixture request) is now read from actual Python syntax (a NAME token, via
+`tokenize` — never from a comment or a string), and the exemption path is
+this separate, explicit marker: the two are no longer the same regex, so
+a comment merely discussing either vocabulary cannot satisfy either.
+
 ## A ratchet, not a zero baseline
 
 At the time this gate landed, the gap held enough pre-existing files that
@@ -80,17 +93,68 @@ file must never itself flip the gate red.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import re
 import subprocess
 import sys
+import tokenize
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _markers  # noqa: E402 -- sibling module, see _markers.py's own docstring
 
 _ROOT = Path(__file__).resolve().parent.parent
 _BASELINE_PATH = _ROOT / "scripts" / "check_subprocess_reyn_pin_baseline.json"
 
 _SPAWN_RE = re.compile(r"\bsys\.executable\b")
-_DECLARED_RE = re.compile(r"\bout_of_process_reyn\b|\breyn_console_scripts\b")
+
+#: The two fixture names that count as a genuine declaration — see
+#: `_declares_fixture` below. Matched as Python NAME tokens, never as a
+#: text substring (#5919).
+_FIXTURE_NAMES = frozenset({"out_of_process_reyn", "reyn_console_scripts"})
+
+#: #5919: a `# EXEMPT: <name>` line, anchored to a comment's own start
+#: (`_markers.fixed_comment_marker`), for a file whose `sys.executable`
+#: spawn genuinely never touches `reyn` (the module docstring's own
+#: "Population imprecision" example) — the ONE case a text scan cannot
+#: settle from the fixture names alone, so it needs its own explicit,
+#: hand-written declaration rather than piggybacking on `_FIXTURE_NAMES`.
+_EXEMPT_RE = _markers.fixed_comment_marker("EXEMPT")
+
+
+def _declares_fixture(text: str) -> bool:
+    """True iff *text* (one `tests/**/*.py` file's own source) either (a)
+    uses `out_of_process_reyn` / `reyn_console_scripts` as a real Python
+    NAME token — a fixture request, a parameter, an attribute access —
+    or (b) carries a `# EXEMPT: <name>` marker at a comment's own start.
+
+    Deliberately NOT a text-substring search over the whole file (#5919's
+    own incident): a COMMENT merely *mentioning* one of the fixture names
+    — including one explaining that the file does NOT need it, e.g.
+    ``# this subprocess call never touches out_of_process_reyn — plain
+    smoke check`` — used to satisfy the old `_DECLARED_RE.search(text)`,
+    silently and permanently removing that file from the gap (the class
+    of failure this gate exists to catch, applied to itself: "no
+    declaration" read as "declared"). `tokenize` distinguishes a NAME
+    token used as code from the SAME text appearing inside a COMMENT or
+    STRING token, which a bare regex over raw text cannot do at all.
+
+    A file that tokenizes with a genuine syntax error is treated as NOT
+    declaring — refusing to guess is safer than either direction here,
+    and a `tests/**/*.py` file that does not parse has a problem this
+    gate is not the one to report."""
+    for line in text.splitlines():
+        if _EXEMPT_RE.match(line):
+            return True
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        for tok in tokens:
+            if tok.type == tokenize.NAME and tok.string in _FIXTURE_NAMES:
+                return True
+    except (tokenize.TokenizeError, SyntaxError, IndentationError, ValueError):
+        return False
+    return False
 
 
 def _iter_tests_py(root: Path = _ROOT) -> "list[Path]":
@@ -137,7 +201,7 @@ def gap_files(root: Path = _ROOT) -> "set[str]":
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if _SPAWN_RE.search(text) and not _DECLARED_RE.search(text):
+        if _SPAWN_RE.search(text) and not _declares_fixture(text):
             offenders.add(str(path.relative_to(root)))
     return offenders
 
@@ -203,11 +267,15 @@ def main(argv: "list[str] | None" = None) -> int:
         "`PYTHONPATH` (see tests/conftest.py's fixture docstring, and "
         "tests/interfaces/test_textual_chat_phase1_3273.py for a worked "
         "example). If it runs a `[project.scripts]` console script by "
-        "name: request `reyn_console_scripts` instead. If the spawn "
-        "genuinely never touches `reyn` (e.g. `sys.executable -c "
-        "\"print('ok')\"`), that's fine too — but say so and regenerate "
-        "the baseline (--write-baseline) rather than leaving it "
-        "unexplained.",
+        "name: request `reyn_console_scripts` instead. A declaration must "
+        "be REAL Python syntax (the fixture name used as a NAME token, "
+        "e.g. a test parameter) — a comment merely mentioning the name "
+        "does not count (#5919). If the spawn genuinely never touches "
+        "`reyn` (e.g. `sys.executable -c \"print('ok')\"`), that's fine "
+        "too — but say so with a fixed marker: add a comment line reading "
+        "exactly `# EXEMPT: <short reason>`, starting at that line's own "
+        "first character, then regenerate the baseline (--write-baseline) "
+        "rather than leaving it unexplained.",
         file=sys.stderr,
     )
     return 1

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -52,6 +52,19 @@ in a multi-line comment is merely less likely to be read as a claim, it is
 structurally excluded, because ``evaluate`` never hands anything past a
 comment's first line to either the marker regex or the SHA search.
 
+#5919: the first-line restriction above closes self-reference from a
+MULTI-line comment, but was not by itself enough to close it within the
+first line — a one-line comment that merely DENIES a note ("This PR is not
+ready for a TESTS-READ note yet — still investigating 9cc1006.") is still
+entirely "first line" and, under a bare ``.search()`` for the keyword,
+matched exactly like a real claim, with the trailing SHA-shaped token then
+read as the tree it names. ``_NOTE_MARKER`` (:mod:`_markers`) now requires
+the marker to OPEN the line, immediately after the CLAUDE.md rule-2 role
+prefix every comment already carries — ordinary prose discussing the
+marker does not open a comment with a role prefix followed directly by the
+keyword, so this excludes the denial case the same way the first-line
+restriction excludes the multi-line one: syntactically, not statistically.
+
 The claim is also deliberately NOT read from the PR **body**. A body is one
 document serving many purposes at once — description, Test plan, reviewer
 blocking points, bootstrap notes — and a whole-body search cannot tell
@@ -102,14 +115,23 @@ import json
 import re
 import subprocess
 import sys
+from pathlib import Path
 
-#: A TESTS-READ note's claim line is recognised by this marker appearing on a
-#: comment's FIRST LINE (see ``_first_line`` / ``evaluate``) — never a line 2+
-#: only appearance, and never the PR body. Matched case-insensitively and
-#: tolerating the ``TESTS-READY`` typo that several sessions produce, because
-#: the gate must not turn a typo into "no note landed" (that would fail the
-#: PR for the wrong reason).
-_NOTE_MARKER = re.compile(r"TESTS-READ(?:Y)?", re.IGNORECASE)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _markers  # noqa: E402 -- sibling module, see _markers.py's own docstring
+
+#: A TESTS-READ note's claim line is recognised by this marker ONLY when it
+#: OPENS a comment's FIRST LINE, immediately after the CLAUDE.md rule-2 role
+#: prefix (see ``_markers.role_prefixed_marker``) — never a bare `.search()`
+#: over free text (#5919: "This PR is not ready for a TESTS-READ note yet"
+#: used to match, because the keyword appeared anywhere on the line; a
+#: sentence DENYING the note is not distinguishable from one STATING it by
+#: keyword search alone). Matched case-insensitively and tolerating the
+#: ``TESTS-READY`` typo that several sessions produce, because the gate must
+#: not turn a typo into "no note landed" (that would fail the PR for the
+#: wrong reason). Required syntax: a comment's first line reading
+#: ``**[role]** — TESTS-READ (...) (head <sha>)``.
+_NOTE_MARKER = _markers.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
 
 #: A 7-40 char hex run, the shape `git rev-parse` prints. Bounded on both sides
 #: by a non-hex boundary so a longer word containing hex letters is not read as
@@ -259,9 +281,13 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         return 1, [
             "RED — this PR touches tests/ but carries no TESTS-READ note.",
             "  House rule 8: a PR touching tests/ does not self-merge until a",
-            "  reviewer's TESTS-READ note lands on it — the marker and the head",
-            "  SHA must both be on a comment's FIRST line; a marker mentioned",
-            "  only from line 2 onward does not count as a note.",
+            "  reviewer's TESTS-READ note lands on it. Required syntax (#5919):",
+            "  a comment's FIRST line must OPEN with the role prefix immediately",
+            "  followed by the marker and the head SHA, e.g.",
+            "  `**[role]** — TESTS-READ (head abc1234)` — a marker appearing",
+            "  anywhere else on the line, or only from line 2 onward, does not",
+            "  count as a note (a sentence merely discussing TESTS-READ, e.g.",
+            "  \"not ready for a TESTS-READ note yet\", must not read as one).",
             f"  tests/ files touched: {len(touched_tests)}",
         ]
 

--- a/tests/scripts/test_check_blocking_has_reread_note_5453.py
+++ b/tests/scripts/test_check_blocking_has_reread_note_5453.py
@@ -192,3 +192,53 @@ def test_a_tests_read_note_with_no_resolvable_sha_is_rejected():
     ))
     assert code == 1
     assert "none of them names a" in "\n".join(lines)
+
+
+# ── #5919: fixed-marker syntax, census + architect deny fixtures ────────────
+
+
+def test_a_sentence_denying_a_re_read_is_not_read_as_one():
+    """Tier 1: deny side — #5919's own census input. Before the fix,
+    `_RE_READ_MARKER.search` matched "RE-READ" anywhere on the first line,
+    so a comment DENYING that a re-read is needed read as the note itself
+    ("No RE-READ (head start) needed here..." even carries a SHA-shaped
+    token, "start", that this gate must not treat as a real claim)."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("bbbbbbb"),
+            {"body": "No RE-READ (head start) needed here, this is a docs-only typo fix."},
+        ],
+        commits=[_commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 1
+    assert "no TESTS-READ- or RE-READ-shaped" in "\n".join(lines)
+
+
+def test_a_backtick_fenced_re_read_marker_is_not_a_claim():
+    """Tier 1: architect (#5919) — column-0 alone is not enough; a
+    backtick-fenced marker can open a line while still being a mention."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("bbbbbbb"),
+            {"body": "`RE-READ (head bbbbbbb)` is the syntax, per the gate."},
+        ],
+        commits=[_commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 1
+    assert "no TESTS-READ- or RE-READ-shaped" in "\n".join(lines)
+
+
+def test_a_quoted_re_read_marker_is_not_a_claim():
+    """Tier 1: architect (#5919) — a markdown-quoted line."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("bbbbbbb"),
+            {"body": "> RE-READ (head bbbbbbb)"},
+        ],
+        commits=[_commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 1
+    assert "no TESTS-READ- or RE-READ-shaped" in "\n".join(lines)

--- a/tests/scripts/test_check_pr_closing_intent.py
+++ b/tests/scripts/test_check_pr_closing_intent.py
@@ -1050,3 +1050,30 @@ def test_check4_stays_silent_when_the_body_canonically_covers_the_commit_leak():
         commit_messages=[_PR5484_COMMIT_WITH_LEAK],
     )
     assert findings == []
+
+
+# ── #5919: the census's own live false-positive input ───────────────────────
+
+
+def test_check1_fires_on_the_5919_census_prose_shape_without_a_marker():
+    """Tier 1: deny side — #5919's own census input, PR #2989's real body
+    prose "Order-dependency is resolved: #2975" (quoted verbatim in this
+    module's docstring as the motivating example for the `discussing`
+    marker's existence). Without the marker, `resolve[sd]` + `#N` is a
+    real GitHub closing keyword match, so check 1 correctly fires
+    (fail-CLOSED — noisy, never silent) when the parser did not resolve
+    #2975: this is the documented, intended behaviour the marker exists to
+    let an author opt out of, not a defect in itself."""
+    body = "Order-dependency is resolved: #2975"
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert _checks(findings) == [(1, 2975)]
+
+
+def test_check1_is_silenced_by_the_discussing_marker_for_the_same_shape():
+    """Tier 1: accept side, same prose — adding the `discussing` marker
+    (the documented escape hatch, #5919's shared-helper refactor of
+    `_DISCUSSING_MARKER_RE` must not change this) silences check 1 for the
+    same #2975 that fired above."""
+    body = "Order-dependency is resolved: #2975\n\n<!-- closing-check: discussing #2975 -->"
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert findings == []

--- a/tests/scripts/test_check_subprocess_reyn_pin_5028.py
+++ b/tests/scripts/test_check_subprocess_reyn_pin_5028.py
@@ -29,6 +29,18 @@ from scripts.check_subprocess_reyn_pin import (
     new_files,
 )
 
+# EXEMPT: this-file-tests-the-scanner-and-spawns-no-subprocess-of-its-own
+#
+# #5919 stage 1 migration — the module docstring above mentions
+# `sys.executable`/`out_of_process_reyn` BY NAME (prose describing what the
+# gate under test does), which is exactly the population-imprecision
+# over-count `check_subprocess_reyn_pin.py`'s own docstring already
+# discloses: this file's own real subprocess calls are `git init`/`git add`
+# (`_init_repo`), never `sys.executable` itself, so requesting the fixture
+# would gain it nothing. Before #5919 that prose mention alone satisfied
+# `_DECLARED_RE.search(text)`; now a declaration must be a real NAME token
+# (this file uses none) or this explicit, fixed-syntax marker.
+
 # `tests/scripts/test_check_subprocess_reyn_pin_5028.py`'s own source
 # mentions `sys.executable` and the two fixture names in prose above — split
 # so this file's own text never contains a run the scanner under test would
@@ -193,6 +205,77 @@ def test_the_real_baseline_has_no_new_files_against_the_current_tree() -> None:
     baseline = load_baseline()
     measured = gap_files(_ROOT)
     assert new_files(measured, baseline) == set()
+
+
+# ── #5919: declaration must be real syntax, not a text mention ─────────────
+
+
+def test_a_comment_denying_the_declaration_does_not_declare_it(tmp_path) -> None:
+    """Tier 1: deny side — #5919's own census input, the false positive
+    that motivated this fix. Before the fix, `_DECLARED_RE.search(text)`
+    matched `out_of_process_reyn` appearing ANYWHERE in the file's text,
+    so a comment EXPLAINING that the fixture is not needed satisfied the
+    same regex as actually requesting it — this file's real violation
+    (spawning `sys.executable` with nothing declared) was silently, and
+    permanently, removed from the gap."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_a.py").write_text(
+        f"proc = subprocess.run([{_SPAWN}, '-c', 'import reyn'])\n"
+        f"# this subprocess call never touches {_DECLARED} -- plain smoke check\n",
+        encoding="utf-8",
+    )
+    _init_repo(tmp_path)
+    assert gap_files(tmp_path) == {_T + "test_a.py"}
+
+
+def test_an_exempt_marker_declares_the_file(tmp_path) -> None:
+    """Tier 1: accept side — the fixed `# EXEMPT: <reason>` marker
+    (anchored to a comment's own start) is a genuine declaration, for the
+    one case a real fixture request cannot cover: a spawn that truly
+    never touches `reyn`."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_a.py").write_text(
+        "# EXEMPT: plain-smoke-check-no-reyn-involved\n"
+        f"proc = subprocess.run([{_SPAWN}, '-c', 'import reyn'])\n",
+        encoding="utf-8",
+    )
+    _init_repo(tmp_path)
+    assert gap_files(tmp_path) == set()
+
+
+def test_an_exempt_marker_not_at_the_comments_own_start_does_not_declare(tmp_path) -> None:
+    """Tier 1: deny side — the marker word appearing mid-comment (not
+    opening the comment's own line) must not declare, the same anchoring
+    discipline as the PR-comment marker gates."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_a.py").write_text(
+        f"proc = subprocess.run([{_SPAWN}, '-c', 'import reyn'])\n"
+        "# see EXEMPT: below for the real one on the next line\n",
+        encoding="utf-8",
+    )
+    _init_repo(tmp_path)
+    assert gap_files(tmp_path) == {_T + "test_a.py"}
+
+
+def test_a_real_fixture_parameter_with_no_spawn_stays_out_of_the_gap(tmp_path) -> None:
+    """Tier 1: accept side, through the public `gap_files` surface — a
+    genuine fixture request (a NAME token, not merely mentioned in a
+    comment) keeps declaring the file even when a nearby comment ALSO
+    mentions the same name in prose; the code-usage path and the
+    EXEMPT-marker path are independent, and either alone is enough."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_a.py").write_text(
+        f"# requests {_DECLARED} below, for real\n"
+        f"def test_x({_DECLARED}):\n"
+        f"    proc = subprocess.run([{_SPAWN}, '-c', 'import reyn'])\n",
+        encoding="utf-8",
+    )
+    _init_repo(tmp_path)
+    assert gap_files(tmp_path) == set()
 
 
 def test_baseline_is_a_flat_list_of_existing_tracked_files() -> None:

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -482,3 +482,67 @@ def test_tests_commits_after_takes_no_head_argument():
         ],
     )
     assert [c["oid"] for c in later] == ["bbbbbbbb"]
+
+
+# ── #5919: fixed-marker syntax, census + architect deny fixtures ────────────
+
+
+def test_a_sentence_denying_a_note_is_not_read_as_one():
+    """Tier 1: deny side — #5919's own census input. Before the fix,
+    `_NOTE_MARKER.search` matched "TESTS-READ" anywhere on the first line,
+    so a comment DENYING that a note is ready read as a claim, with the
+    trailing SHA-shaped token ("9cc1006") then read as the tree it names.
+    Must fall into the same "no note" bucket as a comment that never
+    mentions TESTS-READ at all."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{
+            "body": "This PR is not ready for a TESTS-READ note yet — "
+                    "still investigating 9cc1006.",
+        }],
+        commits=[_commit("9cc1006aa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+        head="9cc1006aa",
+    ))
+    assert code == 1
+    assert "no TESTS-READ note" in "\n".join(lines)
+
+
+def test_a_backtick_fenced_marker_is_not_a_claim():
+    """Tier 1: architect (#5919) — column-0 alone is not enough; a
+    backtick-fenced marker can also open a line (`` `TESTS-READ ...` ``)
+    while still being a MENTION, not a declaration. The marker regex
+    requires the literal keyword or role prefix, so a leading backtick
+    character excludes it structurally."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "`TESTS-READ (head 9cc1006aa)` is the syntax this gate wants."}],
+        commits=[_commit("9cc1006aa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+        head="9cc1006aa",
+    ))
+    assert code == 1
+    assert "no TESTS-READ note" in "\n".join(lines)
+
+
+def test_a_quoted_marker_is_not_a_claim():
+    """Tier 1: architect (#5919) — a markdown-quoted line (`> TESTS-READ
+    ...`) opens with the quote marker, not the keyword or role prefix."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "> TESTS-READ (head 9cc1006aa)"}],
+        commits=[_commit("9cc1006aa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+        head="9cc1006aa",
+    ))
+    assert code == 1
+    assert "no TESTS-READ note" in "\n".join(lines)
+
+
+def test_a_mid_sentence_mention_is_not_a_claim():
+    """Tier 1: the marker discussed mid-sentence, not opening the line."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "The reviewer marks it as TESTS-READ (head 9cc1006aa) once done."}],
+        commits=[_commit("9cc1006aa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+        head="9cc1006aa",
+    ))
+    assert code == 1
+    assert "no TESTS-READ note" in "\n".join(lines)

--- a/tests/scripts/test_markers_5919.py
+++ b/tests/scripts/test_markers_5919.py
@@ -1,0 +1,133 @@
+"""Tier 1: `scripts/_markers.py`'s own contract — the shared marker-detection
+primitives four gates now build their declaration/exemption regexes from
+(#5919 stage 1).
+
+Each primitive's job is narrow: produce a pattern that ordinary prose
+cannot satisfy by accident, while still matching every real, deliberate
+declaration shape already in use across the repo (bare marker, role-prefixed
+marker, HTML-comment marker, fixed source-comment marker). These tests pin
+that contract directly against `_markers.py`, independent of any one gate
+that consumes it — a change here is exactly the "next gate reopens the same
+hole" risk the module's own docstring names, so its own behaviour needs its
+own witness.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+from tests._support.paths import REPO_ROOT
+
+_SPEC = importlib.util.spec_from_file_location(
+    "_check_markers_5919", REPO_ROOT / "scripts" / "_markers.py",
+)
+_MOD = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MOD)
+
+
+# ── role_prefixed_marker ─────────────────────────────────────────────────
+
+
+def test_bare_keyword_at_line_start_matches():
+    """Tier 1: accept — the keyword alone, opening the line."""
+    pattern = _MOD.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+    assert pattern.match("TESTS-READ (head abc1234)")
+
+
+def test_role_prefixed_keyword_matches():
+    """Tier 1: accept — the CLAUDE.md rule-2 role prefix immediately
+    followed by the keyword."""
+    pattern = _MOD.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+    assert pattern.match("**[e2e-coder]** — TESTS-READ (B: independent) (head abc1234)")
+
+
+def test_a_denying_sentence_does_not_match():
+    """Tier 1: deny — #5919's own census input. The keyword appears on
+    the line, but does not OPEN it."""
+    pattern = _MOD.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+    assert not pattern.match(
+        "This PR is not ready for a TESTS-READ note yet — still investigating 9cc1006.",
+    )
+
+
+def test_a_backtick_fenced_marker_does_not_match():
+    """Tier 1: deny — architect (#5919): column-0 alone is not enough,
+    since a backtick can also open a line."""
+    pattern = _MOD.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+    assert not pattern.match("`TESTS-READ (head abc1234)`")
+
+
+def test_a_quoted_marker_does_not_match():
+    """Tier 1: deny — a markdown blockquote opens with `>`, not the
+    keyword or role prefix."""
+    pattern = _MOD.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+    assert not pattern.match("> TESTS-READ (head abc1234)")
+
+
+def test_a_mid_sentence_mention_does_not_match():
+    """Tier 1: deny — the keyword discussed mid-sentence."""
+    pattern = _MOD.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+    assert not pattern.match("The reviewer marks it as TESTS-READ once done.")
+
+
+# ── html_comment_marker ──────────────────────────────────────────────────
+
+
+def test_html_comment_marker_matches_the_real_syntax():
+    """Tier 1: accept — the exact `<!-- closing-check: discussing #N -->`
+    shape `check_pr_closing_intent.py` uses."""
+    pattern = _MOD.html_comment_marker("closing-check", r"discussing\s+((?:#\d+[\s,]*)+?)")
+    match = pattern.search("prose <!-- closing-check: discussing #2620 #2972 --> more prose")
+    assert match is not None
+    assert match.group(1).strip() == "#2620 #2972"
+
+
+def test_html_comment_marker_does_not_match_prose_about_it():
+    """Tier 1: deny — a sentence merely discussing the tag/payload words
+    without the HTML-comment syntax itself must not match."""
+    pattern = _MOD.html_comment_marker("closing-check", r"discussing\s+((?:#\d+[\s,]*)+?)")
+    assert pattern.search("this PR is closing-check discussing #2620, sort of") is None
+
+
+# ── fixed_comment_marker ─────────────────────────────────────────────────
+
+
+def test_fixed_comment_marker_matches_at_the_comments_own_start():
+    """Tier 1: accept — `# EXEMPT: <name>` opening its own comment line."""
+    pattern = _MOD.fixed_comment_marker("EXEMPT")
+    match = pattern.match("# EXEMPT: out_of_process_reyn")
+    assert match is not None
+    assert match.group(1) == "out_of_process_reyn"
+
+
+def test_fixed_comment_marker_does_not_match_a_mention_inside_prose():
+    """Tier 1: deny — #5919's own census input for
+    `check_subprocess_reyn_pin.py`: a comment merely mentioning the
+    exempted name, not opening with the directive."""
+    pattern = _MOD.fixed_comment_marker("EXEMPT")
+    assert pattern.match(
+        "# this subprocess call never touches out_of_process_reyn -- plain smoke check",
+    ) is None
+
+
+def test_fixed_comment_marker_does_not_match_mid_comment():
+    """Tier 1: deny — the directive word appearing after other text on
+    the same comment line."""
+    pattern = _MOD.fixed_comment_marker("EXEMPT")
+    assert pattern.match("# see EXEMPT: below for the real one") is None
+
+
+# ── first_line ────────────────────────────────────────────────────────────
+
+
+def test_first_line_isolates_only_the_first_line():
+    """Tier 1: the exclusion every marker in this module depends on — a
+    document's line 2 onward must never even be handed to a pattern."""
+    assert _MOD.first_line("TESTS-READ (head abc)\n\ngrounds go here") == "TESTS-READ (head abc)"
+
+
+def test_first_line_of_a_single_line_string_is_itself():
+    """Tier 1: the no-newline case — a string with nothing to split on
+    returns unchanged, so callers need no special-case for a one-line
+    comment/body."""
+    assert _MOD.first_line("only one line") == "only one line"


### PR DESCRIPTION
**[lead-coder-subagent]** — stage 1 of #5919 (architect's scope ruling, https://github.com/tya5/reyn/issues/5919#issuecomment-5567441928): four declaration/exemption/note gates read prose looking for a human's declaration by `.search()`-ing free text for a keyword, unanchored. A sentence DENYING the declaration still contains the keyword, so the gate read "no" as "yes" (fail-open) or, for `check_pr_closing_intent.py`'s check 1, read ordinary prose as a false declaration (fail-closed, noisy). `check_open_blocking_checkboxes.py`'s `_resolves_via_body` is stage 2 — a house-rule change, architect's own call — and is **not touched here**.

part of #5919

## What changed

- **`scripts/_markers.py`** (new) — shared primitives: `role_prefixed_marker` (line must OPEN with the keyword, bare or after the CLAUDE.md rule-2 role prefix), `html_comment_marker` (`<!-- tag: payload -->`), `fixed_comment_marker` (`# DIRECTIVE: value` anchored to a comment's own start), `first_line`. Each gate now builds its marker regex from here instead of hand-rolling its own — the shared-boundary requirement from the architect's ruling.
- **`check_subprocess_reyn_pin.py`** — a declaration is now (a) the fixture name used as a real Python **NAME token** (`tokenize`, not a text-substring search — a genuine fixture request), or (b) an explicit `# EXEMPT: <reason>` marker anchored to a comment's own start. Error message documents both forms.
- **`check_tests_read_names_its_tree.py`** / **`check_blocking_has_reread_note.py`** — the TESTS-READ / RE-READ marker must OPEN a comment's first line (bare, or immediately after the role prefix). Excludes a denying sentence, AND (per architect's later finding from #5924's own live incident) a backtick-fenced marker, a quoted marker, and a mid-sentence mention — column-0 alone is not enough, since a backtick or `>` can also sit at column 0.
- **`check_pr_closing_intent.py`** — no behaviour change. Its `<!-- closing-check: discussing #N -->` marker already had the "prose cannot write this by accident" shape; only the regex construction moved into `_markers.html_comment_marker`.
  Why this satisfies architect's 5-scripts ruling without a behaviour change: the ruling's own discriminator is "does the misread make the gate say YES" — for this gate that YES is "a discussing/mention-only marker is present", and that marker was ALREADY the fixed HTML-comment syntax (`<!-- closing-check: discussing #N -->`) prose cannot produce by accident, pre-#5919. Check 1's own false-positive direction (reading ordinary prose like "resolved: #N" as a closing declaration) is a SEPARATE, deliberately-ratified design decision (module docstring: "no marker, no token, no fence" for a genuine Closes/Fixes/Resolves declaration) with its own documented escape hatch — the same marker. No new gap was found here; only the shared-helper extraction applied.
- No grace period, no clock, no `--write-baseline` regeneration hidden inside this PR: the migration window closes by the enumeration below landing in this same PR.

## ① Counted before migrating (gate's own judgment, not the git-grep population)

`check_subprocess_reyn_pin.py`'s old `_DECLARED_RE` matched **32 files** (one `print()` of the matched-file set, via the gate's own regex — not the 32-file/218-line `git grep` population the architect measured over `src/` + `tests/`, which is the superset, not the declaration count). Of those 32:

- **31** already declare via a real NAME token (a genuine fixture request/parameter) — no change needed, verified by re-running the scan.
- **1** — `tests/scripts/test_check_subprocess_reyn_pin_5028.py` (this gate's own test file) — declared only via prose mentioning the fixture names to describe what the gate does; its own real subprocess calls are `git init`/`git add`, never `sys.executable`. Migrated to an explicit `# EXEMPT: this-file-tests-the-scanner-and-spawns-no-subprocess-of-its-own` marker in this PR.

All 32 accounted for; `python scripts/check_subprocess_reyn_pin.py` still reports 62 gap files, all baselined — 0 new, 0 silently reverted.

`check_tests_read_names_its_tree.py` / `check_blocking_has_reread_note.py` / `check_pr_closing_intent.py` carry **no committed baseline file** (unlike the pin gate) — they evaluate live PR comment/body text at CI-run time, not a persisted population in this tree, so there is nothing to enumerate-and-migrate here. This is disclosed, not assumed: I did not attempt to count historical PR-comment matches across GitHub (not enumerable from this repo's tree within this PR's scope) — only the currently-open PRs (#5916/#5924/#5925/#5926) were available to spot-check, and none carries a note this fix would newly reject.

## Real inputs used as deny-side fixtures

- `check_subprocess_reyn_pin.py`: `# this subprocess call never touches out_of_process_reyn -- plain smoke check` (census).
- `check_tests_read_names_its_tree.py`: `This PR is not ready for a TESTS-READ note yet -- still investigating 9cc1006.` (census) + backtick/quote/mid-sentence variants (architect, #5924's own incident).
- `check_blocking_has_reread_note.py`: `No RE-READ (head start) needed here, this is a docs-only typo fix.` (census) + backtick/quote variants.
- `check_pr_closing_intent.py`: `Order-dependency is resolved: #2975` (census — real PR #2989 body prose, already quoted in the script's own docstring) — deny side (fires without the marker, fail-closed as designed) and accept side (marker silences it).

<!-- closing-check: discussing #2975 -->
(the line above is this gate's own escape hatch for the `Order-dependency is resolved: #2975` demonstration text two paragraphs up, which otherwise reads as this PR body declaring closing intent for #2975 — check 1 firing on that reading is the documented, correct fail-closed behaviour the marker exists to silence.)

## Gates run locally

- `ruff check .` — clean.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 124/124 OK.
- `python scripts/check_bare_tests_import_reference.py` — OK.
- `python scripts/check_file_depth_reference.py` — OK.
- `python scripts/check_subprocess_reyn_pin.py` (the changed gate itself, against the whole repo) — OK, 62 baselined, 0 new.
- `python scripts/check_tests_path_literal_reference.py` — OK.
- `python scripts/mypy_ratchet.py` — OK, 0 new findings.
- `python scripts/flat_tests_ratchet.py` — OK.
- `pytest` scoped to the 5 changed/added test files, foreground, timeout 590s — 124 passed.

CLAUDE.md was not touched (house rule for `_resolves_via_body` stays architect's).

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on all 5 changed/added test files
- [x] `check_subprocess_reyn_pin.py` self-run against the real tree
- [x] `mypy_ratchet.py`
- [x] scoped `pytest`, foreground, 124/124 passed
- [x] (skipped — Visual, standing waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LZ2nN392xjGJNJzpCc8T5

