### PR TITLE
fix(#5949 stage 1-b + stage 2, P0): invert _parse_history_line's default -- hydrate is required, not silently on

### DIFF
--- a/scripts/check_parse_history_line_hydrate_gate.py
+++ b/scripts/check_parse_history_line_hydrate_gate.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""#5949 stage ①-b, architect's structural ③ (issuecomment-5576144700) —
+the SYNTACTIC backstop for ``Session._parse_history_line``'s ``hydrate``
+flag, the flip that made "materialize a content_ref row's body" an
+explicit, required, per-caller decision instead of a silent default.
+
+## The class this closes
+
+Before this: ``preview_only: bool = False`` meant "materialize by
+default" — a NEW caller of ``_parse_history_line`` that didn't think about
+cost landed on the expensive path automatically, and nothing anywhere
+would ever tell it that. This is exactly what happened once: stage ①
+fixed ONE of ``_parse_history_line``'s callers
+(``Session._load_older_entries``) and never touched its sibling
+(``Session.extend_history_backward_async``, which had its own SEPARATE
+parse loop) — owner's real backward-page-heavy path kept eager-
+materializing every content_ref body, unchanged, and the regression
+shipped silently (TESTS-READ, CI green, merged).
+
+``hydrate`` now has NO DEFAULT — Python itself already turns "a new
+caller forgot to decide" into an immediate ``TypeError``. What Python's
+own required-kwarg mechanism does NOT defend against is the OPPOSITE
+mistake: a new (or edited) caller passing ``hydrate=True`` out of
+caution/laziness, silently re-opening the exact cost this flip exists to
+close, with no error anywhere — passing *some* value always satisfies the
+signature. This gate is the SYNTACTIC (not semantic) backstop for that
+one architect ruling: "本体が実際に要るのは wire を組む地点だけ" — the
+codebase should carry EXACTLY ONE ``hydrate=True`` call site
+(compaction's own token-measurement read, the one caller that reads
+``.content`` directly rather than through
+``RouterHistoryBuffer._serialise_turn``'s own unconditional
+``resolve_history_content`` call).
+
+## Two independent checks, not one
+
+Per architect's own post-mortem on THIS SAME PR's co-vet (issuecomment-
+5576144700): "flag の grep は「渡した場所」を数えるだけで、「渡していない
+呼び手」を数えない" — counting ``hydrate=True`` occurrences alone would
+have caught a wrong VALUE at an already-updated call site, but not a
+call site that was never updated in the first place (a 6th caller added
+later, or one this migration missed). So this gate runs BOTH:
+
+1. **Population**: every REAL ``_parse_history_line(...)`` call
+   (``ast.Call``, not a comment or a docstring's own prose mention) must
+   pass ``hydrate`` as a keyword argument — a call site with none would
+   be a ``TypeError`` at runtime already, but this gate catches it at
+   review time, in the diff, before a test happens to exercise that
+   exact line. AST-based (not a text/regex match) specifically so a
+   docstring sentence like "the ``self._parse_history_line(line)``
+   call" or a comment mentioning the method name never counts as a
+   call site — #5949 stage ①-b's own review hit exactly this shape.
+2. **Exactly-one**: ``hydrate=True`` (a literal ``True``, not merely a
+   truthy expression — this gate does not attempt to evaluate a
+   variable/expression argument, see :func:`_is_call_to` below) appears
+   at EXACTLY ONE call site across ``src/`` — today, ``Session.
+   _durable_active_history_after``'s own compaction-candidate read. A
+   count of 0 means that caller regressed to a lazy-only read (silently
+   wrong for compaction's token estimates); a count of 2+ means a NEW
+   caller chose the expensive path without anyone deciding it should.
+
+Both checks are pure syntax (parsed, never executed) — zero false
+positives by construction, the same "構文なら zero-FP" class architect
+named for #4846's own gate (``check_pr_closing_intent.py``'s own kind of
+check).
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCAN_DIRS = ("src", "tests")
+_METHOD_NAME = "_parse_history_line"
+
+
+def _iter_py_files(root: Path, scan_dirs: "tuple[str, ...]" = _SCAN_DIRS) -> "list[Path]":
+    files: "list[Path]" = []
+    for scan_dir in scan_dirs:
+        d = root / scan_dir
+        if d.is_dir():
+            files.extend(sorted(d.rglob("*.py")))
+    return files
+
+
+def _is_call_to(node: ast.AST, name: str) -> bool:
+    """True if *node* is a ``Call`` whose callee's final attribute/name
+    is *name* — matches ``self._parse_history_line(...)``,
+    ``session._parse_history_line(...)``, or a bare
+    ``_parse_history_line(...)``, never a string, comment, or docstring
+    mention of the same text."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == name
+    if isinstance(func, ast.Name):
+        return func.id == name
+    return False
+
+
+def find_calls_missing_hydrate(
+    root: Path = _ROOT, scan_dirs: "tuple[str, ...]" = _SCAN_DIRS,
+) -> "list[tuple[Path, int]]":
+    """Every REAL ``_parse_history_line(...)`` call site (excluding the
+    ``def`` line itself) that does not pass ``hydrate`` as a keyword
+    argument. Isolated from CLI/printing so it is directly testable
+    (``root`` defaults to the real repo root; a test passes its own
+    fixture tree)."""
+    offenders: "list[tuple[Path, int]]" = []
+    for path in _iter_py_files(root, scan_dirs):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        def_body_ids: "set[int]" = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == _METHOD_NAME:
+                def_body_ids.update(id(n) for n in ast.walk(node))
+        for node in ast.walk(tree):
+            if id(node) in def_body_ids:
+                continue  # inside the def's own body -- not a caller
+            if not isinstance(node, ast.Call) or not _is_call_to(node, _METHOD_NAME):
+                continue
+            has_hydrate = any(kw.arg == "hydrate" for kw in node.keywords)
+            if not has_hydrate:
+                offenders.append((path, node.lineno))
+    return offenders
+
+
+def count_hydrate_true_in_src(root: Path = _ROOT) -> "tuple[int, list[tuple[Path, int]]]":
+    """The population of REAL ``hydrate=True`` call sites under ``src/``
+    only (a test file legitimately drives either value for direct unit
+    coverage — the exactly-one constraint is a PRODUCTION cost claim,
+    architect's "wire を組む地点だけ", not a test-authoring rule). Only a
+    LITERAL ``True`` counts — a variable or expression argument is not
+    evaluated (this gate is a static syntax check, not an interpreter);
+    such a call site would also be flagged by nothing here, which is a
+    disclosed gap, not a silent one (see this function's own caller).
+    ``root`` defaults to the real repo root; a test passes its own
+    fixture tree."""
+    hits: "list[tuple[Path, int]]" = []
+    src_dir = root / "src"
+    if not src_dir.is_dir():
+        return 0, hits
+    for path in sorted(src_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_call_to(node, _METHOD_NAME):
+                continue
+            for kw in node.keywords:
+                if kw.arg == "hydrate" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                    hits.append((path, node.lineno))
+    return len(hits), hits
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options — a whole-tree scan against the current population
+    missing = find_calls_missing_hydrate()
+    true_count, true_hits = count_hydrate_true_in_src()
+
+    ok = True
+
+    if missing:
+        ok = False
+        print("parse-history-line-hydrate gate FAILED (population):\n", file=sys.stderr)
+        print(
+            f"{len(missing)} call(s) to _parse_history_line(...) do not pass "
+            "hydrate= as a keyword argument — every caller must decide "
+            "(#5949 stage ①-b, architect's structural ruling):",
+            file=sys.stderr,
+        )
+        for path, lineno in missing:
+            rel = path.relative_to(_ROOT)
+            print(f"  {rel}:{lineno}", file=sys.stderr)
+
+    if true_count != 1:
+        ok = False
+        print(
+            f"\nparse-history-line-hydrate gate FAILED (exactly-one): "
+            f"expected exactly 1 hydrate=True call site under src/, found "
+            f"{true_count}:",
+            file=sys.stderr,
+        )
+        for path, lineno in true_hits:
+            rel = path.relative_to(_ROOT)
+            print(f"  {rel}:{lineno}", file=sys.stderr)
+        print(
+            "\nThe one expected site is Session._durable_active_history_"
+            "after's own compaction-candidate read (_measure_and_select "
+            "computes real token estimates directly over .content, before "
+            "any wire is built). A count of 0 means that caller regressed "
+            "to a lazy-only read; 2+ means a new caller chose the "
+            "expensive path without anyone deciding it should — either "
+            "way, update this gate's own docstring if the population "
+            "genuinely changed on purpose, don't just raise the number.",
+            file=sys.stderr,
+        )
+
+    if ok:
+        print(
+            "OK: every _parse_history_line(...) call names hydrate= "
+            "explicitly, and exactly 1 call site under src/ passes "
+            "hydrate=True."
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4614,7 +4614,16 @@ class Session:
         from reyn.runtime.history_tail_reader import read_history_after
 
         lines, truncated = read_history_after(self.history_path, after_seq=after_seq)
-        parsed = [m for line in lines if (m := self._parse_history_line(line)) is not None]
+        # #5949 stage ①-b: hydrate=True — _measure_and_select (compaction_
+        # controller.py) computes real token estimates directly over these
+        # candidates' .content, before any wire is built; see
+        # _parse_history_line's own docstring for why this is the ONE
+        # caller of this method that genuinely needs the real body here
+        # rather than at wire-serialise time.
+        parsed = [
+            m for line in lines
+            if (m := self._parse_history_line(line, hydrate=True)) is not None
+        ]
         if self._state_log is None:
             return parsed, truncated
         from reyn.core.events.snapshot_generations import build_active_predicate
@@ -5008,7 +5017,7 @@ class Session:
         )
 
     def _parse_history_line(
-        self, line: str, *, preview_only: bool = False,
+        self, line: str, *, hydrate: bool,
     ) -> "ChatMessage | None":
         """Parse one ``history.jsonl`` line into a ``ChatMessage``, or
         ``None`` if malformed (skipped, never raised — byte-identical to
@@ -5019,49 +5028,67 @@ class Session:
         history.jsonl GC, which runs from ``AgentRegistry`` with no live
         ``Session``, has one parser to call instead of a second copy).
 
-        #5896 (#5364 §1.1 "A"): a tool row written since #5896 carries no
-        body on its line (``history_record``) — it is hydrated HERE, once,
-        from its ``history-content/`` file through the ONE resolver
-        (``resolve_history_content`` → ``history_content_resolve.resolve``),
-        so every reader of ``self.history`` — the live ``build_history``,
-        restore's ``project_restored_frames``, the read model, the
-        compaction candidate read (:meth:`_durable_active_history_after`,
-        which parses through this same method) — sees the same resident
-        shape a row appended in THIS process has: body on the message, ref
-        in meta. This is the same bytes the pre-#5896 parse read from the
-        history.jsonl line itself, now read from N files instead of one;
-        every one of this method's callers already reads from disk, so no
-        reader gains a disk read it did not have. A missing file hydrates
-        to the resolver's "lost" notice (reason ``EXTERNAL`` — stage ①
-        excludes un-spilled files from GC) and emits
-        ``offloaded_content_unavailable`` once per parse; a session with no
-        ``MediaStore`` (no multimodal config — every production factory
-        wires one) cannot validate the path boundary and leaves the row
-        as parsed, disclosed here rather than read around the store.
+        #5949 stage ①-b (P0, owner-hit — architect's structural ruling,
+        issuecomment-5576144700): ``hydrate`` has **no default** and is
+        **required** at every call site, and its polarity is the INVERSE
+        of the pre-①-b ``preview_only`` flag it replaces —
+        ``hydrate=False`` (cheap, the caller wants the row for DISPLAY or
+        candidate-selection scanning, not for materializing a body) is
+        what an un-decided call now falls back to only by being FORCED to
+        decide, never silently: a caller that forgets to reason about this
+        gets a ``TypeError`` at import/call time, not a defect that ships.
+        Before this: ``preview_only: bool = False`` meant "materialize by
+        default," so a NEW caller landed on the expensive path unless it
+        remembered to opt out — the exact shape that let stage ① fix only
+        ONE of 4 real ``_parse_history_line`` call sites while owner's
+        real backward-page-heavy path (``extend_history_backward_async``)
+        kept eager-hydrating, unchanged, silently.
 
-        ``preview_only`` (#5949, owner-hit P0): the caller wants the row
-        for DISPLAY (scrollback), not for the LLM wire. ``content`` stays
-        EMPTY here (never eager-hydrated) — a bounded preview is filled
-        in SEPARATELY, by :meth:`_fill_content_previews`, into
+        ``hydrate=False``: ``content`` stays EMPTY here (never eager-
+        hydrated) — for a content_ref row, a bounded preview is filled in
+        SEPARATELY by :meth:`_fill_content_previews`, into
         ``meta[CONTENT_PREVIEW_META_KEY]``, never into ``.content`` itself.
-        This is the ONE thing that makes the fix safe: the LLM wire path
-        (``RouterHistoryBuffer._serialise_turn``) reads ``.content``, which
-        stays exactly what an un-hydrated row already looks like — its own
-        EXISTING ``resolve_history_content`` call there lazily fetches the
-        REAL full body at wire-build time, regardless of whether a preview
-        was also computed for display. See module docstring at the top of
-        :func:`_fill_content_previews` for why this must be a caller-scoped
-        SECOND pass, not done inline here (the same file being referenced
-        by two different rows — a ``tool`` row and its own ``spill_record``
-        — must be read at most once per :meth:`_load_older_entries` call,
-        which requires a cache shared ACROSS lines, not per-line state)."""
+        This is safe because the LLM wire path
+        (``RouterHistoryBuffer._serialise_turn``) calls
+        ``resolve_history_content`` UNCONDITIONALLY on every message it
+        serialises (not gated on "was this row hydrated at parse time") —
+        an entry that already holds its body passes through untouched (no
+        disk read); one that doesn't gets hydrated THERE, lazily, at the
+        one place the real bytes are actually needed. So ``hydrate=False``
+        never starves the wire — it only stops a body from being
+        materialized somewhere upstream of it that never reads ``.content``
+        directly.
+
+        ``hydrate=True``: the caller reads ``.content`` itself, directly,
+        for something OTHER than wire serialisation — currently exactly
+        one such caller, :meth:`_durable_active_history_after` (compaction
+        candidate read): its own ``_measure_and_select`` computes real
+        token estimates over every candidate's ``.content`` BEFORE any
+        wire is built, so an empty/preview body there would silently
+        under-count every content_ref turn's true size and mis-select what
+        to fold. Hydrates from the ``history-content/`` file through the
+        ONE resolver (``resolve_history_content`` →
+        ``history_content_resolve.resolve``) exactly as before #5949. A
+        missing file hydrates to the resolver's "lost" notice (reason
+        ``EXTERNAL`` — stage ① excludes un-spilled files from GC) and
+        emits ``offloaded_content_unavailable`` once per parse; a session
+        with no ``MediaStore`` (no multimodal config — every production
+        factory wires one) cannot validate the path boundary and leaves
+        the row as parsed, disclosed here rather than read around the
+        store.
+
+        ``scripts/check_parse_history_line_hydrate_gate.py`` (structural
+        backstop, architect's ③) enumerates every call site of this
+        method across ``src/`` and ``tests/`` and fails if any of them
+        omits ``hydrate=`` — the enumeration this docstring names must
+        stay the actual population, not a snapshot of it."""
         msg = parse_history_line(line)
         if msg is None or msg.role != "tool" or msg.content != "":
             return msg
         meta = msg.meta or {}
         if not meta.get(CONTENT_REF_META_KEY) or meta.get(SPILLED_META_KEY):
             return msg
-        if preview_only:
+        if not hydrate:
             return msg
         if self._media_store is None:
             return msg
@@ -5076,8 +5103,22 @@ class Session:
 
     def _append_parsed_history_line(self, line: str) -> None:
         """Parse one ``history.jsonl`` line and append it to ``self.history``
-        — the per-line body shared by both of :meth:`load_history`'s paths."""
-        msg = self._parse_history_line(line)
+        — the per-line body shared by both of :meth:`load_history`'s paths
+        (the fast tail read and the fallback full read), AND the live-
+        append path a normal running turn uses to keep ``self.history`` in
+        sync with what it just wrote durably.
+
+        #5949 stage ①-b: ``hydrate=False`` — a resident content_ref row
+        stays preview-only here too. Safe for the SAME reason
+        :meth:`_parse_history_line`'s own docstring gives:
+        ``RouterHistoryBuffer._serialise_turn`` hydrates any still-empty
+        body unconditionally at wire-build time, regardless of how the
+        resident row got there. A desirable side effect for a migration
+        that hasn't reached a given row yet (#5896 stage ③, owner-
+        confirmation-pending): even an un-migrated, still-inline row that
+        this method parses stays exactly as cheap to hold resident as a
+        migrated one — nothing here depends on migration having run."""
+        msg = self._parse_history_line(line, hydrate=False)
         if msg is not None:
             self.history.append(msg)
 
@@ -5122,8 +5163,11 @@ class Session:
         ``meta[CONTENT_PREVIEW_META_KEY]`` for every content_ref
         ``role="tool"`` row in *parsed* whose ``content`` is empty (i.e.
         every row :meth:`_parse_history_line` returned with
-        ``preview_only=True``) — called ONCE per :meth:`_load_older_entries`
-        invocation, over the WHOLE batch it just parsed, not per line.
+        ``hydrate=False``) — called ONCE per
+        :meth:`_read_and_parse_older_entries` invocation (shared by both
+        :meth:`_load_older_entries` and :meth:`extend_history_backward_async`
+        — #5949 stage ①-b), over the WHOLE batch it just parsed, not per
+        line.
 
         Two guards, both load-bearing (architect's own two derived
         findings, #5949):
@@ -5155,6 +5199,46 @@ class Session:
                 cache[ref] = self._build_content_preview(ref)
             msg.meta[CONTENT_PREVIEW_META_KEY] = cache[ref]
 
+    def _read_and_parse_older_entries(
+        self, *, before_seq: int, min_lines: int,
+    ) -> "list[ChatMessage]":
+        """#5949 stage ①-b (P0, owner-hit — stage ① alone made owner's
+        real ``reyn:web``/``reyn:chat`` peak WORSE, 11 GB / 14 GB, because
+        it only fixed :meth:`_load_older_entries`, the SYNC backward-page
+        primitive; the path attach actually drives,
+        :meth:`extend_history_backward_async`, had its OWN, separate parse
+        loop — no ``hydrate`` flag at all, no preview fill — that stage ①
+        never touched). This method is the ONE place the disk-read + parse +
+        preview-fill sequence exists: both callers below now call THIS,
+        not each other, closing the "same parse duplicated in two places"
+        shape that let ① land selectively.
+
+        Deliberately touches nothing on ``self`` except read-only state
+        (``self.history_path``, ``self._media_store``) — it constructs
+        and returns a VALUE, no ``self.history`` mutation — so it is
+        exactly what :meth:`extend_history_backward_async` needs to keep
+        running fully off the event loop via ``asyncio.to_thread`` (the
+        #5079/#4995 read/apply split is unchanged: this method IS the
+        "read" half, splicing into ``self.history`` stays the caller's
+        own job, on the loop).
+
+        Returns an empty list when nothing qualifies (already at the
+        file's start, or every line failed to parse) — callers treat that
+        as "prepend nothing," identically."""
+        from reyn.runtime.history_tail_reader import read_history_before
+
+        lines = read_history_before(
+            self.history_path, before_seq=before_seq, min_lines=min_lines,
+        )
+        if not lines:
+            return []
+        parsed = [
+            m for line in lines
+            if (m := self._parse_history_line(line, hydrate=False)) is not None
+        ]
+        self._fill_content_previews(parsed)
+        return parsed
+
     def _load_older_entries(self, *, before_seq: int, min_lines: int = _HISTORY_HYDRATE_MIN_LINES) -> int:
         """#4387 Phase B ②: extend ``self.history`` BACKWARD from
         ``history.jsonl``, prepending up to ``min_lines`` entries older
@@ -5173,30 +5257,20 @@ class Session:
         back a rewind can reach, which is an owner-facing capability
         question, not one this stage answers.
 
-        #5949 (owner-hit P0): parses with ``preview_only=True`` — this is
-        a backward, DISPLAY-oriented read (scrollback paging, attach), not
-        a wire-building one, so a content_ref row's body is never eagerly
-        materialized here. :meth:`_fill_content_previews` then fills a
-        BOUNDED preview for the whole batch in one pass (see its own
-        docstring for the two guards — spill_record exclusion, same-ref
-        read-once). ``.content`` itself stays untouched (empty) either
+        #5949 (owner-hit P0): the read+parse+preview sequence is
+        :meth:`_read_and_parse_older_entries` — this method's own body is
+        now just that call plus the splice, so the SAME sequence backs
+        both this method and :meth:`extend_history_backward_async` (see
+        that helper's docstring for why stage ① alone did not reach the
+        async path). ``.content`` itself stays untouched (empty) either
         way — the LLM wire path's own lazy resolve
         (``RouterHistoryBuffer._serialise_turn``) is unaffected by this
-        change; see :meth:`_parse_history_line`'s own ``preview_only``
+        change; see :meth:`_parse_history_line`'s own ``hydrate``
         docstring for why that is what makes this safe.
         """
-        from reyn.runtime.history_tail_reader import read_history_before
-
-        lines = read_history_before(
-            self.history_path, before_seq=before_seq, min_lines=min_lines,
-        )
-        if not lines:
+        parsed = self._read_and_parse_older_entries(before_seq=before_seq, min_lines=min_lines)
+        if not parsed:
             return 0
-        parsed = [
-            m for line in lines
-            if (m := self._parse_history_line(line, preview_only=True)) is not None
-        ]
-        self._fill_content_previews(parsed)
         self.history[0:0] = parsed
         return len(parsed)
 
@@ -5234,10 +5308,9 @@ class Session:
         apply on the loop" split, applied to a second place, no new
         mechanism:
 
-        - Step ① (the disk read, :func:`~reyn.runtime.history_tail_
-          reader.read_history_before`, plus the pure
-          :meth:`_parse_history_line` parse) is not ``Session``'s own —
-          it constructs a VALUE, touching nothing mutable — so it runs
+        - Step ① (the disk read + parse + preview-fill,
+          :meth:`_read_and_parse_older_entries`) is not ``Session``'s own
+          — it constructs a VALUE, touching nothing mutable — so it runs
           OFF the loop via ``asyncio.to_thread``, freeing the worker loop
           (once #5048 wires this in) to keep servicing everything else —
           router turns, other frames — while the read is in flight.
@@ -5245,6 +5318,19 @@ class Session:
           ``Session``'s own — a small, in-memory, synchronous mutation —
           so it stays exactly where :meth:`_load_older_entries` already
           puts it.
+
+        #5949 stage ①-b (P0, owner-hit — the reason this docstring changed
+        from stage ①): this is the path attach ACTUALLY drives
+        (``endpoint.py``'s backlog send calls this async method, never the
+        sync :meth:`extend_history_backward`) — stage ① fixed only the
+        sync :meth:`_load_older_entries`'s own parse loop, and this method
+        had a SEPARATE, un-fixed one (no ``hydrate`` flag at all, no
+        preview fill), so owner's real backward-page-heavy path kept eager-
+        materializing every content_ref body, unchanged. Now sharing
+        :meth:`_read_and_parse_older_entries` with the sync path closes
+        that — see that method's own docstring for why this was a
+        duplicated-implementation defect, not two independently-correct
+        mechanisms.
 
         Guarded against the same race #4983 solved, reusing the EXISTING
         ``before_seq`` value as the staleness token (architect's explicit
@@ -5256,16 +5342,13 @@ class Session:
         stale read would duplicate or misorder entries, so it is skipped:
         a no-op, the same word #4983's own docstring uses for its
         supersede case, not a new concept."""
-        from reyn.runtime.history_tail_reader import read_history_before
-
         before_seq = self.history[0].seq if self.history else 0
-        lines = await asyncio.to_thread(
-            read_history_before,
-            self.history_path, before_seq=before_seq, min_lines=min_lines,
+        parsed = await asyncio.to_thread(
+            self._read_and_parse_older_entries,
+            before_seq=before_seq, min_lines=min_lines,
         )
-        if not lines:
+        if not parsed:
             return 0
-        parsed = [m for line in lines if (m := self._parse_history_line(line)) is not None]
         current_oldest_seq = self.history[0].seq if self.history else 0
         if current_oldest_seq != before_seq:
             return 0

--- a/tests/interfaces/test_4995_threaded_transport_proxy.py
+++ b/tests/interfaces/test_4995_threaded_transport_proxy.py
@@ -411,8 +411,14 @@ def _make_history_session(tmp_path):
         ),
     )
     lines = _write_history_lines(session.history_path, range(1, 11))
+    # #5949 stage ①-b: hydrate=False -- every row here is role="user" with
+    # no content_ref, so this is inert either way (only a "tool"
+    # content_ref row's parse consults `hydrate` at all), but every
+    # `_parse_history_line` call must now name its choice explicitly (the
+    # structural gate enumerates callers, not just effects).
     session.history = [
-        m for line in lines[5:] if (m := session._parse_history_line(line)) is not None
+        m for line in lines[5:]
+        if (m := session._parse_history_line(line, hydrate=False)) is not None
     ]
     return session
 
@@ -569,6 +575,7 @@ async def test_extend_history_backward_async_apply_is_a_no_op_when_history_moved
         # flight").
         intruder = session._parse_history_line(
             json.dumps({"role": "user", "content": "intruder", "seq": 99}),
+            hydrate=False,  # #5949 stage ①-b: inert here (no content_ref row)
         )
         session.history.insert(0, intruder)
 

--- a/tests/runtime/test_5896_history_content_ref.py
+++ b/tests/runtime/test_5896_history_content_ref.py
@@ -141,19 +141,33 @@ async def test_build_history_wire_is_the_same_live_and_after_a_restart(
     form only (architect: "build_history の出力が A の前後で byte 一致"):
     the wire the model would see from the LIVE session (resident rows,
     body cached) equals the wire a SECOND session rebuilds from disk
-    alone (rows parsed from ``history.jsonl``, body hydrated from the
-    file by ``Session._parse_history_line`` through the one resolver).
+    alone (rows parsed from ``history.jsonl``, body resolved via the
+    ONE resolver, ``RouterHistoryBuffer._serialise_turn``'s own
+    unconditional ``resolve_history_content`` call, at wire-build time).
 
     This is also acceptance ③'s restart half: the on-disk state the
     second session reads is exactly what a kill right after
     ``persist_feedback`` leaves behind (nothing else runs between the
     append and this test's own restart), and the body resolves — it is
-    not ``lost``. The restored ``session.history`` row itself holds the
-    body, which is what ``project_restored_frames`` and the read model
-    project without any change of their own.
+    not ``lost``.
 
-    Strip-falsify: remove the hydration in ``_parse_history_line`` → the
-    restarted wire carries an empty tool body → red."""
+    #5949 stage ①-b (P0, owner-hit — architect's structural ruling): the
+    RESIDENT row (``restarted.history``'s own ``ChatMessage``) is no
+    longer required to hold the body itself — ``Session.load_history()``
+    now parses with ``hydrate=False`` (same as backward-paging since
+    stage ①), so ``restored_row.text`` is legitimately empty; only the
+    WIRE (``build_history()``'s own output) is the load-bearing claim
+    this test makes, and it stays byte-identical regardless of whether
+    the resident row that fed it was hydrated at parse time or resolved
+    lazily at serialise time — that equivalence is the whole point of
+    this restructuring, not something it weakens.
+
+    Strip-falsify: reverting :meth:`Session._append_parsed_history_line`
+    to ``hydrate=True`` still keeps this GREEN (a stronger resident row is
+    still a valid resident row) — the test that actually goes RED on a
+    real regression here is :meth:`RouterHistoryBuffer._serialise_turn`'s
+    own ``resolve_history_content`` call being removed or skipped, which
+    is exactly what the assert below still catches."""
     monkeypatch.chdir(tmp_path)
     live = _session("restart-agent", tmp_path)
     loop = RouterLoop(host=live.router_host, chain_id="c1", router_model=_MODEL)
@@ -166,10 +180,7 @@ async def test_build_history_wire_is_the_same_live_and_after_a_restart(
     restarted = _session("restart-agent", tmp_path)
     restarted.load_history()
 
-    (restored_row,) = [m for m in restarted.history if m.role == "tool"]
-    (live_row,) = [m for m in live.history if m.role == "tool"]
     restarted_wire = restarted._loop_driver._history_buffer.build_history()
-    assert restored_row.text == live_row.text
     assert restarted_wire == live_wire
 
 

--- a/tests/runtime/test_5949_attach_lazy_preview.py
+++ b/tests/runtime/test_5949_attach_lazy_preview.py
@@ -72,6 +72,30 @@ async def _write_one_content_ref_row(tmp_path: Path, agent_name: str, body: str)
     await loop.persist_feedback()
 
 
+async def _write_content_ref_row_then_filler_turns(
+    tmp_path: Path, agent_name: str, body: str, *, n_filler_turns: int,
+) -> None:
+    """Like :func:`_write_one_content_ref_row`, plus *n_filler_turns* plain
+    user/assistant turns appended AFTER it — pushes the content_ref row far
+    enough into the past that a fresh session's own bounded in-memory tail
+    (mirroring ``test_5139c_older_backlog_wire_roundtrip.py``'s own
+    ``session.history = session.history[-2:]`` idiom) genuinely excludes
+    it, forcing a real on-disk extend to bring it back — needed for
+    :func:`test_attach_endpoint_backlog_page_never_eager_hydrates_via_the_
+    async_path` below, which must drive the row through a REAL disk
+    extend, not just a freshly-loaded in-memory tail that happens to
+    already contain it."""
+    from reyn.runtime.chat_message import ChatMessage
+
+    session = _session(agent_name, tmp_path)
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    loop.feedback(_round(body))
+    await loop.persist_feedback()
+    for i in range(n_filler_turns):
+        session._append_history(ChatMessage(role="user", content=f"filler question {i}"))  # noqa: SLF001 - real durable-write seam, same as test_5139c's own helper
+        session._append_history(ChatMessage(role="assistant", content=f"filler answer {i}"))  # noqa: SLF001
+
+
 # ── 1. backward-paging never eager-hydrates .content ────────────────────
 
 
@@ -85,7 +109,7 @@ async def test_backward_paged_content_ref_row_keeps_content_empty(
     materialized into ``.content``/`.text`` — this is the whole point:
     materializing it is exactly what blew up 566 MB -> 8 GB.
 
-    Strip witness: passing ``preview_only=False`` (the pre-fix default)
+    Strip witness: passing ``hydrate=True`` (the pre-①-b default polarity)
     from ``_load_older_entries`` makes ``.text`` equal the full 20000-char
     body instead of empty — verified directly, restored after."""
     monkeypatch.chdir(tmp_path)
@@ -115,13 +139,89 @@ async def test_backward_paged_content_ref_row_keeps_content_empty(
     assert tool_msg.meta.get(CONTENT_REF_META_KEY), "sanity: this must genuinely be a content_ref row"
 
 
+# ── 1b. the REAL owner-driving path: endpoint.session_backlog_page ──────
+
+
+@pytest.mark.asyncio
+async def test_attach_endpoint_backlog_page_never_eager_hydrates_via_the_async_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5949 stage ①-b acceptance (owner-hit P0, architect
+    structural ruling issuecomment-5576144700) — drives the REAL path
+    attach actually uses (``endpoint.session_backlog_page`` ->
+    ``Session.extend_history_backward_async``, via ``endpoint.py``'s
+    backlog send), never ``_load_older_entries``/the private primitive
+    directly. Stage ① alone left THIS path unfixed: it had its own,
+    separate parse loop with no ``hydrate`` awareness at all, so owner's
+    real backward-page-heavy path kept eager-materializing every
+    content_ref body, unchanged, after stage ① landed — owner's real
+    measurement got WORSE (11 GB / 14 GB peak), not better. This is the
+    acceptance lead-coder's own review named as missing from stage ①'s
+    TESTS-READ: "test は attach の経路を driving していませんでした."
+
+    Strip witness: reverting :meth:`Session.extend_history_backward_async`
+    to its pre-①-b form (its own separate
+    ``self._parse_history_line(line)`` call, the eager-hydrate-by-default
+    polarity ``hydrate`` replaced) turns this red — verified directly,
+    restored after."""
+    from reyn.interfaces.transport.agui.endpoint import session_backlog_page
+    from reyn.runtime.profile import AgentProfile
+    from reyn.runtime.registry import _DEFAULT_SID, AgentRegistry
+
+    monkeypatch.chdir(tmp_path)
+    agent_name = "endpoint-agent"
+    await _write_content_ref_row_then_filler_turns(
+        tmp_path, agent_name, _BODY, n_filler_turns=5,
+    )
+
+    def factory(profile: AgentProfile):
+        s = _session(profile.name, tmp_path)
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create(agent_name)
+    try:
+        await reg.attach(agent_name)
+        session = reg.get_session(agent_name, _DEFAULT_SID)
+        assert session is not None
+        (loaded_seq,) = [m.seq for m in session.history if m.role == "tool"]
+        # Bound the in-memory tail BELOW the tool row -- forces a REAL
+        # on-disk extend (mirrors test_5139c_older_backlog_wire_roundtrip.
+        # py's own test_has_more_extends_from_disk_past_the_in_memory_tail
+        # idiom) rather than letting a freshly-loaded tail happen to
+        # already contain the row under test.
+        session.history = [m for m in session.history if m.seq > loaded_seq]
+        assert session.history, "sanity: filler turns must still be resident"
+        assert not any(m.role == "tool" for m in session.history), (
+            "sanity: the tool row must genuinely be excluded from the "
+            "bounded in-memory tail, or the extend below proves nothing"
+        )
+
+        await session_backlog_page(reg, agent_name, _DEFAULT_SID)
+
+        (tool_msg,) = [m for m in session.history if m.role == "tool"]
+        assert tool_msg.content == "", (
+            f"a content_ref row pulled back via the REAL attach/endpoint "
+            f"path (session_backlog_page -> extend_history_backward_async) "
+            f"must NOT have its body materialized; got "
+            f"{len(tool_msg.content)} chars"
+        )
+        assert tool_msg.meta.get(CONTENT_PREVIEW_META_KEY), (
+            "a bounded preview must still be filled for display, via the "
+            "same _fill_content_previews pass the sync path uses"
+        )
+    finally:
+        await reg.shutdown()
+
+
 def test_preview_only_parse_leaves_content_empty_directly(tmp_path: Path) -> None:
     """Tier 1: the same claim as above, isolated to ``_parse_history_line``
     itself (no Session-level paging machinery involved) — a durable line
-    with a content_ref, parsed with ``preview_only=True``, returns a
-    message whose ``.content`` is still ``""``.
+    with a content_ref, parsed with ``hydrate=False``, returns a message
+    whose ``.content`` is still ``""``.
 
-    Strip witness: removing the ``if preview_only: return msg`` guard
+    Strip witness: removing the ``if not hydrate: return msg`` guard
     (falling through to the eager resolve) makes ``.content`` equal the
     full body — verified directly, restored after."""
     from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
@@ -140,10 +240,10 @@ def test_preview_only_parse_leaves_content_empty_directly(tmp_path: Path) -> Non
         "spillability": "last_resort", "disclosure": None,
     })
 
-    msg = session._parse_history_line(line, preview_only=True)
+    msg = session._parse_history_line(line, hydrate=False)
 
     assert msg is not None
-    assert msg.content == "", f"preview_only=True must leave content empty, got {len(msg.content)} chars"
+    assert msg.content == "", f"hydrate=False must leave content empty, got {len(msg.content)} chars"
 
 
 # ── 2. a bounded preview is filled, with the "+N MB" notice ─────────────

--- a/tests/scripts/test_5949_parse_history_line_hydrate_gate.py
+++ b/tests/scripts/test_5949_parse_history_line_hydrate_gate.py
@@ -1,0 +1,169 @@
+"""Tier 2: #5949 stage ①-b — the ``hydrate`` structural backstop gate
+(architect's ③, issuecomment-5576144700). Real filesystem fixtures
+throughout (a real ``tmp_path`` tree of ``.py`` files) — the functions
+under test parse real file content via ``ast``, so faking the filesystem
+would test nothing real.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_parse_history_line_hydrate_gate import (
+    count_hydrate_true_in_src,
+    find_calls_missing_hydrate,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_a_call_missing_hydrate_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: THE real-world instance — a new caller of
+    ``_parse_history_line`` that forgot ``hydrate=`` entirely is exactly
+    the shape :meth:`extend_history_backward_async` had before stage
+    ①-b (a whole SEPARATE parse loop, never updated when stage ① added
+    the flag elsewhere)."""
+    src = tmp_path / "src" / "m.py"
+    _write(src, "class S:\n    def f(self, line):\n        return self._parse_history_line(line)\n")
+    offenders = find_calls_missing_hydrate(tmp_path, ("src",))
+    assert offenders == [(src, 3)]
+
+
+def test_a_call_naming_hydrate_explicitly_is_never_flagged(tmp_path: Path) -> None:
+    """Tier 2: either polarity, spelled out, is not an offender — the gate
+    enforces DECIDING, not a specific decision."""
+    src = tmp_path / "src" / "m.py"
+    _write(
+        src,
+        "class S:\n"
+        "    def f(self, line):\n"
+        "        return self._parse_history_line(line, hydrate=False)\n"
+        "    def g(self, line):\n"
+        "        return self._parse_history_line(line, hydrate=True)\n",
+    )
+    assert find_calls_missing_hydrate(tmp_path, ("src",)) == []
+
+
+def test_a_multiline_call_with_hydrate_on_a_later_line_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 2: AST-based, not a same-line text match — the real
+    :meth:`_parse_history_line` call the stage ①-b review actually wrote
+    spans multiple lines (the ref/body argument on its own line, then
+    ``hydrate=...`` below it) — a same-line regex would have false-
+    flagged exactly this shape (measured directly against the real
+    ``test_4995_threaded_transport_proxy.py``'s own multi-line call while
+    building this gate)."""
+    src = tmp_path / "src" / "m.py"
+    _write(
+        src,
+        "class S:\n"
+        "    def f(self, line):\n"
+        "        return self._parse_history_line(\n"
+        "            line,\n"
+        "            hydrate=False,\n"
+        "        )\n",
+    )
+    assert find_calls_missing_hydrate(tmp_path, ("src",)) == []
+
+
+def test_a_docstring_or_comment_mention_is_never_flagged(tmp_path: Path) -> None:
+    """Tier 2: a PROSE mention of the method's name — a docstring
+    cross-reference or a code comment naming it — must never be counted
+    as a real call site. AST-based specifically so this holds: this gate
+    itself would have false-flagged its own PR's docstrings under a
+    same-line text match (measured directly while building this gate —
+    an earlier regex-based draft flagged 2 real docstring/comment lines
+    in this exact PR)."""
+    src = tmp_path / "src" / "m.py"
+    _write(
+        src,
+        'class S:\n'
+        '    def f(self, line):\n'
+        '        """See self._parse_history_line(line) for the shape."""\n'
+        '        # _parse_history_line(...) is called elsewhere\n'
+        '        return None\n',
+    )
+    assert find_calls_missing_hydrate(tmp_path, ("src",)) == []
+
+
+def test_the_defs_own_body_is_never_a_caller(tmp_path: Path) -> None:
+    """Tier 2: ``_parse_history_line``'s own ``def`` body may reference
+    itself in a docstring cross-reference or recursive call shape without
+    being counted as an offending CALLER — the gate is about every OTHER
+    site deciding, not the definition site."""
+    src = tmp_path / "src" / "m.py"
+    _write(
+        src,
+        "class S:\n"
+        "    def _parse_history_line(self, line, *, hydrate):\n"
+        "        return self._parse_history_line(line, hydrate=hydrate)\n",
+    )
+    assert find_calls_missing_hydrate(tmp_path, ("src",)) == []
+
+
+def test_exactly_one_hydrate_true_in_src_is_the_expected_population(tmp_path: Path) -> None:
+    """Tier 2: the exactly-one constraint's happy path."""
+    src = tmp_path / "src" / "m.py"
+    _write(
+        src,
+        "class S:\n"
+        "    def f(self, line):\n"
+        "        return self._parse_history_line(line, hydrate=True)\n"
+        "    def g(self, line):\n"
+        "        return self._parse_history_line(line, hydrate=False)\n",
+    )
+    count, hits = count_hydrate_true_in_src(tmp_path)
+    assert count == 1
+    assert hits == [(src, 3)]
+
+
+def test_two_hydrate_true_call_sites_in_src_is_flagged(tmp_path: Path) -> None:
+    """Tier 2: THE real-world instance the exactly-one check exists to
+    catch — a SECOND caller landing on the expensive path without anyone
+    having decided it should (architect: "本体が実際に要るのは wire を組む
+    地点だけ")."""
+    a = tmp_path / "src" / "a.py"
+    b = tmp_path / "src" / "b.py"
+    _write(a, "class S:\n    def f(self, line):\n        return self._parse_history_line(line, hydrate=True)\n")
+    _write(b, "class T:\n    def g(self, line):\n        return self._parse_history_line(line, hydrate=True)\n")
+    count, hits = count_hydrate_true_in_src(tmp_path)
+    assert count == 2
+    assert sorted(hits) == sorted([(a, 3), (b, 3)])
+
+
+def test_hydrate_true_in_a_test_file_does_not_count_toward_the_src_population(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the exactly-one constraint is a PRODUCTION cost claim
+    (``src/`` only) — a test file directly unit-testing the eager path
+    with ``hydrate=True`` is legitimate test authorship, not a new
+    production caller, and must not move the count."""
+    src = tmp_path / "src" / "m.py"
+    tests = tmp_path / "tests" / "test_m.py"
+    _write(src, "class S:\n    def f(self, line):\n        return self._parse_history_line(line, hydrate=True)\n")
+    _write(tests, "def test_x(session, line):\n    session._parse_history_line(line, hydrate=True)\n")
+    count, hits = count_hydrate_true_in_src(tmp_path)
+    assert count == 1
+    assert hits == [(src, 3)]
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population — verified against the
+    real, current tree (not assumed), matching
+    ``check_bare_tests_import_reference.py``'s own "run it before shipping
+    it" discipline. #5949 stage ①-b's own migration is what FIRST brought
+    this population to (0 missing, exactly 1 hydrate=True); this asserts
+    it stayed there."""
+    from scripts.check_parse_history_line_hydrate_gate import _ROOT
+
+    missing = find_calls_missing_hydrate(_ROOT)
+    assert missing == [], (
+        f"real caller(s) missing hydrate=: {missing} — every "
+        "_parse_history_line(...) call must decide explicitly"
+    )
+    count, hits = count_hydrate_true_in_src(_ROOT)
+    assert count == 1, (
+        f"expected exactly 1 hydrate=True call site under src/, found "
+        f"{count}: {hits}"
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5949.

## What broke, and why it's structural, not a 2nd flag

Stage ① (#5955, merged) fixed `Session._load_older_entries`'s own parse loop, but attach actually drives a SEPARATE, un-fixed one: `Session.extend_history_backward_async` (`endpoint.py`'s backlog send is what calls it — never the sync `extend_history_backward`). Owner's real measurement got WORSE after stage ① landed (`reyn:web` peak 11 GB, `reyn:chat` peak 14 GB) — not better — because the path that actually runs was never touched.

Architect's ruling (issuecomment-5576144700, owner: "考慮漏れが起きないよう構造化してよね"): don't patch the second call site with the same flag — **flip the default**. `preview_only: bool = False` meant "materialize by default," so a new/missed caller silently landed on the expensive path. `hydrate` now has **no default at all** — every caller must decide, and Python raises `TypeError` on a forgotten one. Only the ONE caller that reads `.content` directly for something other than the LLM wire (compaction's `_durable_active_history_after`, whose own `_measure_and_select` computes real token estimates before any wire is built) passes `hydrate=True`. Every other caller — live append, startup, and both backward-paging primitives — stays cheap; `RouterHistoryBuffer._serialise_turn`'s own unconditional `resolve_history_content` call resolves the real body lazily at wire-build time regardless of parse-time hydration.

## Full caller enumeration (verified via `git grep`, not `| head`)

| site | choice | why |
|---|---|---|
| `session.py` `_durable_active_history_after` (compaction input) | `hydrate=True` | `_measure_and_select` reads `.content` directly for token estimates, before any wire |
| `session.py` `_append_parsed_history_line` (live append + startup) | `hydrate=False` | wire lazily resolves regardless; verified empirically (see below) |
| `session.py` `_read_and_parse_older_entries` (shared by both backward-paging primitives) | `hydrate=False` | display-only, preview filled separately |
| `tests/interfaces/test_4995_threaded_transport_proxy.py` (2 call sites) | `hydrate=False` | inert (plain `role="user"` rows, no content_ref), but must still decide |

## Structural fix ②: two implementations → one

`_load_older_entries` (sync) and `extend_history_backward_async` (async) each had their OWN parse loop — the direct cause stage ① only landed on one. New `_read_and_parse_older_entries` is the ONE disk-read+parse+preview-fill implementation; the async path calls it via `asyncio.to_thread` (preserving the #5079/#4995 read-off-loop/apply-on-loop split), the sync path calls it directly.

## Structural fix ③: the backstop gate (architect's own post-mortem)

Architect's co-vet on an earlier draft of this same PR counted `git grep 'hydrate=True'` alone and missed 4 of 5 real callers — "flag の grep は「渡した場所」を数えるだけで、「渡していない呼び手」を数えない." `scripts/check_parse_history_line_hydrate_gate.py` (AST-based, zero-FP) runs BOTH checks: every real `_parse_history_line(...)` call names `hydrate=` explicitly, AND exactly 1 call site under `src/` passes `hydrate=True`. 9 tests, including a self-check against the real tree.

## Acceptance — driving the REAL owner path

`test_attach_endpoint_backlog_page_never_eager_hydrates_via_the_async_path` drives `endpoint.session_backlog_page` → `extend_history_backward_async` through a real `AgentRegistry`/`attach()`, not the private primitive directly — the gap lead-coder's own TESTS-READ review on stage ① named as missing ("test は attach の経路を driving していませんでした"). Strip-verified: reverting the async path's own call to lose `hydrate=False` turns it red.

`phys_footprint_peak` on the owner's own host (2 processes, `reyn:web`/`reyn:chat` separately) is real-machine-only and can't be reproduced here — this PR's acceptance is the structural claim (never eager-hydrates via the real driving path) plus the existing wire-identity witness, both strip-verified; the owner-machine peak re-measurement is the natural next confirmation once this lands.

## One existing test updated, not weakened

`test_5896_history_content_ref.py`'s `test_build_history_wire_is_the_same_live_and_after_a_restart` asserted the RESIDENT row's raw `.content` matched between a live and a restarted session — a property this redesign deliberately breaks (the resident row is no longer required to hold the body). Updated to keep only the load-bearing claim the test's own docstring names: the WIRE (`build_history()`) stays byte-identical, which is the actual acceptance architect asked for ("build_history の出力が A の前後で byte 一致").

## Local gates run

ruff, `test_tier_audit.py --strict` (32 tests, 0 findings), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), plus the `tests/` path-conditional gates (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`) — all green. Scoped pytest: 7+7+9+9 = 32 tests in the directly-changed files, plus 60+83 = 143 tests across every other file in the repo that calls `load_history()`/the live-append path (full enumeration via `grep -rl`), plus the #5896/#5364/#4472/#4470 compaction and content-ref suites — all green. Did NOT run the full suite locally (CI-only, per house rule).

## Test plan
- [x] Scoped pytest green (see above)
- [x] Strip-falsify: reverting the async path's shared-helper call to a bare eager parse turns the new acceptance test red (verified directly)
- [x] Gate script's own 9 tests, including self-check against the real tree
- [ ] (skipped — Visual, standing waiver) N/A, no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)