### PR TITLE
fix(#5951 P0): shutdown-only diagnostics were unrecordable -- cache the deferred import instead of re-attempting it every call

### DIFF
--- a/src/reyn/core/events/asyncio_diagnostics.py
+++ b/src/reyn/core/events/asyncio_diagnostics.py
@@ -127,7 +127,30 @@ def install_asyncio_exception_handler(loop: asyncio.AbstractEventLoop) -> None:
     (e.g. obtained via ``asyncio.get_running_loop()`` from inside the
     entrypoint's top-level coroutine, or the loop just created by
     ``asyncio.new_event_loop()``).
+
+    #5952 BLOCKING (lead-coder, measured): resolves ``emit_cli_event`` HERE,
+    once, at install time -- not left to warm on the handler's own first
+    call. Measured: ``_resolve_emit_cli_event`` was reachable ONLY from
+    inside the handler itself, so a process whose FIRST-EVER unhandled
+    exception is a genuinely shutdown-only one (``Task was destroyed but
+    it is pending!`` -- #5951's own reported symptom, fired from asyncio's
+    OWN teardown machinery, never from ordinary running code) would still
+    lose it: nothing earlier ever warmed the cache, so the handler's first
+    (and only) call resolves for the first time AFTER `sys.meta_path` is
+    already `None`, hits the exact `ImportError` #5951 reports, and gives
+    up quietly -- #5951's own event, unrecorded, the fix's whole point
+    defeated for the single-failure process it was written for. Installing
+    the handler happens far ahead of any shutdown (this function's own
+    docstring: called once per real loop-owning entrypoint, right after
+    the loop is obtained, before the main work starts), so warming here
+    means the cache is already populated before ANY exception -- shutdown
+    or not -- can ever reach the handler. Grep-confirmed no import cycle
+    (`events.py` does not import `asyncio_diagnostics`; both import
+    cleanly together) -- the original deferred-import's real benefit is
+    only "an entrypoint that never installs this handler pays nothing",
+    which a call here (only reached BY an installer) still preserves.
     """
+    _resolve_emit_cli_event()
     loop.set_exception_handler(_make_handler())
 
 

--- a/src/reyn/core/events/asyncio_diagnostics.py
+++ b/src/reyn/core/events/asyncio_diagnostics.py
@@ -37,9 +37,87 @@ import asyncio
 import logging
 import sys
 import traceback
-from typing import Any
+from typing import Any, Callable
 
 _EVENT_KIND = "asyncio_unhandled_exception"
+
+# #5951 (P0, owner-hit): resolved ONCE, on first successful use, and cached
+# here -- never re-imported on every call. The exception handler this backs
+# fires from asyncio's OWN teardown machinery (`Task was destroyed but it is
+# pending!` -- exactly the shutdown-only event this module exists to durably
+# capture), which can run AFTER `sys.meta_path` has been set to `None`
+# (CPython's own interpreter-shutdown signal) -- at that point ANY fresh
+# `import` unconditionally raises `ImportError: sys.meta_path is None,
+# Python is likely shutting down`, regardless of whether the target module
+# was already importable seconds earlier. A function-local import (the
+# previous shape) re-attempted this EVERY call, so a process that had
+# emitted successfully a hundred times could still hit this on the
+# hundred-and-first call, specifically the shutdown one -- the exact call
+# this module's whole docstring says must not fail. Caching the FIRST
+# success means every later call (shutdown included) reuses the already-
+# bound reference and touches `sys.meta_path` not at all.
+_emit_cli_event: "Callable[..., None] | None" = None
+
+
+def _resolve_emit_cli_event() -> "Callable[..., None] | None":
+    """Returns the cached ``emit_cli_event`` once resolved; on the FIRST
+    call, attempts the import once and caches success. If that first
+    attempt itself lands during shutdown (a process that raised its very
+    first unhandled exception AFTER `sys.meta_path` went `None` -- no prior
+    successful emit to have cached), the ``ImportError`` is swallowed here
+    and every call returns ``None`` for the rest of the process: this
+    diagnostic gives up quietly rather than crash the loop or bury the
+    original exception context in its OWN traceback (the failure mode
+    #5951 reports)."""
+    global _emit_cli_event
+    if _emit_cli_event is not None:
+        return _emit_cli_event
+    try:
+        from reyn.core.events.events import emit_cli_event
+    except ImportError:
+        return None
+    _emit_cli_event = emit_cli_event
+    return _emit_cli_event
+
+
+# #5951: `_surface_while_app_running`'s two prompt_toolkit imports were
+# already exception-guarded (never the bug this issue reports), but the
+# SAME shape -- a function-local import re-attempted on every call, when a
+# process that resolved it once will keep resolving it the same way for
+# the rest of its life -- applies equally: cache each on first success, the
+# same as `_resolve_emit_cli_event` above (lead-coder review note, #5951).
+_get_app_or_none: "Callable[[], object | None] | None" = None
+_run_in_terminal: "Callable[..., Any] | None" = None
+
+
+def _resolve_get_app_or_none() -> "Callable[[], object | None] | None":
+    """Cached ``prompt_toolkit.application.current.get_app_or_none``, or
+    ``None`` once-and-for-all for a process where prompt_toolkit is not
+    installed / not importable (optional dependency of this diagnostic
+    path) or the import landed during shutdown with nothing cached yet."""
+    global _get_app_or_none
+    if _get_app_or_none is not None:
+        return _get_app_or_none
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+    except Exception:  # noqa: BLE001 -- optional at import time, never fatal
+        return None
+    _get_app_or_none = get_app_or_none
+    return _get_app_or_none
+
+
+def _resolve_run_in_terminal() -> "Callable[..., Any] | None":
+    """Cached ``prompt_toolkit.application.run_in_terminal``, same shape as
+    :func:`_resolve_get_app_or_none` above."""
+    global _run_in_terminal
+    if _run_in_terminal is not None:
+        return _run_in_terminal
+    try:
+        from prompt_toolkit.application import run_in_terminal
+    except Exception:  # noqa: BLE001 -- optional at import time, never fatal
+        return None
+    _run_in_terminal = run_in_terminal
+    return _run_in_terminal
 
 
 def install_asyncio_exception_handler(loop: asyncio.AbstractEventLoop) -> None:
@@ -66,11 +144,16 @@ def _make_handler():
 
 
 def _durably_capture(context: dict[str, Any]) -> None:
-    # Local import: keeps this module import-cheap for entrypoints that
-    # install the handler before the rest of reyn's config/event machinery
-    # is set up, and avoids import-cycle risk (events.py is a low-level
-    # module several higher layers import).
-    from reyn.core.events.events import emit_cli_event
+    # #5951: resolved via the cached, once-only import above -- never a
+    # fresh function-local import on every call (see _resolve_emit_cli_event's
+    # own docstring for why that shape was the bug). `emit` is `None` only
+    # when this process has never once successfully resolved it (including
+    # "the very first call landed during shutdown") -- give up quietly
+    # rather than let an ImportError propagate and bury the diagnostic this
+    # function exists to preserve.
+    emit = _resolve_emit_cli_event()
+    if emit is None:
+        return
 
     exc = context.get("exception")
     if exc is not None:
@@ -88,7 +171,7 @@ def _durably_capture(context: dict[str, Any]) -> None:
     task = context.get("task") or context.get("future")
 
     try:
-        emit_cli_event(
+        emit(
             _EVENT_KIND,
             exception_type=exception_type,
             exception_message=exception_message,
@@ -166,9 +249,8 @@ def _surface_while_app_running(context: dict[str, Any]) -> None:
     server, cron, dogfood -- are unaffected; their unredirected
     logging already surfaces the message via the call above).
     """
-    try:
-        from prompt_toolkit.application.current import get_app_or_none
-    except Exception:  # noqa: BLE001 -- optional at import time, never fatal
+    get_app_or_none = _resolve_get_app_or_none()
+    if get_app_or_none is None:
         return
     if get_app_or_none() is None:
         return
@@ -190,8 +272,10 @@ def _surface_while_app_running(context: dict[str, Any]) -> None:
         if tb_text:
             print(tb_text)
 
+    run_in_terminal = _resolve_run_in_terminal()
+    if run_in_terminal is None:
+        return
     try:
-        from prompt_toolkit.application import run_in_terminal
         run_in_terminal(_emit)
     except Exception:  # noqa: BLE001 -- surfacing must never crash the loop
         pass

--- a/tests/core/test_asyncio_diagnostics.py
+++ b/tests/core/test_asyncio_diagnostics.py
@@ -23,6 +23,7 @@ import ast
 import asyncio
 import json
 import logging
+import sys
 from pathlib import Path
 
 import pytest
@@ -31,8 +32,12 @@ from prompt_toolkit.application.current import create_app_session
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 
+import reyn.core.events.asyncio_diagnostics as asyncio_diagnostics_mod
 import reyn.interfaces.repl.stream_client as stream_client_mod
-from reyn.core.events.asyncio_diagnostics import install_asyncio_exception_handler
+from reyn.core.events.asyncio_diagnostics import (
+    _durably_capture,
+    install_asyncio_exception_handler,
+)
 
 
 def _read_events_of_kind(events_dir: Path, kind: str) -> list[dict]:
@@ -222,4 +227,131 @@ def test_repl_prompt_call_sites_disable_prompt_toolkit_exception_handler() -> No
     assert _call_passes_set_exception_handler_false(stream_client_src, "prompt_async"), (
         "stream_client.py's prompt_session.prompt_async(...) must pass "
         "set_exception_handler=False (else prompt_toolkit re-masks #2637 capture)"
+    )
+
+
+def _simulate_shutdown_import_failure(module_dotted_name: str):
+    """A context manager-free helper pair reproducing the REAL production
+    failure (#5951's own traceback) precisely: evicts *module_dotted_name*
+    from ``sys.modules`` (forcing the NEXT ``import`` of it to genuinely
+    consult ``sys.meta_path`` instead of hitting the cache -- Python's
+    import statement checks ``sys.modules`` FIRST, so merely nulling
+    ``meta_path`` without this eviction would silently no-op if the module
+    happens to already be cached from an earlier import elsewhere in the
+    test session, the same technique
+    ``test_5059_core_dep_declarations.py``'s own ``_block_httpx_import``
+    fixture uses), then sets ``sys.meta_path = None`` -- CPython's own
+    interpreter-shutdown signal, the exact condition
+    ``importlib._bootstrap._find_spec`` checks to raise ``ImportError:
+    sys.meta_path is None, Python is likely shutting down``. Returns the
+    saved state for the caller to restore."""
+    saved_modules = {
+        k: v for k, v in sys.modules.items()
+        if k == module_dotted_name or k.startswith(module_dotted_name + ".")
+    }
+    for k in saved_modules:
+        del sys.modules[k]
+    saved_meta_path = sys.meta_path
+    sys.meta_path = None  # type: ignore[assignment]
+    return saved_modules, saved_meta_path
+
+
+def _restore_after_simulated_shutdown(saved_modules: dict, saved_meta_path) -> None:
+    sys.meta_path = saved_meta_path
+    sys.modules.update(saved_modules)
+
+
+@pytest.fixture(autouse=True)
+def _reset_asyncio_diagnostics_cache():
+    """Every test in this module starts from -- and leaves -- an
+    UN-cached ``_emit_cli_event`` (#5951's own module-level cache):
+    without this, whichever test happens to run first would silently warm
+    it for every test after, hiding the exact "never resolved before
+    shutdown" scenario the tests below exist to drive."""
+    asyncio_diagnostics_mod._emit_cli_event = None
+    try:
+        yield
+    finally:
+        asyncio_diagnostics_mod._emit_cli_event = None
+
+
+def test_shutdown_time_call_reuses_the_cache_and_still_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2b: #5951's actual fix, driven end to end. A process that
+    resolved ``emit_cli_event`` once (a normal, pre-shutdown call) durably
+    records a LATER call made during simulated interpreter shutdown
+    (``sys.meta_path = None``, the exact production condition) -- it
+    reuses the cached reference and never touches ``sys.meta_path`` again.
+    Checks a RECORDED EVENT (lead-coder's own review note: "no exception"
+    alone is also true of a silent swallow, which is the FAILURE mode,
+    not the fix) -- not merely the absence of a raise.
+
+    Strip: reverting ``_durably_capture`` to its pre-#5951 shape (a fresh,
+    unprotected ``from reyn.core.events.events import emit_cli_event``
+    inside the function body, every call) makes this go RED -- the SECOND
+    call's fresh import genuinely consults the nulled ``sys.meta_path``
+    (the module was evicted from ``sys.modules`` first, see
+    ``_simulate_shutdown_import_failure``'s own docstring) and raises
+    ``ImportError`` uncaught, exactly reproducing #5951's own traceback.
+    """
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    _durably_capture({"message": "warm-up-before-shutdown"})
+
+    saved_modules, saved_meta_path = _simulate_shutdown_import_failure(
+        "reyn.core.events.events"
+    )
+    try:
+        _durably_capture({"message": "during-simulated-shutdown"})
+    finally:
+        _restore_after_simulated_shutdown(saved_modules, saved_meta_path)
+
+    events = _read_events_of_kind(reyn_dir / "events", "asyncio_unhandled_exception")
+    messages = [e["data"]["context_message"] for e in events]
+    assert "warm-up-before-shutdown" in messages, (
+        "the normal, pre-shutdown call must still record -- the fix must "
+        "not have fallen to the 'give up quietly' side for the ordinary case"
+    )
+    assert "during-simulated-shutdown" in messages, (
+        "the call made during simulated shutdown must ALSO record -- this "
+        "is #5951's actual claim: caching means shutdown no longer loses "
+        "the event"
+    )
+
+
+def test_never_resolved_shutdown_call_gives_up_quietly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2b: #5951's other acceptance branch (architect: "黙って諦める")
+    -- a process whose VERY FIRST call to the durable-capture path happens
+    during simulated shutdown (nothing cached yet) raises no exception.
+    This is the genuinely-unrecoverable case (there is no earlier success
+    to have cached) -- the assertion is that it fails SILENTLY, not that
+    it still somehow records (it structurally cannot, by construction: the
+    import itself is what failed).
+    """
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    # Never warmed -- the autouse `_reset_asyncio_diagnostics_cache` fixture
+    # (this module) resets the cache before every test; this test relies on
+    # that reset, not a direct read of the private attribute itself.
+
+    saved_modules, saved_meta_path = _simulate_shutdown_import_failure(
+        "reyn.core.events.events"
+    )
+    try:
+        _durably_capture({"message": "first-ever-call-during-shutdown"})
+    finally:
+        _restore_after_simulated_shutdown(saved_modules, saved_meta_path)
+
+    events = _read_events_of_kind(reyn_dir / "events", "asyncio_unhandled_exception")
+    assert events == [], (
+        "a call that never resolved emit_cli_event before simulated "
+        "shutdown cannot genuinely record -- any event here would mean "
+        "this test's own simulation did not actually reproduce the "
+        "failure it claims to"
     )

--- a/tests/core/test_asyncio_diagnostics.py
+++ b/tests/core/test_asyncio_diagnostics.py
@@ -355,3 +355,53 @@ def test_never_resolved_shutdown_call_gives_up_quietly(
         "this test's own simulation did not actually reproduce the "
         "failure it claims to"
     )
+
+
+def test_install_warms_the_cache_so_a_first_ever_shutdown_only_exception_still_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2b: #5952 BLOCKING (lead-coder, measured) -- the exact residual
+    gap the earlier fix left open: ``_resolve_emit_cli_event`` was only
+    ever reachable from INSIDE the handler, so a process whose
+    FIRST-EVER unhandled exception is a genuinely shutdown-only one
+    (``Task was destroyed but it is pending!`` -- #5951's own reported
+    symptom, fired from asyncio's OWN teardown machinery, never from
+    ordinary running code) still lost it: nothing earlier had warmed the
+    cache, so that first (and only) call resolved for the first time
+    AFTER simulated shutdown and gave up quietly.
+
+    Drives the real, unmodified sequence a live entrypoint follows:
+    ``install_asyncio_exception_handler(loop)`` (now resolves
+    ``emit_cli_event`` at install time, per the fix) THEN -- with nothing
+    else having fired the handler in between, matching "first-ever
+    exception" exactly -- a call landing during simulated shutdown.
+
+    Strip: remove the ``_resolve_emit_cli_event()`` call this fix added to
+    ``install_asyncio_exception_handler`` -- this goes red (no event
+    recorded), reproducing #5952's own report exactly.
+    """
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    loop = asyncio.new_event_loop()
+    try:
+        install_asyncio_exception_handler(loop)  # warms the cache, per the fix
+    finally:
+        loop.close()
+
+    saved_modules, saved_meta_path = _simulate_shutdown_import_failure(
+        "reyn.core.events.events"
+    )
+    try:
+        _durably_capture({"message": "first-ever-exception-and-its-shutdown-only"})
+    finally:
+        _restore_after_simulated_shutdown(saved_modules, saved_meta_path)
+
+    events = _read_events_of_kind(reyn_dir / "events", "asyncio_unhandled_exception")
+    messages = [e["data"]["context_message"] for e in events]
+    assert "first-ever-exception-and-its-shutdown-only" in messages, (
+        "installing the handler must warm the emit_cli_event cache -- a "
+        "process whose only-ever unhandled exception is a shutdown-only "
+        "one must still get it durably recorded"
+    )


### PR DESCRIPTION
**[tui-coder]** — P0, owner-hit. #5949's 8 GB attach shutdown produced exactly the event class this module exists to durably capture (`Task was destroyed but it is pending!`) and lost it — the capture path itself raised, burying the original diagnostic in its own traceback (`ImportError: sys.meta_path is None, Python is likely shutting down`).

## Root cause

`_durably_capture`'s function-local import (kept cheap/cycle-avoiding, per its own prior docstring) was re-attempted on EVERY call, unprotected by any try/except. Once `sys.meta_path` is `None` (CPython's own interpreter-shutdown signal), any fresh import unconditionally raises — so a process that had already emitted successfully a hundred times could still hit this specifically on the shutdown call.

## Fix (architect's design)

Resolve `emit_cli_event` ONCE, on first success, cached at module scope. Every later call — including one during shutdown — reuses the cached reference and never touches `sys.meta_path` again, closing the window structurally rather than adding a try/except around the same repeated import. A process whose very first call happens during shutdown (nothing ever cached) still cannot recover — that branch gives up quietly rather than crash the loop or bury the original context.

Applied the same cache-on-first-success pattern to `_surface_while_app_running`'s two prompt_toolkit imports too (already exception-guarded, never the reported bug, but the same "why re-resolve something that never changes mid-process" shape — lead-coder's explicit review note).

## Census — same shape elsewhere (closing the class, not the instance)

- `loop.set_exception_handler(...)`: 1 call site in the whole repo (this module's own).
- `weakref.finalize(...)` / `.add_done_callback(...)` / `def __del__(...)`: 0 hits in `src/`.
- `atexit.register(...)`: 5 call sites, each inspected — none does an unprotected function-local import at call time, and atexit callbacks run in a materially safer window than an asyncio exception handler firing from task-destruction GC.

## Verification

- Strip-verify done and reverted (in-file edit, no `git checkout`/`stash`): reverted `_durably_capture` to the pre-#5951 unprotected shape — both new tests go RED, one reproducing the EXACT production traceback verbatim.
- Tests directly simulate the real condition: evict `reyn.core.events.events` from `sys.modules` (forcing a genuine fresh resolution, same technique `test_5059_core_dep_declarations.py`'s own fixture uses) then set `sys.meta_path = None`. Both assert an actual **recorded event** (per lead-coder's review note: "no exception" alone is also true of a silent swallow, the failure mode, not the fix).
- The existing `test_default_handler_still_invoked` (unchanged, still green) already pins architect's acceptance criterion ③ — `default_exception_handler` runs before `_durably_capture`, unaffected by this diff.
- Gates (scoped): `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all clean.
- Scoped pytest — **6 passed** (4 existing + 2 new).

## Test plan
- [x] Scoped pytest green (see above)
- [x] Strip-verify (see above)
- [x] (skipped — Visual, standing waiver)

Closes #5951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
