### PR TITLE
feat(part of #5896): reyn storage migrate-bodies reports its own start/end footprint

### DIFF
--- a/src/reyn/interfaces/cli/commands/storage.py
+++ b/src/reyn/interfaces/cli/commands/storage.py
@@ -24,6 +24,14 @@ stopped** — this rewrites ``history.jsonl`` on disk; a live session's own
 in-memory ``self.history`` would not see the change and a concurrent
 write from that session could race this command's own read.
 
+Also prints THIS process's own ``phys_footprint``/``rss`` at start and
+end (architect ruling, follow-up to PR #5947 — #5851's own reader,
+``reyn.runtime.process_memory``): pairs this run's own cost against the
+effect the owner's own acceptance criterion measures separately (a
+post-migration STARTUP peak an order of magnitude smaller) — both
+numbers from the SAME run, not two an operator has to correlate by
+hand. Two snapshots only, never a duration.
+
 Named ``storage``, not ``media`` (renamed from the original #4485 name once
 #4476 landed on the same command — lead-coder review on #4488): once
 ``history.jsonl`` reports through here too, "media" no longer describes
@@ -52,6 +60,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Callable
 
 
 def register(sub) -> None:
@@ -174,6 +183,14 @@ def run_migrate_manifest(args: argparse.Namespace) -> None:
     )
 
 
+def _print_footprint(label: str, reader: "Callable[[], int | None]", metric: "str | None") -> None:
+    value = reader()
+    if metric is not None and value is not None:
+        print(f"footprint ({label}): {value:,} bytes ({metric})")
+    else:
+        print(f"footprint ({label}): not measurable on this platform")
+
+
 def run_migrate_bodies(args: argparse.Namespace) -> None:
     """#5896 stage ③ (owner-hit P0) — see
     ``history_body_migration.migrate_inline_history_bodies``'s own
@@ -183,18 +200,40 @@ def run_migrate_bodies(args: argparse.Namespace) -> None:
     ``session_id="storage-migrate"`` is a fixed, clearly-labeled value
     for this offline tool, not tied to any live session (nothing else
     ever needs to guess it back; the row's own ``content_ref`` is the
-    only thing a future reader follows)."""
+    only thing a future reader follows).
+
+    Also reports THIS process's own footprint at start and end (#5851's
+    own reader, ``reyn.runtime.process_memory`` — architect ruling,
+    follow-up to PR #5947): pairs this run's own COST (it streams one
+    row at a time — see ``migrate_inline_history_bodies``'s own
+    docstring for why a single oversized row is still a real, bounded
+    peak — but writing N migrated bodies and rewriting the file is real
+    work) against the EFFECT the owner's own acceptance criterion
+    measures separately (a post-migration startup peak an order of
+    magnitude smaller) — both numbers from the SAME run, not two
+    separate ones an operator has to correlate by hand. Two points only
+    (start, end) — never a byte figure derived from elapsed time, this
+    is a snapshot pair, not a duration."""
     from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+    from reyn.runtime.process_memory import (
+        make_process_memory_reader,
+        process_memory_metric_name,
+    )
     from reyn.runtime.services.history_body_migration import (
         DEFAULT_MIN_BYTES,
         migrate_inline_history_bodies,
     )
+
+    metric = process_memory_metric_name()
+    reader = make_process_memory_reader()
+    _print_footprint("start", reader, metric)
 
     project_root = Path(args.project_root).resolve()
     min_bytes = args.min_bytes if args.min_bytes is not None else DEFAULT_MIN_BYTES
     agents_dir = project_root / ".reyn" / "agents"
     if not agents_dir.is_dir():
         print("no .reyn/agents/ directory — nothing to migrate.")
+        _print_footprint("end", reader, metric)
         return
 
     if args.agent is not None:
@@ -240,6 +279,7 @@ def run_migrate_bodies(args: argparse.Namespace) -> None:
         else:
             print(f"{agent_name}: nothing over {min_bytes:,} bytes to migrate.")
 
+    _print_footprint("end", reader, metric)
     print(
         f"\ntotal: {total_migrated} row(s) migrated, {total_reused} reused "
         f"an existing ref, {total_written:,} new byte(s) written.",

--- a/src/reyn/runtime/services/history_body_migration.py
+++ b/src/reyn/runtime/services/history_body_migration.py
@@ -67,6 +67,25 @@ FILE-LEVEL ATOMICITY AND ``.bak``
     original's place (also atomic). A ``.bak`` from an earlier run is
     NEVER silently overwritten — see below.
 
+PEAK MEMORY IS BOUND BY THE LARGEST SINGLE LINE, NOT THE FILE SIZE
+    (architect ruling, follow-up to PR #5947's BLOCKING) — this is the
+    property the streaming design above actually establishes, said
+    directly rather than left implicit in "stream-read" mechanics: this
+    module never holds ``history.jsonl``'s FULL TEXT resident (neither
+    pass ever calls ``Path.read_text()``/``readlines()`` on it — see
+    :func:`_spill_supersede_refs` and :func:`migrate_inline_history_bodies`'s
+    own bodies, both ``for raw in <file>``), so a 663 MB file with a
+    369 MB single row costs a peak proportional to that ONE largest
+    row, never to the whole file. ``tests/runtime/
+    test_5896_stage3_migrate_bodies.py::test_migration_never_reads_the_whole_file_at_once``
+    is the pin that keeps this true (a real ``Path.read_text`` call-spy,
+    strip-falsified in both directions against this exact regression). A
+    single oversized row is still a real, unavoidable transient peak
+    for the ONE line being processed (unavoidable without changing what
+    a JSON line IS) — what streaming closes is "whole file" (or worse,
+    "whole file twice," the actual PR #5947 BLOCKING defect), not that
+    single-line floor.
+
 WHAT AN INTERRUPTED RUN LEAVES BEHIND (owner-hit correction: this must be
 designed, not assumed)
     - Crash during the per-row scan/write phase: ``history.jsonl`` is

--- a/tests/interfaces/test_4488_storage_cli.py
+++ b/tests/interfaces/test_4488_storage_cli.py
@@ -186,3 +186,78 @@ def test_migrate_bodies_honors_the_agent_filter(tmp_path: Path):
     )
     assert alice_line["content"] == "", "the targeted agent must be migrated"
     assert bob_line["content"] == big, "an un-targeted agent must be left untouched"
+
+
+def test_migrate_bodies_reports_start_and_end_footprint_bracketing_the_work(
+    tmp_path: Path, capsys,
+):
+    """Tier 1: architect ruling, follow-up to PR #5947 — the command
+    reports THIS process's own footprint at start AND end (2 points,
+    #5851's own reader), and does so BRACKETING the actual migration
+    work — start before any row is touched, end after every agent has
+    been processed but before the final total summary. Ordering
+    (``<``), not a line count, is the claim: a duplicate or missing
+    footprint line would break this chain regardless of how many total
+    lines happen to appear.
+
+    Real reader, no mock (same platform-variance idiom
+    ``test_5851a_process_memory_observe.py`` already established): on a
+    platform this repo declares supported (darwin/linux), both lines
+    carry the real metric name; on any other platform both say "not
+    measurable"."""
+    import json
+
+    from reyn.interfaces.cli.commands.storage import run_migrate_bodies
+    from reyn.runtime.process_memory import process_memory_metric_name
+
+    d = tmp_path / ".reyn" / "agents" / "alice"
+    d.mkdir(parents=True)
+    row = {
+        "role": "tool", "content": "x" * 2000, "ts": "", "seq": 1, "meta": {},
+        "tool_calls": None, "tool_call_id": "c1", "name": "t",
+        "spillability": "last_resort", "disclosure": None,
+    }
+    (d / "history.jsonl").write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    run_migrate_bodies(
+        Namespace(project_root=str(tmp_path), agent=None, min_bytes=1000),
+    )
+    lines = capsys.readouterr().out.splitlines()
+
+    start_idx = next(i for i, ln in enumerate(lines) if ln.startswith("footprint (start):"))
+    migrated_idx = next(i for i, ln in enumerate(lines) if ln.startswith("alice: migrated"))
+    end_idx = next(i for i, ln in enumerate(lines) if ln.startswith("footprint (end):"))
+    total_idx = next(i for i, ln in enumerate(lines) if ln.startswith("total:"))
+    assert start_idx < migrated_idx < end_idx < total_idx, (
+        f"footprint must bracket the migration work, in this order; got {lines!r}"
+    )
+
+    metric = process_memory_metric_name()
+    if metric is None:
+        assert "not measurable on this platform" in lines[start_idx]
+        assert "not measurable on this platform" in lines[end_idx]
+    else:
+        assert metric in lines[start_idx] and metric in lines[end_idx]
+
+
+def test_migrate_bodies_reports_footprint_even_with_nothing_to_migrate(
+    tmp_path: Path, capsys,
+):
+    """Tier 1: accept-side — the "no .reyn/agents/ directory" early-
+    return path still reports both footprint points, not just the
+    common (work-to-do) path. A tool meant to pair cost against effect
+    must report ITS OWN cost even on a run that changed nothing. The
+    start line must be the FIRST line printed and the end line the
+    LAST — position, not a count, is the claim."""
+    from reyn.interfaces.cli.commands.storage import run_migrate_bodies
+
+    run_migrate_bodies(Namespace(project_root=str(tmp_path), agent=None, min_bytes=None))
+    lines = capsys.readouterr().out.splitlines()
+
+    assert lines[0].startswith("footprint (start):"), (
+        f"the start footprint must be the very first line printed; got {lines!r}"
+    )
+    assert lines[-1].startswith("footprint (end):"), (
+        f"the end footprint must be the very last line printed on this no-op "
+        f"path; got {lines!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5896.

## What this does

Follow-up PR per lead-coder's dispatch (architect ruling, 2 points, after PR #5947 merged):

1. **`reyn storage migrate-bodies` now reports its own footprint at start and end** (2 snapshots, #5851's own reader — `process_memory_metric_name()`/`make_process_memory_reader()`, no new mechanism). Pairs this run's own cost against the effect the owner's own acceptance criterion measures separately (a post-migration startup peak an order of magnitude smaller) — both numbers now come from the same run instead of two an operator has to correlate by hand. Two points only, byte figures — never a duration.
2. **`history_body_migration.py`'s module docstring now states directly** (new "PEAK MEMORY IS BOUND BY THE LARGEST SINGLE LINE, NOT THE FILE SIZE" section) the property PR #5947's streaming fix actually established, tied to the exact pin test (`test_migration_never_reads_the_whole_file_at_once`) that guards it.

Output form matches the existing `reyn storage` commands' own style (plain print lines, same as `run_stats`/`run_migrate_manifest`) — no new CLI flag, always-on (cheap: ~39µs per read on darwin, #5851's own measurement).

## Tests

2 new (`tests/interfaces/test_4488_storage_cli.py`, Tier 1):
- The real-migration path asserts start/migrated/end/total print in that **order** (not a line count — an earlier draft used `len(footprint_lines) == 2` and `test_tier_audit.py --strict` correctly flagged it as a Tier 4 format-pin; rewritten to ordering/position assertions, which make the claim strictly stronger: footprint genuinely brackets the work, not just "two lines exist somewhere").
- The no-op ("no `.reyn/agents/`" early-return) path asserts the start line is literally first and the end line is literally last.

Both **strip-falsified directly**: removing all three footprint-reporting call sites turns both tests concretely red (a `StopIteration` on the missing bracketing line, and an `AssertionError` showing the actual wrong first line captured) — confirmed, restored before commit.

**27 tests total** across the full related regression scope (storage CLI + migration + `process_memory`), all green.

## Local gates

`ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` (0 new findings), the 4 `tests/`-path-conditional gates, `check_tests_path_literal_reference.py` (fresh `origin/main` right before push) — all green.

## Test plan

- [x] `pytest` scoped to diff + full related regression scope — 27 passed, 0 regressions
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on the changed test file
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `tests/`-path-conditional gates
- [x] (skipped — standing Visual-item waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
