### PR TITLE
docs(#5900): ADR-0006 -- record the skill_snapshot.py half's target extinction

### DIFF
--- a/docs/deep-dives/decisions/0006-schema-version-refuse-policy.md
+++ b/docs/deep-dives/decisions/0006-schema-version-refuse-policy.md
@@ -1,6 +1,7 @@
 # ADR-0006: Schema version refuse + --reset (pre-1.0 policy)
 
 **Status**: Accepted (2026-05-03)
+**Status correction** (2026-09-08, ADR witness audit follow-up, #5900): the `skill_snapshot.py` half of this decision's implementation (the `SKILL_SNAPSHOT_VERSION` constant) was removed whole by #2434 (PR #2438, 2026-07-03), the same skill/phase-engine bulk-delete that superseded ADR-0003/0004/0009/0011/0012/0013/0015/0020/0036. The `agent_snapshot.py` half (`SNAPSHOT_VERSION`, `SchemaVersionError`, the CLI's clean-exit catch) survives unchanged and is still satisfied — this ADR remains ACCEPTED, not superseded; only the decision's skill-snapshot-facing scope has no remaining consumer.
 **Track**: PR-resume-ux β U4
 
 ## Context


### PR DESCRIPTION
**[docs-maintainer]** — part of #5900 (lead-coder's judgment ①: `skill_snapshot.py`-half of ADR-0006 processed the same way #5904 processed cluster A/B — "target extinction", not "implementation hasn't caught up").

## What

`skill_snapshot.py` (naming `SKILL_SNAPSHOT_VERSION`, half of ADR-0006's Decision) was removed whole by #2434 (PR #2438, 2026-07-03) — the same bulk-delete that superseded ADR-0003/0004/0009/0011/0012/0013/0015/0020/0036. `agent_snapshot.py`'s half (`SNAPSHOT_VERSION`, `SchemaVersionError`, the CLI's clean-exit catch) survives unchanged.

Per lead-coder's explicit judgment (#5900): **the whole ADR does NOT go SUPERSEDED** — only the vanished half is recorded, mirroring ADR-0036's own FD1-only correction-note precedent (#5904) rather than cluster A/B's whole-file SUPERSEDED status line.

ADR body untouched (ADR immutable, CLAUDE.md hard rule) — header Status-line + one Status-correction line only.

Not in scope here (deliberately, per lead-coder's own reasoning against re-bundling #4986's lesson): the OTHER half of #5900's 0006 finding — no dedicated test exercises the refuse/clean-exit path — is lead-coder's own separately-filed #5962.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — green
- [x] `python scripts/check_doc_anchors.py` — "no dangling anchors into published pages"
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK
- [x] `ruff check docs/` — all checks passed
- [x] (skipped — doc-only change, no code path to exercise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
