### PR TITLE
fix(#5888 stage 2): forced /compact runs rung① spill when fold selects nothing

### DIFF
--- a/src/reyn/interfaces/slash/compact.py
+++ b/src/reyn/interfaces/slash/compact.py
@@ -35,14 +35,17 @@ compact op uses), so the freed-token report is the **same contract** as the op:
    reactive ladder's shortfall (#5719's rule, which exists to stop the
    ladder's own over-fold and was never a reason to refuse an operator).
 
-Still open, deliberately not implemented here: #5888's 3″ — on the
-forced path, offer rung ① SPILL even when zero fold candidates were
-selected. Spill swaps a tool result's body for a reference without
-splitting the message, so it reaches content head/tail is protecting
-without loosening that protection; a 3 MB tool result sitting in the
-tail is exactly what it is for. Until that lands (stage 2), a history
-whose head+tail genuinely hold everything still stops here — it just now
-says exactly that instead of claiming nothing was eligible.
+3. **(stage 2, #5888 3″) Zero fold candidates was not the floor either.**
+   Rung ① SPILL now runs on that SAME pass (``CompactionController.
+   force_compact_now``'s own ``if not candidates:`` branch) — it swaps a
+   tool result's body for a reference without splitting the message, so
+   it reaches content head/tail is protecting WITHOUT loosening that
+   protection (#2289's keep-whole invariant is untouched; spill runs
+   orthogonal to it). A 3 MB tool result sitting in the tail — the
+   owner's own real-machine case — is exactly what this reaches. When
+   spilling made progress, the reply says so instead of "all protected";
+   when the driver has no spill capability at all (#5717), it says that
+   too, rather than folding both into one silent "nothing to compact".
 """
 from __future__ import annotations
 
@@ -243,19 +246,40 @@ async def compact_cmd(ctx: "SlashContext", args: str) -> None:
     # measured against the compaction trigger, which is exactly how a
     # 75%-full window got reported as full (#5888).
     eligible = result.get("eligible_count")
+    # #5888 3″ (stage 2): on the SAME zero-candidate pass, rung① spill
+    # ran too (`CompactionController.force_compact_now`'s own `if not
+    # candidates:` branch) — read its report BEFORE deciding which
+    # "nothing was folded" sentence applies, so a pass that genuinely
+    # freed something never gets described as having done nothing.
+    spilled_count = result.get("spilled_count") or 0
+    if eligible is not None and eligible > 0 and spilled_count > 0:
+        chars_freed = result.get("spilled_chars_freed") or 0
+        result_word = "result" if spilled_count == 1 else "results"
+        await reply(
+            ctx,
+            f"✓ Nothing was folded, but spilled {spilled_count} tool "
+            f"{result_word} (~{chars_freed} chars) out of the protected "
+            "head/tail groups — their bodies are now references, freeing "
+            "that much from the wire without loosening protection." +
+            measured + free_tail,
+        )
+        return
     if eligible is not None and eligible > 0:
         # Eligible entries existed; head/tail protection held every one of
-        # them back. Reaching that content is stage 2's job (#5888 3″:
-        # spill on the forced path, which does not loosen protection) —
-        # until then this reply's job is to say plainly which boundary
-        # stopped it, so the operator is not left guessing at an
-        # empty-sounding "nothing to fold".
+        # them back, and rung① spill (#5888 3″, above) either found
+        # nothing eligible to spill or has no capability on this driver
+        # at all (#5717) — named explicitly so an operator with no spill
+        # mechanism is told THAT, not left to guess why nothing changed.
         word = "entry" if eligible == 1 else "entries"
+        spill_note = (
+            " (spill is not available on this path)"
+            if not result.get("spill_capability_present", True) else ""
+        )
         await reply(
             ctx,
             f"Nothing was folded: all {eligible} eligible {word} are "
             "protected by the head/tail keep-window, so there was no "
-            "unprotected middle left to compact." + measured + free_tail,
+            f"unprotected middle left to compact{spill_note}." + measured + free_tail,
         )
         return
     await reply(

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -150,6 +150,20 @@ class ForceCompactResult:
     middle_room_tokens: int = 0
     middle_used_tokens: int = 0
     covers_through_seq: int = 0
+    # #5888 3″ (architect ruling): rung① spill still runs even when
+    # ``candidate_count == 0`` — these two name what THAT pass did, kept
+    # separate from ``candidate_count`` because spilling a protected
+    # group folds nothing (no summary is persisted, ``covers_through_seq``
+    # does not advance) — a caller must never read a nonzero
+    # ``spilled_count`` as if it were a fold.
+    spilled_count: int = 0
+    spilled_bytes_freed: int = 0
+    # Threaded straight from the ``spill_capability_present`` argument
+    # (#5717's own fact) so a caller with only this result in hand can
+    # tell "spill ran and found nothing" apart from "spill was never a
+    # possibility on this path" — the same distinction #5717 drew for
+    # the reactive ladder's own MID_FLOOR message, now available here too.
+    spill_capability_present: bool = True
 
 
 @dataclass(frozen=True)
@@ -174,6 +188,50 @@ class _SelectionMeasurement:
     tail_turns: int
     middle_room_tokens: int
     middle_used_tokens: int
+
+
+def _spill_all_faces(
+    decompose_for_retry: "Callable[[], tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]]",
+    spill_fn: "Callable[..., list[tuple[int, dict]]]",
+) -> "tuple[int, int]":
+    """#5888 3″: rung① spill over EVERY face of the resident wire — head,
+    raw_middle, tail (#5364 §1.3's own staged order, never mixed into
+    one call) — the exact decomposition ``decompose_for_retry`` (bound to
+    ``RouterHistoryBuffer.decompose_history_for_retry`` at the real call
+    site) already builds for the reactive ladder's own ``_attempt_
+    reactive_spill``, reused rather than a second copy.
+
+    Unlike ``_attempt_reactive_spill`` (stops at the FIRST face that
+    progresses — the reactive question is "has enough happened to retry
+    the call now"), this tries every face: an operator's explicit
+    ``/compact`` is asking to shrink as much as this rung can, matching
+    ``_measure_and_select``'s own shortfall/operator split (#5888 ruling
+    2 — "operator mode widens what may fold, never what is protected").
+
+    ``spill_fn`` is called once per face with that face's own wire dicts
+    and the SHARED ``seq_by_id`` decompose returned (id-keyed — see
+    ``decompose_history_for_retry``'s own docstring for why passing the
+    unmodified face lists straight through keeps the id() lookup valid).
+    Each call's own real, durable side effect (``spill_turn_content``,
+    inside ``_spill_batch_within_face``) is what future turns see; there
+    is no local pool here for this function to apply the returned edits
+    to — only the byte count they represent is read back.
+
+    Returns ``(results spilled, chars freed)`` — a CHARACTER count read
+    directly off the before/after content strings, never a token
+    estimate (this file's own #5592 standing rule: never report a
+    user-facing number built on an estimate when the exact one is
+    already in hand)."""
+    head, raw_middle, tail, _summary, seq_by_id = decompose_for_retry()
+    spilled_count = 0
+    spilled_chars_freed = 0
+    for face in (head, raw_middle, tail):
+        for idx, replacement in spill_fn(face, seq_by_id=seq_by_id):
+            old_content = face[idx].get("content") or ""
+            new_content = replacement.get("content") or ""
+            spilled_chars_freed += max(0, len(old_content) - len(new_content))
+            spilled_count += 1
+    return spilled_count, spilled_chars_freed
 
 
 def _measured_fields(m: "_SelectionMeasurement", covers_through_seq: int) -> dict:
@@ -483,8 +541,19 @@ class CompactionController:
             head_budget = tail_budget = fallback // 4
             main_M_room = fallback - head_budget - tail_budget
 
-        head_messages = trim_head(messages, head_budget, model, use_chars4=use_chars4)
-        tail_messages = trim_tail(messages, tail_budget, model, use_chars4=use_chars4)
+        # #5888 (architect ruling, observation ①): ``events=`` was never
+        # threaded through on this call path — ``trim_head``/``trim_tail``
+        # already emit ``tool_cycle_kept_whole_over_budget`` when a single
+        # tool-cycle group alone exceeds its budget (``engine.py``'s own
+        # ``_emit_over_budget_group``), but only when handed a real
+        # ``EventLog``; the reactive ladder's own callers already pass one,
+        # this one never did (measured: 0 emissions from this path).
+        head_messages = trim_head(
+            messages, head_budget, model, use_chars4=use_chars4, events=self._events,
+        )
+        tail_messages = trim_tail(
+            messages, tail_budget, model, use_chars4=use_chars4, events=self._events,
+        )
         head_id_set = {id(t) for t in head_messages}
         tail_id_set = {id(t) for t in tail_messages}
         unprotected = [
@@ -548,6 +617,22 @@ class CompactionController:
         spill_fn: "Callable[..., list[tuple[int, dict]]]",
         spill_capability_present: bool = True,
         selection: str = "shortfall",
+        # #5888 3″ (architect ruling, owner-hit: "ctx 75% ... ユーザは圧縮
+        # したいのにできない" -> a tail-protected 2.8 MB tool result never
+        # reached ANY shrink lever): zero-argument callable returning
+        # ``decompose_history_for_retry()``'s own ``(head, raw_middle,
+        # tail, summary, seq_by_id)`` — the SAME resident, wire-shaped
+        # decomposition the reactive ladder's own ``_attempt_reactive_
+        # spill`` already builds (``RouterLoopDriver``), never a second,
+        # independently-derived copy. ``None`` (the default, and every
+        # existing caller's behaviour — #5712/#5716's own reactive-ladder
+        # fallback call site never passes this) means "no spill-on-empty-
+        # candidates attempt" — byte-identical to before this parameter
+        # existed. See the ``if not candidates:`` branch below for why
+        # this is call-scoped rather than constructor-injected: it is
+        # only ever actually invoked (and its O(history bytes) cost only
+        # ever paid) on the ONE pass where fold selected nothing.
+        decompose_for_retry: "Callable[[], tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]] | None" = None,
     ) -> ForceCompactResult:
         """Synchronous force-trigger — single pass (#1128 PR-c).
 
@@ -716,8 +801,29 @@ class CompactionController:
             middle_used_tokens=measured.middle_used_tokens,
         )
         if not candidates:
+            # #5888 3″: everything eligible was protected (head/tail) —
+            # before this, that was the end of the pass. Rung① spill
+            # still reaches this content: it replaces a tool result's
+            # BODY with a reference, never splits or removes a message,
+            # so it reaches a protected group WITHOUT loosening
+            # protection (#2289's own keep-whole invariant is untouched —
+            # spill runs orthogonal to it, not instead of it). Reactive
+            # (413) recovery keeps its own separate spill-first path
+            # (ADR-0044, `_attempt_reactive_spill`) unchanged; this is
+            # the forced (`/compact`) path's own rung①, offered only
+            # when fold found nothing (never runs alongside a real fold
+            # — see the ``self._compacting`` guard a few lines down,
+            # which this branch returns before ever reaching).
+            spilled_count = 0
+            spilled_bytes_freed = 0
+            if spill_capability_present and decompose_for_retry is not None:
+                spilled_count, spilled_bytes_freed = await asyncio.to_thread(
+                    _spill_all_faces, decompose_for_retry, spill_fn,
+                )
             return ForceCompactResult(
                 outcome=outcome, candidate_count=0, batch_truncated=batch_truncated,
+                spilled_count=spilled_count, spilled_bytes_freed=spilled_bytes_freed,
+                spill_capability_present=spill_capability_present,
                 **_measured_fields(measured, prev_cover),
             )
 
@@ -753,6 +859,7 @@ class CompactionController:
         return ForceCompactResult(
             outcome=outcome, candidate_count=len(candidates),
             batch_truncated=batch_truncated, failed=failed,
+            spill_capability_present=spill_capability_present,
             **_measured_fields(measured, prev_cover),
         )
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -11448,6 +11448,18 @@ class Session:
             _partial(_spill_impl, chain_id="manual-compact")
             if _spill_impl is not None else (lambda _candidates: [])
         )
+        # #5888 3″: the SAME optional-collaborator degrade as ``_spill_
+        # impl`` right above (a driver with no ``_spill_batch_for_retry``
+        # — e.g. ``PipelineExecutorDriver`` — has no ``_history_buffer``
+        # either; both live on ``RouterLoopDriver``). ``None`` here is
+        # exactly "force_compact_now must not attempt the empty-candidates
+        # spill" (its own default), so an absent driver degrades to the
+        # pre-3″ behaviour, never a crash.
+        _history_buffer = getattr(self._loop_driver, "_history_buffer", None)
+        _decompose_for_retry = (
+            _history_buffer.decompose_history_for_retry
+            if _history_buffer is not None else None
+        )
         compaction_outcome = await self._compaction_controller.force_compact_now(
             spill_fn=_spill_fn,
             # #5717 (lead-coder review): "no capability" and "tried, found
@@ -11457,6 +11469,7 @@ class Session:
             # `spill_was_offered` field never claims rung① ran when there
             # was no mechanism to run it with.
             spill_capability_present=_spill_impl is not None,
+            decompose_for_retry=_decompose_for_retry,
             # #5888: "/compact" asks to shrink; the reactive ladder asks
             # whether it still fits. See force_compact_now's own docstring.
             selection=selection,
@@ -11524,6 +11537,13 @@ class Session:
             # left with no way to reach this caller — the exception itself
             # stays swallowed (intentional, #5633), only the FACT survives.
             "compaction_failed": compaction_outcome.failed,
+            # #5888 3″: rung① spill's own report — populated only on the
+            # candidate_count==0 pass that actually attempted it (every
+            # other pass carries the dataclass defaults, 0/0/True); never
+            # re-derived here from anything else the caller measured.
+            "spilled_count": compaction_outcome.spilled_count,
+            "spilled_chars_freed": compaction_outcome.spilled_bytes_freed,
+            "spill_capability_present": compaction_outcome.spill_capability_present,
             # #5888 (owner real-machine incident, "ctx 75% なのに ... ユーザ
             # は圧縮したいのにできない"): the quantities the pass ACTUALLY
             # measured, so `/compact` names each as itself. Before this,

--- a/tests/runtime/test_5888_stage2_forced_spill.py
+++ b/tests/runtime/test_5888_stage2_forced_spill.py
@@ -1,0 +1,359 @@
+"""Tier 2: #5888 stage 2 (architect's 3″ ruling) — an explicit ``/compact``
+that selected ZERO fold candidates (head/tail protection held every
+eligible entry back) still runs rung① spill over the RESIDENT wire before
+giving up, reaching exactly the content that was previously unreachable by
+any lever.
+
+owner real-machine incident (the root #5888 traces to): a 2.8 MB ``exec``
+tool result sat in the tail's own keep-whole group (#2289) — never a fold
+candidate (head/tail protection holds it back BY DESIGN), never reached by
+the reactive ladder (that only fires on a genuine overflow, and #5719's
+shortfall rule stops the reactive ladder from folding a middle that
+already fits — see ``test_5888_operator_selection.py``). ``/compact``
+therefore reported "all protected" and could do nothing about it. Spill
+reaches this WITHOUT loosening protection: it replaces a tool result's
+BODY with a reference, never splits or removes a message (#2289's own
+keep-whole invariant is untouched — spill runs orthogonal to it).
+
+Reuses ``test_5888_operator_selection.py``'s own ``_make_controller``
+harness (real ``CompactionController``/``ChatMessage``/``EventLog``/
+``CompactionConfig``) and ``test_5712_...``'s own real, working spill_fn
+contract shape (content+spillability-shaped wire dicts in, ``(index,
+replacement)`` edits out — the class of fake this suite's own docstrings
+already establish as acceptable: the engine and spill_fn are the two
+collaborators standing in for the provider LLM/network boundary and the
+real ``RouterHistoryBuffer.spill_turn_content`` durable write,
+respectively).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Callable
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.compaction_controller import CompactionController
+from reyn.services.compaction.engine import CompactionEngine, ComputedBudgets
+from tests._support.events import collect_events
+
+# Same shape as test_5888_operator_selection.py's own _STUB_BUDGETS: head
+# fits 1 turn, tail fits 1 turn, main_M_room fits 3 turns of unprotected
+# middle — a 4-turn history is head+tail+an-already-fitting-middle, the
+# owner's own shape (zero fold candidates, everything eligible protected).
+_STUB_BUDGETS = ComputedBudgets(
+    main_pool=100_000, head_budget=50, body_budget=5_000, tail_budget=50,
+    new_msg_budget=10_000, B_M=80_000, main_M_room=150, effective_trigger=150,
+)
+
+
+class _NeverCalledEngine(CompactionEngine):
+    """Fails the test outright if ``compact()`` is ever invoked — every
+    test in this file has zero fold candidates, so no LLM call belongs on
+    this path at all; spill is the ONLY thing that may run."""
+
+    def __init__(self) -> None:
+        self._model = ""
+        self._events = EventLog()
+        self._budgets = _STUB_BUDGETS
+
+    async def compact(self, input_chunk, *, covers_through):  # noqa: ANN001
+        raise AssertionError(
+            "compact() must never be called on a zero-candidate pass — "
+            "spill is orthogonal to fold, not a way to reach one"
+        )
+
+
+def _history(n: int) -> "list[ChatMessage]":
+    return [
+        ChatMessage(role="user" if i % 2 == 1 else "assistant", content="x" * 200, seq=i)
+        for i in range(1, n + 1)
+    ]
+
+
+def _make_controller(
+    *, history: "list[ChatMessage]", engine: CompactionEngine, events: EventLog,
+) -> CompactionController:
+    return CompactionController(
+        event_log=events,
+        config=CompactionConfig(use_chars4_estimate=True),
+        history_from_disk=lambda after_seq: (
+            [m for m in history if m.seq == 0 or m.seq > after_seq], False,
+        ),
+        latest_summary=lambda: None,
+        compaction_engine_factory=lambda: engine,
+        history_appender=history.append,
+        make_summary_message=lambda rendered, structured, covers, *, covers_from_seq: ChatMessage(
+            role="summary", content=rendered, seq=0,
+            meta={
+                "structured": structured,
+                "covers_through_seq": covers,
+                "covers_from_seq": covers_from_seq,
+            },
+        ),
+        render_summary=lambda s: str(s),
+    )
+
+
+def _wire(content: str, *, spillability: str = "first_choice", seq: int = 1) -> dict:
+    return {"role": "tool", "content": content, "spillability": spillability, "seq": seq}
+
+
+def _decompose_returning(
+    head: "list[dict]", raw_middle: "list[dict]", tail: "list[dict]",
+) -> "Callable[[], tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]]":
+    """A real ``decompose_history_for_retry()`` contract stand-in — the
+    SAME shape ``force_compact_now`` reads (head, raw_middle, tail,
+    summary, seq_by_id), ``seq_by_id`` id-keyed off the very wire dicts
+    handed back (matching the real function's own guarantee, see its
+    docstring), so a fake spill_fn threading ``seq_by_id`` through
+    ``_mid_seq_of``-shaped lookups behaves identically to production."""
+    seq_by_id = {id(w): w["seq"] for face in (head, raw_middle, tail) for w in face}
+
+    def _decompose() -> "tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]":
+        return head, raw_middle, tail, None, seq_by_id
+
+    return _decompose
+
+
+def _spill_once_per_call(
+    spilled_faces: "list[list[dict]]",
+) -> "Callable[..., list[tuple[int, dict]]]":
+    """A real, working spill_fn contract (test_5712's own shape): spills
+    the FIRST non-``never`` candidate offered, records which face it was
+    called with (by identity — the exact list object ``force_compact_now``
+    handed it) so a test can assert on call order/count without pinning
+    an internal iteration detail."""
+
+    def _spill_fn(
+        offered: "list[dict]", *, seq_by_id: "dict[int, int] | None" = None,
+    ) -> "list[tuple[int, dict]]":
+        spilled_faces.append(offered)
+        for idx, item in enumerate(offered):
+            if item.get("spillability") == "never":
+                continue
+            content = item.get("content", "")
+            if content.startswith("[spilled]"):
+                continue
+            return [(idx, {**item, "content": "[spilled]"})]
+        return []
+
+    return _spill_fn
+
+
+def test_forced_compact_spills_a_protected_tail_group_when_fold_selected_nothing() -> None:
+    """Tier 2: #5888 3″ accept ① — fold candidates 0 (head+tail protect
+    everything eligible, the owner's own shape), tail has a large
+    spillable tool result on the RESIDENT wire → ``/compact`` spills it
+    and reports both the count and the bytes freed.
+
+    strip witness (executed, not reasoned): reverting the ``if not
+    candidates:`` branch to its pre-#5888-stage-2 form (unconditional
+    early return, no spill attempt) makes ``spilled_count``/
+    ``spilled_bytes_freed`` both 0 here — verified directly during this
+    fix, restored after."""
+    history = _history(4)
+    events = EventLog()
+    ctrl = _make_controller(history=history, engine=_NeverCalledEngine(), events=events)
+    big = "y" * 5000
+    decompose = _decompose_returning([], [], [_wire(big, seq=99)])
+    spilled_faces: "list[list[dict]]" = []
+
+    result = asyncio.run(
+        ctrl.force_compact_now(
+            spill_fn=_spill_once_per_call(spilled_faces),
+            spill_capability_present=True,
+            decompose_for_retry=decompose,
+        ),
+    )
+
+    assert result.candidate_count == 0, "test setup sanity: this pass must select no fold candidate"
+    assert result.spilled_count == 1, f"expected exactly one spilled result; got {result.spilled_count}"
+    assert result.spilled_bytes_freed == len(big) - len("[spilled]"), (
+        f"expected the exact char delta between the original body and its "
+        f"spill placeholder; got {result.spilled_bytes_freed}"
+    )
+    assert result.spill_capability_present is True
+
+
+def test_spill_tries_every_face_not_just_the_first_that_progresses() -> None:
+    """Tier 2: #5888 3″ — unlike the REACTIVE ladder's own
+    ``_attempt_reactive_spill`` (stops at the first face that progresses,
+    since the reactive question is only "has enough happened to retry the
+    call"), an operator's explicit ``/compact`` tries EVERY face: head
+    progresses AND tail still gets its own spill attempt in the same
+    pass — maximum effect for one explicit ask, matching #5888 ruling 2's
+    own "operator mode widens what may fold, never what is protected"
+    precedent for the shortfall/operator split.
+
+    strip witness: an implementation that ``return``s after the first
+    face with edits (the reactive shape) reports ``spilled_count == 1``
+    here instead of 2 — verified directly, restored after."""
+    events = EventLog()
+    ctrl = _make_controller(history=_history(4), engine=_NeverCalledEngine(), events=events)
+    head_face = [_wire("head body", seq=1)]
+    raw_middle_face: "list[dict]" = []
+    tail_face = [_wire("tail body", seq=99)]
+    decompose = _decompose_returning(head_face, raw_middle_face, tail_face)
+    spilled_faces: "list[list[dict]]" = []
+
+    result = asyncio.run(
+        ctrl.force_compact_now(
+            spill_fn=_spill_once_per_call(spilled_faces),
+            spill_capability_present=True,
+            decompose_for_retry=decompose,
+        ),
+    )
+
+    assert result.spilled_count == 2, (
+        f"both the head and the tail candidate must be spilled in one pass; got {result.spilled_count}"
+    )
+    # Identity checks, not a count: each of the three faces
+    # `decompose_history_for_retry()` returns — including the EMPTY
+    # `raw_middle` — must be the exact object `force_compact_now` offers
+    # to `spill_fn`, proving every face is tried rather than iteration
+    # stopping at the first one that progresses.
+    assert any(face is head_face for face in spilled_faces), (
+        "spill_fn was never offered the head face"
+    )
+    assert any(face is raw_middle_face for face in spilled_faces), (
+        "spill_fn was never offered the (empty) raw_middle face"
+    )
+    assert any(face is tail_face for face in spilled_faces), (
+        "spill_fn was never offered the tail face"
+    )
+
+
+def test_spill_is_skipped_when_capability_is_absent() -> None:
+    """Tier 2: #5888 3″ accept ② — ``spill_capability_present=False``
+    (#5717's own fact: the attached driver has no spill mechanism at all)
+    means the empty-candidates pass must not even ATTEMPT spill — proven
+    here by handing it a ``decompose_for_retry`` that fails the test if
+    it is ever called, mirroring ``_NeverCalledEngine``'s own "must not
+    be reached" pattern."""
+    def _must_not_be_called() -> "tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]":
+        raise AssertionError(
+            "decompose_for_retry must never be called when spill_capability_present is False"
+        )
+
+    events = EventLog()
+    ctrl = _make_controller(history=_history(4), engine=_NeverCalledEngine(), events=events)
+
+    result = asyncio.run(
+        ctrl.force_compact_now(
+            spill_fn=lambda _candidates, **_kw: [],
+            spill_capability_present=False,
+            decompose_for_retry=_must_not_be_called,
+        ),
+    )
+
+    assert result.spilled_count == 0
+    assert result.spilled_bytes_freed == 0
+    assert result.spill_capability_present is False
+
+
+def test_spill_is_skipped_when_decompose_is_not_wired() -> None:
+    """Tier 2: #5888 3″ non-regression — the DEFAULT (``decompose_for_
+    retry=None``, every pre-#5888-stage-2 caller's own behaviour, and the
+    reactive ladder's own fallback caller in ``router_loop_driver.py``,
+    which never passes this parameter at all): a zero-candidate pass
+    degrades to exactly the pre-stage-2 outcome — no spill attempted, no
+    crash — even with ``spill_capability_present=True``."""
+    events = EventLog()
+    ctrl = _make_controller(history=_history(4), engine=_NeverCalledEngine(), events=events)
+
+    result = asyncio.run(
+        ctrl.force_compact_now(
+            spill_fn=lambda _candidates, **_kw: [],
+            spill_capability_present=True,
+        ),
+    )
+
+    assert result.candidate_count == 0
+    assert result.spilled_count == 0
+    assert result.spilled_bytes_freed == 0
+
+
+def test_decompose_is_never_called_when_fold_selected_real_candidates() -> None:
+    """Tier 2: #5888 3″ — the O(history bytes) decompose (#5898's own
+    class: re-serialises every resident turn) is paid ONLY on the one
+    pass where fold found nothing; a normal fold (candidates > 0) must
+    never touch it, so this stage adds no cost to the common case.
+    Proven with a fold that GENUINELY has candidates (main_M_room=0, so
+    any nonempty middle overflows the room) and a decompose stand-in that
+    fails the test if invoked."""
+    def _must_not_be_called() -> "tuple[list[dict], list[dict], list[dict], dict | None, dict[int, int]]":
+        raise AssertionError("decompose_for_retry must never run when candidates were selected")
+
+    budgets = ComputedBudgets(
+        main_pool=100_000, head_budget=50, body_budget=5_000, tail_budget=50,
+        new_msg_budget=10_000, B_M=80_000, main_M_room=0, effective_trigger=0,
+    )
+
+    class _SucceedingEngine(CompactionEngine):
+        def __init__(self, events: EventLog) -> None:
+            self._model = ""
+            self._events = events
+            self._budgets = budgets
+
+        async def compact(self, input_chunk, *, covers_through):  # noqa: ANN001
+            from reyn.services.compaction.engine import ChatSummary
+            seqs = [int(t.get("seq", 0)) for t in input_chunk.messages if isinstance(t, dict)]
+            return ChatSummary(topic_arc="stub", covers_through_seq=max(seqs) if seqs else 0)
+
+    events = EventLog()
+    history = _history(4)
+    ctrl = _make_controller(history=history, engine=_SucceedingEngine(events), events=events)
+
+    result = asyncio.run(
+        ctrl.force_compact_now(
+            spill_fn=lambda _candidates, **_kw: [],
+            selection="operator",
+            decompose_for_retry=_must_not_be_called,
+        ),
+    )
+
+    assert result.candidate_count > 0, "test setup sanity: this pass must genuinely select candidates"
+    assert result.spilled_count == 0, "spilled_count only ever means something on a 0-candidate pass"
+
+
+def test_trim_head_and_tail_now_emit_the_kept_whole_event() -> None:
+    """Tier 2: #5888 3″ observation ① (architect ruling) — the controller's
+    own ``trim_head``/``trim_tail`` calls now pass ``events=self._events``
+    (measured before this fix: 0 emissions from this path ever, though
+    the emitter itself — ``engine.py``'s ``_emit_over_budget_group`` —
+    already existed and the reactive ladder's own callers already wired
+    it). A tool-cycle group (assistant-with-tool_calls + its own
+    tool-role result) alone over the head budget now emits
+    ``tool_cycle_kept_whole_over_budget`` where it silently emitted
+    nothing before.
+
+    strip witness: dropping either ``events=self._events`` argument
+    (reverting to the bare ``trim_head(messages, head_budget, model,
+    use_chars4=use_chars4)`` call) makes ``collect_events`` empty here —
+    verified directly, restored after."""
+    big_tool_cycle = [
+        ChatMessage(
+            role="assistant", content="", seq=1,
+            tool_calls=[{"id": "c1", "type": "function", "function": {"name": "exec", "arguments": "{}"}}],
+        ),
+        ChatMessage(role="tool", content="z" * 400, tool_call_id="c1", name="exec", seq=2),
+    ]
+    history = big_tool_cycle + _history(1)  # a lone small tail turn so the group is unambiguously HEAD
+    for i, m in enumerate(history[2:], start=3):
+        m.seq = i
+    events = EventLog()
+    collected = collect_events(events)
+    ctrl = _make_controller(history=history, engine=_NeverCalledEngine(), events=events)
+
+    result = asyncio.run(
+        ctrl.force_compact_now(spill_fn=lambda _candidates, **_kw: [], selection="operator"),
+    )
+
+    kept_whole = [e for e in collected if e.type == "tool_cycle_kept_whole_over_budget"]
+    assert kept_whole, (
+        "the over-head-budget tool cycle must emit tool_cycle_kept_whole_over_budget "
+        f"via the controller's own trim_head call; collected types: {[e.type for e in collected]}"
+    )
+    assert kept_whole[0].data.get("budget_kind") == "head"
+    assert result.protected_head_turns >= 2, "the whole tool cycle (2 turns) must be kept, not split"


### PR DESCRIPTION
**[e2e-coder]** — part of #5888. Stage 1 (#5893) is merged (2026-09-06T22:16:13Z).

## What this does

Architect's "3″" ruling: when `/compact`'s forced fold pass selects **zero
candidates** because everything eligible was protected (head/tail
keep-whole groups), the pass no longer just reports "nothing to do." It
now runs **rung① spill** against every face of the resident history
(head, raw_middle, tail), reusing the SAME `spill_fn` the reactive (413)
ladder already uses (#5712's shared implementation) and the SAME
`decompose_history_for_retry()` the reactive path already reads —
no second decomposition, no second spill implementation.

Unlike the reactive ladder's `_attempt_reactive_spill` (stops at the
first face that progresses — reactive semantics only need "enough
happened to retry"), this operator path **tries every face** for
maximum effect on one explicit ask, matching #5888 ruling 2's own
shortfall/operator split precedent ("operator mode widens what may
fold, never what is protected").

## Acceptance criteria

1. **Rung① spill runs on a zero-candidate forced pass.** `force_compact_now` now takes an optional `decompose_for_retry` kwarg (defaults to `None` — zero behavior change for any existing caller that doesn't pass it, e.g. the reactive ladder's own fallback path). When wired (from `session.py`, off the loop driver's `_history_buffer`) and `spill_capability_present` is `True`, a zero-candidate pass spills every spillable body across all three faces. Tested directly.
2. **Every face is tried, not just the first that progresses.** Tested by identity (not count — `test_tier_audit.py --strict` correctly flagged an earlier count-based assertion as a Tier 4 pin; rewritten to assert the exact face objects were offered).
3. **`offload.enabled` untouched.** Verified via `grep -rn "OffloadConfig\|offload.enabled" <diff>` — no match. This is a distinct mechanism from the shrink/spill flow (owner: "offload 規定 False 勝手に変えないで。縮小フローとは別機能と何度も言ってる").
4. **Owner real-machine confirmation** after a large exec return — deferred to a post-merge follow-up, matching stage 1's own pattern.

## Observation points (architect's request)

- `trim_head`/`trim_tail` (`engine.py`) now receive `events=self._events` from the controller's own call sites (`_measure_and_select`), so `tool_cycle_kept_whole_over_budget` actually fires — **0 emissions before this change**, confirmed via a dedicated test.
- `/compact`'s reply now reports what was spilled (count + chars freed) when nothing was folded but something was spilled, and notes when spill itself is unavailable (`spill_capability_present=False`).

## Tests

6 new (`tests/runtime/test_5888_stage2_forced_spill.py`, Tier 2):
- rung① spill fires on a zero-candidate pass
- all three faces are tried (asserted by identity, not count)
- spill is skipped when `spill_capability_present=False`
- spill is skipped when `decompose_for_retry` is not wired (`None` default — zero behavior change)
- `decompose_for_retry` is never invoked on a real-candidate (fold-succeeds) pass
- `trim_head`/`trim_tail` now emit `tool_cycle_kept_whole_over_budget`

Plus 62 pre-existing compaction tests re-run green (**68 passed total**, zero regressions) — `test_5712_compact_shares_shrink_ladder_with_spill.py`, `test_5888_operator_selection.py`, `test_5719_compact_folds_only_the_shortfall.py`, `test_5721_compact_uses_window_relative_caps.py`, `test_compaction_controller_invariants.py`, `test_compaction_controller_tool_aware.py`, `test_slash_compact_191.py`, `test_slash_compact_cmd.py`, `test_5578_persist_recovery_summary.py`, `test_5633_ladder_compact_failure_closes_marker.py`, `test_5765_compaction_range_covers_head_gap.py`.

Strip-falsification done and executed (not just reasoned): reverting the zero-candidate spill branch turns 3 of the 6 new tests red with the expected failure messages; restored before commit.

## Local gates

ruff (clean, one import-sort auto-fix applied), `test_tier_audit.py --strict` (6/6 OK — one assertion rewritten from a count-based Tier 4 pin to an identity-based check per the gate's own finding), `verify_module_docstrings.py`, `mypy_ratchet.py` (7 findings, all pre-existing/baselined), `flat_tests_ratchet.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_tests_path_literal_reference.py` (re-run against fresh `origin/main` right before push) — all green.

## Test plan

- [x] `pytest` scoped to diff — 68 passed, 0 regressions
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on new test file
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `tests/`-path-conditional gates (file added under `tests/`)
- [x] (skipped — standing Visual-item waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
