### PR TITLE
fix(#5944 P0): grep has no upper bound on its return -- byte cap added, head_limit defaulted

### DIFF
--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -937,20 +937,68 @@ def _execute_grep_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
         return {"kind": "file", "op": "grep", "status": "ok",
                 "output_mode": "count", "count": result.count}, result.count
 
+    # #5944 P0 (owner-hit): grep's matched LINE has no per-item size bound —
+    # unlike glob (paths, tens of bytes each), a `.reyn/` JSONL line is a
+    # whole conversation message, up to hundreds of MB observed live. head_limit
+    # (match COUNT) alone does not bound that; this is the other half of the
+    # fix — the SAME shared inline byte cap read/load_skill already use
+    # (`control_ir_inline_cap`, config-driven via `ctx.read_cap_config`, no
+    # new ungrounded constant), applied per match/context-line here in the
+    # presentation layer (the backend returns matched lines verbatim — see
+    # its own Protocol docstring).
+    from reyn.core.context_builder import byte_safe_prefix, control_ir_inline_cap
+
+    cap = control_ir_inline_cap(ctx.read_cap_config)
+
+    def _cap_line(text: str) -> tuple[str, bool]:
+        """Byte-cap one line for presentation. Returns (display_text,
+        was_truncated) — a truncated line gets an explicit ``...(+N bytes)``
+        suffix (never silent) naming exactly how much was cut, mirroring
+        read's own self-bounding truncation contract."""
+        raw_bytes = len(text.encode("utf-8"))
+        if raw_bytes <= cap:
+            return text, False
+        prefix = byte_safe_prefix(text, cap)
+        cut = raw_bytes - len(prefix.encode("utf-8"))
+        return f"{prefix}...(+{cut} bytes)", True
+
     matches: list[dict] = []
+    returned_bytes = 0
+    content_truncated = False
     for hit in result.matches:
+        content, was_cut = _cap_line(hit["content"])
+        content_truncated = content_truncated or was_cut
         entry: dict[str, Any] = {
             "path": _rel(hit["path"]),
             "line_number": hit["line_number"],
-            "content": hit["content"],
+            "content": content,
         }
+        returned_bytes += len(content.encode("utf-8"))
         if "context" in hit:
-            entry["context"] = hit["context"]
+            capped_context = []
+            for c in hit["context"]:
+                c_content, c_cut = _cap_line(c["content"])
+                content_truncated = content_truncated or c_cut
+                returned_bytes += len(c_content.encode("utf-8"))
+                capped_context.append({**c, "content": c_content})
+            entry["context"] = capped_context
         matches.append(entry)
 
-    return {"kind": "file", "op": "grep", "status": "ok",
-            "output_mode": "content", "pattern": op.pattern,
-            "matches": matches, "count": len(matches)}, len(matches)
+    out: dict[str, Any] = {"kind": "file", "op": "grep", "status": "ok",
+                            "output_mode": "content", "pattern": op.pattern,
+                            "matches": matches, "count": len(matches),
+                            "returned_bytes": returned_bytes}
+    if content_truncated:
+        out["content_truncated"] = True
+    # #2998's glob precedent, same field names: `truncated` + a real N-of-M,
+    # not just "there might be more" — result.total_matches is exact (see
+    # GrepResult's own docstring for why counting past head_limit is cheap).
+    if result.total_matches > len(matches):
+        out["truncated"] = True
+        out["total_count"] = result.total_matches
+        out["returned_count"] = len(matches)
+
+    return out, len(matches)
 
 
 async def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:

--- a/src/reyn/environment/backend.py
+++ b/src/reyn/environment/backend.py
@@ -45,13 +45,25 @@ class GrepResult:
       - ``"files_with_matches"`` → ``files`` (absolute Paths of matching files)
       - ``"count"``              → ``count`` (total match count)
       - ``"content"``            → ``matches`` (list of hit dicts, ``path`` as a
-        Path; the caller relativizes for presentation)
+        Path; the caller relativizes for presentation) + ``total_matches``
+
+    #5944 (P0, owner-hit): ``total_matches`` is the TRUE total match count for
+    ``"content"`` mode, always accurate regardless of ``head_limit`` — the
+    backend keeps scanning past ``head_limit`` (cheaply: a ``regex.search``
+    per remaining line, no entry/context dict built, so memory stays bounded
+    by ``head_limit`` even when ``total_matches`` is huge) instead of
+    stopping the walk the moment the cap is hit. ``len(matches) <
+    total_matches`` is the truncation signal the op_runtime caller surfaces
+    as ``truncated``/``total_count``/``returned_count`` (#2998's glob
+    precedent, same field names). Unset (``0``) for the other two
+    ``output_mode``s, which have no separate cap to report against.
     """
 
     output_mode: str
     files: list[Path] = field(default_factory=list)
     count: int = 0
     matches: list[dict] = field(default_factory=list)
+    total_matches: int = 0
 
 
 @runtime_checkable
@@ -131,5 +143,14 @@ class EnvironmentBackend(Protocol):
         (default ``**/*``) under it, optionally filtered to ``file_type``
         (extension), are scanned. This is the environment-internal scan
         primitive (see module docstring).
+
+        #5944: ``"content"`` mode keeps scanning past ``head_limit`` matches
+        to populate :attr:`GrepResult.total_matches` accurately — it does
+        NOT build the (potentially large) match/context dicts past the cap,
+        so this costs a cheap regex search per remaining line, not the
+        memory the cap exists to bound. Per-match BYTE bounding is NOT this
+        primitive's job — it returns matched lines verbatim; the caller
+        (``op_runtime/file.py``) applies the shared inline byte cap for
+        presentation, the same seam ``read``/``load_skill`` already share.
         """
         ...

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -328,19 +328,24 @@ _GREP = (
     "    except OSError: pass\n"
     "  out['count']=t\n"
     "else:\n"
-    "  done=False\n"
+    # #5944: no early break on hl -- keep scanning every candidate to report
+    # an accurate `total_matches` (mirrors host_backend.py's own comment):
+    # matches past the cap are counted (`t`) but never dict-built, so memory
+    # stays bounded by hl while the total is still exact.
+    "  t=0\n"
     "  for f in cands:\n"
-    "    if done: break\n"
     "    try: lines=f.read_text('utf-8','replace').splitlines()\n"
     "    except OSError: continue\n"
     "    for i,line in enumerate(lines):\n"
     "      if not rx.search(line): continue\n"
+    "      t+=1\n"
+    "      if hl>=0 and len(out['matches'])>=hl: continue\n"
     "      e={'path':str(f),'line_number':i+1,'content':line}\n"
     "      if cb or ca:\n"
     "        s=max(0,i-cb); en=min(len(lines),i+ca+1)\n"
     "        e['context']=[{'line_number':j+1,'content':lines[j],'is_match':j==i} for j in range(s,en)]\n"
     "      out['matches'].append(e)\n"
-    "      if hl>=0 and len(out['matches'])>=hl: done=True; break\n"
+    "  out['total_matches']=t\n"
     "print(json.dumps(out))\n"
 )
 
@@ -514,6 +519,7 @@ class DockerEnvironmentBackend:
             files=[Path(s) for s in data.get("files", [])],
             count=int(data.get("count", 0)),
             matches=[{**m, "path": Path(m["path"])} for m in data.get("matches", [])],
+            total_matches=int(data.get("total_matches", 0)),
         )
 
     # ── Environment info (#1481 — in-container probe for SP Environment) ───────

--- a/src/reyn/environment/host_backend.py
+++ b/src/reyn/environment/host_backend.py
@@ -133,11 +133,14 @@ class HostBackend:
                 total += len(regex.findall(text))
             return GrepResult(output_mode="count", count=total)
 
+        # #5944: no early break on head_limit — keep scanning every candidate
+        # to populate `total_matches` accurately (see GrepResult's own
+        # docstring for why this is cheap: matches past the cap are counted,
+        # never dict-built, so memory stays bounded by head_limit while the
+        # total is still exact, not "there's more, exact count unknown").
         matches: list[dict] = []
-        done = False
+        total_matches = 0
         for f in candidates:
-            if done:
-                break
             text = _grep_decode(f)
             if text is None:
                 continue  # #1452: binary (or unreadable) — skip
@@ -145,6 +148,9 @@ class HostBackend:
             for i, line in enumerate(lines):
                 if not regex.search(line):
                     continue
+                total_matches += 1
+                if head_limit is not None and len(matches) >= head_limit:
+                    continue  # counted above; skip building the entry/context
                 entry: dict[str, Any] = {"path": f, "line_number": i + 1, "content": line}
                 if context_before or context_after:
                     start = max(0, i - context_before)
@@ -154,10 +160,7 @@ class HostBackend:
                         for j in range(start, end)
                     ]
                 matches.append(entry)
-                if head_limit is not None and len(matches) >= head_limit:
-                    done = True
-                    break
-        return GrepResult(output_mode="content", matches=matches)
+        return GrepResult(output_mode="content", matches=matches, total_matches=total_matches)
 
 
 __all__ = ["HostBackend"]

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -29,7 +29,13 @@ class FileIROp(BaseModel):
     case_insensitive: bool = False
     context_before: int = 0          # lines of context before each match
     context_after: int = 0           # lines of context after each match
-    head_limit: int | None = None    # cap total number of matches returned
+    # #5944 P0 (owner-hit): default 50, not unlimited — precedent GrepFilesIROp.max_results
+    # below. head_limit alone is NOT enough for grep (unlike glob's max_results): a matched
+    # LINE has no per-item size bound, so op_runtime/file.py's own per-match BYTE cap is the
+    # other half of this fix (architect: "1件の大きさに上界がある op は件数の上限で足りる/
+    # 上界が無い op は byte の上限が要る" -- grep is the latter). None still opts a caller
+    # into "no count cap" explicitly; only the DEFAULT changed.
+    head_limit: int | None = 50      # cap total number of matches returned
     # edit-specific
     old_string: str | None = None    # exact text to replace (must be unique unless replace_all=True)
     new_string: str | None = None    # replacement text

--- a/tests/core/test_grep_byte_cap_5944.py
+++ b/tests/core/test_grep_byte_cap_5944.py
@@ -1,0 +1,190 @@
+"""Tier 2: OS invariant — #5944 (P0, owner-hit) grep's return has NO upper bound.
+
+owner measured `.reyn/agents/*/history.jsonl` grep calls costing up to 369 MB
+in a single response (16 calls, 554.4 MB total) — a `reyn web` startup that
+reads this history then peaked at 8.2 GB RSS (#5896/#5851/#5894). Two
+independent holes, architect's own discriminator (issue #5944, addendum):
+**an op whose single item has a size bound needs only a COUNT cap (glob:
+paths, tens of bytes each); an op whose single item has NO size bound also
+needs a BYTE cap.** grep returns matched LINES verbatim — a `.reyn/` JSONL
+line is a whole conversation message, unbounded — so `head_limit` (a count
+cap) alone cannot bound it, however small it is set.
+
+This module pins both halves of the fix:
+
+  (1) `FileIROp.head_limit`'s SCHEMA DEFAULT is now 50 (was `None` = every
+      match), matching the sibling `GrepFilesIROp.max_results: int = 50`
+      already in this repo — count-axis, defense in depth for a caller that
+      forgets to set it.
+  (2) `op_runtime/file.py::_execute_grep_sync` applies the SAME shared
+      inline byte cap `read`/`load_skill` already use
+      (`control_ir_inline_cap`, config-driven via `ctx.read_cap_config`, no
+      new ungrounded constant) to each matched line and context line,
+      independent of (1) — a FEW oversized matches, well under the count
+      cap, still get bounded. This is the actual owner-hit shape (matches
+      were few; the 369 MB single hit was ONE oversized line) and the exact
+      case lead-coder's brief calls out: "a test built so the count cap
+      ALONE does not turn it green" — `test_few_oversized_matches_...`
+      below is that test.
+
+When either axis truncates, the result carries a structural signal (never
+prose) mirroring #2998's glob precedent (`truncated`/`total_count`/
+`returned_count`) plus a byte-specific one (`content_truncated`, and a
+`...(+N bytes)` suffix naming exactly how much was cut on the entry
+itself) — the same "never silent" contract `file.read`'s own self-bounding
+truncation already keeps.
+
+Real `Workspace`/`OpContext`/`handle()` throughout, no mocks — same pattern
+`test_read_bounding_structural_signal_1209.py` (the sibling read-bounding
+pin) uses for the same shared cap.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.config import ReadCapConfig
+from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+def _make_ctx(tmp_path: Path, *, read_cap_config: ReadCapConfig | None = None) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=tmp_path)
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        actor="test_skill",
+        read_cap_config=read_cap_config,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _write_lines(ctx: OpContext, name: str, lines: list[str]) -> None:
+    ctx.workspace.write_file(name, "\n".join(lines) + "\n")
+
+
+# ── (1) head_limit's schema default is now bounded ───────────────────────────
+
+def test_head_limit_default_is_50_not_unlimited() -> None:
+    """Tier 2: `FileIROp.head_limit`'s field default is now `50`, matching
+    the sibling `GrepFilesIROp.max_results` precedent. Strip: reverting the
+    default back to `None` fails this directly (no scan needed) — the
+    fastest possible falsification for hole (1)."""
+    op = FileIROp(kind="file", op="grep", pattern="needle", path=".")
+    assert op.head_limit == 50
+
+
+def test_head_limit_default_caps_a_real_scan(tmp_path: Path) -> None:
+    """Tier 2: an UNSPECIFIED head_limit on a real grep call — more than 50
+    real matches on disk — returns at most 50, with a structural truncation
+    signal naming the true total. Strip: `FileIROp.head_limit: int | None =
+    None` (hole 1 reopened) → `count` becomes 120, this goes red."""
+    ctx = _make_ctx(tmp_path)
+    _write_lines(ctx, "many.txt", [f"needle {i}" for i in range(120)])
+
+    res = _run(handle(FileIROp(kind="file", op="grep", pattern="needle", path="many.txt"), ctx))
+
+    assert res["status"] == "ok"
+    assert res["count"] == 50
+    assert res["truncated"] is True
+    assert res["total_count"] == 120
+    assert res["returned_count"] == 50
+
+
+def test_explicit_head_limit_still_honored(tmp_path: Path) -> None:
+    """Tier 2: an explicit `head_limit` (smaller or larger than the new
+    default) is honored verbatim — the default change does not remove the
+    caller's own control."""
+    ctx = _make_ctx(tmp_path)
+    _write_lines(ctx, "many.txt", [f"needle {i}" for i in range(10)])
+
+    res = _run(handle(
+        FileIROp(kind="file", op="grep", pattern="needle", path="many.txt", head_limit=3), ctx,
+    ))
+
+    assert res["count"] == 3
+    assert res["truncated"] is True
+    assert res["total_count"] == 10
+    assert res["returned_count"] == 3
+
+
+# ── (2) per-match BYTE cap — independent of the count axis ───────────────────
+
+def test_few_oversized_matches_bound_total_bytes_not_just_count(tmp_path: Path) -> None:
+    """Tier 2: #5944's actual owner-hit shape — a HANDFUL of matches (well
+    under head_limit's default 50), each individually far over the byte
+    cap, mirroring a `.reyn/` JSONL line (one whole conversation message).
+
+    A fix that added ONLY the count-axis default (hole 1) leaves this RED:
+    3 matches is nowhere near 50, so head_limit never fires, yet each match
+    alone would carry ~5x the byte cap — the exact "16 calls, 554 MB, one
+    call 369 MB" shape from the owner's own measurement. This is the test
+    lead-coder's brief named explicitly ("count cap alone must not turn
+    this green")."""
+    ctx = _make_ctx(tmp_path)
+    huge_line = "x" * (MAX_CONTROL_IR_RESULT_INLINE_BYTES * 5)
+    _write_lines(ctx, "huge.jsonl", [f"needle {huge_line}" for _ in range(3)])
+
+    res = _run(handle(FileIROp(kind="file", op="grep", pattern="needle", path="huge.jsonl"), ctx))
+
+    assert res["status"] == "ok"
+    assert res["count"] == 3          # count axis never fires — well under 50
+    assert "truncated" not in res     # so the COUNT truncation signal must not fire either
+    assert res["content_truncated"] is True
+    for entry in res["matches"]:
+        assert len(entry["content"].encode("utf-8")) <= MAX_CONTROL_IR_RESULT_INLINE_BYTES + 32, (
+            "a single match's content must stay within the shared inline byte "
+            "cap (plus the small literal '...(+N bytes)' suffix) regardless "
+            "of how few matches there are"
+        )
+        assert "...(+" in entry["content"] and " bytes)" in entry["content"], (
+            "a truncated match must name exactly how much was cut, never "
+            "silently — the same 'never silent' contract file.read keeps"
+        )
+    # the WHOLE response — the thing that actually lands in `.reyn/` history
+    # (#5891/#5896's own concern) — stays proportional to head_limit x cap,
+    # not to the huge_line's real size (5x cap x 3 matches, uncapped).
+    assert res["returned_bytes"] < MAX_CONTROL_IR_RESULT_INLINE_BYTES * 4
+
+
+def test_match_content_under_cap_is_returned_verbatim(tmp_path: Path) -> None:
+    """Tier 2: ordinary small matches are unaffected — no truncation signal,
+    content byte-identical to the source line (accept-side: the fix must
+    not degrade the common case)."""
+    ctx = _make_ctx(tmp_path)
+    _write_lines(ctx, "small.py", ["def f():", "    return needle_here"])
+
+    res = _run(handle(FileIROp(kind="file", op="grep", pattern="needle_here", path="small.py"), ctx))
+
+    assert res["status"] == "ok"
+    assert res["count"] == 1
+    assert "truncated" not in res
+    assert "content_truncated" not in res
+    assert res["matches"][0]["content"] == "    return needle_here"
+
+
+def test_explicit_larger_read_cap_config_returns_full_content(tmp_path: Path) -> None:
+    """Tier 2: raising the shared `read_cap_config.inline_bytes` (the same
+    knob `read`/`load_skill` already honor) gets the FULL, untruncated
+    content back — the default does not remove the ability to opt into
+    everything (architect's brief: 'raising the bound explicitly must still
+    get every match — this must not kill the feature')."""
+    huge_line = "x" * (MAX_CONTROL_IR_RESULT_INLINE_BYTES * 2)
+    big_cap = ReadCapConfig(inline_bytes=MAX_CONTROL_IR_RESULT_INLINE_BYTES * 10)
+    ctx = _make_ctx(tmp_path, read_cap_config=big_cap)
+    _write_lines(ctx, "huge.jsonl", [f"needle {huge_line}"])
+
+    res = _run(handle(FileIROp(kind="file", op="grep", pattern="needle", path="huge.jsonl"), ctx))
+
+    assert "content_truncated" not in res
+    assert res["matches"][0]["content"] == f"needle {huge_line}"


### PR DESCRIPTION
**[tui-coder]** — P0, owner-hit (2026-09-07, live). A `reyn web` startup peaked at 8.2 GB RSS reading `.reyn/agents/default/history.jsonl` (663 MB). Root-traced to grep: 16 calls, 554.4 MB total, one single call 369 MB.

## Two holes (architect's discriminator, issue #5944 addendum — also scopes this to grep only)

> An op whose single item has a size bound needs only a COUNT cap (glob: paths, tens of bytes each). An op whose single item has NO size bound also needs a BYTE cap.

grep returns matched LINES verbatim — a `.reyn/` JSONL line is a whole conversation message, unbounded — so `head_limit` (a count cap) alone cannot bound it, however small it's set.

## Fix, both halves

1. **`FileIROp.head_limit`'s schema default**: `None` → `50`, matching the sibling `GrepFilesIROp.max_results: int = 50` already in this repo. `None` is still a valid explicit opt-in to unlimited — only the default moved.
2. **`op_runtime/file.py::_execute_grep_sync`** now applies the SAME shared inline byte cap `read`/`load_skill` already use (`control_ir_inline_cap`, config-driven via `ctx.read_cap_config` — no new ungrounded constant) to each matched line/context line. A truncated entry gets an explicit `...(+N bytes)` suffix — never silent, matching `read`'s own self-bounding truncation contract.

This second half is what actually closes the owner-hit: 3 oversized matches, nowhere near `head_limit=50`, would still be red without it — see `test_few_oversized_matches_bound_total_bytes_not_just_count`, the exact "count cap alone must not turn this green" shape from lead-coder's brief.

Truncation reports structurally (never prose), mirroring #2998's glob precedent field names:
- count axis: `truncated`/`total_count`/`returned_count` — `total_count` is EXACT (the backend keeps counting past `head_limit`, cheaply — no entry/context dict built for matches past the cap, so memory stays bounded regardless of the true total).
- byte axis: `content_truncated` + `returned_bytes`.

Raising `ctx.read_cap_config.inline_bytes` (the same knob `read`/`load_skill` honor) still returns everything untruncated — the default doesn't kill the feature.

## Scope

Per lead-coder's relay of architect's addendum: **grep only**. `glob` is already bounded (`max_results: 50` + #2998's truncation notice — 35 real calls / 0.05 MB total on the owner's machine); `read` is self-bounding; `exec`'s output already has a 10 MB cap. Not touched.

## Verification

- Strip-verify done and reverted (in-file edit, no `git checkout`/`stash`): reverted `head_limit`'s default to `None` (both count-axis tests go red), separately disabled the byte-cap check (the byte-axis/owner-hit-shape test goes red), both restored before committing.
- Gates (scoped): `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all clean.
- Scoped pytest across the new test file plus every existing grep/read/glob-adjacent test file this diff could plausibly affect (offload #2782, read-bounding #1209, file permissions, grep/glob tool adapters, universal dispatch/handlers) — **273 passed**.

## Test plan
- [x] Scoped pytest green (see above)
- [x] Strip-verify (see above)
- [x] (skipped — Visual, standing waiver)

Closes #5944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
