### PR TITLE
fix(part of #5896): cache a ChatMessage's own resident-byte size instead of re-serializing it every eviction pass

### DIFF
--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -809,7 +809,7 @@ class ChatMessage:
         self.name = name
         self.spillability = _normalize_spillability(spillability)
         self.disclosure = _normalize_disclosure(disclosure, role=role, meta=self.meta)
-        # #5939 P0 (owner-hit, 2026-09-07): a plain instance attribute, NOT
+        # #5896 P0 (owner-hit, 2026-09-07): a plain instance attribute, NOT
         # a dataclass field — deliberately NO class-level annotation, so
         # `dataclasses.fields()`/`asdict()`/`__eq__`/`repr()` never see it.
         # If it WERE a declared field, `resident_bytes()`'s own

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -809,6 +809,44 @@ class ChatMessage:
         self.name = name
         self.spillability = _normalize_spillability(spillability)
         self.disclosure = _normalize_disclosure(disclosure, role=role, meta=self.meta)
+        # #5939 P0 (owner-hit, 2026-09-07): a plain instance attribute, NOT
+        # a dataclass field — deliberately NO class-level annotation, so
+        # `dataclasses.fields()`/`asdict()`/`__eq__`/`repr()` never see it.
+        # If it WERE a declared field, `resident_bytes()`'s own
+        # `asdict(self)` call below would include this cache slot in what
+        # it measures, drifting the computed size from what the pre-fix
+        # `json.dumps(asdict(m))` call (still used verbatim as the
+        # equivalence baseline in tests) would have produced.
+        self._resident_bytes_cache: "int | None" = None
+
+    def resident_bytes(self) -> int:
+        """This message's own serialized size in bytes — computed the
+        FIRST time this is called, cached for the rest of this object's
+        lifetime. Owner-hit incident (2026-09-07): ``Session.
+        _evict_oldest_resident_entries`` used to run
+        ``len(json.dumps(asdict(m), ensure_ascii=False).encode("utf-8"))``
+        for EVERY resident message on EVERY eviction pass (every append) —
+        a single 369 MB row on the owner's real history made that ONE
+        re-serialize cost another 369 MB copy, on the hot append path.
+
+        Caching here is safe (never goes stale) because nothing in this
+        codebase mutates a ``ChatMessage``'s ``content``/``meta`` after it
+        becomes resident: the sole in-place ``.content =`` write outside
+        this class (``Session._parse_history_line``'s ref-resolve) runs on
+        a freshly-parsed message strictly BEFORE it is appended to
+        ``self.history``, and the sole in-place ``.meta[...] =`` write
+        (``Session._append_history``'s ``wal_seq`` stamp) runs before that
+        same append too — confirmed by reading every ``.content =`` /
+        ``.meta[...] =`` site in ``runtime/session.py`` and
+        ``runtime/services/*.py``, not assumed. A message built via
+        ``dataclasses.replace()`` goes back through ``__init__`` (this
+        cache is reset to ``None`` there), so a copy never inherits a
+        stale value from the original."""
+        if self._resident_bytes_cache is None:
+            self._resident_bytes_cache = len(
+                json.dumps(asdict(self), ensure_ascii=False).encode("utf-8"),
+            )
+        return self._resident_bytes_cache
 
     @property
     def text(self) -> str:

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -830,18 +830,38 @@ class ChatMessage:
         re-serialize cost another 369 MB copy, on the hot append path.
 
         Caching here is safe (never goes stale) because nothing in this
-        codebase mutates a ``ChatMessage``'s ``content``/``meta`` after it
-        becomes resident: the sole in-place ``.content =`` write outside
-        this class (``Session._parse_history_line``'s ref-resolve) runs on
-        a freshly-parsed message strictly BEFORE it is appended to
-        ``self.history``, and the sole in-place ``.meta[...] =`` write
-        (``Session._append_history``'s ``wal_seq`` stamp) runs before that
-        same append too — confirmed by reading every ``.content =`` /
-        ``.meta[...] =`` site in ``runtime/session.py`` and
-        ``runtime/services/*.py``, not assumed. A message built via
+        codebase in-place-mutates ANY field ``asdict(self)`` can see
+        (``role`` / ``content`` / ``ts`` / ``seq`` / ``meta`` /
+        ``tool_calls`` / ``tool_call_id`` / ``name`` / ``spillability`` /
+        ``disclosure`` — all 9 dataclass fields, not just
+        ``content``/``meta``) AFTER a message becomes resident.
+        Confirmed by reading every in-place write to any of them across
+        the whole of ``src/`` (lead-coder review, PR #5945 BLOCKING —
+        widened from an earlier draft that only checked ``.content =``/
+        ``.meta[...] =``, missing the one below), not assumed. All THREE
+        that exist run strictly BEFORE the write that first makes a
+        message resident (``self.history.append(msg)``,
+        ``Session._append_history``):
+
+        - ``msg.seq = self._next_seq`` (``session.py:4267``)
+        - ``msg.meta["wal_seq"] = ...`` (``session.py:4278``, the
+          ``wal_seq`` stamp)
+        - ``msg.content = resolve_history_content(...)``
+          (``session.py:5039``, ``_parse_history_line``'s ref-resolve, on
+          a freshly-parsed message before its own later append)
+
+        A 4th candidate, ``router_loop.py:4496``'s
+        ``result.tool_calls = tcs[:cap]``, mutates a completion RESULT
+        object before ``ChatMessage.__init__`` ever runs on it — not a
+        resident ``ChatMessage`` field write at all. A message built via
         ``dataclasses.replace()`` goes back through ``__init__`` (this
         cache is reset to ``None`` there), so a copy never inherits a
-        stale value from the original."""
+        stale value from the original. If a future change adds an
+        in-place write to any of the 9 fields AFTER a message is
+        resident, this cache goes silently stale — re-run this same
+        search (``.content =`` / ``.meta[...] =`` / ``.seq =`` / etc.,
+        across ``src/``, not just ``runtime/``) before trusting it
+        again."""
         if self._resident_bytes_cache is None:
             self._resident_bytes_cache = len(
                 json.dumps(asdict(self), ensure_ascii=False).encode("utf-8"),

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 
 logger = logging.getLogger(__name__)
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 
 from reyn.config import (  # noqa: F401
@@ -4367,11 +4367,23 @@ class Session:
         and tests that reassign ``s.history`` directly to simulate a bounded
         load), so an incrementally-maintained counter would silently drift
         from the true resident set the first time any of those paths ran
-        without also updating it. Recomputing is O(n) per append, but n is
-        bounded by construction (that is the entire point of this cap), so
-        the cost stays small — and the invariant "resident size <= cap after
-        every append" holds by construction, with no cached state that could
-        desync from reality.
+        without also updating it. Recomputing the SUM is O(n) per append,
+        but n is bounded by construction (that is the entire point of this
+        cap), so the cost stays small — and the invariant "resident size <=
+        cap after every append" holds by construction, with no cached SUM
+        that could desync from reality.
+
+        #5939 P0 (owner-hit, 2026-09-07): the PER-MESSAGE serialization
+        underneath that sum used to be redone from scratch too, every
+        call, for every still-resident message — ``m.resident_bytes()``
+        (``ChatMessage``'s own method) now caches each message's OWN size
+        the first time it's asked, so a message that survives N eviction
+        passes gets serialized once, not N times. This is a different
+        claim from the paragraph above: the per-row VALUE never goes
+        stale (content/meta are immutable after append — see
+        ``resident_bytes()``'s own docstring for the exact sites checked),
+        so caching IT is safe even though caching the resident-set SUM
+        would not be.
 
         ONLY called from the tail-growth path (:meth:`_append_history`, a
         normal turn appending the newest entry) — deliberately NOT called
@@ -4387,10 +4399,7 @@ class Session:
 
         Returns the count evicted (0 = already within budget)."""
         cap = self._history_resident_config.max_bytes
-        sizes = [
-            len(json.dumps(asdict(m), ensure_ascii=False).encode("utf-8"))
-            for m in self.history
-        ]
+        sizes = [m.resident_bytes() for m in self.history]
         total = sum(sizes)
         evict_count = 0
         # Never evict the newest (last) entry, even if it alone exceeds the

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4373,7 +4373,7 @@ class Session:
         cap after every append" holds by construction, with no cached SUM
         that could desync from reality.
 
-        #5939 P0 (owner-hit, 2026-09-07): the PER-MESSAGE serialization
+        #5896 P0 (owner-hit, 2026-09-07): the PER-MESSAGE serialization
         underneath that sum used to be redone from scratch too, every
         call, for every still-resident message — ``m.resident_bytes()``
         (``ChatMessage``'s own method) now caches each message's OWN size

--- a/tests/runtime/test_5896_p0_resident_bytes_cache.py
+++ b/tests/runtime/test_5896_p0_resident_bytes_cache.py
@@ -1,4 +1,4 @@
-"""#5939 P0 (owner-hit, 2026-09-07): ``Session._evict_oldest_resident_entries``
+"""#5896 P0 (owner-hit, 2026-09-07): ``Session._evict_oldest_resident_entries``
 used to re-serialize EVERY still-resident ``ChatMessage`` on EVERY eviction
 pass (every append) just to measure its size — on the owner's real machine a
 single 369 MB row made that ONE re-serialize cost another 369 MB copy, on the

--- a/tests/runtime/test_5896_p0_resident_bytes_cache.py
+++ b/tests/runtime/test_5896_p0_resident_bytes_cache.py
@@ -1,0 +1,198 @@
+"""#5939 P0 (owner-hit, 2026-09-07): ``Session._evict_oldest_resident_entries``
+used to re-serialize EVERY still-resident ``ChatMessage`` on EVERY eviction
+pass (every append) just to measure its size — on the owner's real machine a
+single 369 MB row made that ONE re-serialize cost another 369 MB copy, on the
+hot append path, contributing to a startup-time peak footprint of 8.2 GB.
+``ChatMessage.resident_bytes()`` now caches each message's own serialized
+size the first time it is asked.
+
+Tier split: the pure-caching claim (a message's own size is computed once,
+never re-serialized on repeat calls) is Tier 1 — it is a property of
+``ChatMessage`` alone, no ``Session`` involved. The wiring claim (the real
+eviction call site actually GETS that caching benefit across many real
+append/evict cycles, not just that the method caches in isolation) is Tier 2.
+
+No duration anywhere: every assertion here counts real ``json.dumps``
+calls, never timing. The counter wraps the ACTUAL stdlib function (still
+executes it — a spy, not a fake; testing.md: never fake a collaborator
+when the real one is cheap). ``json.dumps`` is also called once per append
+by ``Session._append_history``'s own durable-write line (unrelated to
+this fix, unconditional every append) — the Tier 2 test below accounts
+for that known, constant contribution explicitly rather than assuming
+``resident_bytes()`` is the only caller (measured directly while building
+this test: an earlier version of this counter wrapped
+``ChatMessage.resident_bytes`` itself and checked its OWN cache attribute
+before delegating to the real method — which cannot distinguish a guarded
+cache from an unguarded one, since both eventually leave the SAME
+attribute populated; that self-referential design silently passed even
+with the guard fully removed, caught only by deliberately stripping the
+guard and finding the test stayed green). Per lead-coder's own dispatch:
+"duration を書かない（測るなら『json.dumps が呼ばれない』を見る）".
+"""
+from __future__ import annotations
+
+import json as _json_module
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import HistoryResidentConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime import chat_message as chat_message_module
+from reyn.runtime.chat_message import ChatMessage
+from tests._support.agent_session import make_session
+
+
+def _counting_json_dumps(monkeypatch: pytest.MonkeyPatch) -> "list[int]":
+    """Wraps the REAL ``json.dumps`` (the exact name ``chat_message.py``
+    calls) to count invocations without changing its behaviour. Patched
+    on the shared ``json`` module object itself (``import json`` in any
+    module returns the same singleton), so this counts every call in the
+    process, not just ``chat_message.py``'s own — the Tier 2 test below
+    accounts for the other known caller explicitly. Returns a 1-element
+    mutable box the test reads afterward."""
+    real_dumps = _json_module.dumps
+    calls = [0]
+
+    def _wrapped(*args: object, **kwargs: object) -> str:
+        calls[0] += 1
+        return real_dumps(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(chat_message_module.json, "dumps", _wrapped)
+    return calls
+
+
+# ── 1. Tier 1: ChatMessage.resident_bytes() caches on its own ──────────────
+
+
+def test_resident_bytes_computes_once_then_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 1: calling ``resident_bytes()`` N times on the SAME message
+    calls the real ``json.dumps`` exactly once. No ``Session`` involved
+    here, so no other caller of ``json.dumps`` is in play — the count is
+    unambiguous.
+
+    Strip witness: removing the ``if self._resident_bytes_cache is None:``
+    guard in ``ChatMessage.resident_bytes`` (recomputing unconditionally)
+    turns this red (``calls[0] == 3`` instead of ``1``) — verified
+    directly, restored after."""
+    calls = _counting_json_dumps(monkeypatch)
+    msg = ChatMessage(role="user", content="x" * 500)
+
+    first = msg.resident_bytes()
+    second = msg.resident_bytes()
+    third = msg.resident_bytes()
+
+    assert first == second == third, "the cached value must be stable across calls"
+    assert calls[0] == 1, (
+        f"resident_bytes() must serialize this message ONCE, not on every "
+        f"call; got {calls[0]} real json.dumps call(s)"
+    )
+
+
+def test_resident_bytes_matches_the_pre_fix_computation_exactly() -> None:
+    """Tier 1: equivalence — ``resident_bytes()`` must produce the EXACT
+    same number the old inline
+    ``len(json.dumps(asdict(m), ensure_ascii=False).encode("utf-8"))``
+    expression did, for a variety of message shapes (str content, list
+    content, tool_calls, meta). This is the byte-identical witness
+    lead-coder's dispatch required — a caching fix that quietly changed
+    the VALUE would be worse than the bug it fixes."""
+    import json
+    from dataclasses import asdict
+
+    messages = [
+        ChatMessage(role="user", content="hello"),
+        ChatMessage(role="assistant", content="", tool_calls=[
+            {"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}},
+        ]),
+        ChatMessage(role="tool", content="result body", tool_call_id="c1", name="t"),
+        ChatMessage(
+            role="user",
+            content=[{"type": "text", "text": "multimodal"}],
+            meta={"wal_seq": 7, "custom": "value"},
+        ),
+        ChatMessage(role="summary", content="folded"),
+    ]
+
+    for m in messages:
+        old_way = len(json.dumps(asdict(m), ensure_ascii=False).encode("utf-8"))
+        new_way = m.resident_bytes()
+        assert new_way == old_way, (
+            f"resident_bytes() drifted from the pre-fix computation for "
+            f"role={m.role!r}: old={old_way}, new={new_way}"
+        )
+
+
+def test_resident_bytes_cache_does_not_leak_into_asdict_or_equality() -> None:
+    """Tier 1: the cache slot must be invisible to ``dataclasses.asdict``,
+    ``==``, and ``repr`` — it is deliberately NOT a declared dataclass
+    field (see ``ChatMessage.__init__``'s own comment). If it ever became
+    one, ``resident_bytes()``'s own ``asdict(self)`` call would include
+    the cache slot in what it measures, silently drifting the computed
+    size from the equivalence test above."""
+    from dataclasses import asdict
+
+    a = ChatMessage(role="user", content="same")
+    b = ChatMessage(role="user", content="same")
+    a.resident_bytes()  # populate a's cache; b's stays unset
+
+    assert a == b, "a populated cache must not affect dataclass equality"
+    assert "_resident_bytes_cache" not in asdict(a), (
+        "the cache slot leaked into asdict() output"
+    )
+
+
+# ── 2. Tier 2: the real eviction path gets the caching benefit ─────────────
+
+
+def _session(tmp_path: Path, state_log: StateLog, *, max_bytes: int) -> "object":
+    return make_session(
+        agent_name="p0-resident-bytes-test", state_log=state_log,
+        snapshot_path=tmp_path / "snap.json",
+        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_eviction_never_reserializes_a_still_resident_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a message that survives MULTIPLE eviction passes (stays
+    resident across several later appends before finally aging out) must
+    still only ever be serialized ONCE across its whole resident lifetime
+    — not once per eviction pass it survives.
+
+    Expected total: ``2 * n_appends`` real ``json.dumps`` calls — ``n``
+    from ``resident_bytes()`` (one per DISTINCT message, ever) plus ``n``
+    from ``_append_history``'s own unrelated durable-write line
+    (``f.write(json.dumps(history_record(msg), ...))``, unconditional,
+    once per append, untouched by this fix). Any count ABOVE that means
+    some still-resident message got re-measured on a later pass.
+
+    Strip witness: reverting ``_evict_oldest_resident_entries``'s
+    ``sizes = [m.resident_bytes() for m in self.history]`` back to the
+    pre-fix inline ``json.dumps(asdict(m))`` list comprehension makes the
+    total exceed ``2 * n_appends`` — verified directly, restored after."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    # Cap sized so several messages stay resident across MANY appends
+    # (each ~150-250 bytes serialized, the dataclass carries many fields;
+    # 300 bytes keeps ~1-2 resident at once, so the oldest of those
+    # survives at least one extra eviction pass before it ages out —
+    # exactly the repeat-measurement scenario the pre-fix code paid for
+    # on every one of those passes).
+    s = _session(tmp_path, state_log, max_bytes=300)
+
+    calls = _counting_json_dumps(monkeypatch)
+
+    n_appends = 20
+    for i in range(n_appends):
+        s._append_history(ChatMessage(role="user", content=f"turn {i}"))
+
+    assert calls[0] == 2 * n_appends, (
+        f"expected exactly {2 * n_appends} real json.dumps calls "
+        f"({n_appends} from resident_bytes(), one per distinct message, "
+        f"plus {n_appends} from the unrelated durable-write line) — got "
+        f"{calls[0]}, which is more than the fixed total if any message "
+        f"were being re-measured on a later eviction pass"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5896.

## What was wrong

Owner-hit P0 (2026-09-07): a single 369 MB row in the owner's real `history.jsonl` made `Session._evict_oldest_resident_entries`'s own size measurement — `len(json.dumps(asdict(m), ensure_ascii=False).encode("utf-8"))` — run fresh for EVERY resident message on EVERY eviction pass (every append). Cost another 369 MB copy on the hot append path, one of the amplification points architect named in the same incident thread (alongside the un-migrated 663 MB history that's the target of #5896 stage 3, landing separately).

## What this does

`ChatMessage.resident_bytes()` now computes this SAME expression once and caches it as a plain instance attribute — deliberately NOT a declared dataclass field (no class-level annotation, so `dataclasses.fields()`/`asdict()`/`__eq__()`/`repr()` never see it; if it were a field, `resident_bytes()`'s own `asdict(self)` call would include the cache slot in what it measures, drifting the computed size from the pre-fix baseline).

Caching is safe because nothing in this codebase mutates a `ChatMessage`'s `content`/`meta` after it becomes resident — confirmed by reading every `.content =` / `.meta[...] =` site in `runtime/session.py` and `runtime/services/*.py`, not assumed: the sole in-place `.content =` write (`_parse_history_line`'s ref-resolve) runs on a freshly-parsed message strictly BEFORE it is appended to `self.history`, and the sole `.meta[...] =` write (`_append_history`'s `wal_seq` stamp) runs before that same append too.

`_evict_oldest_resident_entries`'s own `sizes` list now reads `m.resident_bytes()` instead of re-deriving the expression inline; `asdict` dropped from `session.py`'s imports (its only remaining use).

No band-aid: this closes the class (every resident message, every eviction pass), not just the 369 MB row that surfaced it.

## Tests

4 new (`tests/runtime/test_5896_p0_resident_bytes_cache.py`, Tier 1 ×3 + Tier 2 ×1):
- `resident_bytes()` serializes once then caches (verified via a real `json.dumps` call counter, not timing)
- byte-identical equivalence with the pre-fix computation across 5 message shapes (str/list content, `tool_calls`, `meta`)
- the cache slot is invisible to `asdict()`/equality
- a real `Session`'s real append/evict cycle across 20 appends produces exactly `2*n_appends` real `json.dumps` calls (`n` from `resident_bytes()`, one per distinct message ever; `n` from the unrelated durable-write line, unconditional every append) — any count above that would mean a still-resident message got re-measured on a later pass

Plus the 37 pre-existing eviction/`chat_message` tests, all green.

**Strip-falsification executed directly** (not reasoned): removing the cache guard turns both the Tier 1 caching test (1→3 calls) and the Tier 2 real-session test (40→59 calls) red — confirmed, restored before commit. An earlier draft of the Tier 2 counter wrapped `ChatMessage.resident_bytes` itself and checked its own cache attribute before delegating — that design cannot distinguish a guarded cache from an unguarded one (both eventually leave the same attribute populated) and silently passed even with the guard fully removed; caught only by deliberately stripping and finding it still green, then rebuilt around a real `json.dumps` call counter instead.

## Local gates

`ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` (6 findings, all baselined), the 3 `tests/`-path-conditional gates, `check_tests_path_literal_reference.py` (fresh `origin/main` right before push) — all green.

## Test plan

- [x] `pytest` scoped to diff + related regression scope — 41 passed (4 new + 37 pre-existing), 0 regressions
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `tests/`-path-conditional gates (file added under `tests/`)
- [x] (skipped — standing Visual-item waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
