### PR TITLE
docs: testing.md/ja -- a marker's guarantee holds only under the invocation that enables it

### DIFF
--- a/docs/deep-dives/contributing/testing.ja.md
+++ b/docs/deep-dives/contributing/testing.ja.md
@@ -495,6 +495,18 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
 
 #4081: このブロックは以前 `python -m pytest tests/test_replay_*.py -v` と `python -m pytest tests/test_os_invariants.py -v` も示していましたが、glob もリテラルパスも今は何にも一致しません（`tests/test_replay_skill_router.py` 系と `tests/test_os_invariants.py` は #2435/#2438 の skill/phase engine 一括削除で消え、後継はありません）。未検証の新しい例に差し替えるのではなく削除しました——自分の変更が実際に触るファイル/キーワードにスコープを絞って実行してください（下の「プッシュ前」参照）。
 
+### marker の保証は、それを有効化する起動形の下でしか成立しない
+
+**契機**: テストの正しさが marker の**保証に依存する**その瞬間——「疑ったら」ではない。marker がソースに存在し、import が通り、plugin の collection hook に読まれること自体は、「この run で効果が active である」という主張と同じではない。
+
+**一般則**: pytest plugin が提供する marker は、**起動形自体のフラグがその plugin を対応する mode に置いて初めて**、ドキュメント通りに効く。marker がソースに存在することはその証拠にならない——実際の command line（あるいは plugin 自身のソースから読む既定挙動）だけが証拠になる。
+
+**実例（#5926、#5909）**: `@pytest.mark.xdist_group` が同じ worker に載せる保証を持つのは、`pytest-xdist` の `loadgroup` 分配 mode（`--dist loadgroup`）の時**だけ**。本 repo の CI（`.github/workflows/test.yml:160`）は `python -m pytest -q -n auto --timeout=120 …` を実行しており、`--dist` フラグは一切無い。`pytest-xdist 3.8.0` 自身のソース（`xdist.plugin.pytest_cmdline_main`）を読むと: `numprocesses` が設定され（`-n auto` がそうする）、`dist` がまだ `"no"`（フラグ無指定時の既定）のとき、xdist は `dist = "load"` にする——`"loadgroup"` には**ならない**。∴ この CI では `xdist_group` は何もグループ化しない。「対になった test が同じ worker に載る」ことに正しさが依存する test は、`-n auto` の下で別 worker に分かれ、**自分が触っていない diff と無関係な赤**になり得る。
+
+**確かめ方（依存している marker があれば毎回）**:
+1. CI job が実際に実行している起動行を読む——marker 自身の docstring ではなく、「普段こう設定されているはず」という記憶でもなく。
+2. 対応する CLI フラグが無指定のとき plugin 自身の option が何を既定にするかをソースで読む（`inspect.getsource(<plugin>.<module>.<hook>)` で十分——option 名から推測しない）。
+
 ---
 
 ## プッシュ前 — 3 つの CI ゲート

--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -1150,6 +1150,18 @@ REYN_LLM_RECORD=1 python -m pytest tests/ -v
 
 #4081: this block used to also show `python -m pytest tests/test_replay_*.py -v` and `python -m pytest tests/test_os_invariants.py -v` — both the glob and the literal path resolve to nothing today (the `tests/test_replay_skill_router.py` family and `tests/test_os_invariants.py` were removed in the #2435/#2438 skill/phase-engine bulk deletions, no successor). Dropped rather than replaced with an unverified new example — scope your own run to the files/keywords your change actually touches (see "Before you push" below).
 
+### A marker's guarantee holds only under the invocation that enables it
+
+**Trigger**: the moment a test's correctness DEPENDS ON a marker's guarantee — not "if you suspect the marker might not be active." A marker that exists, imports cleanly, and is read by its plugin's collection hook is not the same claim as "its effect is active under THIS run."
+
+**General rule**: a marker supplied by a pytest plugin only does what its docs say when the invocation's own flags put that plugin into the matching mode. The marker's presence in source is not evidence of that; only the actual command line (or its own defaulting logic, read from the plugin's source) is.
+
+**Instance (#5926, #5909)**: `@pytest.mark.xdist_group` only groups tests onto the same worker under `pytest-xdist`'s `loadgroup` distribution mode (`--dist loadgroup`). This repo's CI (`.github/workflows/test.yml:160`) runs `python -m pytest -q -n auto --timeout=120 …` — no `--dist` flag at all. Reading `pytest-xdist 3.8.0`'s own source (`xdist.plugin.pytest_cmdline_main`): when `numprocesses` is set (as `-n auto` does) and `dist` is still `"no"` (its own default, unset by any flag here), xdist sets `dist = "load"` — never `"loadgroup"`. So under this CI, `xdist_group` groups nothing. A test whose correctness depends on "runs on the same worker as its pair" can land on separate workers under `-n auto` and go red on a diff it never touched.
+
+**How to verify, for any marker whose guarantee a test leans on**:
+1. Read the actual invocation line the CI job runs — not the marker's own docstring, not a memory of "how this is usually configured."
+2. Read the plugin's own source for what its option defaults to when the matching CLI flag is absent (`inspect.getsource(<plugin>.<module>.<hook>)` is enough — don't guess from the option's name).
+
 ---
 
 ## Before you push — the five CI gates


### PR DESCRIPTION
**[docs-maintainer]** — part of #5909. lead-coder-dispatched: add a general rule to `testing.md`/`testing.ja.md` — a pytest marker's guarantee holds only under the invocation that actually enables the plugin mode it needs.

**Instance (#5926)**: `@pytest.mark.xdist_group` only groups tests onto the same worker under `pytest-xdist`'s `loadgroup` distribution mode (`--dist loadgroup`). This repo's CI (`.github/workflows/test.yml:160`) runs `python -m pytest -q -n auto --timeout=120 …` — no `--dist` flag. Verified directly against the installed `pytest-xdist 3.8.0`'s own source (`inspect.getsource(xdist.plugin.pytest_cmdline_main)`): when `numprocesses` is set (`-n auto` sets it) and `dist` is still its own default `"no"`, xdist sets `dist = "load"` — never `"loadgroup"`. So under this CI, `xdist_group` groups nothing; a test leaning on "runs on the same worker as its pair" can land on separate workers and fail on a diff it never touched.

Written as the general rule requested, not `xdist_group`-specific — trigger is "a test's correctness depends on a marker's guarantee," not "if you suspect it." Verification method given: read the actual CI invocation line, plus the plugin's own defaulting source — not the marker's docstring or a memory of how it's usually configured.

Not added to `CLAUDE.md` (per-session load cost, per instruction) — deep-dive only. Doesn't touch `verification-hazards.md` (avoiding the in-flight #5925/#5922 conflict, same file).

## Test plan
- [x] `ruff check .` — clean
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — builds; only pre-existing INFO-level en/ja anchor-parity gaps
- [x] `python scripts/check_doc_anchors.py` — no dangling anchors
- [x] `python scripts/check_retired_config_keys_denylist.py` — 0 hits
- [x] Verified the xdist defaulting claim directly against the installed package (not from memory)
- [x] (skipped — docs-only diff, no `tests/`/`src/` files touched, no `CLAUDE.md` touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
