### PR TITLE
fix(part of #5265): a draft PR's absent required context is expected, not a #5265 block

### DIFF
--- a/scripts/detect_5265_missing_required_context.py
+++ b/scripts/detect_5265_missing_required_context.py
@@ -63,6 +63,29 @@ See ``tests/scripts/test_detect_5265_missing_required_context.py`` for
 the fixture-driven 4/4 (captured from these same 4 real heads' `gh api`
 output, not synthesized).
 
+## False positive #1 (2026-09-07, production, lead-coder's own
+independent reproduction) -- draft PRs
+
+The FIRST live run of the deployed script (BOOTSTRAP.md §5, an actually-
+BLOCKED-unchanged PR) fired RED on `#5928`'s draft-time head
+(`89494b66f6c1...`). The classification was factually accurate for that
+head's shape (the pytest family's newest suite really was the
+unexpanded template) -- but the underlying CAUSE was different from
+#5265: `#5928` was a DRAFT PR, and draft PRs intentionally never run CI
+at all (`test.yml`'s own `draft == false` guard, #4239's own ruling: "a
+draft PR is 'not yet asking for CI'"). An absent required context on a
+draft is the EXPECTED, visible state, not #5265's silent permanent
+block.
+
+Fix: a `--pr` invocation now fetches `isDraft` and short-circuits to OK
+without running the classifier at all when true -- the underlying
+classification stays exactly as accurate as before (a draft head really
+does have the unexpanded-template shape; that fact does not change), the
+CAUSE is what determines whether it is #5265's failure mode. A
+`--head-sha` invocation cannot check draft status (no PR context) --
+a RED verdict from that path now carries an explicit caveat rather than
+asserting #5265 with full confidence.
+
 ⚠️ The OTHER #5265 mechanism (`startup_failure`/`jobs==0`, no workflow
 run at all) has NOT been re-verified against a real head by this PR --
 lead-coder does not have a saved head sha for it (that branch's own
@@ -163,19 +186,49 @@ def find_permanently_blocked_required_contexts(
     """The union #5265's 2026-09-07 comment asks for: every required
     context this head will never satisfy under its own name, by either
     mechanism (①: never reported at all; ②: matrix family reversed onto
-    an unexpanded newer run)."""
+    an unexpanded newer run). This is the CLASSIFICATION only -- whether
+    that classification means "#5265" depends on the PR's draft status,
+    which this function has no access to; see ``evaluate``."""
     return sorted(
         set(find_never_reported(required, status_contexts, check_runs))
         | set(find_matrix_family_blocked(required, check_runs)),
     )
 
 
-def format_notification(pr_number: "str | int", head_sha: str, blocked_names: "list[str]") -> str:
+def evaluate(
+    required: "list[str]", status_contexts: "list[dict]", check_runs: "list[dict]",
+    *, is_draft: "bool | None",
+) -> "list[str]":
+    """The verdict this script actually acts on: ``find_permanently_
+    blocked_required_contexts``'s own classification, EXCEPT a known
+    draft PR (``is_draft=True``) never blocks -- a draft PR intentionally
+    never runs CI (``test.yml``'s own ``draft == false`` guard, #4239's
+    own ruling) so an absent required context there is the EXPECTED,
+    visible state, not #5265's silent permanent block (2026-09-07
+    production false positive, `#5928` -- lead-coder's own independent
+    reproduction: the classification was factually accurate, the CAUSE
+    was different). ``is_draft=None`` (the ``--head-sha`` path, which has
+    no PR context to check) is evaluated the same as a real PR for THIS
+    function -- the caller is responsible for attaching an indeterminate
+    caveat to a RED verdict in that case (see ``format_notification``'s
+    own ``draft_caveat``)."""
+    if is_draft:
+        return []
+    return find_permanently_blocked_required_contexts(required, status_contexts, check_runs)
+
+
+def format_notification(
+    pr_number: "str | int", head_sha: str, blocked_names: "list[str]", *, draft_caveat: bool = False,
+) -> str:
     """Names the PR/head AND the specific required-context names stuck --
     a reader must not have to re-run the query themselves to know which
-    of the 7 required contexts are the problem."""
+    of the 7 required contexts are the problem. ``draft_caveat`` (the
+    ``--head-sha`` path, no PR context available) makes explicit that
+    draft status could not be ruled out -- #5928's own false positive
+    shape, reproduced with full confidence and no caveat, is what this
+    flag exists to never repeat."""
     names_text = ", ".join(blocked_names)
-    return (
+    text = (
         f"RED #5265 -- PR #{pr_number} (head {head_sha[:12]}) is silently "
         f"BLOCKED: required context(s) will never report under their own "
         f"name: {names_text}. Not visible as red anywhere on the PR (`gh "
@@ -184,6 +237,15 @@ def format_notification(pr_number: "str | int", head_sha: str, blocked_names: "l
         "WORKFLOW JOB rows, not the required CONTEXT). Detection is "
         "read-only; do not use `gh api -X PUT .../merge` to check this."
     )
+    if draft_caveat:
+        text += (
+            " ⚠️ Draft status could not be checked (no --pr given, so "
+            "no PR context) -- a draft PR intentionally skips CI "
+            "(test.yml's draft==false guard, #4239) and would show this "
+            "exact shape as a false positive (#5928, 2026-09-07). "
+            "Re-run with `--pr <N>` if this head belongs to a known PR."
+        )
+    return text
 
 
 # ---------------------------------------------------------------------------
@@ -243,9 +305,13 @@ def _gh_json(args: "list[str]") -> "list[dict]":
     return _parse_paginated_json(result.stdout)
 
 
-def _fetch_head_sha_for_pr(pr_number: str) -> str:
-    pages = _gh_json(["pr", "view", pr_number, "--repo", _REPO, "--json", "headRefOid"])
-    return pages[0]["headRefOid"]
+def _fetch_pr_info(pr_number: str) -> "tuple[str, bool]":
+    """head sha AND draft status in one call -- #5928's own false
+    positive (2026-09-07) was exactly the gap this closes: a `--pr`
+    invocation used to resolve only the head sha and never checked
+    whether the PR was a draft at all."""
+    pages = _gh_json(["pr", "view", pr_number, "--repo", _REPO, "--json", "headRefOid,isDraft"])
+    return pages[0]["headRefOid"], bool(pages[0]["isDraft"])
 
 
 def _fetch_required_contexts() -> "list[str]":
@@ -281,10 +347,11 @@ def main(argv: "list[str] | None" = None) -> int:
     args = parser.parse_args(argv)
 
     pr_label: "str | int" = "?"
+    is_draft: "bool | None" = None
     try:
         if args.pr is not None:
             pr_label = args.pr
-            head_sha = _fetch_head_sha_for_pr(args.pr)
+            head_sha, is_draft = _fetch_pr_info(args.pr)
         else:
             head_sha = args.head_sha
         required = _fetch_required_contexts()
@@ -294,9 +361,17 @@ def main(argv: "list[str] | None" = None) -> int:
         print(f"gh call failed: {exc.stderr}", file=sys.stderr)
         return 2
 
-    blocked = find_permanently_blocked_required_contexts(required, status_contexts, check_runs)
+    if is_draft:
+        print(
+            f"OK -- PR #{pr_label} (head {head_sha[:12]}) is a draft; draft PRs "
+            "intentionally skip CI (test.yml's draft==false guard, #4239) -- "
+            "required-context absence here is the EXPECTED state, not #5265.",
+        )
+        return 0
+
+    blocked = evaluate(required, status_contexts, check_runs, is_draft=is_draft)
     if blocked:
-        print(format_notification(pr_label, head_sha, blocked))
+        print(format_notification(pr_label, head_sha, blocked, draft_caveat=(args.pr is None)))
         return 1
 
     print(f"OK -- head {head_sha[:12]} has a report (or a live path to one) for all {len(required)} required contexts.")

--- a/tests/scripts/test_detect_5265_missing_required_context.py
+++ b/tests/scripts/test_detect_5265_missing_required_context.py
@@ -19,6 +19,15 @@ Two rules, each with its own accept/deny pair:
     ANY unexpanded run anywhere in its history would still pass every
     other test here.
 
+A third rule, added after this script's own first production run
+(2026-09-07, BOOTSTRAP.md §5's first live invocation on an actually-
+BLOCKED-unchanged PR): a draft PR intentionally never runs CI at all
+(``test.yml``'s own ``draft == false`` guard, #4239) -- the FIRST live
+run fired RED on `#5928`'s draft-time head, factually accurately (the
+classification tests below prove this), but a draft's absent required
+context is the EXPECTED state, not #5265's failure. ``evaluate`` layers
+that check on top of the classification without changing it.
+
 The 4 fixtures below (``PYTEST_POSITIVE``/``PYTEST_NEGATIVE_*``) are
 ``check_runs`` arrays captured verbatim via ``gh api
 repos/tya5/reyn/commits/<sha>/check-runs?per_page=100`` against the 4
@@ -39,6 +48,7 @@ detector reads suite recency, not mere presence.
 from __future__ import annotations
 
 from scripts.detect_5265_missing_required_context import (
+    evaluate,
     find_matrix_family_blocked,
     find_never_reported,
     find_permanently_blocked_required_contexts,
@@ -120,6 +130,26 @@ PYTEST_NEGATIVE_LATER_UNRELATED_WORKFLOWS = [
     {"name": "sandbox boundary is load-method independent (ld-linux + mmap-load,", "suite": 92353647708},
     {"name": "file-depth-reference gate", "suite": 92353647590},
     {"name": "TESTS-READ note names the tree it read", "suite": 92353647380},
+]
+
+# PR #5928, DRAFT-TIME shape (head 89494b66f6c1..., 2026-09-07) -- the
+# script's own FIRST production false positive (BOOTSTRAP.md §5's real
+# first live run, lead-coder's own independent reproduction). Captured
+# from `gh api .../check-runs` while the PR was still a draft: only the
+# unexpanded-template suite exists for the pytest family -- a REAL
+# matrix suite never ran at all (draft PRs skip CI entirely, test.yml's
+# draft==false guard, #4239). The CLASSIFICATION is correctly RED here
+# (there genuinely is no non-template pytest report on this head) --
+# what's wrong is treating that classification as #5265 without
+# checking draft status first; see the ``evaluate`` tests below.
+PYTEST_DRAFT_TIME_UNEXPANDED_ONLY = [
+    {"name": "mypy (ratchet)", "suite": 92380066549},
+    {"name": "docs build (strict)", "suite": 92380066549},
+    {"name": "pytest (Python ${{ matrix.python-version }})", "suite": 92380066549},
+    {"name": "test-tier audit", "suite": 92380066549},
+    {"name": "ruff", "suite": 92380066549},
+    {"name": "TESTS-READ note names the tree it read", "suite": 92380066621},
+    {"name": "BLOCKING PR carries a re-read note naming its tree", "suite": 92380066540},
 ]
 
 
@@ -254,3 +284,70 @@ def test_notification_names_the_pr_the_head_and_the_specific_blocked_names():
     assert "0ee007268fe1" in text
     assert "pytest (Python 3.11)" in text
     assert "read-only" in text.lower()
+
+
+def test_notification_carries_no_draft_caveat_by_default():
+    """Tier 1: the ``--pr`` path (draft status IS known, and already
+    handled before this function is even reached) must not print the
+    indeterminate caveat -- it would be actively misleading noise on a
+    verdict that already accounted for draft status."""
+    text = format_notification(5912, "0ee007268fe1bfb366f40b3d598cd74525d5d937", ["pytest (Python 3.11)"])
+    assert "draft" not in text.lower()
+
+
+def test_notification_carries_a_draft_caveat_when_requested():
+    """Tier 1: the ``--head-sha`` path (no PR context, draft status
+    UNKNOWN) must attach the caveat -- #5928's own false positive was
+    reported with full, unqualified confidence; this is what stops that
+    from repeating on the head-only path, which has no way to check."""
+    text = format_notification(
+        "?", "89494b66f6c1bd0decf1bd2d2d00648eb8848dfb", ["pytest (Python 3.11)"], draft_caveat=True,
+    )
+    assert "draft" in text.lower()
+    assert "--pr" in text
+
+
+# ── evaluate -- the draft-aware verdict (#5928, 2026-09-07 production
+# false positive) ──
+
+
+def test_the_draft_time_5928_head_classification_is_correctly_red():
+    """Tier 1: the CLASSIFICATION itself (no draft awareness) is
+    factually accurate for #5928's real draft-time shape -- there
+    genuinely was no non-template pytest report on that head yet. This
+    is lead-coder's own finding, verbatim: "判定は事実に忠実ですが、偽陽性です"
+    -- the bug is not in this function, it is in treating this
+    classification as #5265 without checking draft status (the next
+    test)."""
+    blocked = find_permanently_blocked_required_contexts(REQUIRED, STATUS_CONTEXTS, PYTEST_DRAFT_TIME_UNEXPANDED_ONLY)
+    assert blocked == ["pytest (Python 3.11)", "pytest (Python 3.12)"]
+
+
+def test_evaluate_suppresses_a_known_draft_even_though_the_shape_is_red():
+    """Tier 1: THE fix for #5928's production false positive --
+    ``evaluate(..., is_draft=True)`` must return empty even though the
+    underlying classification (proven by the test above) is RED. Without
+    this test, a regression that dropped the draft check entirely would
+    still pass every other test in this file (none of them exercise
+    ``evaluate`` with a draft head)."""
+    blocked = evaluate(REQUIRED, STATUS_CONTEXTS, PYTEST_DRAFT_TIME_UNEXPANDED_ONLY, is_draft=True)
+    assert blocked == []
+
+
+def test_evaluate_still_flags_a_known_non_draft_with_the_same_shape():
+    """Tier 1: deny sibling -- ``is_draft=False`` (a real, ready PR
+    proven to have this exact blocked shape) must NOT be suppressed.
+    Without this test, ``evaluate`` reduced to "always return []" would
+    still pass the suppression test above."""
+    blocked = evaluate(REQUIRED, STATUS_CONTEXTS, PYTEST_DRAFT_TIME_UNEXPANDED_ONLY, is_draft=False)
+    assert blocked == ["pytest (Python 3.11)", "pytest (Python 3.12)"]
+
+
+def test_evaluate_with_unknown_draft_status_still_flags_the_real_positive():
+    """Tier 1: ``is_draft=None`` (the ``--head-sha`` path, no PR context)
+    must behave exactly like ``is_draft=False`` for the VERDICT itself
+    (still flags a genuinely blocked head) -- the caller attaches the
+    indeterminate caveat separately (``format_notification``'s own
+    ``draft_caveat``), never by silently suppressing here."""
+    blocked = evaluate(REQUIRED, STATUS_CONTEXTS, PYTEST_POSITIVE, is_draft=None)
+    assert blocked == ["pytest (Python 3.11)", "pytest (Python 3.12)"]


### PR DESCRIPTION
**[backlog-watcher]** — part of #5265

## What

`scripts/detect_5265_missing_required_context.py`'s own first production run (2026-09-07, BOOTSTRAP.md §5's first live invocation on an actually-BLOCKED-unchanged PR) fired RED on `#5928`'s draft-time head. lead-coder independently reproduced it: **the classification was factually accurate, but the cause was different from #5265** — `#5928` was a draft PR, and draft PRs intentionally never run CI at all (`test.yml`'s own `draft == false` guard, #4239's own ruling: "a draft PR is 'not yet asking for CI'"). An absent required context on a draft is the EXPECTED, visible state, not #5265's silent permanent block.

- `evaluate(..., is_draft)` layers the draft check on top of the unchanged classification — `find_permanently_blocked_required_contexts` itself is untouched (proven still-correct by a dedicated classification-only test).
- `--pr` invocations now fetch `isDraft` in the same `gh pr view` call (no extra round-trip) and short-circuit to OK, without running the classifier at all, when true.
- `--head-sha` invocations cannot check draft status (no PR context available) — a RED verdict from that path now carries an explicit caveat (`draft_caveat=True`) rather than asserting #5265 with full, unqualified confidence.

## Fixture

`#5928`'s real draft-time `check-runs` (head `89494b66f6c1...`, captured via `gh api` while the PR was still a draft): only the unexpanded-template suite exists for the pytest family — a real matrix suite had never run at all. This is a genuine 4th negative for the underlying #5265 mechanism (lead-coder's own request) — it does NOT belong in the original 4-head accept/deny set (the classification correctly says RED for it; what changes is whether that RED means #5265).

## Verification

- 6 new tests (19 total, up from 13) — strip-falsify: the classification-only test proves the RED itself is correct (not a detector bug), the suppression test proves `evaluate(is_draft=True)` actually overrides it, the sibling deny test proves `is_draft=False` does not over-suppress a real positive.
- Live-verified: the original 4 `--head-sha` heads behave unchanged (the one RED among them now carries the draft caveat, since `--head-sha` has no PR context); `#5928` itself now reads OK via `--pr` (the PR is ready as of this writing — lead-coder promoted it, real CI reran with a real matrix suite).

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_detect_5265_missing_required_context.py` — 19/19 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py scripts/detect_5265_missing_required_context.py` — OK
- [x] `python scripts/mypy_ratchet.py` — OK, 0 findings
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK
- [x] `python scripts/check_bare_tests_import_reference.py` — OK
- [x] `python scripts/check_file_depth_reference.py` — OK
- [x] `python scripts/check_subprocess_reyn_pin.py` — OK
- [x] `pytest tests/scripts/test_detect_5265_missing_required_context.py -v` — 19 passed
- [x] Live: `--pr 5928` → OK; original 4 `--head-sha` heads unchanged (1 RED now carries draft caveat)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
