### PR TITLE
ci(part of #5909): surface the worker test-order trace instead of just its peak RSS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,18 +207,33 @@ jobs:
       # #5909: name the killer of a worker that died with no Python-side
       # record. `tests/conftest.py` (`reyn.dev.testing.worker_forensics`)
       # writes `.reyn-worker-down.log` from xdist's own `pytest_testnodedown`
-      # hook — the dead worker's EXIT CODE (`-9` = SIGKILL: the host's OOM
-      # killer or a reaper, never reyn; `1` = pytest-timeout's thread-method
+      # hook, but ONLY when that hook's own `error` argument is not `None`
+      # — the worker's EXIT CODE (`-9` = SIGKILL: the host's OOM killer or
+      # a reaper, never reyn; `1` = pytest-timeout's thread-method
       # `os._exit`; `97` = reyn's memory ceiling) and the last tests it ran
       # (from `.reyn-worker-trace/<gw>.log`, one nodeid per test start).
-      # Every worker's peak RSS lands in its trace at session end — the
-      # figure a host OOM kill judges, which the memory-ceiling log above
-      # never shows for a worker that stayed under reyn's own 2 GB. `dmesg`
-      # is the host's side of the same story (an OOM kill logs there and
-      # nowhere else); `|| true` because a runner that denies dmesg must
-      # not turn this informational step red. `if: always()`: forensics
-      # must print on exactly the runs that failed.
-      - name: Worker forensics (#5909 — only non-empty if a worker died)
+      # BUG FOUND AND FIXED (lead-coder review, #5934): an earlier version
+      # of the hook wrote a line on EVERY call — xdist's own `dsession.py`
+      # calls this same hook, with `error=None`, from
+      # `worker_workerfinished`, the ORDINARY per-worker completion path,
+      # not only a crash path (`worker_errordown`) — so this file was
+      # non-empty on EVERY run, always, and this step's own
+      # `[ -s .reyn-worker-down.log ]` "did anything die" check fired its
+      # `::warning::` unconditionally as a result. Confirmed directly: 3
+      # real CI job logs (one of them fully GREEN) all showed 4 lines,
+      # `error=None` every time. `error is None` is exactly xdist's own
+      # discriminator between the two call sites (confirmed by reading
+      # `dsession.py` itself) — see `worker_forensics.py`'s own
+      # `pytest_testnodedown` for the fix; this file is now genuinely
+      # non-empty only when a worker actually died. Every worker's peak
+      # RSS lands in its trace at session end — the figure a host OOM kill
+      # judges, which the memory-ceiling log above never shows for a
+      # worker that stayed under reyn's own 2 GB. `dmesg` is the host's
+      # side of the same story (an OOM kill logs there and nowhere else);
+      # `|| true` because a runner that denies dmesg must not turn this
+      # informational step red. `if: always()`: forensics must print on
+      # exactly the runs that failed.
+      - name: Worker forensics (#5909 — only non-empty if a worker actually died)
         if: always()
         run: |
           if [ -s .reyn-worker-down.log ]; then
@@ -229,20 +244,19 @@ jobs:
           fi
           echo "--- per-worker peak RSS (MB) ---"
           grep -H "peak_rss_mb=" .reyn-worker-trace/*.log 2>/dev/null || echo "(no worker traces)"
-          # part of #5909: `.reyn-worker-down.log`'s own `last_test=`/
-          # `before_it=` fields are written by `pytest_testnodedown`, which
-          # only fires when the CONTROLLER is alive to observe the node
-          # going down. Three same-day #5909 recurrences (#5926, #5916,
-          # #5931) left `.reyn-worker-down.log` EMPTY — the controller
-          # never got a chance to run that hook — so the trace files
-          # (`.reyn-worker-trace/<gw>.log`, written incrementally as each
-          # test STARTS, independent of the controller) were the only
-          # surviving test-order evidence, and this step never printed
-          # them: the `grep` above only ever pulled the one `peak_rss_mb=`
-          # line, never the nodeid lines above it. Print each worker's
-          # full test-order trace here too, so the next silent-death CI
-          # run names what was running without a second investigation
-          # round-trip.
+          # part of #5909: this step's own `grep` above only ever pulled
+          # the one `peak_rss_mb=` line out of each worker's trace file,
+          # never the nodeid lines above it — the actual per-worker
+          # test-order trace was written to disk every run and never
+          # printed or kept. That gap is real independent of the
+          # down-log bug above (fixed in this same PR): even once
+          # `.reyn-worker-down.log` correctly names ONLY a worker that
+          # died, its own `last_test=`/`before_it=` fields are a short,
+          # fixed-length tail (`RECENT_TESTS = 5` in worker_forensics.py)
+          # — for a run that needs the FULL order, or needs a dead
+          # worker's trace that was too large for the job log's own size
+          # ceiling, printing (and uploading, below) the whole file is
+          # still the thing worth doing.
           echo "--- per-worker test-order trace (last test each ran = last line) ---"
           if ls .reyn-worker-trace/*.log >/dev/null 2>&1; then
             for f in .reyn-worker-trace/*.log; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,9 +229,50 @@ jobs:
           fi
           echo "--- per-worker peak RSS (MB) ---"
           grep -H "peak_rss_mb=" .reyn-worker-trace/*.log 2>/dev/null || echo "(no worker traces)"
+          # part of #5909: `.reyn-worker-down.log`'s own `last_test=`/
+          # `before_it=` fields are written by `pytest_testnodedown`, which
+          # only fires when the CONTROLLER is alive to observe the node
+          # going down. Three same-day #5909 recurrences (#5926, #5916,
+          # #5931) left `.reyn-worker-down.log` EMPTY — the controller
+          # never got a chance to run that hook — so the trace files
+          # (`.reyn-worker-trace/<gw>.log`, written incrementally as each
+          # test STARTS, independent of the controller) were the only
+          # surviving test-order evidence, and this step never printed
+          # them: the `grep` above only ever pulled the one `peak_rss_mb=`
+          # line, never the nodeid lines above it. Print each worker's
+          # full test-order trace here too, so the next silent-death CI
+          # run names what was running without a second investigation
+          # round-trip.
+          echo "--- per-worker test-order trace (last test each ran = last line) ---"
+          if ls .reyn-worker-trace/*.log >/dev/null 2>&1; then
+            for f in .reyn-worker-trace/*.log; do
+              echo "== $f =="
+              cat "$f"
+            done
+          else
+            echo "(no worker traces)"
+          fi
           echo "--- host OOM kills (dmesg) ---"
           (sudo dmesg -T 2>/dev/null || dmesg -T 2>/dev/null) | grep -iE "out of memory|killed process|oom" || echo "no OOM kill in dmesg (or dmesg unavailable)"
           true
+
+      # part of #5909: the step above prints to the job LOG, which GitHub
+      # Actions truncates past its own size ceiling and which is awkward
+      # to diff/grep after the fact. Upload the raw files too, so a full
+      # trace survives even past that ceiling and is fetchable long after
+      # the run without re-triggering CI. `if-no-files-found: ignore`
+      # (not `error`) because "no worker died" is the common, correct
+      # case — most runs have nothing under `.reyn-worker-trace/`.
+      - name: Upload worker forensics artifact (#5909)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: worker-forensics-py${{ matrix.python-version }}-${{ github.run_attempt }}
+          path: |
+            .reyn-worker-trace/
+            .reyn-worker-down.log
+          if-no-files-found: ignore
+          retention-days: 14
 
       # #4331: what a green run above does NOT say — the skip census (count
       # + reason breakdown) and the collection-error count, on the SAME

--- a/src/reyn/dev/testing/worker_forensics.py
+++ b/src/reyn/dev/testing/worker_forensics.py
@@ -48,28 +48,47 @@ WHAT THIS RECORDS (all under the repo cwd, like ``memory_ceiling``'s log)
     ``peak_rss_mb=<n>`` line at session end (``resource.ru_maxrss``, the same
     reader the memory ceiling uses).
 
-    ``.reyn-worker-down.log`` — one line per dead worker, written by the
-    CONTROLLER from xdist's ``pytest_testnodedown`` hook: worker id, xdist's
-    own error text, the worker process's exit code (best-effort: execnet's
-    private ``Popen`` handle, ``None`` if the shape ever changes), and the
-    last few nodeids from that worker's trace.
+    ``.reyn-worker-down.log`` — one line per worker that xdist reports
+    DIED, written from ``pytest_testnodedown`` when (and only when) its
+    ``error`` argument is not ``None``: worker id, xdist's own error text,
+    the worker process's exit code (best-effort: execnet's private
+    ``Popen`` handle, ``None`` if the shape ever changes), and the last few
+    nodeids from that worker's trace. **Bug found and fixed by #5934**
+    (lead-coder review): an earlier version of this hook wrote a line on
+    EVERY call, not only crash calls — xdist's own ``dsession.py`` calls
+    this same hook, with ``error=None``, from ``worker_workerfinished``,
+    the ORDINARY per-worker completion path — so every worker in an
+    ``-n auto``/``-n N`` run wrote a line here at the end of EVERY run,
+    whether or not anything went wrong, and the CI step's own
+    ``[ -s .reyn-worker-down.log ]`` "did anything die" check fired its
+    ``::warning::`` on every single run as a result (confirmed directly:
+    3 real CI job logs, one of them fully green, all showing 4 lines,
+    ``error=None`` every time). ``error is None`` is exactly xdist's own
+    discriminator between the two call sites (``worker_workerfinished``
+    vs. ``worker_errordown`` — confirmed by reading ``dsession.py``
+    itself, not inferred), so the hook now skips the write on that path —
+    this file is now genuinely non-empty only when a worker actually died.
 
     ``.github/workflows/test.yml`` prints both after every run (with the
     host's ``dmesg`` OOM lines and ``free -m``/``nproc`` before), so the next
     crash names its killer in the job log instead of costing another
-    investigation round-trip. ``.reyn-worker-down.log`` needs the
-    CONTROLLER alive to observe the node going down (its own
-    ``pytest_testnodedown`` hook), so it stays empty on a run where the
-    whole job dies before the controller gets that chance — the per-worker
-    trace files are written incrementally as each test STARTS, independent
-    of the controller, and are the only test-order evidence left in that
-    case (measured on three same-day #5909 recurrences: #5926, #5916,
-    #5931 — ``.reyn-worker-down.log`` empty all three times). Because of
-    that, the workflow prints each worker's FULL trace (part of #5909),
-    not only the down-worker's, and also uploads ``.reyn-worker-trace/``
-    and ``.reyn-worker-down.log`` as a build artifact — a run's job log is
-    truncated past GitHub's own size ceiling, and the artifact survives
-    that and stays fetchable long after the run without re-triggering CI.
+    investigation round-trip. The per-worker trace files are written
+    incrementally as each test STARTS, independent of the controller, so
+    they are the only test-order evidence that survives a run where the
+    WHOLE JOB dies before the controller can even reach its own
+    ``pytest_testnodedown`` hook. The workflow prints each worker's FULL
+    trace (part of #5909), not only ``peak_rss_mb=``, and also uploads
+    ``.reyn-worker-trace/`` and ``.reyn-worker-down.log`` as a build
+    artifact — a run's job log is truncated past GitHub's own size
+    ceiling, and the artifact survives that and stays fetchable long after
+    the run without re-triggering CI. (An earlier version of this
+    docstring claimed three same-day #5909 recurrences — #5926, #5916,
+    #5931 — left ``.reyn-worker-down.log`` EMPTY, offered as this feature's
+    own motivating measurement. That claim was checked against the wrong
+    evidence and was false: all three jobs' logs show 4 lines, all
+    ``error=None returncode=None`` — the ordinary-completion shape above,
+    not evidence of a crash at all. See #5934's PR discussion for the
+    corrected reading of those three incidents.)
 
 COST
     One small append per test start (open/append/close — no held fd, so
@@ -190,7 +209,24 @@ def pytest_sessionfinish(session: object, exitstatus: int) -> None:
 
 
 def pytest_testnodedown(node: object, error: object) -> None:
-    """Controller: a worker went down — write the one line that names how."""
+    """Controller: xdist calls this hook on BOTH a worker's ordinary
+    completion AND a genuine crash (``dsession.py``'s own
+    ``worker_workerfinished`` — the ordinary path — calls it with
+    ``error=None``; only ``worker_errordown`` — the crash path — calls it
+    with a real error object). Bug found and fixed by this same PR
+    (#5934, lead-coder review): an earlier version of this hook wrote a
+    line for EVERY call, so ``.reyn-worker-down.log`` had one line per
+    worker on every run, ALWAYS non-empty regardless of whether anything
+    went wrong — verified directly against 3 real CI runs (one fully
+    green) all showing 4 lines, ``error=None`` every time, and the CI
+    step's own ``[ -s .reyn-worker-down.log ]`` check firing its
+    ``::warning::`` on every single run as a result. ``error is None`` is
+    exactly xdist's own discriminator for "this was ordinary completion,
+    not a crash" — skip the write there; a normal worker's own recent
+    tests are already visible in its own trace file if anyone wants them,
+    with no need to duplicate them into the crash log."""
+    if error is None:
+        return
     wid = str(getattr(getattr(node, "gateway", None), "id", "?"))
     _append(
         Path(os.getcwd()) / DOWN_LOG,

--- a/src/reyn/dev/testing/worker_forensics.py
+++ b/src/reyn/dev/testing/worker_forensics.py
@@ -57,7 +57,19 @@ WHAT THIS RECORDS (all under the repo cwd, like ``memory_ceiling``'s log)
     ``.github/workflows/test.yml`` prints both after every run (with the
     host's ``dmesg`` OOM lines and ``free -m``/``nproc`` before), so the next
     crash names its killer in the job log instead of costing another
-    investigation round-trip.
+    investigation round-trip. ``.reyn-worker-down.log`` needs the
+    CONTROLLER alive to observe the node going down (its own
+    ``pytest_testnodedown`` hook), so it stays empty on a run where the
+    whole job dies before the controller gets that chance — the per-worker
+    trace files are written incrementally as each test STARTS, independent
+    of the controller, and are the only test-order evidence left in that
+    case (measured on three same-day #5909 recurrences: #5926, #5916,
+    #5931 — ``.reyn-worker-down.log`` empty all three times). Because of
+    that, the workflow prints each worker's FULL trace (part of #5909),
+    not only the down-worker's, and also uploads ``.reyn-worker-trace/``
+    and ``.reyn-worker-down.log`` as a build artifact — a run's job log is
+    truncated past GitHub's own size ceiling, and the artifact survives
+    that and stays fetchable long after the run without re-triggering CI.
 
 COST
     One small append per test start (open/append/close — no held fd, so

--- a/tests/dev/test_5909_worker_forensics.py
+++ b/tests/dev/test_5909_worker_forensics.py
@@ -92,6 +92,41 @@ def test_returncode_of_reads_a_finished_process_through_execnets_popen_shape() -
     assert wf.returncode_of(object()) is None
 
 
+def test_testnodedown_writes_only_on_a_real_error_not_ordinary_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5934 (lead-coder review) — xdist's own ``dsession.py``
+    calls ``pytest_testnodedown`` from BOTH ``worker_workerfinished``
+    (ordinary per-worker completion, ``error=None``) and
+    ``worker_errordown`` (a genuine crash, a real ``error`` object) —
+    confirmed by reading ``dsession.py`` itself, not inferred. An earlier
+    version of this hook wrote a ``.reyn-worker-down.log`` line on EVERY
+    call, so the file was non-empty on every CI run, always, regardless
+    of whether anything died — measured directly against 3 real CI job
+    logs, one of them fully green.
+
+    Strip witness: removing the hook's ``if error is None: return`` guard
+    makes this test's own ``assert not down_log.exists()`` line fail —
+    verified directly, restored after."""
+    monkeypatch.chdir(tmp_path)
+
+    class _Gateway:
+        id = "gw4"
+
+    class _Node:
+        gateway = _Gateway()
+
+    wf.pytest_testnodedown(_Node(), None)
+    down_log = tmp_path / wf.DOWN_LOG
+    assert not down_log.exists(), (
+        "ordinary completion (error=None) must not write a down-log line"
+    )
+
+    wf.pytest_testnodedown(_Node(), "Not properly terminated")
+    assert down_log.exists(), "a genuine error must write a down-log line"
+    assert "worker=gw4" in down_log.read_text(encoding="utf-8")
+
+
 def test_the_setup_hook_records_this_very_test_under_its_worker_id(
     request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
**[e2e-coder]** — part of #5909.

## 🔴→✅ Correction (lead-coder review, head `1379f38cf`)

The original PR body / commit below claimed three same-day #5909 recurrences (#5926, #5916, #5931) left `.reyn-worker-down.log` **EMPTY**. **lead-coder pulled all three jobs' attempt-1 logs and found that false** — all three show 4 lines (one per worker), every one `error=None returncode=None`. I independently re-verified this myself against fresh pulls of all three job logs.

**Root cause, confirmed by reading pytest-xdist's own `dsession.py` source**: `pytest_testnodedown` fires from BOTH `worker_workerfinished` (ordinary per-worker completion, `error=None`) and `worker_errordown` (a genuine crash, a real error object). This repo's own hook (`worker_forensics.py`, from #5913) wrote a line on **every** call, not only crash calls — so `.reyn-worker-down.log` was non-empty on **every** CI run, always, and the CI step's own `[ -s .reyn-worker-down.log ]` check fired its `::warning::` unconditionally. Confirmed directly against a 4th job: the most recent fully **green** main run still emitted "#5909 an xdist worker went down" — a real, structural false-positive bug in the #5913 mechanism I authored, not merely a wording problem in this PR's own comment.

**Fixed in the same PR** (commit `1379f38cf`): `pytest_testnodedown` now skips the write when `error is None`. The file is now genuinely non-empty only when a worker actually died. 1 new test (Tier 2), strip-falsified.

For the three original incidents: two had their real evidence sitting in the **pre-existing** `.reyn-ci-stall-trace.log` controller dump a few lines up in the same job output — execnet receiver threads still blocked in `gateway_base.py:534 read()` after all tests had already passed, matching architect's own "variant A" teardown-hang hypothesis from the #5909 issue thread; the third had an unrelated `RuntimeError: Event loop is closed` during teardown. **None of the three were the SIGKILL/OOM #5909 shape this trace-surfacing change was originally framed around** — that motivating claim is retracted; the trace-surfacing change itself (below) stands on its own merits (a genuine future crash's down-log will now have `error`/`returncode` populated with something real, and the full test-order trace is still worth having either way).

## What was wrong (original PR)

The "Worker forensics" step's `grep -H "peak_rss_mb=" .reyn-worker-trace/*.log` only ever pulled the ONE `peak_rss_mb=` line out of each worker's trace file — never the nodeid lines above it, which are the actual test-order trace (`reyn.dev.testing.worker_forensics.pytest_runtest_setup` writes one nodeid per test start). That trace was written to disk on every CI run but never reached the job log or an artifact — lost the moment the run ended. This part of the original claim stands independent of the correction above.

## What this does

- **"Worker forensics" step** now `cat`s each worker's full trace file, not just its `peak_rss_mb=` line.
- **New "Upload worker forensics artifact" step** uploads `.reyn-worker-trace/` and `.reyn-worker-down.log` via `actions/upload-artifact@v4` (`if-no-files-found: ignore` — most runs have nothing to upload), so the trace survives past the job log's own truncation ceiling and is fetchable after the run without re-triggering CI. Artifact name includes the python-version matrix leg and `run_attempt` to avoid collisions.
- **`pytest_testnodedown` now only writes `.reyn-worker-down.log` on a genuine crash** (`error is not None`) — see correction above.
- **`worker_forensics.py`'s own module docstring and the workflow's own comments** updated in the same PR (per CLAUDE.md: a describing doc is stale the moment the code it describes changes) to record the corrected facts, not the original (false) motivating claim.

Remaining #4986/#5909 tool-ticket items (`stall_dump.py`'s per-worker arm, background-step process observation) landed separately: #5938.

## Tests

- `tests/dev/test_5909_worker_forensics.py` — **6 tests** (5 pre-existing + 1 new): the new test asserts `pytest_testnodedown(node, error=None)` writes nothing and `pytest_testnodedown(node, error=<real>)` writes the line. Strip-falsification executed directly: removing the `error is None` guard fails the new test's own first assertion — confirmed, restored before commit.
- YAML syntax (`yaml.safe_load`)
- `ruff check` on touched `.py` files — clean
- `test_tier_audit.py --strict` on the touched test file — clean
- `verify_module_docstrings.py` — clean
- `mypy_ratchet.py` — 0 new findings
- `tests/`-path-conditional gates (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`) — clean (a `tests/` file is now touched)
- `check_tests_path_literal_reference.py` re-run against fresh `origin/main` right before each push — clean

## Test plan

- [x] `pytest` scoped to the module's test file — 6 passed, 0 regressions
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on the changed test file
- [x] `verify_module_docstrings.py` on changed `.py` files
- [x] `mypy_ratchet.py`
- [x] `tests/`-path-conditional gates
- [x] YAML syntax check on `.github/workflows/test.yml`
- [x] (skipped — standing Visual-item waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
