### PR TITLE
fix(#5058 P1): a core-dependency importorskip is a silent-skip broken install -- close the class, not the instances

### DIFF
--- a/.github/workflows/no-core-dep-importorskip-gate.yml
+++ b/.github/workflows/no-core-dep-importorskip-gate.yml
@@ -1,0 +1,51 @@
+name: no-core-dep-importorskip gate
+
+# #5058: reject any pytest.importorskip(...)/importorskip(...) call whose
+# checked package names a pyproject.toml [project].dependencies (core)
+# entry -- a core dependency's absence is a broken install, not a normal
+# missing-extra path, so the correct behaviour is a loud collection
+# failure, not a silent skip (CLAUDE.md's six-questions Q4). 17
+# fastapi/starlette/uvicorn/websockets files (#5051) and 12 mcp files were
+# found and fixed by hand across this issue's own thread -- this gate
+# closes the CLASS so a future core-dep importorskip (a new file, or a
+# reintroduced one) is caught automatically, without a human census.
+#
+# Two independent triggers: tests/** (a new/changed importorskip call) and
+# pyproject.toml (a dependency moving from optional to core makes an
+# EXISTING, previously-correct importorskip newly wrong -- the exact shape
+# #5051/#5058's own history is). See
+# scripts/check_no_core_dep_importorskip.py's module docstring for the
+# full design (the classifier, the name-mismatch manifest, and why it is
+# AST-based rather than a text/regex scan).
+#
+# No diff/base-ref needed -- a whole-tree scan against a baseline of zero,
+# same shape as bare-tests-import-reference-gate.yml. A shallow checkout
+# is enough.
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  no-core-dep-importorskip:
+    name: no-core-dep-importorskip gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_no_core_dep_importorskip.py is stdlib-only (ast /
+      # tomllib / pathlib / sys). No pip install needed.
+      - name: Check no importorskip() names a core dependency
+        run: |
+          python scripts/check_no_core_dep_importorskip.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ checkout. A green scoped `pytest` is **not** a green CI run.
 Path-conditional gates:
 
 - `docs/` → `mkdocs build --strict -f .mkdocs/mkdocs.yml && python scripts/check_doc_anchors.py && python scripts/check_retired_config_keys_denylist.py`, in that order (anchors needs the built `site/`).
-- `tests/` → `python scripts/check_bare_tests_import_reference.py`, `python scripts/check_file_depth_reference.py`, and `python scripts/check_subprocess_reyn_pin.py`.
+- `tests/` → `python scripts/check_bare_tests_import_reference.py`, `python scripts/check_file_depth_reference.py`, `python scripts/check_subprocess_reyn_pin.py`, and `python scripts/check_no_core_dep_importorskip.py` (#5058 — an `importorskip` naming a `pyproject.toml` core dependency).
 - `CLAUDE.md` / `**/CLAUDE.md` → `python scripts/claude_md_word_count_ratchet.py` (#4872: word count is a ratchet, not a report — raising it needs `--write-baseline` committed in the same PR).
 
 1. **Finish your own Test plan before merge.** Tick every Manual/Visual item or replace with `- [x] (skipped — <reason>)`. **Never tick a check that did not happen.** **Standing waiver, Visual items only** (owner 2026-08-08): merge with the Visual box unchecked — do not fabricate it.

--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -113,6 +113,22 @@ whose root, resolved from the file's OWN current location, escapes
 static, add-time proxy for "this path expression won't survive a
 future move," not a check that anything has actually moved yet.
 
+**Also run `python scripts/check_no_core_dep_importorskip.py`** (#5058)
+— a third dedicated, path-filtered workflow (triggered on `tests/**`
+*and* `pyproject.toml`, an AST whole-tree scan against a baseline of
+zero, not part of `test.yml`). Rejects `pytest.importorskip(...)` /
+bare `importorskip(...)` naming a `pyproject.toml` `[project].
+dependencies` (core) package — its absence is a broken install, not a
+normal missing-extra path, so the correct behaviour is a loud
+collection failure, not a silent skip. The core/non-core classifier is
+declaration-derived (`pyproject.toml`'s own dependency list), never
+read off the test file itself, via an explicit, exhaustive distribution-
+name→import-name manifest (the gate fails loud, distinctly, if a new
+core dependency has no manifest entry — the `pillow`→`PIL` /
+`pyyaml`→`yaml` mismatch class must be a deliberate decision, not a
+silent miss). An `importorskip` naming an OPTIONAL extra stays green —
+only core-dependency names are in scope.
+
 A green scoped `pytest` alone is
 **not** a green CI run (`pytest-green ≠ CI-green`): ruff `I001` import-sort
 and a Tier-4 format pin (`len(...) == N`) both fail CI while `pytest`

--- a/scripts/check_no_core_dep_importorskip.py
+++ b/scripts/check_no_core_dep_importorskip.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""#5058 — a ``pytest.importorskip`` naming a CORE dependency turns a broken
+install into a silent skip (CLAUDE.md's six-questions Q4: "would it stay
+green having never run?"). ``importorskip`` means "this dependency is
+optional, skip if absent" — that declaration is correct for an ``extra``,
+wrong for anything in ``pyproject.toml``'s ``[project].dependencies``: its
+absence there is not a normal configuration, it is a broken install, and
+the correct behaviour is a loud collection failure, not a green skip.
+
+17 ``fastapi``/``starlette``/``uvicorn``/``websockets`` files (#5051) and 12
+``mcp`` files were found and fixed by hand across this issue's own thread —
+the class, not the instances, is what this gate closes: a FUTURE core-dep
+``importorskip`` (a new file, or one reintroduced by a revert) must be
+caught here, not found again by a human census.
+
+## The classifier: declaration-derived, not test-file-derived
+
+(architect's ruling, #5058) the judgment "is this dependency core" comes
+from ONE source — ``pyproject.toml``'s own ``[project].dependencies`` — never
+from anything the test file itself says (a test's own ``reason=`` string is
+not evidence; #5058's own thread found one that was already stale/false).
+
+## The name-mismatch trap (architect, #5058) — and how this gate stays honest
+
+A distribution name is not always its import name (``pillow`` imports as
+``PIL``; ``pyyaml`` imports as ``yaml``). A NAIVE derivation (lowercase +
+hyphen-to-underscore) would silently miss those two today, and would
+silently miss whatever the NEXT mismatch is when a new core dependency
+is declared. So this gate does not derive an import name — it looks one
+up in :data:`IMPORT_NAME_MANIFEST`, an EXPLICIT, exhaustive table (every
+current core dependency has an entry, not just the mismatched ones), and
+FAILS LOUD (a distinct failure mode from the usual scan, see ``main()``)
+if ``pyproject.toml`` ever names a core dependency this table does not
+cover — "increased -> decide", never "increased -> silently pass" (the
+same shape #5944's byte-cap alias table would have needed had grep's
+match targets ever needed one). Scope explicitly declared: this manifest
+covers each dependency's PRIMARY import name(s) only — a package that
+exposes read-only compatibility shims under other top-level names is out
+of this gate's reach unless added here.
+
+## What counts as "using" a name (AST, not text)
+
+A real ``ast.Call`` node whose function is ``pytest.importorskip`` (the
+overwhelmingly common shape in this repo) or a bare ``importorskip`` (the
+shape after ``from pytest import importorskip``), with the checked
+package name as its first positional string-literal argument. This is
+deliberately NOT a text/regex scan: #5058's own manual census had to
+hand-filter prose/docstring hits that merely NAME the pattern (this very
+module's sibling, ``tests/interfaces/test_5051_web_core_deps_import.py``,
+says ``pytest.importorskip("fastapi", ...)`` in its OWN docstring, never
+calls it) — ``ast.walk`` only ever sees real calls, so that class of false
+positive cannot occur here by construction.
+
+## Scope: only ``tests/`` (extras stay green)
+
+An ``importorskip`` naming an OPTIONAL extra (``watchdog``, ``linebot.v3``,
+``slack_bolt``, ...) is the CORRECT use of the mechanism and must keep
+passing — this gate's only job is the core/non-core distinction, so a
+package name that resolves to no manifest entry (because it names
+something outside ``[project].dependencies`` entirely — an extra, a dev
+tool, a test-only package) is silently fine, by construction: it is
+never even checked against the manifest-completeness failure mode, which
+only walks ``pyproject.toml``'s own core list.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+_PYPROJECT = _ROOT / "pyproject.toml"
+
+# Every CURRENT `[project].dependencies` entry's distribution name (lowercased,
+# as extracted by `core_dependency_names`) -> its acceptable top-level import
+# name(s). Exhaustive by design (see module docstring) -- `main()` fails loud
+# if `pyproject.toml` names a core dependency missing from this table, rather
+# than silently treating an unlisted-but-actually-core package as non-core.
+IMPORT_NAME_MANIFEST: dict[str, frozenset[str]] = {
+    "litellm": frozenset({"litellm"}),
+    "pydantic": frozenset({"pydantic"}),
+    "jsonschema": frozenset({"jsonschema"}),
+    "setproctitle": frozenset({"setproctitle"}),
+    "pyyaml": frozenset({"yaml"}),  # the mismatch architect named
+    "prompt_toolkit": frozenset({"prompt_toolkit"}),
+    "ddgs": frozenset({"ddgs"}),
+    "rich": frozenset({"rich"}),
+    "textual": frozenset({"textual"}),
+    "textual-flowview": frozenset({"textual_flowview"}),
+    "numpy": frozenset({"numpy"}),
+    "croniter": frozenset({"croniter"}),
+    "charset-normalizer": frozenset({"charset_normalizer"}),
+    "mcp": frozenset({"mcp"}),
+    "anyio": frozenset({"anyio"}),
+    "httpx": frozenset({"httpx"}),
+    "cryptography": frozenset({"cryptography"}),
+    "pyperclip": frozenset({"pyperclip"}),
+    "pillow": frozenset({"PIL"}),  # the other mismatch architect named
+    "fastapi": frozenset({"fastapi"}),
+    "starlette": frozenset({"starlette"}),
+    "uvicorn": frozenset({"uvicorn"}),
+    "websockets": frozenset({"websockets"}),
+}
+
+# A PEP 508 requirement string's name ends at the first of: an extras
+# bracket, a version/marker operator, an environment-marker `;`, or a
+# direct-URL `@` (`"textual-flowview @ git+https://...")`) -- whichever
+# comes first, or whitespace before any of those.
+_NAME_BOUNDARY = re.compile(r"[\[<>=~! @;]")
+
+
+def core_dependency_names(pyproject_path: Path = _PYPROJECT) -> "list[str]":
+    """Every ``[project].dependencies`` entry's distribution name, lowercased
+    -- the SINGLE source of truth this gate's classifier reads (architect's
+    ruling: never derive "is this core" from a test file)."""
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+    raw = data.get("project", {}).get("dependencies", [])
+    return [_NAME_BOUNDARY.split(entry, 1)[0].lower() for entry in raw]
+
+
+def manifest_gaps(core_deps: "list[str]") -> "list[str]":
+    """Core dependency names ``IMPORT_NAME_MANIFEST`` has no entry for --
+    non-empty means the manifest is stale (a new core dependency was
+    declared and nobody added its import name here). This is a DIFFERENT
+    failure from the usual scan: it means the gate cannot currently judge
+    every core dependency, not that a violation was found."""
+    return [name for name in core_deps if name not in IMPORT_NAME_MANIFEST]
+
+
+def core_import_names(core_deps: "list[str]") -> "set[str]":
+    """The set of top-level import names that name a CURRENT core
+    dependency, per the manifest. Callers should check :func:`manifest_gaps`
+    first -- a name missing from the manifest is silently absent here too,
+    which is exactly the failure mode ``main()`` treats separately."""
+    names: set[str] = set()
+    for dep in core_deps:
+        names |= IMPORT_NAME_MANIFEST.get(dep, frozenset())
+    return names
+
+
+def _importorskip_calls(path: Path) -> "list[tuple[int, str]]":
+    """``(lineno, checked_name)`` for every REAL ``pytest.importorskip(...)``
+    / bare ``importorskip(...)`` call in *path* whose first positional
+    argument is a string literal -- an ``ast.Call`` node, never a text/regex
+    match, so a docstring or comment merely naming the pattern (this repo
+    has one, see module docstring) cannot appear here."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return []
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_importorskip = (
+            (isinstance(func, ast.Attribute) and func.attr == "importorskip")
+            or (isinstance(func, ast.Name) and func.id == "importorskip")
+        )
+        if not is_importorskip or not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            hits.append((node.lineno, first.value))
+    return hits
+
+
+def offending_calls(
+    tests_dir: Path = _TESTS_DIR, pyproject_path: Path = _PYPROJECT
+) -> "list[tuple[Path, int, str]]":
+    """``(file, lineno, argument)`` for every ``importorskip`` call whose
+    checked package's TOP-LEVEL name (``"mcp.server"`` -> ``"mcp"``) is a
+    core dependency's import name. Isolated from CLI/printing so it is
+    directly testable (mirrors ``check_bare_tests_import_reference.py``'s
+    own ``offending_files`` split)."""
+    core_names = core_import_names(core_dependency_names(pyproject_path))
+    offenders: list[tuple[Path, int, str]] = []
+    for path in sorted(tests_dir.rglob("*.py")):
+        for lineno, arg in _importorskip_calls(path):
+            top = arg.split(".", 1)[0]
+            if top in core_names:
+                offenders.append((path, lineno, arg))
+    return offenders
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options -- a whole-tree scan against a baseline of zero
+
+    core_deps = core_dependency_names(_PYPROJECT)
+    gaps = manifest_gaps(core_deps)
+    if gaps:
+        print(
+            "no-core-dep-importorskip gate FAILED (manifest incomplete):\n",
+            file=sys.stderr,
+        )
+        print(
+            f"pyproject.toml declares {len(gaps)} core dependenc"
+            f"{'y' if len(gaps) == 1 else 'ies'} with no entry in this "
+            "script's IMPORT_NAME_MANIFEST -- the gate cannot judge "
+            "importorskip calls against a dependency it cannot map to an "
+            "import name:",
+            file=sys.stderr,
+        )
+        for name in gaps:
+            print(f"  {name!r}", file=sys.stderr)
+        print(
+            "\nAdd each one to IMPORT_NAME_MANIFEST in "
+            "scripts/check_no_core_dep_importorskip.py (its top-level "
+            "import name -- check whether it differs from the "
+            "distribution name, e.g. pillow -> PIL) before this gate can "
+            "run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    offenders = offending_calls(_TESTS_DIR, _PYPROJECT)
+    if not offenders:
+        print("OK: no importorskip() names a core dependency.")
+        return 0
+
+    print("no-core-dep-importorskip gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} importorskip() call(s) name a CORE dependency "
+        "(pyproject.toml [project].dependencies) -- its absence is a "
+        "broken install, not a normal missing-extra path, so the correct "
+        "behavior is a loud collection failure, not a silent skip (#5058):",
+        file=sys.stderr,
+    )
+    for path, lineno, arg in offenders:
+        rel = path.relative_to(_ROOT)
+        print(f"  {rel}:{lineno}: importorskip({arg!r}, ...)", file=sys.stderr)
+
+    print(
+        "\nRemove the guard (a plain `import` at module/function scope is "
+        "the correct replacement -- a missing core dependency should now "
+        "raise ModuleNotFoundError and fail collection loudly). An "
+        "OPTIONAL extra's importorskip is unaffected by this gate -- only "
+        "names in pyproject.toml's core dependencies are flagged.\n"
+        "\nThis gate's own starting population is zero (#5058's own "
+        "cleanup), so any hit here is a new regression, not inherited debt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/claude_md_word_count_baseline.json
+++ b/scripts/claude_md_word_count_baseline.json
@@ -1,5 +1,5 @@
 {
-  "CLAUDE.md": 2621,
+  "CLAUDE.md": 2628,
   "src/reyn/core/events/CLAUDE.md": 74,
   "src/reyn/interfaces/CLAUDE.md": 396,
   "src/reyn/mcp/CLAUDE.md": 22,

--- a/tests/scripts/test_check_no_core_dep_importorskip_5058.py
+++ b/tests/scripts/test_check_no_core_dep_importorskip_5058.py
@@ -1,0 +1,220 @@
+"""Tier 2: #5058 — the core-dependency ``importorskip`` gate.
+
+``pytest.importorskip("x")`` declares "x is optional, skip if absent" —
+correct for an ``extra``, wrong for a ``pyproject.toml`` ``[project].
+dependencies`` entry: a broken install there should fail collection
+loudly, not skip green (CLAUDE.md's six-questions Q4). 17
+``fastapi``/``starlette``/``uvicorn``/``websockets`` files (#5051) and 12
+``mcp`` files were found and fixed by hand across this issue's own
+thread — this gate closes the CLASS so a future core-dep
+``importorskip`` (a new file, or a reintroduced one) is caught
+automatically.
+
+Real filesystem fixtures throughout (a real ``tmp_path`` tree of ``.py``
+files and a real synthetic ``pyproject.toml``) — the functions under
+test read real file content and parse a real TOML document, so faking
+either would test nothing real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_no_core_dep_importorskip import (
+    _ROOT,
+    _TESTS_DIR,
+    IMPORT_NAME_MANIFEST,
+    core_dependency_names,
+    core_import_names,
+    manifest_gaps,
+    offending_calls,
+)
+
+_SYNTHETIC_PYPROJECT = """\
+[project]
+name = "synthetic"
+dependencies = [
+    "reallycore>=1.0",
+    "pillow>=11.0",
+    "uvicorn[standard]>=0.27",
+    "textual-flowview @ git+https://example.invalid/x.git@deadbeef",
+]
+"""
+
+# A pyproject.toml naming a REAL, already-IMPORT_NAME_MANIFEST-covered core
+# dependency ("mcp") -- used by the actual gate (offending_calls) tests below,
+# which need a name the manifest already maps, unlike _SYNTHETIC_PYPROJECT's
+# "reallycore" (deliberately unmapped, for the name-extraction/gap tests
+# above).
+_SYNTHETIC_PYPROJECT_WITH_MCP = '[project]\ndependencies = ["mcp>=2.0"]\n'
+
+
+def _write_pyproject(tmp_path: Path, content: str = _SYNTHETIC_PYPROJECT) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ── core_dependency_names: the single source of truth, parsed not guessed ──
+
+
+def test_core_dependency_names_strips_extras_versions_and_direct_urls(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the PEP 508 shapes actually present in reyn's own
+    pyproject.toml today — a version specifier, an ``[extras]`` bracket
+    (``uvicorn[standard]``), and a direct ``@ git+`` URL
+    (``textual-flowview``) — all resolve to their bare distribution name,
+    never a hardcoded list."""
+    names = core_dependency_names(_write_pyproject(tmp_path))
+    assert names == ["reallycore", "pillow", "uvicorn", "textual-flowview"]
+
+
+# ── manifest completeness — the "increased -> decide" requirement ──────────
+
+
+def test_manifest_has_no_gaps_for_the_real_repo() -> None:
+    """Tier 2: the REAL repo's pyproject.toml — every current core
+    dependency has an IMPORT_NAME_MANIFEST entry. A gap here means a NEW
+    core dependency was declared and this manifest was not updated —
+    architect's "increased -> decide" requirement, checked against the
+    live tree, not assumed."""
+    real_deps = core_dependency_names(_ROOT / "pyproject.toml")
+    gaps = manifest_gaps(real_deps)
+    assert gaps == [], (
+        f"pyproject.toml declares core dependency name(s) "
+        f"{gaps} with no IMPORT_NAME_MANIFEST entry in "
+        "scripts/check_no_core_dep_importorskip.py -- add its import "
+        "name(s) there"
+    )
+
+
+def test_a_core_dep_missing_from_the_manifest_is_a_distinct_failure(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a synthetic pyproject.toml naming a dependency the manifest
+    has never heard of is reported as a GAP, not silently treated as
+    non-core (which would let a future mismatched name — the next
+    ``pillow``/``PIL`` — pass this gate unnoticed)."""
+    pyproject = _write_pyproject(
+        tmp_path, '[project]\ndependencies = ["totally-unmapped-package>=1.0"]\n'
+    )
+    assert "totally-unmapped-package" not in IMPORT_NAME_MANIFEST
+    gaps = manifest_gaps(core_dependency_names(pyproject))
+    assert gaps == ["totally-unmapped-package"]
+
+
+# ── the name-mismatch trap architect named ──────────────────────────────────
+
+
+def test_name_mismatch_is_caught_via_the_manifest_not_naive_derivation(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``pillow`` (distribution name) imports as ``PIL`` — a naive
+    lowercase-hyphen-to-underscore derivation would produce ``pillow``,
+    missing an actual ``importorskip("PIL")`` entirely. The manifest's
+    explicit entry is what makes this catchable."""
+    pyproject = _write_pyproject(tmp_path)
+    names = core_import_names(core_dependency_names(pyproject))
+    assert "PIL" in names
+    assert "pillow" not in names  # the WRONG (naive) derivation must not appear
+
+
+# ── the actual gate: importorskip naming a core dependency ─────────────────
+
+
+def _make_tests_tree(tmp_path: Path, filename: str, body: str) -> Path:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / filename).write_text(body, encoding="utf-8")
+    return tests_dir
+
+
+def test_a_core_dep_importorskip_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: THE strip witness (#5058's own acceptance criterion) — a
+    file added to the tests tree with ``pytest.importorskip("mcp", ...)``
+    (a REAL, manifest-covered core dependency) is flagged."""
+    pyproject = _write_pyproject(tmp_path, _SYNTHETIC_PYPROJECT_WITH_MCP)
+    tests_dir = _make_tests_tree(
+        tmp_path, "test_a.py",
+        'import pytest\npytest.importorskip("mcp", reason="x")\n',
+    )
+    offenders = offending_calls(tests_dir, pyproject)
+    assert offenders == [(tests_dir / "test_a.py", 2, "mcp")]
+
+
+def test_a_core_dep_importorskip_via_dotted_submodule_is_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``importorskip("mcp.sub")`` names a SUBMODULE of a core
+    dependency — flagged via its top-level component, the same
+    ``"mcp.server"`` -> ``"mcp"`` shape architect's own real-world census
+    found (#5058 thread, comment 8)."""
+    pyproject = _write_pyproject(tmp_path, _SYNTHETIC_PYPROJECT_WITH_MCP)
+    tests_dir = _make_tests_tree(
+        tmp_path, "test_a.py",
+        'import pytest\npytest.importorskip("mcp.sub")\n',
+    )
+    offenders = offending_calls(tests_dir, pyproject)
+    assert offenders == [(tests_dir / "test_a.py", 2, "mcp.sub")]
+
+
+def test_bare_importorskip_after_from_pytest_import_is_also_flagged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: ``from pytest import importorskip; importorskip("x")`` — a
+    bare ``Name`` call, not an ``Attribute`` one — is the same mechanism
+    under a different import shape and must be caught the same way."""
+    pyproject = _write_pyproject(tmp_path, _SYNTHETIC_PYPROJECT_WITH_MCP)
+    tests_dir = _make_tests_tree(
+        tmp_path, "test_a.py",
+        "from pytest import importorskip\nimportorskip('mcp')\n",
+    )
+    offenders = offending_calls(tests_dir, pyproject)
+    assert offenders == [(tests_dir / "test_a.py", 2, "mcp")]
+
+
+def test_an_optional_extra_importorskip_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: ACCEPT SIDE (lead-coder's explicit requirement) — a package
+    NOT in pyproject.toml's core dependencies (an optional extra, a dev
+    tool, anything else) keeps using ``importorskip`` correctly and must
+    stay green under this gate."""
+    pyproject = _write_pyproject(tmp_path)
+    tests_dir = _make_tests_tree(
+        tmp_path, "test_a.py",
+        'import pytest\npytest.importorskip("some_optional_extra", reason="fine")\n',
+    )
+    offenders = offending_calls(tests_dir, pyproject)
+    assert offenders == []
+
+
+def test_a_docstring_mention_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: the actual false-positive class #5058's own manual census
+    had to hand-filter — this repo's real
+    ``tests/interfaces/test_5051_web_core_deps_import.py`` says
+    ``pytest.importorskip("fastapi", ...)`` in its OWN docstring, never
+    calls it. AST-based detection (real ``ast.Call`` nodes only) cannot
+    mistake a string literal for a call, by construction — no regex/text
+    scan involved."""
+    pyproject = _write_pyproject(tmp_path, _SYNTHETIC_PYPROJECT_WITH_MCP)
+    tests_dir = _make_tests_tree(
+        tmp_path, "test_a.py",
+        '"""Some files use ``pytest.importorskip("mcp", ...)``."""\n'
+        "X = 1\n",
+    )
+    offenders = offending_calls(tests_dir, pyproject)
+    assert offenders == []
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population, verified against the
+    real, current tree (not assumed) — mirrors
+    check_bare_tests_import_reference.py's own "run it before shipping
+    it" discipline. #5058's own cleanup (17 fastapi files + 12 mcp files,
+    fixed across this issue's thread) is what makes this zero; any hit
+    here is a NEW regression, not inherited debt."""
+    assert _TESTS_DIR == _ROOT / "tests"
+    offenders = offending_calls(_TESTS_DIR, _ROOT / "pyproject.toml")
+    assert offenders == [], (
+        f"real regression(s) found: {offenders} -- this gate's baseline is "
+        "zero, so any hit here is new, not inherited debt"
+    )


### PR DESCRIPTION
**[tui-coder]** — P1. All 17 `fastapi` files and 12 `mcp` files were already fixed by hand across this issue's own comment thread (`git grep -n "pytest\.importorskip(" origin/main -- tests/` — 0 executable core-dep hits left, only prose mentions remained). What's left is the CLASS: nothing stopped a **future** core-dep `importorskip` from reopening the same silent-skip shape (CLAUDE.md's six-questions Q4).

## Classifier (A/B/C discriminator, per lead-coder's request to record it)

Per architect's ruling: the judgment is **"is this dependency's argument in `pyproject.toml`'s `[project].dependencies`?"** — structural, never read off the test file's own `reason=` string (this issue's own thread found one that was already stale). This PR treats every core-dep `importorskip` the same way (remove-the-guard is the correct fix regardless of A/direct-use vs B/indirect-use vs C/unused — architect's own later ruling on the `mcp` population found the same thing: the fix doesn't depend on which group a hit is in), so this PR is purely the **gate**, not a re-sweep of files (already clean).

## New gate — `scripts/check_no_core_dep_importorskip.py`

- **Declaration-derived**: core/non-core comes from `pyproject.toml` alone, never the test file.
- **Name-mismatch trap** (architect: `pillow`→`PIL`, `pyyaml`→`yaml`): an EXPLICIT, exhaustive `IMPORT_NAME_MANIFEST` — every current core dependency has an entry, not just the mismatched ones — and the gate fails loud, in a distinct failure mode, if `pyproject.toml` ever names a core dependency this table doesn't cover. "Increased → decide", never "increased → silently pass".
- **AST-based**, not text/regex — this issue's own manual census had to hand-filter a docstring that merely NAMES the pattern (`tests/interfaces/test_5051_web_core_deps_import.py`'s own docstring literally contains `pytest.importorskip("fastapi", ...)` and never calls it). Real `ast.Call` nodes only.
- **Optional extras stay green** — accept-side test included (`test_an_optional_extra_importorskip_is_not_flagged`).

Wired the same way this repo's sibling gates already are: a dedicated GitHub Actions workflow (`no-core-dep-importorskip-gate.yml`, triggered on `tests/**` AND `pyproject.toml` — a dependency moving to core makes an EXISTING importorskip newly wrong), a companion `tests/scripts/` pytest file (so CI's normal pytest run also catches a regression), and listed in `CLAUDE.md`'s `tests/` path-conditional gates + a paragraph in `pr-workflow.md`.

## Verification

- Strip-verify done and reverted (in-file edit, no `git checkout`/`stash`): disabled detection (4 tests go red), separately removed the `pillow` manifest entry (2 tests go red for the concrete reason), both restored before committing. Also ran the script standalone against a synthetic file tree outside the repo to confirm the CLI path detects the same regression.
- `CLAUDE.md` word count: 2621 → 2628 (+7) — ratchet baseline updated in this PR, per its own rule for deliberate growth.
- Gates (scoped): `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `claude_md_word_count_ratchet.py`, `mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py` (`docs/` touched), and the new gate against itself — all clean.
- Scoped pytest — **10 passed**.

## Test plan
- [x] Scoped pytest green (see above)
- [x] Strip-verify (see above)
- [x] (skipped — Visual, standing waiver)

Closes #5058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
