### PR TITLE
ci(part of #4986): background process snapshot at t=620s — architect's tool②

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,8 +172,12 @@ jobs:
         # inherited its write end) is: **is the worker process still
         # alive at the moment of the hang.** Backgrounded here (started
         # BEFORE the pytest pipeline, reaped right after it returns) so a
-        # HEALTHY run — which reaps the watcher well under 620s — writes
-        # nothing; only a run still going at 620s (comfortably inside the
+        # HEALTHY run — which reaps the watcher well under 620s — leaves
+        # `/tmp/hang-ps.log` at 0 bytes (shell redirection creates the file
+        # the instant the subshell is backgrounded, not when it finally
+        # writes to it — measured, lead-coder, `( sleep 5; echo x ) >
+        # file 2>&1 &` then `sleep 1`: the file exists at size 0
+        # immediately); only a run still going at 620s (comfortably inside the
         # stall-trace's own 600s-to-720s margin, so this snapshot lands
         # just after stall-trace has already fired and well before
         # `timeout 12m`'s hard kill) gets a real snapshot: `ps -ef` (is
@@ -206,8 +210,9 @@ jobs:
 
           # Reap the watcher the instant pytest itself returns (pass or
           # fail) — on a healthy run this happens long before 620s, so
-          # /tmp/hang-ps.log never gets written at all (the same
-          # "silent unless it fires" contract the dump step below reads).
+          # /tmp/hang-ps.log stays at the 0 bytes redirection already gave
+          # it (never written TO) — the same "-s says not-fired" contract
+          # the dump step below reads.
           kill "$HANG_PS_WATCHER" 2>/dev/null || true
           wait "$HANG_PS_WATCHER" 2>/dev/null || true
           exit "$PYTEST_RC"
@@ -232,12 +237,14 @@ jobs:
           fi
 
       # #4986 "tool②" (architect design, see the "Run tests" step's own
-      # comment above for the full rationale): unlike the stall-trace
-      # file above, THIS one is never pre-created — the background
-      # watcher only ever opens/writes it if it survives to fire, so a
-      # healthy run (watcher reaped well under 620s) leaves no file at
-      # all; `-s` (exists AND non-empty) is still the right test either
-      # way.
+      # comment above for the full rationale): the background watcher's
+      # redirection creates this file at 0 bytes the instant it is
+      # backgrounded, regardless of whether it ever survives to write to
+      # it (lead-coder, measured — see the "Run tests" step's own comment)
+      # — a healthy run (watcher reaped well under 620s) therefore leaves
+      # an EMPTY file, same as the stall-trace file above, not a missing
+      # one; `-s` (exists AND non-empty) is the right test for the same
+      # reason it is there.
       - name: Hang process snapshot (#4986 tool② — only non-empty if the run was still going at 620s)
         if: always()
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,9 +155,62 @@ jobs:
         # cancel their own watchdog the instant the last item's protocol
         # returns (`_pytest/faulthandler.py`'s own source, confirmed, not
         # guessed). See `reyn/dev/testing/stall_dump.py`'s own docstring.
+        #
+        # #4986 "tool②" (architect design,
+        # https://github.com/tya5/reyn/issues/4986#issuecomment-5565370636
+        # — a real occurrence's own first-hand data, PR #5912): the stall-trace
+        # dump above answers WHEN the controller stopped making progress,
+        # but it only ever sees the CONTROLLER's own OS threads —
+        # `faulthandler` dumps threads, not asyncio tasks or OTHER
+        # processes, and every xdist worker is its OWN process. On that
+        # occurrence the controller was found still inside
+        # `pytest_runtestloop`, blocked on `queue.get()` — i.e. waiting on
+        # a worker's own report, never sent. The ONE fact that decides
+        # between architect's two live hypotheses (a worker genuinely
+        # alive but stuck inside its own teardown, vs. a dead worker whose
+        # execnet pipe stayed open because some grandchild process
+        # inherited its write end) is: **is the worker process still
+        # alive at the moment of the hang.** Backgrounded here (started
+        # BEFORE the pytest pipeline, reaped right after it returns) so a
+        # HEALTHY run — which reaps the watcher well under 620s — writes
+        # nothing; only a run still going at 620s (comfortably inside the
+        # stall-trace's own 600s-to-720s margin, so this snapshot lands
+        # just after stall-trace has already fired and well before
+        # `timeout 12m`'s hard kill) gets a real snapshot: `ps -ef` (is
+        # any `python`/xdist worker process still there at all), `pgrep
+        # -a python` (which ones, with their args), and — Linux-only,
+        # which this runner is — `/proc/<pid>/fd` for each one (who is
+        # holding the execnet pipe open). `2>&1` into the SAME file as the
+        # snapshot commands themselves, so a `ps`/`pgrep` failure (e.g. a
+        # sandboxed runner denying `/proc` reads) shows up as evidence
+        # too, not a silently-empty file that reads as "nothing was
+        # alive".
         run: |
+          (
+            sleep 620
+            echo "=== #4986 tool② — process snapshot at t=620s (ps -ef) ==="
+            ps -ef
+            echo "--- python processes (pgrep -a python) ---"
+            pgrep -a python || echo "(pgrep found none)"
+            echo "--- open fds of each (who holds the execnet pipe open) ---"
+            for pid in $(pgrep python); do
+              echo "pid=$pid:"
+              ls -l "/proc/$pid/fd" || echo "  (could not read /proc/$pid/fd)"
+            done
+          ) > /tmp/hang-ps.log 2>&1 &
+          HANG_PS_WATCHER=$!
+
           set -o pipefail
           REYN_REPLAY_UNCONSUMED_CHECK=1 REYN_STALL_TRACE_CI=600 timeout 12m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
+          PYTEST_RC=$?
+
+          # Reap the watcher the instant pytest itself returns (pass or
+          # fail) — on a healthy run this happens long before 620s, so
+          # /tmp/hang-ps.log never gets written at all (the same
+          # "silent unless it fires" contract the dump step below reads).
+          kill "$HANG_PS_WATCHER" 2>/dev/null || true
+          wait "$HANG_PS_WATCHER" 2>/dev/null || true
+          exit "$PYTEST_RC"
 
       # #4986: surface the stall dump above if (and only if) it fired. The
       # log file is opened (empty) the moment the watchdog is armed —
@@ -176,6 +229,23 @@ jobs:
             cat .reyn-ci-stall-trace.log
           else
             echo "no stall-trace dump (pytest session finished normally)"
+          fi
+
+      # #4986 "tool②" (architect design, see the "Run tests" step's own
+      # comment above for the full rationale): unlike the stall-trace
+      # file above, THIS one is never pre-created — the background
+      # watcher only ever opens/writes it if it survives to fire, so a
+      # healthy run (watcher reaped well under 620s) leaves no file at
+      # all; `-s` (exists AND non-empty) is still the right test either
+      # way.
+      - name: Hang process snapshot (#4986 tool② — only non-empty if the run was still going at 620s)
+        if: always()
+        run: |
+          if [ -s /tmp/hang-ps.log ]; then
+            echo "::warning::#4986 tool② fired — pytest was still running 620s in; process snapshot follows"
+            cat /tmp/hang-ps.log
+          else
+            echo "no hang-process snapshot (pytest finished before the 620s watcher fired)"
           fi
 
       # #5878 (architect follow-up, #5877 co-vet): the same visibility gap


### PR DESCRIPTION
**[tui-coder]** — #4986 の続き（08-27 に自分が持っていた B/A 判別の後、architect が本日 #5912 の一次データから統合仮説の分岐点と道具2つを設計 — https://github.com/tya5/reyn/issues/4986#issuecomment-5565370636）。**着手前に issue に次の一手を記録**しています: https://github.com/tya5/reyn/issues/4986#issuecomment-5570188169

part of #4986

## 何を実装したか — architect の道具②

architect の言葉どおり「判別する事実はたった1つ ── hang している瞬間に、worker process は生きているか」。stall-trace（既存の #4986 dump）は controller 自身の OS thread しか見えない（faulthandler は thread を出すのであって、asyncio task でも別 process でもない）ので、この 1 点には答えられません。

`.github/workflows/test.yml` の "Run tests" step 内で、pytest の pipeline を開始する**前**に background で `( sleep 620; ps -ef; pgrep -a python; /proc/<pid>/fd ... ) > /tmp/hang-ps.log 2>&1 &` を仕込み、pytest が返った**直後**に kill/wait で reap。健全な run では 620s よりずっと早く reap されるので `/tmp/hang-ps.log` は一度も書かれず、既存 2 つの dump step と同じ「発火した時だけ非空」契約を保ちます。620s に到達している run だけが実物の snapshot を得ます（stall-trace の 600s の直後・`timeout 12m` の 720s kill のかなり前）。新しい "Hang process snapshot" dump step が既存 2 つと同じ形で `cat` します。

道具①（`stall_dump.py` の per-worker arm）は着手していません — #5934（e2e-coder、#5909 領域）で明示的に後続 PR へ defer されており、まだ誰も着手していないため、**衝突を避けてこちら（`.github/workflows/test.yml` のみ、src 非変更）から着手**しました。

## 検証

CI-workflow-only（src/tests/docs 無変更）:
- [x] YAML syntax（`yaml.safe_load`）
- [x] `ruff check .`（Python 無変更なので当然だが、指定コマンドどおり実行）
- [x] bash の機構を local でシミュレーション ── ① 健全系（pytest がすぐ返る）: exit code が正しく伝播し、watcher は log を一度も書かない（0 byte のまま）② hang 系（reap が間に合わない）: watcher は生き残って書く。両方期待どおり。
- `tests/`/`docs/`/`CLAUDE.md` の path-conditional gate は対象外（`.github/workflows/` のみ）

## 気になった点（実装外・未確認、報告のみ）

`scripts/detect_4986_teardown_hang.py` の 3-marker signature（`ERROR at teardown` / `_cancel_all_tasks` / `Timeout (>120`）は、08-21 の初期 2 例（per-item pytest-timeout が捕まえた側）から測定されたものです。本日の #5912（今回の道具②の直接の動機）は **外側の `timeout 12m` による exit 124**（`Timeout (0:10:00)`）で、controller 側 stack も `_cancel_all_tasks` ではなく `xdist/dsession.py:154 loop_once` → `queue.get()` でした。#5912 の PR に detector の通知 comment が見当たらない（`gh pr view 5912 --json comments` で `4986` を含む comment 0 件）ことも合わせると、**現行の signature が今回のような shape を捉えていない可能性**があります。実際の #5912 生ログを取って marker の有無を確認してはいません（推測で書いています）。この PR のスコープ外として issue 側に置きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
