### PR TITLE
fix(#5918): scope the DEFAULT_MAX_RETRIES docstring claim, replace the wire-count test with a structural one

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -504,21 +504,39 @@ class LiteLLMEmbeddingProvider:
         on ``2`` again (measured: still 9 requests). This is the SECOND ``x or
         DEFAULT`` trap in the same code path (the first is the one that made the
         omitted kwarg silently mean ``2`` in the first place) — passing our own
-        falsy value straight into it changes nothing. The fix has to defeat the
-        ``or`` itself: setting ``litellm.DEFAULT_MAX_RETRIES = 0`` makes the
-        right-hand side of that ``or`` resolve to ``0`` too, so ANY falsy
-        ``max_retries`` (ours, or a future omitted one) now correctly means "no
-        SDK-level retry" instead of silently reviving 2. Audited for blast
-        radius: reyn's chat-completion path (`llm.py`) always passes an
-        explicit non-``None`` ``num_retries`` into ``litellm.acompletion``,
-        which litellm maps to its own ``max_retries`` BEFORE this fallback would
-        ever run (`main.py`: ``if num_retries is not None: max_retries =
-        num_retries``) — so this global does not change chat's retry count, only
-        embedding's, which is exactly the intended scope. Set once, permanently
-        for the process (no per-call save/restore) — a temporal monkeypatch
-        would race concurrent litellm calls sharing this event loop; a
-        permanent process-wide 0 does not, because nothing in reyn ever relies
-        on the ``2`` fallback firing.
+        falsy value straight into it changes nothing. A custom ``client=``
+        object doesn't survive either (measured, architect, litellm 1.95.0):
+        ``OpenAIChatCompletion._set_dynamic_params_on_client`` overwrites
+        ``client.max_retries`` with whatever ``max_retries`` the call already
+        resolved to, so a client pre-built with ``max_retries=0`` gets
+        clobbered back to ``2`` the same way the kwarg does.
+
+        This is a **declared, necessary deviation**, not a preference: setting
+        ``litellm.DEFAULT_MAX_RETRIES = 0`` is the only seam that reaches this
+        ``or`` dynamically, at all, in the site this method calls. Scoped
+        claim, verified against litellm 1.100.0 (the version
+        ``ci-constraints.txt`` pins; also true at 1.95.0/1.96.0) —
+        ``llms/openai/openai.py``'s ``OpenAIChatCompletion.embedding`` reads
+        ``litellm.DEFAULT_MAX_RETRIES`` at CALL time, so the global mutation
+        above reaches it on every call, present or future. This is NOT a
+        general "defeat of the ``or`` pattern" claim — the SAME file has two
+        OTHER sites this global does not reach: (1) ``_get_openai_client``'s
+        own ``max_retries: int | None = DEFAULT_MAX_RETRIES`` parameter
+        default is bound at IMPORT time (``from litellm.constants import
+        DEFAULT_MAX_RETRIES``), before reyn ever runs, so mutating
+        ``litellm.DEFAULT_MAX_RETRIES`` later never changes that default; (2)
+        ``main.py``/``router.py`` read ``openai.DEFAULT_MAX_RETRIES`` — the
+        OpenAI SDK's OWN constant, a different symbol entirely, outside
+        reyn's reach. Audited for blast radius: reyn's chat-completion path
+        (`llm.py`) always passes an explicit non-``None`` ``num_retries`` into
+        ``litellm.acompletion``, which litellm maps to its own ``max_retries``
+        BEFORE this fallback would ever run (`main.py`: ``if num_retries is
+        not None: max_retries = num_retries``) — so this global does not
+        change chat's retry count, only embedding's, which is exactly the
+        intended scope. Set once, permanently for the process (no per-call
+        save/restore) — a temporal monkeypatch would race concurrent litellm
+        calls sharing this event loop; a permanent process-wide 0 does not,
+        because nothing in reyn ever relies on the ``2`` fallback firing.
 
         Passing ``max_retries=0`` explicitly as a kwarg too (redundant given the
         above, kept for self-documentation): reyn's own retry loop above is then

--- a/tests/llm/test_embed_max_retries_wire_count_3047.py
+++ b/tests/llm/test_embed_max_retries_wire_count_3047.py
@@ -30,13 +30,26 @@ all: it does ``inference_params.pop("max_retries", 2)``, and reyn's chat path
 `litellm.acompletion`, which `litellm.main.py` maps onto `max_retries` in
 `optional_params` BEFORE `completion()` ever pops it — so the fallback
 literal `2` there is dead code for every reyn chat call, same as the global
-mutation is. `test_chat_acompletion_wire_count_unaffected_by_embed_global_mutation`
-below drives ONE real `litellm.acompletion` call shaped like reyn's chat call
-site (explicit `num_retries`, `stream=False`) against the same
-request-counting server, once with the global at its untouched litellm
-default (2) and once forced to 0 (the fix's post-import state), and asserts
-the wire count is identical — closing the "discussed structurally, not
-driven" gap the architect flagged.
+mutation is.
+
+`test_embedding_max_retries_reflects_embed_global_mutation` and
+`test_chat_max_retries_unaffected_by_embed_global_mutation` below (#5918,
+architect ruling on the earlier version of this pair, which drove 2 real-HTTP
+loops each bounded by a 5-second wall-clock budget and compared wire
+COUNTS — a duration-dependent assertion under parallel CI load, CLAUDE.md's
+"a test writes no duration" rule) replace the wire-count comparison with a
+STRUCTURAL one: no HTTP leaves the process at all. Each spies on the real,
+unmocked `OpenAIChatCompletion._get_openai_client` — the one chokepoint both
+`litellm.aembedding` and `litellm.acompletion` pass their resolved
+`max_retries` through on the way to building (or reconfiguring) the OpenAI
+SDK client — captures the `max_retries` value litellm's OWN code computed
+and passed to it, then aborts with a private sentinel exception before any
+socket is touched. This reads what litellm actually decided, not a
+transcription of the fix's `or` line (test-review question 2: the same
+expression written on both sides only fails when someone edits it, and
+they'd edit both) — if litellm ever changes how `embedding()`'s fallback or
+`completion()`'s `num_retries` mapping works, the captured value changes
+with it and these tests go red for the right reason.
 
 **Why this needs a real request-counting server, not a mock.** A test that
 patches `litellm.aembedding` never exercises the OpenAI SDK client that does
@@ -56,6 +69,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import litellm
 import pytest
+from litellm.llms.openai.openai import OpenAIChatCompletion
 
 from reyn.data.embedding.litellm_provider import LiteLLMEmbeddingProvider
 
@@ -167,52 +181,150 @@ async def test_single_attempt_no_reyn_retry_delivers_exactly_one_request(
     assert counting_server.request_count == 1
 
 
+class _SpyAbort(Exception):
+    """Private sentinel: raised by the `_get_openai_client` spy the instant
+    it captures the `max_retries` litellm's real call graph resolved to —
+    before the spy lets any further code run, so no socket is ever touched.
+    litellm's own `except Exception` / exception-mapping layers (both
+    `embedding()` and `completion()` catch broadly, and the `@client`
+    decorator wrapping both re-raises through `litellm.exceptions.*`) always
+    catch and re-wrap this before it reaches the test — so a caller never
+    matches on `_SpyAbort`'s own type via `pytest.raises`; it instead
+    catches the broad `Exception` litellm surfaces and asserts on
+    `captured` having actually been populated, which only happens if this
+    spy fired first."""
+
+
+def _spy_on_get_openai_client(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Replace the REAL `OpenAIChatCompletion._get_openai_client` (never a
+    Mock/AsyncMock) with a thin capture-then-abort wrapper: it records the
+    `max_retries` kwarg the caller — litellm's own `embedding()`/
+    `completion()`, never this test — resolved and passed in, then raises
+    `_SpyAbort` immediately, before delegating to the real client-building
+    body. Nothing downstream of this chokepoint (cache lookup, `AsyncOpenAI`/
+    `OpenAI` construction, and every later HTTP call) ever runs.
+
+    Captures only the FIRST call (measured, directly): litellm's own
+    `@client`-decorated outer retry wrapper re-invokes the whole
+    `completion()`/`embedding()` body up to `num_retries` times after this
+    spy's abort, and forces `max_retries=0` into every one of those INNER
+    retries deliberately (litellm's own anti-amplification convention,
+    unrelated to what this test is checking) — capturing anything past the
+    first call would read that convention's `0`, not the `or`-fallback's
+    or `num_retries`-mapping's own resolved value under test."""
+    captured: dict[str, object] = {}
+
+    def _spy(self: OpenAIChatCompletion, *args: object, **kwargs: object) -> object:
+        if "max_retries" not in captured:
+            captured["max_retries"] = kwargs.get("max_retries")
+        raise _SpyAbort
+
+    monkeypatch.setattr(OpenAIChatCompletion, "_get_openai_client", _spy)
+    return captured
+
+
 @pytest.mark.asyncio
 @pytest.mark.allow_real_network(
-    reason="#3445/#3451 group B/D: drives ONE real litellm.acompletion call "
-    "against the same real local counting_server, deliberately shaped like "
-    "reyn's real chat call site, to prove a wire-count invariant — @replay "
-    "would return a canned response with no request ever reaching the wire.",
+    reason="#3445/#3451: calls the real litellm.aembedding (reyn's own "
+    "network_gate wraps it at module level, before this test's own "
+    "_get_openai_client spy ever runs) — but the spy aborts the call with "
+    "_SpyAbort at the client-construction chokepoint, before litellm gets "
+    "anywhere near opening a socket, so no request is ever attempted "
+    "against api_base regardless. @replay would return a canned response "
+    "and never reach the spy at all, deleting the exact thing under test.",
 )
-async def test_chat_acompletion_wire_count_unaffected_by_embed_global_mutation(
-    counting_server, monkeypatch: pytest.MonkeyPatch
+async def test_embedding_max_retries_reflects_embed_global_mutation(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: the embed fix's `litellm.DEFAULT_MAX_RETRIES = 0` global mutation
-    does not change chat's wire count (architect co-vet on #3054, driven not
-    inferred).
+    """Tier 2: #5918 — the embed fix's `litellm.DEFAULT_MAX_RETRIES` global
+    mutation reaches the embedding call graph's own `max_retries`, driven
+    through the REAL `litellm.aembedding` call graph — no HTTP, no duration.
 
-    Drives ONE `litellm.acompletion(...)` call — shaped like reyn's real chat
-    call site in `llm.py` (explicit `num_retries=`, `stream=False`, routed at
-    a real local HTTP server via `api_base`, no monkeypatching of litellm or
-    of the call itself) — against the SAME request-counting server the embed
-    tests above use, once with `litellm.DEFAULT_MAX_RETRIES` at the untouched
-    litellm default (2, i.e. the state BEFORE any embed provider has run) and
-    once forced to 0 (the state AFTER `_aembedding_bounded` has run, since the
-    mutation is process-wide and permanent). If the two wire counts differ,
-    the embed fix's global has reached into chat's retry count and the fix
-    needs a different (non-global) shape.
+    Drives `litellm.aembedding(...)` with `max_retries` OMITTED (`None`,
+    reyn's own pre-fix shape) once with `litellm.DEFAULT_MAX_RETRIES` at the
+    untouched litellm default (2) and once forced to 0 (the state
+    `_aembedding_bounded` leaves behind, permanently, once any embed call has
+    run) — asserting the value that reaches `_get_openai_client` tracks the
+    global exactly. Falsify: if litellm's `embedding()` stops reading
+    `litellm.DEFAULT_MAX_RETRIES` in its fallback, the captured value stops
+    tracking the global and this goes red — the fix's whole premise.
     """
-    import os
+    for default_max_retries, expected in ((2, 2), (0, 0)):
+        monkeypatch.setattr(litellm, "DEFAULT_MAX_RETRIES", default_max_retries)
+        captured = _spy_on_get_openai_client(monkeypatch)
+        with pytest.raises(Exception, match=".*"):  # litellm re-wraps _SpyAbort — see its docstring
+            await litellm.aembedding(
+                model=_MODEL,
+                input=["hello"],
+                api_base="http://127.0.0.1:1",  # never reached — spy aborts first
+                api_key="dummy-key-never-used",
+                timeout=5.0,
+            )
+        assert "max_retries" in captured, (
+            "the _get_openai_client spy never fired — litellm's aembedding "
+            "call graph did not reach the client-construction chokepoint "
+            "this test means to observe"
+        )
+        assert captured["max_retries"] == expected, (
+            f"litellm.DEFAULT_MAX_RETRIES={default_max_retries} but "
+            f"_get_openai_client saw max_retries={captured['max_retries']!r} "
+            f"(expected {expected}) — embedding's or-fallback did not track "
+            f"the global the way the fix's docstring claims"
+        )
 
-    api_base = os.environ["LITELLM_API_BASE"]  # set by the counting_server fixture
-    counts: dict[int, int] = {}
+
+@pytest.mark.asyncio
+@pytest.mark.allow_real_network(
+    reason="#3445/#3451: calls the real litellm.acompletion (reyn's own "
+    "network_gate wraps it at module level, before this test's own "
+    "_get_openai_client spy ever runs) — but the spy aborts the call with "
+    "_SpyAbort at the client-construction chokepoint, before litellm gets "
+    "anywhere near opening a socket, so no request is ever attempted "
+    "against api_base regardless. @replay would return a canned response "
+    "and never reach the spy at all, deleting the exact thing under test.",
+)
+async def test_chat_max_retries_unaffected_by_embed_global_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5918 (architect ruling) — the embed fix's
+    `litellm.DEFAULT_MAX_RETRIES = 0` global mutation does NOT change chat's
+    resolved `max_retries`, driven through the REAL `litellm.acompletion`
+    call graph — no HTTP, no duration (replaces the wire-count-under-a-5s-
+    budget version of this test, which was a duration-dependent assertion
+    under CLAUDE.md's "a test writes no duration" rule).
+
+    Drives ONE `litellm.acompletion(...)` call shaped like reyn's real chat
+    call site in `llm.py` (explicit `num_retries=3`, `stream=False`), once
+    with `litellm.DEFAULT_MAX_RETRIES` at the untouched litellm default (2)
+    and once forced to 0 — asserting the value that reaches
+    `_get_openai_client` is `3` (from `num_retries`) both times, proving
+    chat's path never reads the global at all. Falsify: if litellm's
+    `completion()` starts reading `litellm.DEFAULT_MAX_RETRIES` for a call
+    that already has an explicit `num_retries`, the captured value would
+    change between the two global states and this goes red.
+    """
     for default_max_retries in (2, 0):
         monkeypatch.setattr(litellm, "DEFAULT_MAX_RETRIES", default_max_retries)
-        counting_server.request_count = 0
-        with pytest.raises(litellm.exceptions.InternalServerError):
+        captured = _spy_on_get_openai_client(monkeypatch)
+        with pytest.raises(Exception, match=".*"):  # litellm re-wraps _SpyAbort — see its docstring
             await litellm.acompletion(
                 model="openai/gpt-4o-mini",
                 messages=[{"role": "user", "content": "hi"}],
                 num_retries=3,  # same shape as llm.py's call_kwargs["num_retries"]
                 timeout=5.0,
                 stream=False,
-                api_base=api_base,
+                api_base="http://127.0.0.1:1",  # never reached — spy aborts first
+                api_key="dummy-key-never-used",
             )
-        counts[default_max_retries] = counting_server.request_count
-
-    assert counts[2] == counts[0], (
-        f"chat's wire count changed with litellm.DEFAULT_MAX_RETRIES "
-        f"(2 -> {counts[2]} requests, 0 -> {counts[0]} requests) — the embed "
-        f"fix's global mutation is NOT scoped to embedding as intended"
-    )
-    assert counts[2] > 0, "sanity: the stand-in server must have been hit at all"
+        assert "max_retries" in captured, (
+            "the _get_openai_client spy never fired — litellm's acompletion "
+            "call graph did not reach the client-construction chokepoint "
+            "this test means to observe"
+        )
+        assert captured["max_retries"] == 3, (
+            f"litellm.DEFAULT_MAX_RETRIES={default_max_retries} but "
+            f"_get_openai_client saw max_retries={captured['max_retries']!r} "
+            f"(expected 3, from num_retries) — chat's resolved max_retries "
+            f"moved with the embed fix's global, which the docstring claims "
+            f"cannot happen"
+        )


### PR DESCRIPTION
**[tui-coder]** — Architect ruling on #5918 (relayed by lead-coder): the `litellm.DEFAULT_MAX_RETRIES` global mutation in `_aembedding_bounded` stays as-is (a **declared, necessary deviation**, not a preference) — both alternatives are structurally closed, and the docstring/test needed to reflect that instead of overclaiming.

## What changed

**Docstring** (`src/reyn/data/embedding/litellm_provider.py::_aembedding_bounded`): rewrote the "the fix has to defeat the `or` itself" paragraph into a version+site-scoped claim, verified directly against litellm `1.100.0` (the version `ci-constraints.txt` pins — architect's own reading was `1.95.0`, disclosed as partial). Confirmed at 1.100.0 (extracted the actual pinned wheel):
- `llms/openai/openai.py::OpenAIChatCompletion.embedding` reads `litellm.DEFAULT_MAX_RETRIES` dynamically, at call time (the seam that works).
- `_get_openai_client`'s own default parameter is bound at **import time** (`from litellm.constants import DEFAULT_MAX_RETRIES`) — the global mutation never reaches it.
- `main.py`/`router.py` read `openai.DEFAULT_MAX_RETRIES` — the OpenAI SDK's own, different constant.
- A custom `client=` doesn't survive either: `_set_dynamic_params_on_client` overwrites `client.max_retries` with the already-resolved value.

**Test** (`tests/llm/test_embed_max_retries_wire_count_3047.py`): replaced `test_chat_acompletion_wire_count_unaffected_by_embed_global_mutation` — which drove 2 real-HTTP loops each bounded by a 5-second wall-clock budget and compared request counts (duration-dependent under parallel CI load, CLAUDE.md's "a test writes no duration" rule) — with two structural, no-HTTP tests:

- `test_embedding_max_retries_reflects_embed_global_mutation`
- `test_chat_max_retries_unaffected_by_embed_global_mutation`

Both spy on the real (never mocked) `OpenAIChatCompletion._get_openai_client` — the chokepoint both `litellm.aembedding` and `litellm.acompletion` pass their resolved `max_retries` through — capture the value litellm's own call graph computed, then abort before any socket opens. Full detail (including why only the FIRST call is captured — litellm's own outer retry wrapper forces `max_retries=0` into inner retries, a different, unrelated convention) is in the commit message and the test's own docstrings.

## Verification

- Strip-verify done and reverted (in-file edit, no `git checkout`/`stash`): swapped both new tests' expected values to a bogus constant, confirmed both go red for the concrete unexpected-value reason, restored before committing.
- Gates (scoped): `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all clean.
- `pytest tests/llm/test_embed_max_retries_wire_count_3047.py -q --timeout=120` — 4 passed.

## Test plan
- [x] Scoped pytest green (see above)
- [x] Strip-verify (see above)
- [x] (skipped — Visual, standing waiver)

Closes #5918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn

