### PR TITLE
fix(#5949 stage 1, P0): attach's backward-paging previews a content_ref body instead of eager-materializing it

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -2119,6 +2119,57 @@ class MediaStore:
             f"{self._history_content_root} — refusing to read"
         )
 
+    def read_tool_result_preview(
+        self, path_str: str, *, max_bytes: int,
+    ) -> "tuple[str, bool, int]":
+        """#5949 (owner-hit P0): a GENUINELY bounded read — never loads
+        more than ``max_bytes`` of the file into memory, unlike
+        :func:`~reyn.services.offload.store.read_offloaded`'s own
+        ``offset``/``limit`` (which reads the WHOLE file via
+        ``Path.read_text()`` first and only slices AFTER — useless for a
+        preview of a file that is one giant line, exactly this incident's
+        own shape: a 369 MB tool-result body with no internal newlines,
+        where ``limit=1`` would still return the entire line). Opens the
+        file and calls ``f.read(max_bytes)`` directly — the same
+        genuinely-bounded discipline PR #5947's own streaming fix
+        established for ``history.jsonl`` itself, applied here to a
+        single history-content file.
+
+        Returns ``(preview_text, found, total_bytes)`` — ``found=False``
+        (empty preview, ``total_bytes=0``) when the file does not exist.
+        ``total_bytes`` is the file's REAL on-disk size (``os.path.
+        getsize`` — a cheap stat, not a read), read independently of any
+        meta field a caller might already have, since a #5896-stage-③-
+        migrated file predates ``CONTENT_BYTES_META_KEY`` and does not
+        carry one.
+
+        Same path-boundary validation as :meth:`read_tool_result` (both
+        directories checked, ``PermissionError`` on neither matching) —
+        this is a read primitive, not a laxer sibling."""
+        import os
+
+        abs_path = (self._project_root / path_str).resolve()
+        boundary_ok = False
+        for base_dir in (self._history_content_root, self._tool_results_dir):
+            try:
+                abs_path.relative_to(base_dir.resolve())
+                boundary_ok = True
+                break
+            except ValueError:
+                continue
+        if not boundary_ok:
+            raise PermissionError(
+                f"path {path_str!r} is outside both tool_results_dir "
+                f"{self._tool_results_dir} and history_content_root "
+                f"{self._history_content_root} — refusing to read"
+            )
+        if not abs_path.exists():
+            return "", False, 0
+        total_bytes = os.path.getsize(abs_path)
+        with abs_path.open("r", encoding="utf-8", errors="replace") as f:
+            preview = f.read(max_bytes)
+        return preview, True, total_bytes
+
     # ── Cross-host routing (#385 β core impl sub-task 1) ──────────────
 
     def _attach_cross_host_fields(

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -538,6 +538,18 @@ CONTENT_REF_META_KEY = "content_ref"
 # longer carries the bytes they used to measure) without opening files.
 CONTENT_BYTES_META_KEY = "bytes"
 CONTENT_MIME_META_KEY = "mime"
+# #5949 (owner-hit P0): a BOUNDED preview of an un-spilled tool row's body
+# — set ONLY by Session._fill_content_previews, for a row loaded via
+# backward-paging (extend_history_backward/_async, attach's own scrollback
+# read) whose `content` stays EMPTY (durable shape, untouched — this is a
+# SEPARATE field, never a substitute for `.content`, precisely so the LLM
+# wire path's own lazy resolve at _serialise_turn — which reads `.content`,
+# not this key — always sees the REAL full body, never the preview). A
+# reader that wants a bounded, cheap-to-show text for a row it has NOT
+# hydrated reads this key when present; every other reader (build_history,
+# compaction, a live in-process row) is completely unaffected — this key is
+# additive-only, never read by the wire-serialise path.
+CONTENT_PREVIEW_META_KEY = "content_preview"
 # Set once `resolve()` (reyn.core.offload.history_content_resolve) has
 # actually observed the backing file missing — never guessed ahead of
 # that check. ABSENCE means "not (yet) known to be lost", never "present".

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -73,6 +73,7 @@ from reyn.runtime.budget.budget import (
 )
 from reyn.runtime.capability_visibility import CapabilityVisibility
 from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
+    CONTENT_PREVIEW_META_KEY,
     CONTENT_REF_META_KEY,
     SPILLED_META_KEY,
     ChatMessage,
@@ -5006,7 +5007,9 @@ class Session:
             depth=depth, chain_id=chain_id, responder_sid=responder_sid,
         )
 
-    def _parse_history_line(self, line: str) -> "ChatMessage | None":
+    def _parse_history_line(
+        self, line: str, *, preview_only: bool = False,
+    ) -> "ChatMessage | None":
         """Parse one ``history.jsonl`` line into a ``ChatMessage``, or
         ``None`` if malformed (skipped, never raised — byte-identical to
         the pre-#4387 behavior). Pure: does not touch ``self.history``.
@@ -5034,12 +5037,31 @@ class Session:
         ``offloaded_content_unavailable`` once per parse; a session with no
         ``MediaStore`` (no multimodal config — every production factory
         wires one) cannot validate the path boundary and leaves the row
-        as parsed, disclosed here rather than read around the store."""
+        as parsed, disclosed here rather than read around the store.
+
+        ``preview_only`` (#5949, owner-hit P0): the caller wants the row
+        for DISPLAY (scrollback), not for the LLM wire. ``content`` stays
+        EMPTY here (never eager-hydrated) — a bounded preview is filled
+        in SEPARATELY, by :meth:`_fill_content_previews`, into
+        ``meta[CONTENT_PREVIEW_META_KEY]``, never into ``.content`` itself.
+        This is the ONE thing that makes the fix safe: the LLM wire path
+        (``RouterHistoryBuffer._serialise_turn``) reads ``.content``, which
+        stays exactly what an un-hydrated row already looks like — its own
+        EXISTING ``resolve_history_content`` call there lazily fetches the
+        REAL full body at wire-build time, regardless of whether a preview
+        was also computed for display. See module docstring at the top of
+        :func:`_fill_content_previews` for why this must be a caller-scoped
+        SECOND pass, not done inline here (the same file being referenced
+        by two different rows — a ``tool`` row and its own ``spill_record``
+        — must be read at most once per :meth:`_load_older_entries` call,
+        which requires a cache shared ACROSS lines, not per-line state)."""
         msg = parse_history_line(line)
         if msg is None or msg.role != "tool" or msg.content != "":
             return msg
         meta = msg.meta or {}
         if not meta.get(CONTENT_REF_META_KEY) or meta.get(SPILLED_META_KEY):
+            return msg
+        if preview_only:
             return msg
         if self._media_store is None:
             return msg
@@ -5059,6 +5081,80 @@ class Session:
         if msg is not None:
             self.history.append(msg)
 
+    #: #5949: a bounded preview reads at most this many bytes of a large
+    #: tool-result body — not derived from any existing per-row cap (there
+    #: is none for a DISPLAY preview; #5896's `history_resident` bounds the
+    #: RESIDENT set, a different resource role). Round, conservative:
+    #: comfortably enough to show a human something recognizable (a file
+    #: read's opening lines, a command's initial output) while staying
+    #: orders of magnitude below the owner's own 369 MB/157.8 MB incident
+    #: rows regardless of how many are backward-paged at once.
+    _CONTENT_PREVIEW_MAX_BYTES = 4000
+
+    def _build_content_preview(self, ref: str) -> str:
+        """#5949 (owner-hit P0): a bounded, cheap-to-show text for a
+        content_ref row's body — read via :meth:`MediaStore.
+        read_tool_result_preview`, which never loads more than
+        :data:`_CONTENT_PREVIEW_MAX_BYTES` of the backing file (unlike
+        :func:`~reyn.services.offload.store.read_offloaded`'s own
+        ``offset``/``limit``, which reads the WHOLE file first — see that
+        method's own docstring). Format matches architect's own ruling:
+        head bytes, then ``…(+N MB)`` when the file held more than the
+        preview bound; the file's REAL size (a cheap ``os.path.getsize``,
+        never a full read) drives the figure, not any meta field a
+        caller might already carry (a #5896-stage-③-migrated file
+        predates ``CONTENT_BYTES_META_KEY`` and has none)."""
+        if self._media_store is None:
+            return ""
+        head, found, total_bytes = self._media_store.read_tool_result_preview(
+            ref, max_bytes=self._CONTENT_PREVIEW_MAX_BYTES,
+        )
+        if not found:
+            return "(content unavailable — the backing file is missing)"
+        head_bytes = len(head.encode("utf-8"))
+        if head_bytes >= total_bytes:
+            return head
+        remaining_mb = (total_bytes - head_bytes) / (1024 * 1024)
+        return f"{head}…(+{remaining_mb:.1f} MB)"
+
+    def _fill_content_previews(self, parsed: "list[ChatMessage]") -> None:
+        """#5949 (owner-hit P0, architect ruling): fills
+        ``meta[CONTENT_PREVIEW_META_KEY]`` for every content_ref
+        ``role="tool"`` row in *parsed* whose ``content`` is empty (i.e.
+        every row :meth:`_parse_history_line` returned with
+        ``preview_only=True``) — called ONCE per :meth:`_load_older_entries`
+        invocation, over the WHOLE batch it just parsed, not per line.
+
+        Two guards, both load-bearing (architect's own two derived
+        findings, #5949):
+
+        1. A ``spill_record`` row is NEVER a candidate here — the
+           ``msg.role != "tool"`` check alone already excludes it (a
+           ``spill_record``'s own persisted ``content`` is its small
+           ref-preview text, never emptied by ``history_record`` — see
+           that function's own docstring — so it would also fail the
+           ``msg.content != ""`` gate even without the role check). A
+           ledger row never needs a body materialized for it at all.
+        2. ``cache`` is scoped to THIS call, keyed by ``ref`` — when the
+           SAME backing file is named by more than one row in the same
+           batch (measured directly on the owner's own history: a
+           ``tool`` row and its own ``spill_record`` can point at the
+           identical file), the file is read at most ONCE, not once per
+           referencing row."""
+        if self._media_store is None:
+            return
+        cache: "dict[str, str]" = {}
+        for msg in parsed:
+            if msg.role != "tool" or msg.content != "":
+                continue
+            meta = msg.meta or {}
+            ref = meta.get(CONTENT_REF_META_KEY)
+            if not ref or meta.get(SPILLED_META_KEY):
+                continue
+            if ref not in cache:
+                cache[ref] = self._build_content_preview(ref)
+            msg.meta[CONTENT_PREVIEW_META_KEY] = cache[ref]
+
     def _load_older_entries(self, *, before_seq: int, min_lines: int = _HISTORY_HYDRATE_MIN_LINES) -> int:
         """#4387 Phase B ②: extend ``self.history`` BACKWARD from
         ``history.jsonl``, prepending up to ``min_lines`` entries older
@@ -5076,6 +5172,18 @@ class Session:
         memory) and left that way deliberately: bounding it caps how far
         back a rewind can reach, which is an owner-facing capability
         question, not one this stage answers.
+
+        #5949 (owner-hit P0): parses with ``preview_only=True`` — this is
+        a backward, DISPLAY-oriented read (scrollback paging, attach), not
+        a wire-building one, so a content_ref row's body is never eagerly
+        materialized here. :meth:`_fill_content_previews` then fills a
+        BOUNDED preview for the whole batch in one pass (see its own
+        docstring for the two guards — spill_record exclusion, same-ref
+        read-once). ``.content`` itself stays untouched (empty) either
+        way — the LLM wire path's own lazy resolve
+        (``RouterHistoryBuffer._serialise_turn``) is unaffected by this
+        change; see :meth:`_parse_history_line`'s own ``preview_only``
+        docstring for why that is what makes this safe.
         """
         from reyn.runtime.history_tail_reader import read_history_before
 
@@ -5084,7 +5192,11 @@ class Session:
         )
         if not lines:
             return 0
-        parsed = [m for line in lines if (m := self._parse_history_line(line)) is not None]
+        parsed = [
+            m for line in lines
+            if (m := self._parse_history_line(line, preview_only=True)) is not None
+        ]
+        self._fill_content_previews(parsed)
         self.history[0:0] = parsed
         return len(parsed)
 

--- a/tests/runtime/test_5949_attach_lazy_preview.py
+++ b/tests/runtime/test_5949_attach_lazy_preview.py
@@ -1,0 +1,311 @@
+"""Tier 2: #5949 (owner-hit P0) — backward-paging (attach's own
+``extend_history_backward``/``extend_history_backward_async``, TUI
+scrollback paging) must not eager-materialize a content_ref row's full
+body. Owner-hit incident: attach eagerly hydrated ~566 MB across 44 rows
+in the tail 200 lines, ballooning an 8226 MB -> 91 MB migration win right
+back to ~8-10 GB. Stage ① of architect's 4-point ruling (issue #5949):
+the display/backward-paging path gets a BOUNDED preview instead, stored in
+a SEPARATE meta field, never touching ``.content`` itself — which is what
+keeps the LLM wire path (``RouterHistoryBuffer._serialise_turn``, already
+lazily resolving) completely unaffected.
+
+Real ``Session``/``RouterLoop``/``MediaStore`` throughout — a genuine
+content_ref row is produced via the SAME production write seam
+(``RouterLoop.feedback`` -> ``persist_feedback``) #5896's own acceptance
+tests use, never a hand-built row for the rows under direct test.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.config import MultimodalConfig
+from reyn.config.chat import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import (
+    CONTENT_PREVIEW_META_KEY,
+    CONTENT_REF_META_KEY,
+    SPILL_TARGET_CONTENT_HASH_META_KEY,
+    SPILLED_META_KEY,
+)
+from reyn.runtime.router_loop import RouterLoop
+from reyn.tools.scheme import ExecutionResult
+from tests._support.agent_session import make_session
+
+_MODEL = "gpt-4o"
+_BODY = "y" * 20_000  # comfortably over the preview bound, well under a real incident row
+
+
+def _mcp_env(content: str) -> dict:
+    data = {"kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": content, "media_blocks": []}
+    return {"status": "ok", "data": data, "_canonical_source": "mcp"}
+
+
+def _round(content: str) -> ExecutionResult:
+    return ExecutionResult(
+        tool_results=[_mcp_env(content)],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "mcp"}}],
+        assistant_content="",
+    )
+
+
+def _session(agent_name: str, tmp_path: Path, **kwargs):
+    return make_session(
+        agent_name=agent_name,
+        multimodal_config=MultimodalConfig(),
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / f"{agent_name}.snap.json",
+        safety=SafetyConfig(loop=LoopConfig(), on_limit=OnLimitConfig(mode="unattended")),
+        **kwargs,
+    )
+
+
+async def _write_one_content_ref_row(tmp_path: Path, agent_name: str, body: str) -> None:
+    """Writes ONE real content_ref tool row via the production seam, then
+    discards the session object — only the durable history.jsonl + its
+    history-content file matter to the tests below, which reload fresh."""
+    session = _session(agent_name, tmp_path)
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    loop.feedback(_round(body))
+    await loop.persist_feedback()
+
+
+# ── 1. backward-paging never eager-hydrates .content ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backward_paged_content_ref_row_keeps_content_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the core claim — a content_ref row loaded via
+    ``extend_history_backward`` (the same primitive ``_load_older_entries``
+    both attach and TUI scrollback paging use) must NOT have its full body
+    materialized into ``.content``/`.text`` — this is the whole point:
+    materializing it is exactly what blew up 566 MB -> 8 GB.
+
+    Strip witness: passing ``preview_only=False`` (the pre-fix default)
+    from ``_load_older_entries`` makes ``.text`` equal the full 20000-char
+    body instead of empty — verified directly, restored after."""
+    monkeypatch.chdir(tmp_path)
+    await _write_one_content_ref_row(tmp_path, "attach-agent", _BODY)
+
+    restarted = _session("attach-agent", tmp_path)
+    restarted.load_history()
+    (loaded_seq,) = [m.seq for m in restarted.history if m.role == "tool"]
+    # Force a real backward page even though the whole (tiny, 1-turn)
+    # history already loaded at startup — mirrors the real shape (a
+    # caller asking for "more"). Calls the private primitive directly
+    # with an explicit before_seq (one past the row's own seq) rather
+    # than the public wrapper's own `self.history[0].seq if self.history
+    # else 0` auto-derivation, which cannot express "everything, from an
+    # empty resident set" — the same "simulate a bounded resident set"
+    # idiom test_4387_history_resident_eviction.py's own sibling tests
+    # use, just via direct seq rather than list-slicing.
+    restarted.history = []
+    prepended = restarted._load_older_entries(before_seq=loaded_seq + 1, min_lines=10)
+
+    assert prepended >= 1, "sanity: the backward page must have found the tool row"
+    (tool_msg,) = [m for m in restarted.history if m.role == "tool"]
+    assert tool_msg.text == "", (
+        f"a backward-paged content_ref row must NOT have its body materialized "
+        f"into .content; got {len(tool_msg.text)} chars"
+    )
+    assert tool_msg.meta.get(CONTENT_REF_META_KEY), "sanity: this must genuinely be a content_ref row"
+
+
+def test_preview_only_parse_leaves_content_empty_directly(tmp_path: Path) -> None:
+    """Tier 1: the same claim as above, isolated to ``_parse_history_line``
+    itself (no Session-level paging machinery involved) — a durable line
+    with a content_ref, parsed with ``preview_only=True``, returns a
+    message whose ``.content`` is still ``""``.
+
+    Strip witness: removing the ``if preview_only: return msg`` guard
+    (falling through to the eager resolve) makes ``.content`` equal the
+    full body — verified directly, restored after."""
+    from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+    session = _session("preview-only-agent", tmp_path)
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path,
+        agent_name="preview-only-agent", session_id="s1",
+    )
+    session._media_store = store
+    ref_block = store.save_tool_result(_BODY, tool="t", seq=1)
+    line = json.dumps({
+        "role": "tool", "content": "", "ts": "", "seq": 1,
+        "meta": {CONTENT_REF_META_KEY: ref_block["path"], SPILLED_META_KEY: False},
+        "tool_calls": None, "tool_call_id": None, "name": "t",
+        "spillability": "last_resort", "disclosure": None,
+    })
+
+    msg = session._parse_history_line(line, preview_only=True)
+
+    assert msg is not None
+    assert msg.content == "", f"preview_only=True must leave content empty, got {len(msg.content)} chars"
+
+
+# ── 2. a bounded preview is filled, with the "+N MB" notice ─────────────
+
+
+@pytest.mark.asyncio
+async def test_fill_content_previews_produces_a_bounded_head_plus_notice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the preview must be a BOUNDED head of the real body plus a
+    "+N MB" notice when the body exceeds the bound — not empty, not the
+    full body (architect's own ruling: "先頭N byte＋…(+N MB)")."""
+    monkeypatch.chdir(tmp_path)
+    big = "z" * 50_000  # well over the preview bound
+    await _write_one_content_ref_row(tmp_path, "preview-agent", big)
+
+    restarted = _session("preview-agent", tmp_path)
+    restarted.load_history()
+    (loaded_seq,) = [m.seq for m in restarted.history if m.role == "tool"]
+    restarted.history = []
+    restarted._load_older_entries(before_seq=loaded_seq + 1, min_lines=10)
+
+    (tool_msg,) = [m for m in restarted.history if m.role == "tool"]
+    preview = tool_msg.meta.get(CONTENT_PREVIEW_META_KEY)
+    assert preview, "a preview must be filled for a content_ref row"
+    assert preview.startswith("z" * 100), "the preview must start with the real head of the body"
+    assert len(preview) < len(big), "the preview must be strictly bounded, not the full body"
+    assert "MB)" in preview, 'the preview must carry the "...(+N MB)" notice when truncated'
+
+
+# ── 3. the sibling wire-assert: build_history is unaffected ─────────────
+
+
+@pytest.mark.asyncio
+async def test_build_history_still_carries_the_full_body_after_backward_paging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: THE load-bearing sibling assert (lead-coder's own explicit
+    requirement) — without this, "removed the waste" and "broke the
+    feature" are indistinguishable. A row loaded via backward-paging
+    (content empty, preview-only) must STILL serialise its FULL body onto
+    the LLM wire when build_history() actually needs it — proving the
+    preview mechanism never substitutes for the real content at the one
+    place that matters."""
+    monkeypatch.chdir(tmp_path)
+    await _write_one_content_ref_row(tmp_path, "wire-agent", _BODY)
+
+    restarted = _session("wire-agent", tmp_path)
+    restarted.load_history()
+    (loaded_seq,) = [m.seq for m in restarted.history if m.role == "tool"]
+    restarted.history = []
+    restarted._load_older_entries(before_seq=loaded_seq + 1, min_lines=10)
+
+    (tool_msg,) = [m for m in restarted.history if m.role == "tool"]
+    assert tool_msg.text == "", "sanity: still preview-only at this point, not the full body"
+
+    wire = restarted._loop_driver._history_buffer.build_history()
+    (wire_tool,) = [m for m in wire if m.get("role") == "tool"]
+    assert _BODY in wire_tool["content"], (
+        "build_history's own wire output must still carry the FULL body — "
+        "the preview mechanism must never leak into (or substitute for) "
+        "what actually reaches the LLM"
+    )
+
+
+# ── 4. spill_record rows are never hydrate/preview candidates ───────────
+
+
+def test_spill_record_row_is_never_given_a_preview(tmp_path: Path) -> None:
+    """Tier 1: a spill_record row (the durable supersede ledger, #5612) —
+    constructed exactly as ``RouterHistoryBuffer.spill_turn_content``
+    actually produces one (``SPILLED_META_KEY: True``, non-empty content —
+    its own small offloaded preview text, never emptied by
+    ``history_record``, see that function's own docstring) — must never be
+    treated as a preview candidate.
+
+    Two of ``_fill_content_previews``'s guard conditions independently
+    exclude a REAL spill_record row this way — ``msg.content != ""``
+    (true for every real one) and ``meta.get(SPILLED_META_KEY)`` (also
+    always true for one) — measured directly while building this test: an
+    edge-case row with content forced empty AND ``role`` changed away from
+    ``spill_record`` STILL did not leak a preview, because the SPILLED
+    check alone still caught it. This test targets the REALISTIC shape,
+    not an attempt to isolate one guard in artificial isolation.
+
+    Strip witness: removing the entire guard clause (content-emptiness
+    AND spilled-check together) lets a real-shaped spill_record row
+    through — verified directly, restored after."""
+    from reyn.runtime.chat_message import ChatMessage
+
+    session = _session("spill-record-agent", tmp_path)
+    spill_row = ChatMessage(
+        role="spill_record",
+        content="a small offloaded preview, never empty — matches real construction",
+        meta={
+            SPILLED_META_KEY: True,
+            CONTENT_REF_META_KEY: "some/ref/path.txt",
+            SPILL_TARGET_CONTENT_HASH_META_KEY: "sha256:deadbeef",
+        },
+    )
+
+    session._fill_content_previews([spill_row])
+
+    assert CONTENT_PREVIEW_META_KEY not in spill_row.meta, (
+        "a spill_record (ledger) row must never be given a preview — it "
+        "never needs a body materialized for it at all"
+    )
+
+
+# ── 5. the same ref is read at most once per _load_older_entries pass ───
+
+
+@pytest.mark.asyncio
+async def test_same_ref_is_read_once_per_pass_even_with_two_referencing_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: architect's own measured finding — a ``tool`` row and its
+    own ``spill_record`` can point at the SAME backing file. Even though
+    the spill_record itself is excluded (test 4 above), TWO ``tool`` rows
+    pointing at the identical ref (a realistic shape — the same content
+    hash, offloaded once, referenced by more than one row) must still
+    only cost ONE real file read per ``_load_older_entries`` call, not one
+    per referencing row.
+
+    Strip witness: removing the ``if ref not in cache:`` guard in
+    ``_fill_content_previews`` (always calling ``_build_content_preview``)
+    makes the real-read call count 2 instead of 1 — verified directly,
+    restored after."""
+    monkeypatch.chdir(tmp_path)
+    from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+
+    session = _session("dedup-agent", tmp_path)
+    store = MediaStore(
+        MediaStoreConfig(), project_root=tmp_path, agent_name="dedup-agent", session_id="s1",
+    )
+    ref_block = store.save_tool_result(_BODY, tool="t", seq=1)
+    ref = ref_block["path"]
+    lines = [
+        json.dumps({
+            "role": "tool", "content": "", "ts": "", "seq": seq,
+            "meta": {CONTENT_REF_META_KEY: ref, SPILLED_META_KEY: False},
+            "tool_calls": None, "tool_call_id": None, "name": "t",
+            "spillability": "last_resort", "disclosure": None,
+        })
+        for seq in (1, 2)
+    ]
+    session.history_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    session._media_store = store
+
+    calls: "list[str]" = []
+    original = MediaStore.read_tool_result_preview
+
+    def _counting(self: MediaStore, path_str: str, *, max_bytes: int):
+        calls.append(path_str)
+        return original(self, path_str, max_bytes=max_bytes)
+
+    monkeypatch.setattr(MediaStore, "read_tool_result_preview", _counting)
+
+    prepended = session._load_older_entries(before_seq=999, min_lines=10)
+
+    assert prepended == 2, "sanity: both rows sharing the same ref must still be loaded"
+    assert calls == [ref], (
+        f"the same ref must be read exactly once across both referencing rows; "
+        f"got {len(calls)} real read(s): {calls!r}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5949. **Stage① only** — stage②(resolution generally at the wire-consumption point, already structurally in place for this path via `_serialise_turn`'s own existing lazy call) and stage③(rewriting #5901's own resident-equality acceptance to a wire-only one) are explicitly NOT included, per lead-coder's own staging instruction. Confirmed #5901's own acceptance test is unaffected and stays green as-is (it drives `load_history`'s forward path, untouched by this PR).

## What was wrong

Owner-hit P0 (2026-09-07): after #5896 stage 3's migration fixed startup footprint (8226 MB → 91 MB), attaching to the migrated session spiked to 8–10 GB and the owner had to kill it. Architect traced the mechanism directly: attach calls `Session.extend_history_backward_async` (default 200 lines), whose `_load_older_entries` parses each line through `_parse_history_line`, which **eagerly hydrates** a content_ref row's FULL body into `.content`. The tail 200 lines of the owner's own history carry 44 content_ref rows, 566.6 MB of real backing files (the 280 MB and 127 MB migrated bodies among them) — materializing to 8–10 GB (a 14–18x string+dict inflation, the same order as the 663 MB → 8.2 GB startup incident this whole arc started from).

## What this does

- `Session._parse_history_line` gains `preview_only: bool = False`. When `True` (used ONLY by `_load_older_entries` — attach's own `extend_history_backward`/`_async`, TUI scrollback paging), a content_ref row's `.content` stays untouched (empty — the same shape the durable line already has). Every other caller (`load_history`'s own forward tail load, `Session._durable_active_history_after`'s compaction candidate read) is completely unchanged, still eager.
- `Session._fill_content_previews` (new) fills a **bounded preview** into a **new, separate meta field** (`ChatMessage.CONTENT_PREVIEW_META_KEY`) for the whole batch `_load_older_entries` just parsed, in one pass. This is what makes the fix safe: `.content` itself is never touched, so `RouterHistoryBuffer._serialise_turn`'s own **existing** `resolve_history_content` call (already lazy — previously dead code in practice, since eager hydration upstream always filled `.content` first) still sees an empty `.content` for these rows and correctly fetches the REAL full body whenever `build_history()` actually needs one for the wire. **Proven by this PR's own sibling assert, not merely asserted** — see Tests below.
- Two guards inside `_fill_content_previews` (architect's own two derived findings from the owner's real measurement):
  1. A `spill_record` row (the durable supersede ledger, #5612) is never a preview candidate — it's a ledger entry, never a body.
  2. The same backing file named by more than one row in one batch (measured on the owner's own history: a `tool` row and its own `spill_record` can point at the identical file) is read at most **once** per `_load_older_entries` call, via a call-scoped cache.
- `MediaStore.read_tool_result_preview` (new): a **genuinely bounded** read (`f.read(max_bytes)`, never the whole file first) — unlike `services/offload/store.py`'s `read_offloaded`, whose own `offset`/`limit` slice AFTER a full `Path.read_text()` and would still load an entire 369 MB single-line file for a "preview". Same bounded-read discipline PR #5947's own streaming fix established.

## Tests

6 new (`tests/runtime/test_5949_attach_lazy_preview.py`, Tier 1×2 + Tier 2×4):
- backward-paged content stays empty (both at the `Session` level and isolated to `_parse_history_line` itself)
- the preview is a real bounded head + `...(+N MB)` notice
- **the load-bearing sibling assert lead-coder explicitly required**: `build_history()` still carries the FULL body for a backward-paged row — proving the preview never substitutes for real content at the one place that matters
- a `spill_record` row, constructed exactly as production builds one, never gets a preview
- the same ref referenced by two rows in one pass is read exactly once

Plus 43 tests total across the full related regression scope (backward-paging, #5896 stage 1's own acceptance, resident-bytes caching), all green.

**Strip-falsification executed directly** on every load-bearing guard: removing `preview_only`'s early-return leaks the full 20000-char body into two different tests, shown exactly; removing the ref-dedup cache doubles the real read count, shown exactly (both paths listed); removing the spill_record guard clause entirely crashes on the attempted read of a fake ref (proving the guard is what prevents even attempting it). All confirmed, all restored before commit.

## Local gates

`ruff check`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` (6 findings, all baselined), the 4 `tests/`-path-conditional gates, `check_tests_path_literal_reference.py` (fresh `origin/main`) — all green.

## Acceptance (from issue #5949)

- [x] attach on migrated history → peak stays small (structural fix: content never materialized in the first place)
- [x] TUI scrollback shows a preview, not the full body (`CONTENT_PREVIEW_META_KEY`)
- [x] LLM wire still contains the full body (sibling assert, see Tests)
- [x] rows outside the preview path are never materialized differently (compaction/forward-load untouched)
- [x] `spill_record` rows never given a preview
- [x] same ref read once per pass
- [ ] owner real-machine: attach + TUI opens, footprint ~100 MB class — **deferred to post-merge**, owner will verify tomorrow morning per lead-coder

## Test plan

- [x] `pytest` scoped to diff + full related regression scope — 43 passed, 0 regressions
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `verify_module_docstrings.py` on changed src files
- [x] `mypy_ratchet.py`
- [x] `tests/`-path-conditional gates
- [x] (skipped — standing Visual-item waiver, owner 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
