### PR TITLE
fix(#5896 stage 2): a file with no manifest line is protected, not evictable

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -105,7 +105,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Collection
+from typing import TYPE_CHECKING, Callable, Collection
 
 from reyn.services.offload.store import offload_value, read_offloaded
 
@@ -123,7 +123,19 @@ logger = logging.getLogger(__name__)
 #: every eviction pass reads to leave an un-spilled body alone (#5896
 #: stage ①, architect condition: "GC は un-spilled の file を候補にしない"
 #: — the model still sees that body inline, the file is its ONLY durable
-#: copy, so evicting it would turn a byte-identical restart into ``lost``).
+#: copy, so evicting it would turn a byte-identical restart into
+#: ``lost``). Stage ③ (owner-confirmation-pending, NOT part of this
+#: change) would relax this outright exclusion to "spilled 先行"
+#: ORDERING instead — see :func:`cross_session_eviction_candidates`'s own
+#: docstring for why that stays unimplemented here.
+#:
+#: A path this manifest has NO LINE for at all is a SEPARATE case (#5896
+#: stage ② item ②, "unknown ⇒ protect"): never a candidate, at any point
+#: — see :func:`cross_session_eviction_candidates`'s ``known`` parameter
+#: and :func:`migrate_history_content_manifest`, the one-time backfill
+#: that gives every already-written file a real line so "no line" can
+#: mean "unknown" cleanly (not "predates the manifest, was actually
+#: spilled").
 #:
 #: Lives under ``.reyn/memory/`` — PERSIST tier (#4584 fix; previously
 #: ``.reyn/cache/``, moved there from ``tool_results_dir`` by #4432 round
@@ -524,6 +536,127 @@ def parse_resource_uri(uri: str) -> tuple[str, str] | None:
     return agent, artifact
 
 
+def spill_manifest_path_for(project_root: Path) -> Path:
+    """#4584/#5896: the ONE path the spill-provenance manifest lives at
+    (``.reyn/memory/tool_result_spills.jsonl``, PERSIST tier — see
+    :data:`_SPILL_MANIFEST_FILENAME`'s own module docstring) — exposed so
+    a caller with no live :class:`MediaStore` (stage ② item ①'s one-time
+    :func:`migrate_history_content_manifest`, an operator script, a test)
+    computes the SAME path :meth:`MediaStore._spill_manifest_path`
+    resolves, never a second hand-derived copy. Does not depend on
+    *config* — the manifest's own location was never made configurable
+    (same "one operator number, not two" reasoning as every other #4478/
+    #5366 shared-tree path in this module)."""
+    return project_root / ".reyn" / "memory" / _SPILL_MANIFEST_FILENAME
+
+
+def format_spill_manifest_line(path: Path, *, spilled: bool) -> str:
+    """The ONE encoding of a manifest line — every writer (the append in
+    :meth:`MediaStore.save_tool_result`, the prune-rewrite in
+    :meth:`MediaStore._persist_spill_manifest`, and stage ②'s one-time
+    :func:`migrate_history_content_manifest`) must agree, or a prune
+    would silently drop the ``spilled`` flag and re-admit every un-spilled
+    file to GC on the next process start."""
+    entry: dict = {"path": str(path)}
+    if not spilled:
+        entry["spilled"] = False
+    return json.dumps(entry) + "\n"
+
+
+def migrate_history_content_manifest(
+    project_root: Path,
+    *,
+    config: "MediaStoreConfig | None" = None,
+    iter_content_refs: "Callable[[Path], list[tuple[str, bool]]] | None" = None,
+) -> "dict[str, int]":
+    """#5896 stage ② item ① (architect, closing #5901's own disclosed
+    window — "既存 file に一度だけ行を書く移行"): give every
+    history-content file that predates this manifest tracking it, OR
+    whose own manifest-append never landed (a process crash between the
+    content write and its deferred append job actually running — #5364
+    §1.4's own disclosed race), a REAL manifest line — so stage ②'s
+    default flip ("unknown ⇒ protect", item ②) can trust "no line" to
+    mean "genuinely unknown", not "predates the manifest and was actually
+    spilled, safely evictable".
+
+    **One-time, idempotent, never runs on the hot write path** (contrast
+    :meth:`MediaStore.save_tool_result`'s own per-write append): a second
+    call finds every file already tracked and migrates zero — see this
+    module's own test for the witness. Wired as an explicit operator
+    command (``reyn storage migrate-manifest``), not auto-run at
+    :class:`MediaStore` construction, because a full-tree ``rglob`` plus a
+    full ``history.jsonl`` scan on every process start would cost real I/O
+    for a condition normal operation never produces (the crash race is
+    rare; the "predates the manifest" case is a one-off per install).
+
+    For every already-tracked path (read fresh from the manifest, the
+    tree's own record — same "derive from the tree, not caller state"
+    discipline as :meth:`MediaStore._manifest_paths_project_wide`),
+    nothing changes. For every OTHER file physically present under
+    :func:`history_content_root_for`, the TRUTH of whether it was spilled
+    or un-spilled is read from ``history.jsonl`` itself — the row that
+    named this file as its ``content_ref`` is the one place that fact was
+    ever recorded (the manifest is a CACHE of that fact, kept in
+    :class:`MediaStore`'s own reach because GC runs there with no history
+    access — see #5901's own documented deviation) — via
+    *iter_content_refs*, an injected ``(project-relative ref, spilled)``
+    reader (production: ``reyn.runtime.services.router_history_buffer.
+    iter_history_content_refs``) so THIS module never imports
+    ``reyn.runtime``'s meta-key vocabulary (a data-layer module reading a
+    runtime-layer wire format directly would put the layering the wrong
+    way round — the same injection shape
+    :func:`reyn.core.offload.history_content_resolve.resolve` already
+    uses for ``file_exists``/``read_text``). A file no ``history.jsonl``
+    row references at all (truth unknown — e.g. the referencing row was
+    later dropped by rewind/retention) defaults to un-spilled — #5896
+    stage ② item ②'s own "不明なら守る": the safe-if-wrong default is
+    "never evicted", never "silently deleted".
+
+    Returns ``{"migrated": <files given a new line>, "protected_unknown":
+    <of those, how many defaulted un-spilled because no row named them>}``.
+    A missing ``history-content/`` tree returns both as ``0`` — nothing to
+    migrate, not an error."""
+    cfg = config or MediaStoreConfig()
+    manifest_path = spill_manifest_path_for(project_root)
+    known: "set[Path]" = set()
+    try:
+        for line in manifest_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                known.add(Path(entry["path"]))
+            except (json.JSONDecodeError, KeyError, TypeError):
+                continue
+    except OSError:
+        pass  # no manifest yet — every on-disk file is unmigrated
+    root = history_content_root_for(project_root, cfg)
+    if not root.is_dir():
+        return {"migrated": 0, "protected_unknown": 0}
+    truth: "dict[Path, bool]" = {}
+    if iter_content_refs is not None:
+        for ref, spilled in iter_content_refs(project_root):
+            truth[(project_root / ref).resolve()] = spilled
+    to_add: "list[tuple[Path, bool]]" = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        resolved = path.resolve()
+        if resolved in known:
+            continue
+        to_add.append((resolved, truth.get(resolved, False)))
+    if to_add:
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        with manifest_path.open("a", encoding="utf-8") as f:
+            for resolved, spilled in to_add:
+                f.write(format_spill_manifest_line(resolved, spilled=spilled))
+    return {
+        "migrated": len(to_add),
+        "protected_unknown": sum(1 for _, spilled in to_add if not spilled),
+    }
+
+
 def history_content_root_for(
     project_root: Path, config: "MediaStoreConfig | None" = None,
 ) -> Path:
@@ -541,6 +674,7 @@ def history_content_root_for(
 def cross_session_eviction_candidates(
     root: Path, *, pin: "list[str] | None" = None,
     unspilled: "Collection[Path]" = (),
+    known: "Collection[Path] | None" = None,
 ) -> list[Path]:
     """#5366 §3 (architect design, revised — issuecomment-5451564768):
     the project-wide GC's own candidate set. Every file
@@ -552,10 +686,28 @@ def cross_session_eviction_candidates(
     model still sees inline, whose file is its only durable copy (see
     :data:`_SPILL_MANIFEST_FILENAME`; the manifest is project-wide, so
     the store passes every session's un-spilled files here, not just its
-    own). Resolved paths on both sides (``_eviction_order`` yields what
-    ``rglob`` finds under *root*; the store records ``resolve()``d
-    absolute paths — compared after resolving here so a symlinked
-    ``.reyn`` cannot make the two disagree).
+    own), minus (#5896 stage ②, "unknown ⇒ protect") any file NOT in
+    *known* when *known* is given. Resolved paths on both sides
+    (``_eviction_order`` yields what ``rglob`` finds under *root*; the
+    store records ``resolve()``d absolute paths — compared after
+    resolving here so a symlinked ``.reyn`` cannot make the two
+    disagree).
+
+    *known* (#5896 stage ②): the set of paths this project's manifest has
+    an actual line for (see :data:`_SPILL_MANIFEST_FILENAME`) — a file the
+    manifest has never recorded (a write whose manifest append never
+    landed, or a file predating the manifest's own migration, #5896 stage
+    ② item ①) is EXCLUDED from candidacy entirely: "manifest 行が無い" now
+    means "unknown, protect", the flip of the pre-stage-② default
+    ("unknown, evictable") that could silently delete a body nothing else
+    recorded as un-spilled. This is a SEPARATE exclusion from *unspilled*
+    (a tracked, known-un-spilled file) — an unknown file is protected for
+    a different reason and is never merely de-prioritised the way stage
+    ③'s (owner-confirmation-pending, NOT part of this change) spilled-
+    first ordering would treat a known un-spilled one. ``None`` (the
+    default) skips this filter — every caller in THIS module now passes
+    an explicit set; ``None`` exists only so an out-of-tree caller that
+    has no manifest view is not silently broken by a required arg.
 
     Deliberately NO liveness filter (architect's own reversal after
     e2e-coder's #5366 measurement found ``process_registry``'s own
@@ -583,6 +735,9 @@ def cross_session_eviction_candidates(
     a cross-session sweep immediately followed by another session's own
     in-flight ref reading back ``lost``."""
     ordered = _eviction_order(root)
+    if known is not None:
+        known_set = {p.resolve() for p in known}
+        ordered = [p for p in ordered if p.resolve() in known_set]
     if unspilled:
         excluded = {p.resolve() for p in unspilled}
         ordered = [p for p in ordered if p.resolve() not in excluded]
@@ -917,7 +1072,7 @@ class MediaStore:
     def _spill_manifest_path(self) -> Path:
         # #4584: PERSIST tier — `.reyn/memory/`, not `.reyn/cache/` (see
         # :data:`_SPILL_MANIFEST_FILENAME`'s own module docstring).
-        return self._project_root / ".reyn" / "memory" / _SPILL_MANIFEST_FILENAME
+        return spill_manifest_path_for(self._project_root)
 
     def _load_spill_manifest(self) -> "tuple[set[Path], set[Path]]":
         """Returns ``(every path this store wrote, the un-spilled subset)``
@@ -961,26 +1116,34 @@ class MediaStore:
             self._persist_spill_manifest(paths, unspilled)
         return paths, unspilled
 
-    def _unspilled_paths_project_wide(self) -> "set[Path]":
-        """#5896 (architect co-vet 🔴 #2 — "木を歩く pass の除外は木から導く"):
-        the un-spilled set a PROJECT-wide pass must exclude — every session's,
-        not just this store's. ``_unspilled_paths`` is this store's own view,
-        read from the (project-wide) manifest ONCE at construction plus its
-        own later writes; a neighbouring store's writes after that never
-        reach it, so a pass over the whole tree that used it would evict a
+    def _manifest_paths_project_wide(self) -> "tuple[set[Path], set[Path]]":
+        """#5896 (architect co-vet 🔴 #2 — "木を歩く pass の除外は木から導く",
+        stage ② widened to cover ``known`` the same way): ``(known,
+        unspilled)`` a PROJECT-wide pass must use — every session's, not
+        just this store's. ``_history_content_spill_paths``/
+        ``_unspilled_paths`` are this store's own view, read from the
+        (project-wide) manifest ONCE at construction plus its own later
+        writes; a neighbouring store's writes after that never reach them,
+        so a pass over the whole tree that used them would evict a
         neighbour's un-spilled body (measured, architect: alice's pass
-        listed bob's file). So this re-reads the manifest fresh from disk —
-        the tree's own record, no caller state — and unions this store's
-        own in-memory set (its own lines may still be queued in its worker).
+        listed bob's file) or list an UNKNOWN neighbour file as a
+        candidate (the same defect, stage ②'s own subject: a file only
+        bob's manifest line names is invisible to alice's in-memory view).
+        So this re-reads the manifest fresh from disk — the tree's own
+        record, no caller state — and unions this store's own in-memory
+        sets (its own lines may still be queued in its worker).
 
         Disclosed window, not closed: a neighbour's body whose content
         write has landed but whose manifest line is still queued (same
         worker, FIFO, the next job) is not yet in the file this reads. Only
         a project-wide pass from a DIFFERENT store in that instant could
-        select it; the neighbour's own per-session pass never does. See
+        select it as unknown (stage ②: excluded, not evicted — "unknown ⇒
+        protect" makes this window SAFE, where pre-stage-② it silently
+        evicted); the neighbour's own per-session pass never does. See
         ``LostReason.EXTERNAL``'s docstring for what that means for the
         reason a reader derives."""
-        fresh: "set[Path]" = set()
+        known: "set[Path]" = set()
+        unspilled: "set[Path]" = set()
         manifest = self._spill_manifest_path()
         try:
             for line in manifest.read_text(encoding="utf-8").splitlines():
@@ -989,25 +1152,15 @@ class MediaStore:
                     continue
                 try:
                     entry = json.loads(line)
+                    p = Path(entry["path"])
+                    known.add(p)
                     if entry.get("spilled", True) is False:
-                        fresh.add(Path(entry["path"]))
+                        unspilled.add(p)
                 except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
                     continue
         except OSError:
             pass  # no manifest yet / unreadable → only this store's own view below
-        return fresh | self._unspilled_paths
-
-    @staticmethod
-    def _manifest_line(path: Path, *, spilled: bool) -> str:
-        """The ONE encoding of a manifest line (the append in
-        :meth:`save_tool_result` and the prune-rewrite in
-        :meth:`_persist_spill_manifest` must agree, or a prune would
-        silently drop the ``spilled`` flag and re-admit every un-spilled
-        file to GC on the next process start)."""
-        entry: dict = {"path": str(path)}
-        if not spilled:
-            entry["spilled"] = False
-        return json.dumps(entry) + "\n"
+        return known | self._history_content_spill_paths, unspilled | self._unspilled_paths
 
     def _persist_spill_manifest(self, paths: "set[Path]", unspilled: "set[Path]") -> None:
         """#4478: rewrite the MANIFEST ONLY — the ledger of which paths
@@ -1038,7 +1191,7 @@ class MediaStore:
         try:
             manifest.write_text(
                 "".join(
-                    self._manifest_line(p, spilled=p not in unspilled)
+                    format_spill_manifest_line(p, spilled=p not in unspilled)
                     for p in sorted(paths)
                 ),
                 encoding="utf-8",
@@ -1289,8 +1442,8 @@ class MediaStore:
         and the ``history.jsonl`` row carries none). Recorded per file in
         the manifest and read by every eviction pass: an un-spilled file
         is never a GC candidate (stage ① — see the manifest's own
-        docstring; stage ② will relax this to spilled-FIRST ordering once
-        the owner has ruled on un-spilled eviction).
+        docstring; stage ③, owner-confirmation-pending and NOT part of
+        this change, would relax this to spilled-FIRST ordering instead).
         """
         if self.durability_failed:
             raise MediaStoreWriteUnavailable(
@@ -1390,7 +1543,7 @@ class MediaStore:
             try:
                 manifest_path = self._spill_manifest_path()
                 manifest_path.parent.mkdir(parents=True, exist_ok=True)
-                line = self._manifest_line(_resolved_path, spilled=spilled)
+                line = format_spill_manifest_line(_resolved_path, spilled=spilled)
 
                 def _append() -> None:
                     with manifest_path.open("a", encoding="utf-8") as f:
@@ -1428,6 +1581,11 @@ class MediaStore:
         manifest, so it holds across a restart, and project-wide, so a
         cross-session pass sees every session's un-spilled files.
 
+        Stage ③ (owner-confirmation-pending, NOT part of this change)
+        would relax this outright exclusion to spilled-first ORDERING —
+        see :func:`cross_session_eviction_candidates`'s own docstring for
+        why that is deliberately not implemented here.
+
         Resolves *path* the same way :meth:`is_history_content_spill`
         does (relative → against ``project_root``), for the same reason."""
         p = Path(path)
@@ -1436,6 +1594,30 @@ class MediaStore:
         else:
             p = p.resolve()
         return p in self._unspilled_paths
+
+    def is_known_file(self, path: "str | Path") -> bool:
+        """#5896 stage ② item ②: True if *path* has an actual line in this
+        project's spill manifest — a write this store (or, once loaded, a
+        prior process) actually recorded, regardless of ``spilled``
+        value. False for a file physically present under
+        ``history_content_root`` that the manifest has NO record of at
+        all: a write whose deferred manifest-append never landed (#5364
+        §1.4's own disclosed race), or a file predating the manifest's
+        own one-time backfill (:func:`migrate_history_content_manifest`,
+        stage ② item ①). "unknown ⇒ protect" (item ②, the flip of the
+        pre-stage-② default): :meth:`_evict_history_content_over_cap`
+        treats a ``False`` here as excluded from eviction, exactly like a
+        KNOWN un-spilled file — see :meth:`is_unspilled_file`'s sibling
+        exclusion.
+
+        Resolves *path* the same way :meth:`is_history_content_spill`
+        does (relative → against ``project_root``), for the same reason."""
+        p = Path(path)
+        if not p.is_absolute():
+            p = (self._project_root / p).resolve()
+        else:
+            p = p.resolve()
+        return p in self._history_content_spill_paths
 
     def is_open_turn_file(self, path: Path, *, current_chain_id: str) -> bool:
         """#5387: True if ``path`` was written by the SAME chain that is
@@ -1465,14 +1647,21 @@ class MediaStore:
         any file :meth:`is_open_turn_file` says belongs to the turn that
         triggered THIS pass (default: protected; see
         ``MediaStoreConfig.protect_open_turn_from_gc`` for the opt-in to
-        disable this and evict open-turn content too). Scoped to THIS
-        session's own subdirectory, not the whole ``history_content_root``
-        — the cap's own subject is one session's content (see the field's
-        docstring: cross-session growth is #5366's separate subject, not
-        this one's). Best-effort: an ``OSError`` mid-delete is logged and
-        skipped, same policy as :meth:`_purge_session_dir`'s own sibling
-        deletes — a failed eviction must never fail the write it
-        followed.
+        disable this and evict open-turn content too), any file
+        :meth:`is_unspilled_file` says the model still sees inline
+        (#5896 stage ① — an outright exclusion; stage ③'s relaxation to
+        "spilled-first, un-spilled evictable too" is PENDING OWNER
+        CONFIRMATION and is deliberately NOT part of this change — see
+        this method's own #5896 comment below), and any file this store's
+        manifest has NO line for at all (#5896 stage ② item ②, "unknown ⇒
+        protect" — see :func:`cross_session_eviction_candidates`'s
+        ``known`` parameter). Scoped to THIS session's own subdirectory,
+        not the whole ``history_content_root`` — the cap's own subject is
+        one session's content (see the field's docstring: cross-session
+        growth is #5366's separate subject, not this one's). Best-effort:
+        an ``OSError`` mid-delete is logged and skipped, same policy as
+        :meth:`_purge_session_dir`'s own sibling deletes — a failed
+        eviction must never fail the write it followed.
 
         #5387 scope (architect design B, stated explicitly — NOT a
         decision to leave a gap, a reach limit): this only protects the
@@ -1483,11 +1672,12 @@ class MediaStore:
         is where that would first need to be handled, not here.
 
         Disclosed (architect review, non-blocking): if EVERY remaining
-        candidate is protected (all share the triggering chain), this
-        returns having deleted nothing, and the directory stays OVER
-        cap — deliberately: protecting an open turn's content is worth
-        more than strictly enforcing the byte cap on any given pass.
-        Not silent — the caller (:meth:`save_tool_result`) already logs
+        candidate is protected (all share the triggering chain, are
+        un-spilled, or are unknown per stage② item ②), this returns
+        having deleted nothing, and the directory stays OVER cap —
+        deliberately: protecting an open turn's content is worth more
+        than strictly enforcing the byte cap on any given pass. Not
+        silent — the caller (:meth:`save_tool_result`) already logs
         nothing extra here because this is the expected, harmless
         common case (see ``history_content_max_bytes``'s own docstring:
         2 GB default, eviction is not expected to fire under real usage
@@ -1510,6 +1700,13 @@ class MediaStore:
                 continue
             if self.is_unspilled_file(path):
                 continue
+            # #5896 stage ② item ②: "unknown ⇒ protect" — a file this
+            # store's manifest has NO line for at all (a write whose
+            # manifest append never landed, or a file predating the
+            # manifest's own one-time backfill) is never a candidate
+            # either, same as a KNOWN un-spilled file above.
+            if not self.is_known_file(path):
+                continue
             try:
                 size = path.stat().st_size
                 path.unlink()
@@ -1523,47 +1720,58 @@ class MediaStore:
             total -= size
         # #5896 (architect co-vet 🔴): before this PR every file here was a
         # spill, so a pass could always get back under cap; now every
-        # un-spilled body is excluded, and a pass can end over cap having
-        # deleted nothing — say so ONCE, with the reason, never silently.
+        # un-spilled OR unknown body is excluded, and a pass can end over
+        # cap having deleted nothing — say so ONCE, with the reason, never
+        # silently.
         self._note_cap_state("session", total=total, cap=cap, directory=directory)
 
     def _note_cap_state(
         self, scope: str, *, total: int, cap: int, directory: Path,
         unspilled: "set[Path] | None" = None,
+        known: "set[Path] | None" = None,
     ) -> None:
         """#5896 stage ① (architect co-vet 🔴 — "上限が満たせなくなったのに何
-        も言わない"): record whether an eviction pass for *scope* ended
+        も言わない"), stage ② adds a SECOND reason (item ②'s "unknown ⇒
+        protect"): record whether an eviction pass for *scope* ended
         still over *cap*, and WARN exactly once per False→True transition
-        — naming what made the cap unsatisfiable (how many un-spilled
-        bodies, how many bytes, and that stage ② is what will make them
-        evictable again) so an operator who set the number sees WHY the
-        tree keeps growing past it. Not per write: one line per tool
-        result is the class #5873 closed. Cleared when a pass ends under
-        cap, so the NEXT overflow warns again (a latch, not a one-shot).
+        — naming what made the cap unsatisfiable (un-spilled bodies,
+        unknown/unmigrated files, or both — the two are separate
+        exclusions, see :meth:`_evict_history_content_over_cap`) so an
+        operator who set the number sees WHY the tree keeps growing past
+        it. Not per write: one line per tool result is the class #5873
+        closed. Cleared when a pass ends under cap, so the NEXT overflow
+        warns again (a latch, not a one-shot).
 
         CLAUDE.md's three questions: Q1 (who stops it if it repeats) — the
         operator, now that they can see it; Q2 (visible with the shipped
         config) — a WARNING on reyn's own log, no setting needed; Q3 (does
         the repair destroy evidence) — nothing is deleted here.
 
-        ``unspilled`` (#5896 🔴 #2): the exclusion set the pass actually
-        used — the project-wide pass passes its tree-derived set so the
-        figures count EVERY session's un-spilled bodies (a caller-only
-        count could say "0 file(s) un-spilled" for a cap another session
-        filled — a self-contradicting line). ``None`` = this store's own
-        set (the per-session pass, whose tree IS this store's)."""
+        ``unspilled``/``known`` (#5896 🔴 #2's own shape, widened by stage
+        ②): the exclusion sets the pass actually used — the project-wide
+        pass passes its tree-derived sets so the figures count EVERY
+        session's un-spilled/unknown files (a caller-only count could say
+        "0 file(s)" for a cap another session filled — a self-
+        contradicting line). ``None`` = this store's own set (the
+        per-session pass, whose tree IS this store's)."""
         over = total > cap
         was = self._cap_unsatisfiable.get(scope, False)
         if over and not was:
             n_unspilled, unspilled_bytes = self._unspilled_stats_under(
                 directory, unspilled=unspilled,
             )
+            n_unknown, unknown_bytes = self._unknown_stats_under(
+                directory, known=known,
+            )
             logger.warning(
                 "#5896: the %s history-content cap (%d bytes) cannot be met — "
                 "%d bytes on disk after eviction; %d file(s) / %d bytes are "
-                "un-spilled tool bodies the model still sees inline, excluded "
-                "from eviction until a spill supersedes them (stage ②)",
-                scope, cap, total, n_unspilled, unspilled_bytes,
+                "un-spilled tool bodies the model still sees inline (excluded "
+                "from eviction — owner-confirmation-pending stage ③ would "
+                "relax this); %d file(s) / %d bytes have no manifest line "
+                "(stage ② 'unknown ⇒ protect', run `reyn storage "
+                "migrate-manifest` to backfill)",
+                scope, cap, total, n_unspilled, unspilled_bytes, n_unknown, unknown_bytes,
             )
         self._cap_unsatisfiable[scope] = over
 
@@ -1582,6 +1790,28 @@ class MediaStore:
                 path.relative_to(root)
                 total += path.stat().st_size
             except (ValueError, OSError):
+                continue
+            count += 1
+        return count, total
+
+    def _unknown_stats_under(
+        self, directory: Path, *, known: "set[Path] | None" = None,
+    ) -> "tuple[int, int]":
+        """(count, bytes) of the files under *directory* that exist on
+        disk but carry NO manifest line at all — the WARNING's own
+        figures, computed only when it fires (#5896 stage ② item ②).
+        ``known`` defaults to this store's own tracked set; a project-wide
+        caller passes the tree-derived set (see ``_note_cap_state``)."""
+        tracked = self._history_content_spill_paths if known is None else known
+        tracked_resolved = {p.resolve() for p in tracked}
+        count = 0
+        total = 0
+        for path in directory.rglob("*"):
+            try:
+                if not path.is_file() or path.resolve() in tracked_resolved:
+                    continue
+                total += path.stat().st_size
+            except OSError:
                 continue
             count += 1
         return count, total
@@ -1668,10 +1898,15 @@ class MediaStore:
             return
         # #5896 🔴 #2: the exclusion for a pass over the WHOLE tree comes
         # from the tree (every session's manifest lines), never from this
-        # store's own view alone — see _unspilled_paths_project_wide.
-        unspilled = self._unspilled_paths_project_wide()
+        # store's own view alone — see _manifest_paths_project_wide. Stage
+        # ② widens this to a SECOND exclusion (``known``, "unknown ⇒
+        # protect") alongside the stage ① un-spilled one — both are
+        # OUTRIGHT exclusions here (no spilled-first ordering: that is
+        # stage ③, owner-confirmation-pending, NOT part of this change).
+        known, unspilled = self._manifest_paths_project_wide()
         history_content_candidates = cross_session_eviction_candidates(
-            history_content_root, pin=self._storage.pin, unspilled=unspilled,
+            history_content_root, pin=self._storage.pin,
+            unspilled=unspilled, known=known,
         )
         # #4478: a NEW (post-#4478) nested media write's own pin match
         # works exactly like history-content's; a pre-#4478 flat file's
@@ -1697,11 +1932,11 @@ class MediaStore:
             total -= size
         # #5896 (architect co-vet 🔴): same shape as the per-session pass —
         # the refusal below already stops the write, but WHY the cap is
-        # unsatisfiable (un-spilled bodies, not a full tree of spills) is
-        # only said here, once per transition.
+        # unsatisfiable (un-spilled bodies, unknown/unmigrated files, or
+        # both) is only said here, once per transition.
         self._note_cap_state(
             "project", total=total, cap=max_bytes, directory=history_content_root,
-            unspilled=unspilled,
+            unspilled=unspilled, known=known,
         )
         if total > max_bytes:
             raise MediaStoreWriteUnavailable(
@@ -1737,9 +1972,14 @@ class MediaStore:
         total = history_content_total + media_total
         if total <= max_bytes:
             return []
+        # #5896 stage ②: same two-exclusion (un-spilled + unknown)
+        # composition as :meth:`_evict_cross_session_over_cap` — both
+        # outright exclusions, no spilled-first ordering (stage ③,
+        # owner-confirmation-pending, not part of this change).
+        known, unspilled = self._manifest_paths_project_wide()
         history_content_candidates = cross_session_eviction_candidates(
             history_content_root, pin=self._storage.pin,
-            unspilled=self._unspilled_paths_project_wide(),
+            unspilled=unspilled, known=known,
         )
         media_candidates = cross_session_eviction_candidates(
             self._media_dir, pin=self._storage.pin,

--- a/src/reyn/interfaces/cli/commands/storage.py
+++ b/src/reyn/interfaces/cli/commands/storage.py
@@ -3,6 +3,13 @@
 moved the write location), and every ``history.jsonl`` under
 ``.reyn/agents/`` (#4476 Phase 1).
 
+`reyn storage migrate-manifest` — #5896 stage ② item ①: the one-time,
+idempotent backfill that gives every already-written history-content file
+a real spill-manifest line (see
+``reyn.data.workspace.media_store.migrate_history_content_manifest``'s own
+docstring for the mechanism). Unlike ``stats`` this one WRITES (a manifest
+line, never a history-content body) — the only mutation this module makes.
+
 Named ``storage``, not ``media`` (renamed from the original #4485 name once
 #4476 landed on the same command — lead-coder review on #4488): once
 ``history.jsonl`` reports through here too, "media" no longer describes
@@ -53,6 +60,21 @@ def register(sub) -> None:
     )
     stats_p.set_defaults(func=run_stats)
 
+    migrate_p = storage_sub.add_parser(
+        "migrate-manifest",
+        help=(
+            "#5896 stage ② item ①: give every history-content file with no "
+            "spill-manifest line a real one (one-time, idempotent — a "
+            "second run migrates nothing)."
+        ),
+    )
+    migrate_p.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing .reyn/ (default: current directory).",
+    )
+    migrate_p.set_defaults(func=run_migrate_manifest)
+
 
 def run_stats(args: argparse.Namespace) -> None:
     from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
@@ -83,4 +105,22 @@ def run_stats(args: argparse.Namespace) -> None:
     print(
         f"{'history.jsonl':<16}"
         f"{hist.file_count:>10}{hist.total_bytes:>16,}{hist.total_lines:>12,}",
+    )
+
+
+def run_migrate_manifest(args: argparse.Namespace) -> None:
+    """#5896 stage ② item ①: the one-time, idempotent operator command —
+    see ``migrate_history_content_manifest``'s own docstring for the
+    mechanism (unknown-truth files default un-spilled, "不明なら守る")."""
+    from reyn.data.workspace.media_store import migrate_history_content_manifest
+    from reyn.runtime.services.router_history_buffer import iter_history_content_refs
+
+    project_root = Path(args.project_root).resolve()
+    result = migrate_history_content_manifest(
+        project_root, iter_content_refs=iter_history_content_refs,
+    )
+    print(
+        f"migrated {result['migrated']} file(s) into the spill manifest "
+        f"({result['protected_unknown']} defaulted un-spilled — no "
+        "history.jsonl row named them, so 'unknown ⇒ protect' applies).",
     )

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -573,7 +573,7 @@ class LostReason(StrEnum):
     ``CONTENT_REF_META_KEY`` present): no eviction pass selects an
     un-spilled file — the per-session pass by this store's own record,
     the project-wide pass by re-reading every session's manifest lines
-    at pass time (``MediaStore._unspilled_paths_project_wide``, architect
+    at pass time (``MediaStore._manifest_paths_project_wide``, architect
     co-vet 🔴 #2: a pass that used only the calling store's own view
     evicted a neighbour's un-spilled body, and this reason then LIED
     about it) — so a missing one was removed by something outside reyn's
@@ -581,9 +581,10 @@ class LostReason(StrEnum):
     store's body whose content landed while its manifest line was still
     queued (the next job in the same FIFO worker) is invisible to a
     project-wide pass run by a DIFFERENT store in that instant; a loss
-    in that window also reads as ``EXTERNAL``. Stage ② (spilled-first
-    ordering with un-spilled eviction, pending owner ruling) is where
-    this stops being derivable at all and needs its own record."""
+    in that window also reads as ``EXTERNAL``. Stage ③ (spilled-first
+    ordering with un-spilled eviction, owner-confirmation-pending — NOT
+    part of this change) is where this stops being derivable at all and
+    needs its own record."""
 
     GC = "gc"
     NEVER_PERSISTED = "never_persisted"

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -42,7 +42,7 @@ from reyn.runtime.chat_message import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from pathlib import Path
 
 # #5612: the reactive overflow-recovery spill's own durable supersede
 # record role — see chat_message.py's own role-vocabulary entry and
@@ -260,7 +260,9 @@ def resolve_history_content(
     docstring for the disclosed, not-exhaustive caveat) and
     ``LostReason.EXTERNAL`` for an un-spilled one (#5896 stage ①: no
     eviction pass selects an un-spilled file, so only something outside
-    reyn's own GC can have removed it). Surfaced on 2 operator-facing
+    reyn's own GC can have removed it — stage ③, owner-confirmation-
+    pending and NOT part of this change, is where that premise would
+    stop holding). Surfaced on 2 operator-facing
     faces, per architect's own text — never a THIRD hidden one: (1) the
     reason named inline in the placeholder text every reader (model +
     transcript) already sees, (2) one ``offloaded_content_unavailable``
@@ -324,6 +326,62 @@ def resolve_history_content(
             f"(reason: {reason})]"
         )
     return content
+
+
+def iter_history_content_refs(project_root: "Path") -> "list[tuple[str, bool]]":
+    """#5896 stage ② item ① — the ``iter_content_refs`` collaborator
+    :func:`reyn.data.workspace.media_store.migrate_history_content_manifest`
+    injects: every ``(content_ref, spilled)`` pair recorded across EVERY
+    ``history.jsonl`` this project holds (``.reyn/agents/**/history.jsonl``
+    — the same glob :func:`reyn.runtime.history_tail_reader.
+    aggregate_history_stats` already uses to enumerate them).
+
+    This is the RUNTIME-layer half of the migration: it alone knows the
+    wire vocabulary (``CONTENT_REF_META_KEY``/``SPILLED_META_KEY``) a
+    ``history.jsonl`` row carries — the data-layer migration function
+    must not import it directly (layering: a data-layer module reading a
+    runtime-layer wire format would be backwards), so this function is
+    handed in rather than called from there. A row is read with a bare
+    ``json.loads`` (never ``parse_history_line``/``ChatMessage`` — this is
+    a read-only census over rows this project itself already wrote, not a
+    reconstruction that needs the full migration/normalisation a resident
+    ``ChatMessage`` requires) — a malformed line is skipped, same
+    "one bad line never invalidates the rest" policy every other reader
+    of this file already applies.
+
+    Last writer wins when more than one row names the same ref (never
+    expected in practice — a ref is written once, by exactly one
+    ``save_tool_result`` call — so this has no real effect, only a
+    defined one)."""
+    from pathlib import Path as _Path
+
+    root = _Path(project_root) / ".reyn" / "agents"
+    if not root.is_dir():
+        return []
+    refs: "dict[str, bool]" = {}
+    for hist_path in sorted(root.glob("**/history.jsonl")):
+        try:
+            with hist_path.open("r", encoding="utf-8") as f:
+                for raw in f:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(entry, dict) or entry.get("role") != "tool":
+                        continue
+                    meta = entry.get("meta") or {}
+                    if not isinstance(meta, dict):
+                        continue
+                    ref = meta.get(CONTENT_REF_META_KEY)
+                    if not ref:
+                        continue
+                    refs[ref] = bool(meta.get(SPILLED_META_KEY))
+        except OSError:
+            continue
+    return list(refs.items())
 
 
 # #4381 PR-1: warn-once cache for the resource/budget invariant below, keyed

--- a/tests/runtime/test_5896_stage2_manifest_migration.py
+++ b/tests/runtime/test_5896_stage2_manifest_migration.py
@@ -1,0 +1,288 @@
+"""Tier 2: #5896 stage ② — two of the architect's three ruled items only
+(https://github.com/tya5/reyn/issues/5896#issuecomment-5562613871 and the
+lead's follow-up quoting the architect's 2026-09-06 22:42 comment):
+
+  ① a one-time, idempotent migration that gives every existing
+    history-content file a real spill-manifest line
+    (:func:`reyn.data.workspace.media_store.migrate_history_content_manifest`);
+  ② the default flip for a file the manifest has NO line for at all —
+    "不明なら守る" ("unknown ⇒ protect"), the OPPOSITE of the pre-stage-②
+    default ("unknown, evictable").
+
+Item ③ (GC eviction order — "spilled 先行に") is EXPLICITLY NOT this PR's
+subject: the architect's 2026-09-06 22:42 comment folds "un-spilled も退避可"
+into stage ③, "owner 確認" pending — see the lead's own retraction on this
+issue. Stage ① (#5896 stage ① proper — un-spilled is an outright eviction
+exclusion, #5901) is unchanged and already covered by
+``test_5896_history_content_ref.py``; this file adds only the two items
+above, never re-asserting stage ①'s own behaviour.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from reyn.data.workspace.media_store import (
+    MediaStore,
+    MediaStoreConfig,
+    migrate_history_content_manifest,
+    spill_manifest_path_for,
+)
+
+
+def _bump_all_mtimes_forward(directory: Path) -> None:
+    """Mirrors ``test_5896_history_content_ref.py``'s own helper — push
+    every file already in *directory* one second into the past so
+    "oldest" is unambiguous inside a fast test loop."""
+    for path in directory.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            os.utime(path, (st.st_atime, st.st_mtime - 1))
+
+
+_CAP_WARNING = "cannot be met"
+
+
+def _cap_warnings(caplog) -> list[str]:
+    return [
+        r.getMessage() for r in caplog.records
+        if r.levelname == "WARNING" and _CAP_WARNING in r.getMessage()
+    ]
+
+
+def test_a_file_with_no_manifest_line_is_never_an_eviction_candidate(
+    tmp_path: Path, caplog,
+) -> None:
+    """Tier 2: item ② — "unknown ⇒ protect". A file physically present
+    under this session's history-content directory that the manifest has
+    NO line for at all (simulating the #5364 §1.4 crash-race: the content
+    write landed, the deferred manifest-append job never ran) survives an
+    eviction pass even when it is the OLDEST file and the cap is set so
+    low that evicting every KNOWN candidate still leaves the tree over
+    cap — the pass ends over cap, warns once, and never touches the
+    unknown file. Public seam: ``MediaStore.is_known_file``.
+
+    Strip-falsify: drop the ``is_known_file`` skip in
+    ``_evict_history_content_over_cap`` → the unknown file (oldest) is
+    the one evicted → red."""
+    caplog.set_level(logging.WARNING, logger="reyn.data.workspace.media_store")
+    config = MediaStoreConfig(history_content_max_bytes=1)
+    store = MediaStore(config, project_root=tmp_path, agent_name="alice", session_id="main")
+
+    unknown_dir = store.history_content_dir
+    unknown_dir.mkdir(parents=True, exist_ok=True)
+    unknown_file = unknown_dir / "unmigrated.txt"
+    unknown_file.write_bytes(b"x" * 5)
+    _bump_all_mtimes_forward(unknown_dir)
+    assert not store.is_known_file(str(unknown_file.relative_to(tmp_path))), (
+        "test setup sanity: the manifest genuinely has no line for this file"
+    )
+
+    # A real, spilled write — the cap (1 byte) forces an eviction pass the
+    # instant this lands; the ONLY known candidate is this file itself.
+    store.save_tool_result("payload number 0 " * 2, seq=0)
+
+    assert unknown_file.exists(), (
+        "a file with no manifest line must never be an eviction candidate, "
+        "regardless of age or how over-cap the pass ends"
+    )
+    (warning,) = _cap_warnings(caplog)
+    assert "no manifest line" in warning and "1 file(s)" in warning, warning
+
+
+def test_cross_session_gc_never_lists_a_neighbours_unmigrated_file(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the same item ② condition on the PROJECT-wide pass (#5366's
+    ``storage.max_bytes``), in the SAME construction-order shape that
+    broke stage ①'s un-spilled exclusion (architect co-vet 🔴 #2 on
+    #5901): bob's store is constructed FIRST; alice's unmigrated file is
+    placed on disk AFTER — so bob's construction-time view cannot know
+    about it — and bob's project-wide preview must still not list it: the
+    ``known`` set is derived from the tree at pass time
+    (``MediaStore._manifest_paths_project_wide``), not from the caller's
+    own in-memory view.
+
+    Strip-falsify: pass ``self._history_content_spill_paths`` (the
+    caller's own set) instead of the tree-derived ``known`` →
+    bob lists alice's unmigrated file → red."""
+    from reyn.config.infra import StorageConfig
+
+    bob = MediaStore(
+        project_root=tmp_path, agent_name="bob", session_id="main",
+        storage=StorageConfig(max_bytes=10),
+    )
+    alice = MediaStore(project_root=tmp_path, agent_name="alice", session_id="main")
+    unknown_dir = alice.history_content_dir
+    unknown_dir.mkdir(parents=True, exist_ok=True)
+    unknown_file = unknown_dir / "unmigrated.txt"
+    unknown_file.write_bytes(b"x" * 5)
+    _bump_all_mtimes_forward(unknown_dir)
+    assert not bob.is_known_file(str(unknown_file.relative_to(tmp_path))), (
+        "test setup sanity: bob's construction-time view genuinely does not know this file"
+    )
+
+    assert bob.cross_session_eviction_preview() == []
+
+    evictable = alice.save_tool_result("payload number 1 " * 2, seq=1)
+    preview = bob.cross_session_eviction_preview()
+    assert (tmp_path / evictable["path"]).resolve() in {p.resolve() for p in preview}
+    assert unknown_file.resolve() not in {p.resolve() for p in preview}
+
+
+def test_migrate_history_content_manifest_backfills_from_history_truth_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: item ① — the one-time migration. Simulates the manifest-loss
+    disaster the architect's closing #5901 comment names (both a
+    previously-spilled and a previously-un-spilled file losing their line
+    at once): after the manifest file is deleted, an injected
+    ``iter_content_refs`` (standing in for
+    ``router_history_buffer.iter_history_content_refs``'s real
+    ``history.jsonl`` census, #5896 stage ② item ①'s own layering — the
+    data-layer migration function never imports the runtime-layer wire
+    vocabulary directly) supplies the TRUTH for two files; a third file
+    ("orphan" — no row anywhere ever named it, e.g. dropped by rewind)
+    gets no truth at all and defaults un-spilled ("不明なら守る").
+
+    Idempotency witness (PR body requirement — "2 回目が no-op であること"):
+    a second call, same inputs, migrates and protects zero.
+
+    Strip-falsify: drop the ``known`` exclusion in the migration's own
+    scan (re-migrate an already-tracked path) → the spilled file's TRUE
+    entry gets silently re-defaulted on a second run → red (the second
+    call's ``migrated`` would be nonzero)."""
+    store = MediaStore(project_root=tmp_path, agent_name="alice", session_id="main")
+    spilled_block = store.save_tool_result("payload number 0 " * 2, seq=0)  # spilled=True default
+    unspilled_block = store.save_tool_result("payload number 1 " * 2, seq=1, spilled=False)
+
+    manifest_path = spill_manifest_path_for(tmp_path)
+    assert manifest_path.is_file(), "test setup: both real writes already have a normal manifest line"
+
+    # Simulate the manifest-loss disaster: BOTH lines are gone at once.
+    manifest_path.unlink()
+
+    orphan_dir = store.history_content_dir
+    orphan = orphan_dir / "orphan.txt"
+    orphan.write_text("nobody's history.jsonl row references me")
+    orphan_rel = str(orphan.relative_to(tmp_path))
+
+    def _fake_iter_content_refs(_project_root: Path) -> list[tuple[str, bool]]:
+        return [
+            (spilled_block["path"], True),
+            (unspilled_block["path"], False),
+        ]
+
+    result = migrate_history_content_manifest(
+        tmp_path, iter_content_refs=_fake_iter_content_refs,
+    )
+    assert result == {"migrated": 3, "protected_unknown": 2}, result
+
+    reopened = MediaStore(project_root=tmp_path, agent_name="alice", session_id="main")
+    assert reopened.is_known_file(spilled_block["path"])
+    assert reopened.is_known_file(unspilled_block["path"])
+    assert reopened.is_known_file(orphan_rel), "the orphan must get a line too — just a protective one"
+    assert not reopened.is_unspilled_file(spilled_block["path"]), (
+        "the TRUE fact (spilled) must survive the migration, not default"
+    )
+    assert reopened.is_unspilled_file(unspilled_block["path"]), (
+        "the TRUE fact (un-spilled) must survive the migration"
+    )
+    assert reopened.is_unspilled_file(orphan_rel), (
+        "no row named the orphan — '不明なら守る' defaults it un-spilled, never spilled"
+    )
+
+    second = migrate_history_content_manifest(
+        tmp_path, iter_content_refs=_fake_iter_content_refs,
+    )
+    assert second == {"migrated": 0, "protected_unknown": 0}, (
+        "a second run over the same tree must be a true no-op — this IS the "
+        "'一度きり' witness the PR body requires"
+    )
+
+
+def test_migrate_history_content_manifest_is_a_noop_with_no_history_content_tree(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a project with no ``history-content/`` tree at all (nothing
+    ever written) migrates zero, not an error — the function's own
+    documented degrade."""
+    result = migrate_history_content_manifest(tmp_path, iter_content_refs=lambda _p: [])
+    assert result == {"migrated": 0, "protected_unknown": 0}
+
+
+def test_an_unmigrated_files_protection_survives_a_real_wal_truncation_and_reconstruct(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: CLAUDE.md's recovery-feature truncate-falsify gate, applied
+    to #5896 stage ②'s new invariant — "unknown ⇒ protect" — the way
+    ``test_4584_persist_tier_survives_wal_truncation.py`` already applies
+    it to this same manifest for the sibling #4584 claim. Set X (a file
+    with no manifest line is protected from eviction) → run the REAL
+    production WAL-truncation primitive (heavy enough to drop every event
+    this test wrote) across it → open a BRAND-NEW ``StateLog`` (the
+    "reconstruct" step, same primitive ``test_2946_item1_state_log_tail_
+    scan.py`` uses) → open a BRAND-NEW ``MediaStore`` over the SAME
+    project (a later process attaching here) → X must still hold: the
+    unmigrated file is STILL protected, because the manifest (and this
+    file's very absence from it) was never derived from the WAL in the
+    first place — the same "moved somewhere that survives" claim #4584's
+    own test makes for this exact manifest, now applied to stage ②'s new
+    default rather than stage ①'s old one.
+
+    Strip-falsify: this test alone cannot distinguish "genuinely survives"
+    from "the WAL was never touched" — that is exactly WHY it drives a
+    real ``truncate_below`` over real WAL entries this test itself wrote
+    (mirrors #4584's own module docstring on this point) rather than
+    asserting a bare path never changed."""
+    import asyncio
+
+    from reyn.core.events.state_log import StateLog
+
+    project_root = tmp_path
+    config = MediaStoreConfig(history_content_max_bytes=1)
+    store = MediaStore(config, project_root=project_root, agent_name="alice", session_id="main")
+
+    unknown_dir = store.history_content_dir
+    unknown_dir.mkdir(parents=True, exist_ok=True)
+    unknown_file = unknown_dir / "unmigrated.txt"
+    unknown_file.write_bytes(b"x" * 5)
+    _bump_all_mtimes_forward(unknown_dir)
+    store.save_tool_result("payload number 0 " * 2, seq=0)  # forces the cap-1 eviction pass
+    assert unknown_file.exists(), "test setup: X holds before any WAL activity at all"
+
+    wal_path = project_root / ".reyn" / "state" / "wal.jsonl"
+    log = StateLog(wal_path)
+    seen: dict[str, str] = {}
+
+    async def _churn_and_truncate() -> None:
+        for i in range(5):
+            await log.append("inbox_put", target=f"a{i}", payload={})
+        await log.flush()
+        seen["before"] = wal_path.read_text(encoding="utf-8")
+        await log.truncate_below(1_000_000)
+        await log.flush()
+
+    asyncio.run(_churn_and_truncate())
+    assert seen["before"].count('"inbox_put"') == 5, "test setup: the appends must have landed"
+    assert log.last_truncate_stats["dropped"] >= 1, (
+        "test setup: truncate_below dropped nothing — the assertion below would "
+        "then measure an untruncated WAL while claiming otherwise"
+    )
+    StateLog(wal_path)  # the reconstruct step: a fresh process attaching here
+
+    reopened = MediaStore(config, project_root=project_root, agent_name="alice", session_id="main")
+    assert unknown_file.exists(), (
+        "X (an unmigrated file's protection from eviction) must survive a WAL "
+        "truncation it was never derived from"
+    )
+    assert not reopened.is_known_file(str(unknown_file.relative_to(project_root))), (
+        "and it must still read as UNKNOWN after reconstruct — a real spilled "
+        "write forcing eviction again must still leave it alone"
+    )
+    reopened.save_tool_result("payload number 1 " * 2, seq=1)
+    assert unknown_file.exists(), (
+        "post-reconstruct: a fresh eviction pass still must not select the "
+        "unknown file"
+    )


### PR DESCRIPTION
**[lead-coder-subagent]** — stage ② of #5896, scoped to items ① and ② only. Item ③ (GC spilled-first eviction order) was **retracted mid-task by lead-coder**: the architect's 2026-09-06 22:42 comment on #5896 folds "un-spilled も退避可" into stage ③, pending **owner confirmation** — it is deliberately **not** implemented here. An earlier pass of this work did implement item ③; it was reverted with in-file `Edit` (no `git checkout`/`stash`/`restore`) before this commit, so the shipped diff never contained it.

## What landed

**① One-time, idempotent manifest migration** — `media_store.migrate_history_content_manifest`, reachable via the new `reyn storage migrate-manifest` command. For every history-content file physically on disk with no line in the spill-provenance manifest (the #5364 §1.4 crash-race, or manifest-file loss), it derives the TRUE `spilled`/un-spilled fact from `history.jsonl` itself via an injected `iter_content_refs` reader — production wiring is `router_history_buffer.iter_history_content_refs`, kept in the **runtime** layer (it alone knows `CONTENT_REF_META_KEY`/`SPILLED_META_KEY`) so the **data**-layer migration function never imports runtime's wire vocabulary (same injection idiom `history_content_resolve.resolve()` already uses for `file_exists`/`read_text`). A file no `history.jsonl` row references at all (truth unknown — e.g. a row dropped by rewind) defaults **un-spilled** ("不明なら守る").

Idempotency witness (2nd run migrates 0): `test_migrate_history_content_manifest_backfills_from_history_truth_and_is_idempotent` asserts the second call returns `{"migrated": 0, "protected_unknown": 0}`.

**② Default flip — "unknown ⇒ protect"** — a history-content file with **no manifest line at all** is now excluded from every eviction pass (per-session `_evict_history_content_over_cap` and project-wide `_evict_cross_session_over_cap`/`cross_session_eviction_preview`), the same as a *known* un-spilled file. Public seam: `MediaStore.is_known_file`. This is a **separate** exclusion from the existing stage ① un-spilled one — an unknown file's protection reason is "we don't know", not "we know it's un-spilled". `cross_session_eviction_candidates` gained a `known` parameter for this; both project-wide call sites derive it fresh from the tree at pass time (`MediaStore._manifest_paths_project_wide`, renamed from `_unspilled_paths_project_wide` — same "derive exclusion from the tree, not caller state" discipline the architect's stage ① co-vet 🔴 #2 already established, now widened to cover `known` too), not from the calling store's own in-memory view — mirrors the exact construction-order defect (`alice`/`bob`) that co-vet caught for the un-spilled case.

**Write-ahead untouched.** Nothing about item ① or ② reorders the write-ahead invariant ("ref を持つ row の file は append 時点で存在する") — migration only ever adds a manifest line for a file that is **already durable on disk**, never the other way around, and self-prune (drop a manifest line whose target vanished) is unaffected.

## Explicitly out of scope (remainder, filed here — arc-closure rule)

- **Item ③ — GC eviction order (spilled-first, un-spilled evictable)** — owner-confirmation-pending per the architect's 2026-09-06 22:42 comment. `LostReason.EXTERNAL`'s derivation, `is_unspilled_file`'s "never a GC candidate" contract, and `_evict_*_over_cap`'s ordering are all **unchanged** from stage ①/#5901.
- The `mark_spilled`/supersede-record co-atomicity item (a *different* e2e-coder stage-2 proposal, "spill/GC の機構") was never in this brief's 3 items and is not touched.
- Stage ③ proper — the explicit `reyn storage` command to shrink the existing 679 MB `history.jsonl` — is a separate, larger piece not attempted here.

`∴ part of #5896`, not `Closes` — real remainders above.

## Per-store cap current default (unchanged — not moved)

`MediaStoreConfig.history_content_max_bytes` default: **2 * 1024 * 1024 * 1024 (2 GiB)**. `StorageConfig.max_bytes` (project-wide, `reyn.yaml` `storage:` block) default: unset (`None` — cross-session GC off unless an operator sets it). Neither touched by this PR.

## Truncate-falsify test (CLAUDE.md hard rule)

`test_an_unmigrated_files_protection_survives_a_real_wal_truncation_and_reconstruct` (new file): sets X = "an unmigrated (no-manifest-line) file is protected from eviction" → runs the real `StateLog.truncate_below` across 5 real WAL events this test itself wrote (heavy enough to drop every one, confirmed via `last_truncate_stats["dropped"] >= 1`) → opens a fresh `StateLog` (reconstruct) → opens a fresh `MediaStore` over the same project → re-asserts X (the file survives, still reads as unknown, and a fresh eviction pass still leaves it alone). Same shape as `test_4584_persist_tier_survives_wal_truncation.py`'s own falsification for this identical manifest (the manifest lives under `.reyn/memory/`, never derived from the WAL, so this passes by construction — the test's job is to witness that construction directly, not assume it).

## Tests

New file: `tests/runtime/test_5896_stage2_manifest_migration.py` (Tier 2, 5 tests) — real `MediaStore`/`StateLog` throughout, no mocks:
- `test_a_file_with_no_manifest_line_is_never_an_eviction_candidate` (per-session)
- `test_cross_session_gc_never_lists_a_neighbours_unmigrated_file` (project-wide, construction-order shape)
- `test_migrate_history_content_manifest_backfills_from_history_truth_and_is_idempotent`
- `test_migrate_history_content_manifest_is_a_noop_with_no_history_content_tree`
- `test_an_unmigrated_files_protection_survives_a_real_wal_truncation_and_reconstruct`

Existing `tests/runtime/test_5896_history_content_ref.py` (9 tests, stage ①) — unchanged, still green (stage ① behaviour is untouched by this PR).

## Gates (local, scoped)

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict tests/runtime/test_5896_stage2_manifest_migration.py` — 5/5 OK
- `python scripts/verify_module_docstrings.py <4 changed src files>` — OK
- `python scripts/mypy_ratchet.py` — OK (changed-files, all baselined)
- `python scripts/flat_tests_ratchet.py` — OK
- `python scripts/check_tests_path_literal_reference.py` — OK (re-run right before push)
- `python scripts/check_collect_events_settle.py` — OK
- `tests/` path-conditional: `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- Scoped `pytest` (10 files, 57 tests: new file + stage ① file + every GC/eviction/LostReason-adjacent test file) — 57 passed

Not run: full suite (CLAUDE.md — CI's job, clean checkout).

## Test plan
- [x] Scoped pytest green (57/57, listed above)
- [x] Tier audit clean
- [x] Idempotency witness present
- [x] Truncate-falsify test present
- [ ] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LZ2nN392xjGJNJzpCc8T5