### PR TITLE
fix(#4986/#5909 tool ticket): arm the stall-trace watchdog per xdist worker too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,8 +155,40 @@ jobs:
         # cancel their own watchdog the instant the last item's protocol
         # returns (`_pytest/faulthandler.py`'s own source, confirmed, not
         # guessed). See `reyn/dev/testing/stall_dump.py`'s own docstring.
+        # `( sleep 620; ... ) &` (part of #4986/#5909 tool ticket, architect's
+        # tool ②): a stall dump can only show what its OWN process's threads
+        # are doing — whether the pytest CONTROLLER process is even still
+        # ALIVE at all is an OS-level fact no Python-side dump can answer
+        # from inside itself. This backgrounded watcher asks the OS directly,
+        # once, 20s after `REYN_STALL_TRACE_CI=600`'s own dump would have
+        # fired and comfortably before the `timeout 12m` (720s) kill below —
+        # so a genuinely still-running controller has already had its stack
+        # dumped by the time this fires, and the two diagnostics read in the
+        # same causal order the stall-trace file and the per-worker files
+        # already do. On a healthy run (~7-8 min, well under 620s) the
+        # `sleep 620` never returns before this step's own foreground command
+        # exits, so nothing is ever written to `/tmp/hang-ps.log` and the
+        # backgrounded subshell is reaped with the step — no added cost on
+        # the common path. `pgrep -f "pytest -q -n auto"` re-derives the
+        # controller's PID from its own command line rather than threading a
+        # PID through — this stays a single independent watcher, not another
+        # moving part the main run has to hand anything to.
         run: |
           set -o pipefail
+          (
+            sleep 620
+            {
+              echo "=== ps -ef @620s ==="
+              ps -ef
+              echo "=== pgrep -a python @620s ==="
+              pgrep -a python
+              echo "=== controller fd table @620s (Linux only) ==="
+              for pid in $(pgrep -f "pytest -q -n auto"); do
+                echo "--- pid=$pid ---"
+                ls -l "/proc/$pid/fd" 2>/dev/null || echo "(no /proc/$pid/fd for pid=$pid)"
+              done
+            } > /tmp/hang-ps.log 2>&1
+          ) &
           REYN_REPLAY_UNCONSUMED_CHECK=1 REYN_STALL_TRACE_CI=600 timeout 12m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
 
       # #4986: surface the stall dump above if (and only if) it fired. The
@@ -176,6 +208,38 @@ jobs:
             cat .reyn-ci-stall-trace.log
           else
             echo "no stall-trace dump (pytest session finished normally)"
+          fi
+          # part of #4986/#5909 tool ticket: each xdist WORKER now arms its
+          # own separate watchdog too (`stall_dump.py`'s own "WHY ALSO ARMED
+          # PER xdist WORKER" — a hang strictly inside a worker's own
+          # teardown is invisible to the controller's dump above, since the
+          # controller is merely idle in `queue.get()`, nothing of its own
+          # is stuck). One file per worker
+          # (`.reyn-ci-stall-trace.<workerid>.log`), at a threshold BELOW
+          # the controller's own so the two dumps read in causal order —
+          # print every one that actually fired.
+          shopt -s nullglob
+          worker_dumps=(.reyn-ci-stall-trace.*.log)
+          shopt -u nullglob
+          fired=0
+          for f in "${worker_dumps[@]}"; do
+            if [ -s "$f" ]; then
+              fired=1
+              echo "::warning::#4986 per-worker stall-trace fired — $f"
+              cat "$f"
+            fi
+          done
+          if [ "$fired" -eq 0 ]; then
+            echo "no per-worker stall-trace dump (every worker's own session finished normally)"
+          fi
+          # part of #4986/#5909 tool ticket (architect's tool ②): the OS
+          # process snapshot the run step's own backgrounded watcher takes
+          # at 620s — only written on a run that took that long.
+          echo "--- OS process snapshot @620s (only written if the run was still going) ---"
+          if [ -s /tmp/hang-ps.log ]; then
+            cat /tmp/hang-ps.log
+          else
+            echo "(no snapshot — the run finished before 620s)"
           fi
 
       # #5878 (architect follow-up, #5877 co-vet): the same visibility gap

--- a/src/reyn/dev/testing/stall_dump.py
+++ b/src/reyn/dev/testing/stall_dump.py
@@ -62,14 +62,34 @@ WHY A DISK FILE, NOT sys.stderr
     real fd outside pytest's capture is unaffected by whatever pytest does
     to the process's own stdout/stderr streams.
 
-WHY NOT ARMED IN EVERY xdist WORKER
-    The observed hang is in the CONTROLLER's own event loop
-    (``_cancel_all_tasks`` → ``run_until_complete``, per the #4986 stack
-    dumps already on file) — ``config.workerinput`` is xdist's own
-    controller/worker discriminator (present only inside a worker
-    subprocess). Arming per-worker would multiply the timer for no
-    additional signal and, on the rare occasion it DOES fire, multiply the
-    dump output N-workers-over for nothing.
+WHY ALSO ARMED PER xdist WORKER (changed decision — #4986/#5909 tool ticket)
+    This module originally armed the CONTROLLER only, on the reasoning that
+    the observed hang was in the controller's own event loop
+    (``_cancel_all_tasks`` → ``run_until_complete``) and arming per-worker
+    would "multiply the timer for no additional signal." **That reason was
+    falsified by a real incident** (architect finding, same-day #5909
+    investigation): a controller stuck in ``queue.get()`` waiting on a
+    silent WORKER is, by construction, invisible to a dump that only ever
+    captures the controller's own threads — "the controller's dump is
+    enough" was the premise the original reasoning depended on, and a hang
+    genuinely INSIDE a worker's own session teardown is structurally
+    outside what that premise covers. Per CLAUDE.md's rule that a
+    describing comment is stale the moment the code it describes changes,
+    this section (not just the code) moves with that finding.
+
+    Each worker now arms its OWN watchdog too, into its OWN file
+    (``.reyn-ci-stall-trace.<workerid>.log``, ``config.workerinput``'s own
+    ``workerid`` — the same worker id ``reyn.dev.testing.worker_forensics``
+    already keys its trace files by) at a threshold ``WORKER_OFFSET_SECONDS``
+    BELOW the controller's own — e.g. controller 600s, worker 540s — so a
+    run where both fire can be read in CAUSAL order: the worker's dump
+    landing first says the hang started inside that worker, before the
+    controller could have noticed anything wrong. A shared path written by
+    several worker processes was deliberately avoided — faulthandler holds
+    the fd it was armed with for the life of the arm (#5879, measured
+    directly), so a shared path across processes is not "interleaved
+    output", it is silent loss for whichever process's fd is not the one
+    that ends up live.
 
 THE NUMBER
     Must be comfortably under ``.github/workflows/test.yml``'s own outer
@@ -78,7 +98,9 @@ THE NUMBER
     (~7-8 min measured on recent green runs) so a slow-but-healthy run
     never fires it. Set via ``REYN_STALL_TRACE_CI`` at the workflow level
     (not hardcoded here) so the margin can be re-tuned from one place if
-    ``test.yml``'s own outer timeout ever changes.
+    ``test.yml``'s own outer timeout ever changes. Each worker's own
+    threshold is this SAME value minus :data:`WORKER_OFFSET_SECONDS` — one
+    knob, not two, so re-tuning the workflow's env var re-tunes both.
 """
 from __future__ import annotations
 
@@ -95,6 +117,11 @@ _ENV_VAR = "REYN_STALL_TRACE_CI"
 #: could read it, and not ``.reyn/`` (a real project's own dir, which a
 #: bare `pytest` invocation from a fresh checkout may not even have yet).
 LOG_PATH = os.path.join(os.getcwd(), ".reyn-ci-stall-trace.log")
+
+#: See module docstring's "WHY ALSO ARMED PER xdist WORKER" — a worker's
+#: own threshold is the controller's minus this, so a run where both fire
+#: can be read in causal order (worker first = hang started in the worker).
+WORKER_OFFSET_SECONDS = 60.0
 
 #: Kept open for the whole session (faulthandler needs an already-open
 #: file object at ARM time, and may write to it from a background thread
@@ -119,14 +146,45 @@ def _is_xdist_worker(config: "pytest.Config") -> bool:
     return hasattr(config, "workerinput")
 
 
+def worker_log_path(workerid: str, root: "str | os.PathLike[str] | None" = None) -> str:
+    """One file PER WORKER — never a path several worker processes share.
+    See module docstring's "WHY ALSO ARMED PER xdist WORKER" for why a
+    shared path is silent data loss here, not merely interleaved output."""
+    return os.path.join(root if root is not None else os.getcwd(), f".reyn-ci-stall-trace.{workerid}.log")
+
+
+def _worker_id(config: "pytest.Config") -> "str | None":
+    workerinput = getattr(config, "workerinput", None)
+    if not isinstance(workerinput, dict):
+        return None
+    workerid = workerinput.get("workerid")
+    return str(workerid) if workerid else None
+
+
+def worker_seconds_from(controller_seconds: float) -> float:
+    """A worker's own threshold: the controller's own, minus
+    :data:`WORKER_OFFSET_SECONDS`, clamped to a 1s floor (``arm()``'s own
+    ``faulthandler.dump_traceback_later`` rejects a non-positive value).
+    Pulled out as a pure function so the causal-ordering property (a
+    worker's own dump fires BEFORE the controller's) is a fast, exact unit
+    check rather than a race against real subprocess timing."""
+    return max(controller_seconds - WORKER_OFFSET_SECONDS, 1.0)
+
+
 def pytest_configure(config: "pytest.Config") -> None:
-    if _is_xdist_worker(config):
-        return
     seconds = _seconds_from_env()
     if seconds is None:
         return
     global _dump_file
     from reyn.runtime.stall_trace import arm
+
+    if _is_xdist_worker(config):
+        workerid = _worker_id(config)
+        if workerid is None:
+            return
+        _dump_file = open(worker_log_path(workerid), "a", buffering=1)  # noqa: SIM115 — see module docstring
+        arm(worker_seconds_from(seconds), file=_dump_file)
+        return
 
     _dump_file = open(LOG_PATH, "a", buffering=1)  # noqa: SIM115 — see module docstring
     arm(seconds, file=_dump_file)

--- a/tests/dev/test_stall_dump_4986.py
+++ b/tests/dev/test_stall_dump_4986.py
@@ -25,6 +25,7 @@ genuinely is the subject, not a guessed wait.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -58,6 +59,24 @@ def test_body():
 """
 
 _INNER_TEST_NORMAL = "def test_body():\n    assert True\n"
+
+_INNER_TEST_WORKER_HANGS_AT_TEARDOWN = """
+from pathlib import Path
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def _hang_forever_at_teardown():
+    yield
+    # A FIFO, not stdin: see the outer test's own docstring for why —
+    # execnet remaps a worker's sys.stdin, so the controller-hang tests'
+    # own readline() idiom does not reach into a worker.
+    with open("release.fifo") as f:
+        f.read()
+
+def test_body():
+    Path("test_started.marker").write_text("started")
+    assert True
+"""
 
 _INNER_TEST_HANGS_AT_ATEXIT = """
 import atexit
@@ -228,6 +247,100 @@ def test_a_normal_session_produces_no_stall_dump(
         "#4986 REGRESSION: a normal, fast session must not leave a "
         "stall-trace DUMP (non-empty content) behind"
     )
+
+
+def test_an_xdist_worker_teardown_hang_produces_its_own_worker_dump(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: #4986/#5909 tool ticket — architect's finding that a hang
+    strictly INSIDE an xdist worker's own session teardown is invisible to
+    the CONTROLLER's own dump (the controller is idle in ``queue.get()``,
+    nothing of its own is stuck). ``stall_dump.py`` now arms a SEPARATE
+    watchdog inside the worker itself, writing to the worker's OWN file
+    (``worker_log_path``) rather than the controller's ``LOG_PATH`` — this
+    is the property that changed decision (see module docstring's "WHY
+    ALSO ARMED PER xdist WORKER").
+
+    Strip witness: reverting ``pytest_configure``'s worker branch to the
+    module's original early ``return`` on ``_is_xdist_worker(config)``
+    leaves NO file under ``.reyn-ci-stall-trace.gw0.log`` here — verified
+    directly, restored after.
+
+    No duration anywhere the assertion depends on: the inner worker's
+    teardown hang is a real, deterministic block on a FIFO ``open()``/
+    ``read()``, released by opening its write end and closing it; the
+    outer wait for the worker's dump file is an unbounded poll. A FIFO
+    rather than ``sys.stdin`` (the sibling controller-hang tests' own
+    idiom): measured directly while building this test — execnet remaps
+    an xdist WORKER's own ``sys.stdin``, so ``readline()`` inside a
+    worker returns immediately instead of blocking; a FIFO blocks at the
+    kernel level regardless of what execnet did to this process's stdio."""
+    pytester.makeconftest(_INNER_CONFTEST)
+    pytester.makepyfile(test_inner=_INNER_TEST_WORKER_HANGS_AT_TEARDOWN)
+    monkeypatch.setenv("REYN_STALL_TRACE_CI", "1")
+
+    fifo_path = Path(pytester.path) / "release.fifo"
+    os.mkfifo(fifo_path)
+
+    worker_log = Path(pytester.path) / ".reyn-ci-stall-trace.gw0.log"
+    assert not worker_log.exists(), "test setup invariant: no stale worker dump file"
+
+    proc = pytester.popen(
+        [sys.executable, "-m", "pytest", "-q", "-s", "-n", "1", "test_inner.py"],
+    )
+    try:
+        # Same staged-write wait as the sibling tests: a real stack frame
+        # line is "the dump finished writing", not a guessed duration.
+        content = ""
+        while "File \"" not in content:
+            if worker_log.exists():
+                content = worker_log.read_text()
+            if "File \"" not in content:
+                time.sleep(0)
+    finally:
+        # Releases the worker's blocked FIFO ``open()``: opening the write
+        # end lets the read-side ``open()`` return, and closing it
+        # immediately hands the worker's own ``read()`` an EOF.
+        write_fd = os.open(str(fifo_path), os.O_WRONLY)
+        os.close(write_fd)
+        proc.wait()
+
+    header_at = content.find("Timeout")
+    thread_at = content.find("Thread")
+    frame_at = content.find("File \"")
+    assert -1 < header_at < thread_at < frame_at, (
+        f"the worker's own dump should write its header, then the thread "
+        f"line, then stack frames, in that order — got header@{header_at}, "
+        f"thread@{thread_at}, frame@{frame_at} in {content!r}"
+    )
+    # NOTE: this does NOT assert the controller's own dump stays empty —
+    # with a hanging worker, the controller's own session also never
+    # finishes (it is waiting on that worker), so its own watchdog fires
+    # too; that is expected, not a shared-timer bug. See
+    # test_worker_seconds_from_stays_below_the_controllers_own_threshold
+    # for the actual causal-ordering property (a unit check on the exact
+    # offset arithmetic, not a real-time race between the two).
+
+
+def test_worker_seconds_from_stays_below_the_controllers_own_threshold() -> None:
+    """Tier 1: Contract — ``worker_seconds_from`` (used by
+    ``pytest_configure``'s worker branch) always returns a value strictly
+    below the controller's own configured seconds, clamped to a 1s floor.
+    This is the causal-ordering property module docstring's "WHY ALSO
+    ARMED PER xdist WORKER" names (a worker's own dump should fire before
+    the controller's, so a run where both fire reads in causal order) —
+    checked exactly, as a pure function, rather than raced against real
+    subprocess timing (which the integration test above deliberately does
+    NOT attempt, for exactly this reason)."""
+    from reyn.dev.testing.stall_dump import WORKER_OFFSET_SECONDS, worker_seconds_from
+
+    assert worker_seconds_from(600.0) == 600.0 - WORKER_OFFSET_SECONDS
+    assert worker_seconds_from(600.0) < 600.0
+    # Floored at 1s (never zero/negative — arm()'s own faulthandler call
+    # rejects a non-positive delay) when the controller's own value is
+    # already at or below the offset.
+    assert worker_seconds_from(1.0) == 1.0
+    assert worker_seconds_from(WORKER_OFFSET_SECONDS) == 1.0
 
 
 def test_the_watchdog_stays_off_when_unset(


### PR DESCRIPTION
**[e2e-coder]** — part of #4986, part of #5909. This is the follow-up PR lead-coder authorized ("残りのツール項目は後続のPRで構いません") for the remaining #4986/#5909 tool-ticket items.

## What was wrong

`stall_dump.py` armed the teardown-hang watchdog on the **CONTROLLER only**. Its own docstring's reasoning: "the observed hang is in the controller's own event loop... arming per-worker would multiply the timer for no additional signal." **That reasoning was falsified by a real, same-day incident** (architect's finding during the #5909 investigation): a controller stuck waiting on a silent WORKER is idle in `queue.get()` — nothing of the controller's OWN is stuck, so its dump can never show anything about a hang that lives strictly inside a worker's own session teardown. "The controller's dump is enough" was the premise the old decision rested on, and it doesn't hold for that failure class.

lead-coder confirmed the same finding independently and explicitly ordered the docstring fixed in the same PR as the code (CLAUDE.md hard rule: a describing comment is stale the moment the code it describes changes) — not the code alone.

## What this does

1. **Each xdist WORKER now arms its own watchdog**, into its own file (`.reyn-ci-stall-trace.<workerid>.log`, keyed by the same `workerid` `reyn.dev.testing.worker_forensics` already uses) — never a path shared across worker processes (faulthandler holds the fd it was armed with for the life of the arm, #5879 measured directly, so a shared path would be silent loss for whichever process's fd isn't the one still live).
2. **The worker's own threshold is BELOW the controller's** — `worker_seconds_from(controller_seconds)` = controller's value minus a new `WORKER_OFFSET_SECONDS` (60s), floored at 1s. Pulled into a pure function so the causal-ordering property (worker fires first) is an exact unit check, not a real-time race.
3. **`stall_dump.py`'s module docstring updated in this PR** — the old "WHY NOT ARMED IN EVERY xdist WORKER" section is replaced with "WHY ALSO ARMED PER xdist WORKER (changed decision)", recording that the prior reasoning was falsified and why.
4. **`.github/workflows/test.yml`'s "Stall-trace dump" step** now also prints every worker's own file that actually fired, not just the controller's.
5. **Architect's tool ②** — a backgrounded OS-level watcher in the same run step, firing once at 620s (after the controller's own 600s dump, before the 720s `timeout 12m` kill): `ps -ef`, `pgrep -a python`, and each pytest-controller PID's own `/proc/<pid>/fd` table (Linux runner) — because "is the controller process even still alive" is an OS-level fact no Python-side dump can answer about itself. Zero cost on a healthy run (~7-8 min, well under 620s) — the `sleep 620` never returns before the step's own foreground command exits, so nothing is ever written and the backgrounded subshell is reaped with the step.

## Tests

2 new in `tests/dev/test_stall_dump_4986.py` (Tier 1):
- A real `-n 1` xdist worker whose session teardown hangs (a FIFO `open()`/`read()` block, not `sys.stdin` — measured directly while building this: execnet remaps a worker's own stdin, so the sibling controller-hang tests' own `readline()` idiom does not reach into a worker) produces a real stack dump in its own per-worker file.
- A fast unit check on `worker_seconds_from`'s exact offset/floor arithmetic (the causal-ordering property, checked exactly rather than raced against real subprocess timing).

Plus the 4 pre-existing tests in that file, and the full related regression scope — `test_5898_loop_tripwire.py`, `test_5850_full_suite_collection_guard.py`, `test_5909_worker_forensics.py`, `test_3671_stall_trace_startup_wiring.py` — **30 tests total, all green**.

**Strip-falsification** done and executed (not reasoned): reverting `pytest_configure`'s worker branch to the original early `return` leaves the new worker-dump test unable to ever find its file — it hangs at the outer wait's own unbounded poll, killed only by an external timeout. Verified directly, restored before commit.

## Local gates

`ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` (0 new findings), `flat_tests_ratchet.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_tests_path_literal_reference.py` (re-run against fresh `origin/main` right before push) — all green. YAML syntax of `.github/workflows/test.yml` verified with `yaml.safe_load`.

## Out of scope

`worker_forensics.py`'s own trace-surfacing (part of #5909) already landed separately: #5934.

## Test plan

- [x] `pytest` scoped to diff + related regression scope — 30 passed, 0 regressions
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on the changed test file
- [x] `verify_module_docstrings.py` on the changed src file
- [x] `mypy_ratchet.py`
- [x] `tests/`-path-conditional gates (file touched under `tests/`)
- [x] YAML syntax check on `.github/workflows/test.yml`
- [x] (skipped — standing Visual-item waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
