### PR TITLE
fix(#5919 stage 2): anchor check_open_blocking_checkboxes.py's DECIDING markers, unify checkbox/comment resolution

### DIFF
--- a/scripts/_markers.py
+++ b/scripts/_markers.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 """Shared marker-detection primitives for declaration/exemption/closing-note
-gates (#5919 stage 1).
+gates (#5919 stage 1, extended by stage 2).
 
 ## The class this closes
 
 Five `scripts/` gates each read prose (a PR comment, a PR body, a source
 comment) looking for a human's *declaration* — "TESTS-READ", "RE-READ",
 "BLOCKING-CLEARED", "this file is exempt", "this PR closes #N". Four of
-them (the ones this module serves; the fifth, `check_open_blocking_
-checkboxes.py`'s `_resolves_via_body`, is a separate PR — house-rule
-change, architect's call) used to detect a declaration by `.search()`-ing
-free text for a keyword, unanchored. #5919's census found the shared
+them (the ones stage 1 served; the fifth, `check_open_blocking_
+checkboxes.py`'s `_resolves_via_body` / marker anchoring, landed in
+stage 2, also via this module) used to detect a declaration by
+`.search()`-ing free text for a keyword, unanchored. #5919's census found
+the shared
 defect: **a sentence saying the declaration does NOT apply still contains
 the keyword**, so "no TESTS-READ note yet" and "No RE-READ needed here"
 both read as the note they deny. Each gate had grown its own regex to do
@@ -60,6 +61,16 @@ Three shapes cover the four gates:
   *mentioning* the same fixture name mid-sentence does not start there.
   Used by `check_subprocess_reyn_pin.py`'s exemption declaration.
 
+`undecorated_after_role_prefix` (stage 2) is a companion to
+`role_prefixed_marker`, not a fourth shape: once a gate strips its own
+markdown decoration (backtick/`*`) before matching, a blanket strip over
+the WHOLE line would erase a real role prefix's own literal `**[...]**`
+syntax right along with it — this function strips only AFTER a detected
+role prefix, so `role_prefixed_marker`'s anchor still has something to
+match. Used by `check_open_blocking_checkboxes.py` and (reusing THAT
+gate's own marker regex + decoration pattern, not a second copy)
+`check_blocking_has_reread_note.py`.
+
 ## What this module deliberately does NOT do
 
 It does not decide what counts as a declaration for any one gate — each
@@ -95,6 +106,35 @@ def role_prefixed_marker(keyword_pattern: str, *, flags: int = re.IGNORECASE) ->
     line — never a whole multi-line comment, or the anchor is
     meaningless."""
     return re.compile(rf"^(?:{ROLE_PREFIX})?{keyword_pattern}", flags)
+
+
+def undecorated_after_role_prefix(line: str, decoration: "re.Pattern[str]") -> str:
+    """*line*, with *decoration* stripped EVERYWHERE EXCEPT a leading
+    CLAUDE.md role prefix (:data:`ROLE_PREFIX`), if one opens the line.
+
+    #5919 stage 2 (`check_open_blocking_checkboxes.py`'s own real
+    incident, then reused by `check_blocking_has_reread_note.py` when its
+    own consumption of that gate's rename surfaced the same shape): a role
+    prefix is ITSELF written with literal ``**...**`` — the same character
+    class a gate's own decoration-tolerance (backtick/`*`, #5522) strips.
+    A blanket, unconditional strip run over the WHOLE line would erase the
+    role prefix's own asterisks right along with any decoration AROUND a
+    marker that follows it, so a real, decorated comment like
+    ``**[lead-coder]** — **BLOCKING (head `abc1234`)**`` would never match
+    :func:`role_prefixed_marker`'s own anchored pattern at all post-strip
+    (its `ROLE_PREFIX` requires the literal ``**[...]** — `` a blanket
+    strip would have just erased). Stripping only AFTER the detected role
+    prefix keeps that pattern intact while still tolerating decoration
+    around the marker itself.
+
+    *decoration* is caller-supplied (never a single frozen pattern here)
+    because :mod:`_markers` does not own any one gate's decoration
+    vocabulary — the same "shape here, vocabulary there" boundary
+    :func:`role_prefixed_marker` already draws for the keyword itself."""
+    prefix_match = re.match(ROLE_PREFIX, line)
+    if prefix_match is None:
+        return decoration.sub("", line)
+    return line[:prefix_match.end()] + decoration.sub("", line[prefix_match.end():])
 
 
 def first_line(text: str) -> str:

--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -138,21 +138,33 @@ def _is_reread_note(first_line: str) -> bool:
 def _has_blocking_comment(comment_bodies: "list[str]") -> bool:
     """True iff ANY comment's first non-empty line matches the `BLOCKING
     (head <sha>)` shape (reused from `check_open_blocking_checkboxes.py`
-    — the same form check that excludes prose merely discussing the
-    word, #5318's own false-positive fix).
+    — the same anchored, role-prefix-aware marker #5919 stage 2 built,
+    the same form check that excludes prose merely discussing the word,
+    #5318's own false-positive fix).
 
-    #5522: reads `_blocking._first_nonempty_line`/`_undecorated`, not
-    the old `_first_line` (renamed) with no decoration-stripping — this
-    gate shares the EXACT same real incident #5522 fixed one level up:
-    a BLOCKING comment whose SHA was backtick-wrapped would make
-    `_BLOCKING_MARKER` not match here EITHER, so THIS gate would
-    silently conclude "no BLOCKING comment on this PR" and skip its own
-    TESTS-READ/RE-READ requirement entirely — the #5453 protection
-    quietly opting itself out on the exact same decoration that broke
-    the gate it is layered on top of."""
+    #5522/#5919: reads `_blocking._first_nonempty_line`/`_blocking.
+    _MARKER_BLOCKING`/`_blocking._DECORATION`, and strips decoration via
+    `_markers.undecorated_after_role_prefix` (not `_blocking._undecorated`
+    — a blanket, role-prefix-blind strip) — this gate shares the EXACT
+    same real incidents fixed one level up, TWICE now: #5522's original
+    (a BLOCKING comment whose SHA was backtick-wrapped would make the
+    marker not match here EITHER, so THIS gate would silently conclude
+    "no BLOCKING comment on this PR" and skip its own TESTS-READ/RE-READ
+    requirement entirely), and #5919 stage 2's own (once
+    `_MARKER_BLOCKING` became role-prefix-anchored, a blanket strip would
+    erase a REAL role prefix's own `**[...]** — ` literal right along
+    with any decoration around the marker, breaking every role-prefixed
+    BLOCKING comment — which is every real one in this repo, CLAUDE.md
+    rule 2). Reusing `check_open_blocking_checkboxes.py`'s own marker
+    regex and decoration pattern (rather than a second copy) means a
+    future change to either stays in sync with both gates automatically,
+    the same non-drift property this module's docstring already claims
+    for `_tests_read`."""
     return any(
-        _blocking._BLOCKING_MARKER.search(
-            _blocking._undecorated(_blocking._first_nonempty_line(body)),
+        _blocking._MARKER_BLOCKING.search(
+            _markers.undecorated_after_role_prefix(
+                _blocking._first_nonempty_line(body), _blocking._DECORATION,
+            ),
         )
         for body in comment_bodies
     )

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -65,7 +65,7 @@ names `BLOCKING`/`BLOCKING-CLEARED` but does not parse as either marker
 regex is RED — a THIRD failure mode neither A nor B could see. Real
 incident (lead-coder, 2026-08-29): a BLOCKING comment's first line read
 ``**BLOCKING (head `9862413f0`)**`` — the backtick around the SHA broke
-`_BLOCKING_MARKER`'s match, and the gate said nothing at all for 12
+`_MARKER_BLOCKING`'s match, and the gate said nothing at all for 12
 minutes; the PR only stayed red by the accident of an unrelated
 BLOCKING from a different reviewer. Before #5522, "no marker on this
 comment" and "a marker written wrong" were the same silence — condition
@@ -75,12 +75,28 @@ mid-body mention, including this docstring's OWN repeated use of the
 word, must never trip it).
 
 Same PR (#5522) also strips backtick/`*` decoration from a line before
-either marker regex runs (`_undecorated`) — the root cause of the
-specific incident above, not just its silence. Aligns this gate with
-`check_tests_read_names_its_tree.py`'s own already-permissive `_SHA`
-regex (architect ruling: "許容側が自然" — people decorate SHAs and
-keywords by hand, a machine stripping it once is cheaper than asking
-every writer never to).
+either marker regex runs (`_undecorated`, and — #5919 stage 2 — its
+role-prefix-preserving sibling `_undecorated_for_marker_match`) — the
+root cause of the specific incident above, not just its silence. Aligns
+this gate with `check_tests_read_names_its_tree.py`'s own
+already-permissive `_SHA` regex (architect ruling: "許容側が自然" —
+people decorate SHAs and keywords by hand, a machine stripping it once
+is cheaper than asking every writer never to).
+
+## #5919 stage 2 — anchoring the two DECIDING markers, never the WATCHER
+
+The marker regexes above (`_MARKER_BLOCKING`/`_MARKER_CLEARED`) used to
+be unanchored `\b...` searches over an undecorated first line — #5919's
+census found this let 4 ordinary-prose shapes (a negating sentence, a
+backtick span, a `>` quote, mid-sentence mention) satisfy them exactly
+as `check_tests_read_names_its_tree.py`'s pre-#5919-stage-1 regex could.
+Both are now built with `scripts/_markers.role_prefixed_marker(...)`,
+column-0-anchored exactly like that gate's own `_NOTE_MARKER`.
+
+`_NEAR_MISS_BARE_WORD` (condition C) is deliberately NOT anchored and
+NOT routed through `_markers.py` — see its own docstring for why
+anchoring the WATCHER that exists to catch what the DECIDERS miss would
+eliminate the watcher's entire purpose.
 
 ## What this does NOT buy (disclosed, not hidden)
 
@@ -134,6 +150,9 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _markers  # noqa: E402 -- sibling module, see _markers.py's own docstring
+
 #: An open (unchecked) red blocking checkbox line — unchanged from #5135.
 _OPEN_BLOCK = re.compile(r"^[ \t]*[-*+][ \t]*\[[ \t]*\][ \t]*(?:\*\*[ \t]*)*🔴(.*)$", re.MULTILINE)
 
@@ -142,64 +161,104 @@ _OPEN_BLOCK = re.compile(r"^[ \t]*[-*+][ \t]*\[[ \t]*\][ \t]*(?:\*\*[ \t]*)*🔴
 _CHECKED_BLOCK = re.compile(r"^[ \t]*[-*+][ \t]*\[[xX]\][ \t]*(?:\*\*[ \t]*)*🔴(.*)$", re.MULTILINE)
 
 #: A comment's first line raising or clearing a blocking point (#5314
-#: condition A). Requires the FULL `BLOCKING (head <sha>)` / `BLOCKING-
-#: CLEARED (head <sha>)` shape co-located on one line — not the bare word
-#: found anywhere on the line. Case-sensitive and unanchored otherwise
-#: (a real comment's first line is `**[<role>]** — BLOCKING (head
-#: <sha>)`, the SAME "role prefix before the marker" shape every comment
-#: in this repo already uses, so the marker itself is not required to
-#: start the line — only to be followed by its own `(head <sha>)`).
+#: condition A; #5919 stage 2: now column-0 anchored, via the SAME
+#: `_markers.role_prefixed_marker` shape `check_tests_read_names_its_
+#: tree.py`'s `_NOTE_MARKER` already uses). The marker keyword must OPEN
+#: the line — bare, or immediately after the CLAUDE.md rule-2 role prefix
+#: (`**[role]** — `) — never merely appear somewhere on it.
 #:
-#: architect's TESTS-READ catch, lead-coder's real-world falsification
-#: (#5318, "gate側の読み（1件、非blocking）。" — a review comment
-#: genuinely discussing whether something IS a blocking point, containing
-#: the bare word with no `(head <sha>)` anywhere near it): an EARLIER,
-#: looser version of this regex matched the bare word "BLOCKING" anywhere
-#: on line 1, so an everyday sentence mentioning it ("my blocking is
-#: closed") was miscounted as a formal raise, permanently reddening any
-#: PR whose review prose happened to use the word this way. Requiring the
-#: `(head <sha>)` immediately after the marker (whitespace only between)
-#: is what makes this a FORM check, not a word search — the same
-#: distinction `check_tests_read_names_its_tree.py`'s own marker+SHA
-#: co-location rule draws on its claim side. `IGNORECASE` is dropped
-#: (not just made stricter) for the same reason: prose is far more likely
-#: to write "blocking" lowercase than a deliberate marker is.
-_BLOCKING_MARKER = re.compile(r"\bBLOCKING(?!-CLEARED)\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)")
-_CLEARED_MARKER = re.compile(r"\bBLOCKING-CLEARED\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)")
+#: #5919 (lead-coder census + architect ruling): the PRE-anchoring shape
+#: (`\bBLOCKING...`, unanchored) let 4 prose shapes read as a real marker
+#: — a NEGATING sentence ("my blocking is closed, thanks"), the keyword
+#: inside a backtick span, inside a `>` quote, or mid-sentence — because a
+#: bare `.search()` cannot tell a DECLARATION from a DISCUSSION of the
+#: same word. Column-0 anchoring (with the co-located `(head <sha>)` this
+#: gate already required) closes all four the same way #5919 stage 1
+#: closed them for TESTS-READ/RE-READ/the subprocess-pin exemption: an
+#: ordinary sentence about the topic does not open a comment's first line
+#: with the literal keyword or a role prefix immediately followed by it.
+#:
+#: `IGNORECASE` is dropped (`flags=0`, overriding `role_prefixed_marker`'s
+#: own IGNORECASE default) for the SAME reason the pre-#5919 regex already
+#: gave: prose is far more likely to write "blocking" lowercase than a
+#: deliberate marker is.
+_MARKER_BLOCKING = _markers.role_prefixed_marker(
+    r"BLOCKING(?!-CLEARED)\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)", flags=0,
+)
+_MARKER_CLEARED = _markers.role_prefixed_marker(
+    r"BLOCKING-CLEARED\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)", flags=0,
+)
 
-#: #5522 — a bare word check, deliberately NOT anchored to the marker's own
-#: "(head <sha>)" shape: this is what NEAR-MISS DETECTION runs against, so
-#: it must catch exactly the cases the marker regexes above miss. Matches
-#: inside "BLOCKING-CLEARED" too (the `-` after "BLOCKING" is a non-word
-#: char, satisfying `\b` on both sides of the bare word) — deliberate, not
-#: an oversight: a decorated BLOCKING-CLEARED that fails _CLEARED_MARKER
-#: must ALSO be caught, and this one check does both without a second
-#: pattern. Case-sensitive, matching the marker regexes' own
-#: IGNORECASE-dropped posture (module docstring: prose is more likely to
-#: write "blocking" lowercase than a deliberate marker is).
-_BARE_WORD = re.compile(r"\bBLOCKING\b")
+#: #5522 — a bare word check for NEAR-MISS DETECTION (condition C).
+#:
+#: 🔴 #5919 stage 2 (architect ruling, explicit): deliberately NOT routed
+#: through `_markers.role_prefixed_marker` and deliberately NOT anchored
+#: to column 0 or to the marker's own "(head <sha>)" shape, unlike
+#: `_MARKER_BLOCKING`/`_MARKER_CLEARED` directly above. Those two DECIDE
+#: ("does a real marker exist here?" — YES must be earned, so they are
+#: anchored against ordinary prose producing a false YES). This one
+#: WATCHES FOR WHAT THE DECIDERS MISSED ("did a marker attempt land here
+#: at all, even a malformed one?" — a NO-side safety net, so anchoring it
+#: would remove the exact cases it exists to catch: a decorated/malformed
+#: marker that `_MARKER_BLOCKING`/`_MARKER_CLEARED` correctly reject).
+#: Anchoring this one would make it redundant with — and therefore
+#: silently subsumed by — the deciders it is supposed to be watching,
+#: which is exactly the "one incident, no signal for 12 minutes" failure
+#: #5522 fixed. The distinguishing question (architect, #5919): "is this
+#: regex on the YES-deciding side, or the YES-was-missed watching side?"
+#: Only the former gets anchored.
+#:
+#: Matches inside "BLOCKING-CLEARED" too (the `-` after "BLOCKING" is a
+#: non-word char, satisfying `\b` on both sides of the bare word) —
+#: deliberate, not an oversight: a decorated BLOCKING-CLEARED that fails
+#: `_MARKER_CLEARED` must ALSO be caught, and this one check does both
+#: without a second pattern. Case-sensitive, matching the deciding
+#: markers' own IGNORECASE-dropped posture.
+_NEAR_MISS_BARE_WORD = re.compile(r"\bBLOCKING\b")
 
 #: #5522 (architect ruling on the issue thread): markdown decoration —
 #: backtick code-spans and `**`/`*` emphasis — is stripped from a line
-#: BEFORE either marker regex runs against it, aligning this gate's
-#: previously-strict posture with `check_tests_read_names_its_tree.py`'s
-#: own already-permissive one (that gate's `_SHA` regex tolerates a
-#: backtick between "head" and the hex run structurally; this one's
-#: `\s*` did not). "Align to the permissive side" (architect, quoting
-#: the reasoning): people decorate SHAs and keywords when they write by
-#: hand (lead-coder's own #5517 BLOCKING, architect's own separate
-#: instance, both real, both this same night) — a machine stripping
+#: before the near-miss check (`_NEAR_MISS_BARE_WORD`) runs against it, and
+#: from whatever follows a detected role prefix before either DECIDING
+#: marker (`_MARKER_BLOCKING`/`_MARKER_CLEARED`) runs (see
+#: `_undecorated_for_marker_match` below — the role prefix's OWN `**...**`
+#: syntax must survive, or #5919's new anchoring could never match a
+#: decorated marker that follows a real role prefix). "Align to the
+#: permissive side" (architect, quoting the reasoning): people decorate
+#: SHAs and keywords when they write by hand — a machine stripping
 #: decoration once is cheaper than asking every human writer never to.
-#: Precedent: `check_claude_md_doc_overlap.py` (#4928) already strips
-#: markdown decoration before tokenizing for the same reason. Neither
-#: a SHA nor the BLOCKING/BLOCKING-CLEARED keywords themselves ever
-#: contain a backtick or asterisk, so stripping cannot turn a
+#: Neither a SHA nor the BLOCKING/BLOCKING-CLEARED keywords themselves
+#: ever contain a backtick or asterisk, so stripping cannot turn a
 #: non-marker line into a false-positive match.
 _DECORATION = re.compile(r"[`*]")
 
 
 def _undecorated(line: str) -> str:
     return _DECORATION.sub("", line)
+
+
+def _undecorated_for_marker_match(line: str) -> str:
+    """*line*, with markdown decoration stripped EVERYWHERE EXCEPT a
+    leading CLAUDE.md role prefix (`_markers.ROLE_PREFIX`), if one opens
+    the line.
+
+    #5919 stage 2: a role prefix is itself written with literal `**...**`
+    (`**[role]** — `) — the SAME character class :data:`_DECORATION`
+    strips. A blanket `_undecorated(line)` (the pre-anchoring shape,
+    still used for near-miss detection below, which never has to
+    recognise a role prefix) would strip the role prefix's own asterisks
+    right along with any decoration AROUND the marker that follows it,
+    so a real, decorated comment like ``**[lead-coder]** — **BLOCKING
+    (head `abc1234`)**`` would never match `_markers.role_prefixed_marker`
+    at all post-strip (its own `ROLE_PREFIX` pattern requires the literal
+    `**[...]** — ` it would have just erased). Stripping only AFTER the
+    detected role prefix keeps that pattern intact while still tolerating
+    decoration around the marker itself — the same real-incident shape
+    #5522 fixed, now compatible with #5919's anchoring."""
+    prefix_match = re.match(_markers.ROLE_PREFIX, line)
+    if prefix_match is None:
+        return _undecorated(line)
+    return line[:prefix_match.end()] + _undecorated(line[prefix_match.end():])
 
 
 def _normalize(text: str) -> str:
@@ -242,9 +301,35 @@ def _checked_lines(body: str) -> "list[str]":
     return [_normalize(m.group(1)) for m in _CHECKED_BLOCK.finditer(body) if _normalize(m.group(1))]
 
 
-def _resolves_via_body(text: str, comments: "list[str]") -> bool:
-    normalized = _normalize(text)
-    return any(normalized in _normalize(c) for c in comments if normalized)
+def _cleared_after(identifying_text: str, candidate_bodies: "list[str]", head: str) -> bool:
+    """Does one of *candidate_bodies* clear *identifying_text* for *head*?
+
+    #5919 stage 2 (house rule 7 unification): replaces `_resolves_via_body`
+    for BOTH condition A (a BLOCKING comment's identifying line, searched
+    only in LATER comments) and condition B-2 (a checked checkbox's own
+    line text, searched in ALL comments) — the checkbox form used to
+    resolve on bare substring presence alone (`_resolves_via_body`), which
+    could not tell a comment quoting the line WHILE DISPUTING it apart from
+    one quoting it while resolving it: substring presence carries zero
+    information about which. A comment now resolves EITHER form only when
+    its own first line opens with the anchored `BLOCKING-CLEARED (head
+    <sha>)` marker, that head matches the PR's current one, and its body
+    still contains *identifying_text* verbatim (whitespace-normalized) —
+    quoting is the required FORM for resolution now, not merely evidence
+    of it."""
+    if not identifying_text:
+        return False
+    for candidate_body in candidate_bodies:
+        first_line = _undecorated_for_marker_match(_first_nonempty_line(candidate_body))
+        cleared_match = _MARKER_CLEARED.match(first_line)
+        if not cleared_match:
+            continue
+        cleared_sha = cleared_match.group(1)
+        if not (head and (head.startswith(cleared_sha) or cleared_sha.startswith(head))):
+            continue  # names a stale head, or no head at all -- does not clear
+        if _normalize(identifying_text) in _normalize(candidate_body):
+            return True
+    return False
 
 
 def evaluate(pr: dict) -> "tuple[int, list[str]]":
@@ -271,14 +356,18 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
             "(`- [ ] 🔴`)."
         )
 
-    # Condition B-2 (#5314): a checked checkbox needs a comment quoting its
-    # own text verbatim — ticking alone is not a record.
+    # Condition B-2 (#5314; #5919 stage 2 house rule 7 unification): a
+    # checked checkbox needs a BLOCKING-CLEARED-marked comment (naming the
+    # current head) quoting its own text verbatim — ticking alone, or a
+    # comment quoting the line without the marker, is not a record.
     for line_text in _checked_lines(body):
-        if not _resolves_via_body(line_text, comment_bodies):
+        if not _cleared_after(line_text, comment_bodies, head):
             findings.append(
                 "RED (body) — a checked blocking line (`- [x] 🔴`) has no "
-                f"comment quoting it verbatim: {line_text!r}. Post a comment "
-                "containing that exact line, whitespace differences aside."
+                f"BLOCKING-CLEARED comment quoting it verbatim: {line_text!r}. "
+                f"Post a comment starting 'BLOCKING-CLEARED (head "
+                f"{head[:9] or '<sha>'})' whose body contains that exact "
+                "line, whitespace differences aside."
             )
 
     # Condition A (#5314): a BLOCKING comment needs a LATER CLEARED comment
@@ -295,22 +384,12 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # an unresolved point with no deliberate action at all, worse than
     # the deletion bypass #5311 measured.
     for i, blocking_body in enumerate(comment_bodies):
-        blocking_match = _BLOCKING_MARKER.search(_undecorated(_first_nonempty_line(blocking_body)))
+        blocking_first_line = _undecorated_for_marker_match(_first_nonempty_line(blocking_body))
+        blocking_match = _MARKER_BLOCKING.match(blocking_first_line)
         if not blocking_match:
             continue
         identifying = _identifying_line(blocking_body)
-        resolved = False
-        for later_body in comment_bodies[i + 1:]:
-            cleared_match = _CLEARED_MARKER.search(_undecorated(_first_nonempty_line(later_body)))
-            if not cleared_match:
-                continue
-            cleared_sha = cleared_match.group(1)
-            if not (head and (head.startswith(cleared_sha) or cleared_sha.startswith(head))):
-                continue  # names a stale head, or no head at all — does not clear
-            if identifying and _normalize(identifying) in _normalize(later_body):
-                resolved = True
-                break
-        if not resolved:
+        if not _cleared_after(identifying, comment_bodies[i + 1:], head):
             findings.append(
                 "RED (comment) — a BLOCKING comment has no matching "
                 "BLOCKING-CLEARED comment naming the current head "
@@ -323,7 +402,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # Condition C (#5522) — near-miss detection. lead-coder's own real
     # incident: a BLOCKING comment's first line read
     # "**BLOCKING (head `9862413f0`)**" — the backtick around the SHA
-    # made `_BLOCKING_MARKER` NOT match, and the gate said nothing at
+    # made the marker regex NOT match, and the gate said nothing at
     # all for 12 minutes; the PR only stayed red because of an
     # UNRELATED BLOCKING from another reviewer. "Marker not found" and
     # "marker written wrong" were indistinguishable failure modes.
@@ -341,11 +420,10 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         if not first_line:
             continue
         undecorated_first_line = _undecorated(first_line)
-        if not _BARE_WORD.search(undecorated_first_line):
+        if not _NEAR_MISS_BARE_WORD.search(undecorated_first_line):
             continue  # no BLOCKING/BLOCKING-CLEARED word on this line at all
-        if _BLOCKING_MARKER.search(undecorated_first_line) or _CLEARED_MARKER.search(
-            undecorated_first_line,
-        ):
+        marker_line = _undecorated_for_marker_match(first_line)
+        if _MARKER_BLOCKING.match(marker_line) or _MARKER_CLEARED.match(marker_line):
             continue  # a real marker, already handled by condition A above
         findings.append(
             "RED (near-miss) — a comment's first line names BLOCKING/"

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -238,27 +238,20 @@ def _undecorated(line: str) -> str:
 
 
 def _undecorated_for_marker_match(line: str) -> str:
-    """*line*, with markdown decoration stripped EVERYWHERE EXCEPT a
-    leading CLAUDE.md role prefix (`_markers.ROLE_PREFIX`), if one opens
-    the line.
+    """*line*, with :data:`_DECORATION` stripped EVERYWHERE EXCEPT a
+    leading CLAUDE.md role prefix, if one opens the line.
 
-    #5919 stage 2: a role prefix is itself written with literal `**...**`
-    (`**[role]** — `) — the SAME character class :data:`_DECORATION`
-    strips. A blanket `_undecorated(line)` (the pre-anchoring shape,
-    still used for near-miss detection below, which never has to
-    recognise a role prefix) would strip the role prefix's own asterisks
-    right along with any decoration AROUND the marker that follows it,
-    so a real, decorated comment like ``**[lead-coder]** — **BLOCKING
-    (head `abc1234`)**`` would never match `_markers.role_prefixed_marker`
-    at all post-strip (its own `ROLE_PREFIX` pattern requires the literal
-    `**[...]** — ` it would have just erased). Stripping only AFTER the
-    detected role prefix keeps that pattern intact while still tolerating
-    decoration around the marker itself — the same real-incident shape
-    #5522 fixed, now compatible with #5919's anchoring."""
-    prefix_match = re.match(_markers.ROLE_PREFIX, line)
-    if prefix_match is None:
-        return _undecorated(line)
-    return line[:prefix_match.end()] + _undecorated(line[prefix_match.end():])
+    #5919 stage 2: delegates to `_markers.undecorated_after_role_prefix`
+    (promoted there, not left as a private helper here, once lead-coder's
+    review found `check_blocking_has_reread_note.py` needed the SAME
+    shape for the SAME reason — this gate's marker anchoring is not the
+    only consumer of "strip decoration but keep a real role prefix
+    literal"). See that function's own docstring for the full incident:
+    a blanket strip over the WHOLE line would erase a real role prefix's
+    own `**[...]** — ` syntax right along with any decoration AROUND the
+    marker, so `_markers.role_prefixed_marker`'s anchor would never match
+    a decorated, role-prefixed comment post-strip."""
+    return _markers.undecorated_after_role_prefix(line, _DECORATION)
 
 
 def _normalize(text: str) -> str:

--- a/tests/scripts/test_check_open_blocking_checkboxes.py
+++ b/tests/scripts/test_check_open_blocking_checkboxes.py
@@ -14,6 +14,7 @@ CLI, mirroring `evaluate`'s own combined return)."""
 from __future__ import annotations
 
 import json
+import re
 
 from scripts.check_open_blocking_checkboxes import evaluate, main, run_gate
 
@@ -47,12 +48,20 @@ def test_open_blocking_checkbox_variants_fail() -> None:
 
 
 def test_checked_checkbox_with_verbatim_comment_passes() -> None:
-    """Tier 1: ② a checked checkbox WITH a comment quoting its own text
-    verbatim passes — ticking is not enough on its own, but ticking PLUS
-    a corroborating comment is what #5314 asks authors to do."""
+    """Tier 1: ② a checked checkbox WITH a BLOCKING-CLEARED comment
+    quoting its own text verbatim passes — ticking is not enough on its
+    own, but ticking PLUS a marked, corroborating comment is what #5314
+    (extended by #5919 stage 2's house rule 7 unification) asks authors
+    to do. Pre-#5919 this passed on plain "Fixed — ..." prose alone
+    (`_resolves_via_body`'s bare substring check); that no longer
+    resolves anything — a comment quoting the line WHILE DISPUTING it
+    looked identical to one quoting it while resolving it."""
     code, _ = evaluate(_pr(
         "- [x] 🔴 the widget must validate input",
-        comments=["Fixed — the widget must validate input, confirmed on every call."],
+        comments=[
+            f"BLOCKING-CLEARED (head {_HEAD})\n"
+            "the widget must validate input, confirmed on every call.",
+        ],
     ))
     assert code == 0
 
@@ -328,8 +337,9 @@ def test_blocking_word_only_in_the_middle_of_the_body_is_not_a_near_miss() -> No
 
 def test_blocking_cleared_word_alone_with_no_sha_is_also_a_near_miss() -> None:
     """Tier 1: the bare-word check also catches a decorated/malformed
-    BLOCKING-CLEARED attempt, not just BLOCKING — `_BARE_WORD` matches
-    inside "BLOCKING-CLEARED" too (the hyphen is a word boundary)."""
+    BLOCKING-CLEARED attempt, not just BLOCKING — `_NEAR_MISS_BARE_WORD`
+    matches inside "BLOCKING-CLEARED" too (the hyphen is a word
+    boundary)."""
     code, lines = evaluate(_pr(
         "", comments=["**[x]** — BLOCKING-CLEARED, see above."],
     ))
@@ -351,6 +361,65 @@ def test_a_real_marker_never_also_reports_as_a_near_miss() -> None:
     ))
     assert code == 0
     assert not any("near-miss" in line for line in lines)
+
+
+def test_negating_sentence_with_marker_shape_is_not_a_real_raise() -> None:
+    """Tier 1: LOAD-BEARING — #5919 stage 2's own anchoring fix. A
+    negating sentence containing the full marker shape mid-line ("Not
+    BLOCKING (head <sha>) anymore, already fixed.") must NOT be read as
+    a real BLOCKING raise. Pre-#5919 this satisfied the old
+    `_BLOCKING_MARKER` (a bare `\\b...` search, no column-0 anchor) —
+    the exact class of defect #5927 already closed for TESTS-READ/RE-
+    READ/the subprocess-pin exemption, and #5919 stage 2 closes here:
+    the sentence does not OPEN with the keyword or a role prefix
+    immediately followed by it, so `_MARKER_BLOCKING` correctly does
+    not match. Near-miss detection still catches it (the bare word is
+    present) — anchoring the DECIDING marker does not mean the comment
+    goes unremarked, only that it is no longer misread as a formal
+    raise requiring a CLEARED comment."""
+    code, lines = evaluate(_pr(
+        "",
+        comments=[f"**[x]** — Not BLOCKING (head {_HEAD}) anymore, already fixed."],
+    ))
+    assert code != 0
+    assert any("near-miss" in line for line in lines)
+    assert not any("BLOCKING comment has no matching" in line for line in lines)
+
+
+def test_near_miss_regex_must_stay_unanchored_or_it_would_miss_real_near_misses() -> None:
+    """Tier 1: LOAD-BEARING deny-side witness (architect mandate, #5919
+    stage 2) — `_NEAR_MISS_BARE_WORD` must NOT be column-0-anchored the
+    way `_MARKER_BLOCKING`/`_MARKER_CLEARED` now are, using the exact two
+    real inputs that fire near-miss detection elsewhere in THIS file
+    today (`test_bare_word_on_first_line_with_no_sha_at_all_is_a_near_
+    miss` and `test_near_miss_fires_specifically_not_just_condition_a_
+    reusing_the_message`'s own fixtures). Both open with the CLAUDE.md
+    role prefix (`**[x]** — `), not the bare word itself — a real
+    reviewer's comment always carries that prefix (rule 2). Architect's
+    discriminator: a regex on the YES-DECIDING side earns anchoring
+    (ordinary prose must not satisfy it); a regex that WATCHES FOR WHAT
+    THE DECIDERS MISSED must never be anchored, because anchoring it
+    would make it miss exactly the same role-prefixed cases the deciders
+    already miss, silently erasing the watcher's entire purpose (the
+    same "no marker" / "marker written wrong" silence #5522 fixed, now
+    for the near-miss side specifically)."""
+    from scripts.check_open_blocking_checkboxes import _NEAR_MISS_BARE_WORD, _undecorated
+
+    real_near_miss_first_lines = [
+        "**[x]** — BLOCKING, needs a fix here.",
+        "**[x]** — **BLOCKING** (head `not-hex-at-all`)",
+    ]
+    anchored_would_be = re.compile(r"^BLOCKING\b")
+    for line in real_near_miss_first_lines:
+        undecorated = _undecorated(line)
+        assert _NEAR_MISS_BARE_WORD.search(undecorated), (
+            f"the real (unanchored) near-miss regex must still catch {line!r}"
+        )
+        assert not anchored_would_be.match(undecorated), (
+            f"a column-0-anchored near-miss regex would WRONGLY miss "
+            f"{line!r} -- this is exactly why _NEAR_MISS_BARE_WORD must "
+            "stay unanchored"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +447,7 @@ def test_fixture_cli_supports_both_states(tmp_path) -> None:
     fixture.write_text(
         json.dumps(_pr(
             "- [x] 🔴 done",
-            comments=["Fixed — done."],
+            comments=[f"BLOCKING-CLEARED (head {_HEAD})\ndone."],
         )),
         encoding="utf-8",
     )

--- a/tests/scripts/test_markers_5919.py
+++ b/tests/scripts/test_markers_5919.py
@@ -14,6 +14,7 @@ own witness.
 from __future__ import annotations
 
 import importlib.util
+import re
 
 from tests._support.paths import REPO_ROOT
 
@@ -115,6 +116,50 @@ def test_fixed_comment_marker_does_not_match_mid_comment():
     the same comment line."""
     pattern = _MOD.fixed_comment_marker("EXEMPT")
     assert pattern.match("# see EXEMPT: below for the real one") is None
+
+
+# ── undecorated_after_role_prefix (#5919 stage 2) ───────────────────────────
+
+_DECORATION = re.compile(r"[`*]")
+
+
+def test_undecorated_after_role_prefix_strips_decoration_around_the_marker():
+    """Tier 1: LOAD-BEARING — the exact real shape that broke
+    `check_open_blocking_checkboxes.py`'s own anchored marker before this
+    function existed: a role-prefixed, ADDITIONALLY bold-wrapped marker.
+    The role prefix's own literal `**[...]** — ` must survive untouched
+    (or `role_prefixed_marker`'s anchor could never match afterward), while
+    the decoration AROUND the marker itself is still stripped."""
+    line = "**[lead-coder]** — **BLOCKING (head `abc1234`)**"
+    result = _MOD.undecorated_after_role_prefix(line, _DECORATION)
+    assert result == "**[lead-coder]** — BLOCKING (head abc1234)"
+
+
+def test_undecorated_after_role_prefix_with_no_role_prefix_strips_the_whole_line():
+    """Tier 1: a bare marker (no role prefix at all) falls back to
+    stripping the whole line — the SAME behaviour as an unconditional
+    strip, since there is no role-prefix literal to protect."""
+    line = "**BLOCKING (head `abc1234`)**"
+    result = _MOD.undecorated_after_role_prefix(line, _DECORATION)
+    assert result == "BLOCKING (head abc1234)"
+
+
+def test_undecorated_after_role_prefix_a_blanket_strip_would_break_the_role_prefix():
+    """Tier 1: the deny-side witness for WHY this function exists — an
+    unconditional whole-line strip (the naive fix) erases the role
+    prefix's own required `**[...]**` syntax, which
+    `_markers.ROLE_PREFIX` needs literally intact to match at all."""
+    line = "**[lead-coder]** — **BLOCKING (head `abc1234`)**"
+    naive_whole_line_strip = _DECORATION.sub("", line)
+    assert naive_whole_line_strip == "[lead-coder] — BLOCKING (head abc1234)"
+    assert re.match(_MOD.ROLE_PREFIX, naive_whole_line_strip) is None, (
+        "a blanket strip must destroy the role prefix's own literal "
+        "syntax -- this is the defect undecorated_after_role_prefix fixes"
+    )
+    assert re.match(
+        _MOD.ROLE_PREFIX,
+        _MOD.undecorated_after_role_prefix(line, _DECORATION),
+    ) is not None
 
 
 # ── first_line ────────────────────────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** — #5919 stage 2: `check_open_blocking_checkboxes.py`'s own 3-point fix (stage 1, #5927, deliberately left this gate out).

## Changes

1. **`_MARKER_BLOCKING`/`_MARKER_CLEARED`** (renamed from `_BLOCKING_MARKER`/`_CLEARED_MARKER`) now built via `scripts/_markers.role_prefixed_marker(...)` — column-0 anchored, closing the same 4 fail-open prose shapes (negation, backtick span, quote, mid-sentence) #5927 closed for the other 4 gates. New `_undecorated_for_marker_match()` strips decoration around a marker while preserving a real role prefix's own required `**[role]** — ` syntax.
2. **`_NEAR_MISS_BARE_WORD`** (renamed from `_BARE_WORD`) deliberately stays unanchored and unrouted through `_markers.py` — architect's discriminator: a YES-deciding regex earns anchoring; a regex that watches for what the deciders miss must never be anchored, or it silently loses the exact cases it exists to catch.
3. **`_resolves_via_body` removed**, replaced by a shared `_cleared_after()` helper reused by both condition A and condition B-2 — house rule 7 unification: a checked checkbox now also requires a `BLOCKING-CLEARED (head <sha>)`-marked comment, not bare substring presence.

## Verification (strip-verified in-file, Edit → Edit-back, no `git stash`/`checkout`)

- Reverting `_MARKER_BLOCKING` to the old unanchored `\bBLOCKING...` form (with `.match()`) → 9 tests go red.
- Anchoring `_NEAR_MISS_BARE_WORD` with `^` → 6 tests go red, including a new deny-side witness test (`test_near_miss_regex_must_stay_unanchored_or_it_would_miss_real_near_misses`) using the exact two real near-miss-firing inputs already in this suite.
- Reverting `_undecorated_for_marker_match` call sites to plain `_undecorated` → 9 tests go red (role-prefix's own `**[...]**` gets stripped, breaking every role-prefixed marker).
- All three reverted back; full suite green (26 passed) after each restoration.

Also added `test_negating_sentence_with_marker_shape_is_not_a_real_raise` (proves the anchoring fix specifically) and updated the two condition-B fixtures that relied on plain "Fixed — ..." prose (no longer sufficient under the unification) to the new marked form. Every other existing accept/deny test's outcome is unchanged.

## Gates (all green)

ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`. Scoped pytest: 26 passed.

## Test plan

- [x] Scoped pytest green (`tests/scripts/test_check_open_blocking_checkboxes.py`, 26 passed)
- [x] All pre-PR + path-conditional gates green (listed above)
- [x] (skipped — Visual, standing waiver)

Closes #5919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
