### PR TITLE
feat(#5959, owner-hit): in-process memory breakdown -- who is holding this

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -206,6 +206,7 @@ presented
 process_footprint
 process_footprint_unavailable
 process_marker_reaped
+process_memory_breakdown
 project_context_changed
 project_context_unreadable
 pump_exception_swallowed
@@ -749,6 +750,7 @@ avoid when memory is already tight), ~39µs per read.
 |------|------|-------------|
 | `process_footprint` | Two record points (of the ruling's 4 observation points — the other two, `run_one_iteration`'s process-edge and the router-loop's in-turn iteration head, are DECISION points for a halt check that does not exist until a later stage; nothing to record there yet in stage (a)): `Session.load_history()`'s own `finally` (every `load_history()` caller — registry_bootstrap.py/chat.py/web/deps.py/mcp.py/dogfood.py — funnels through this ONE method, so the emit lives there rather than at 5 separate call sites), and `_run_router_loop`'s `finally`, next to the `turn_end` hook dispatch (once per turn). `metric` rides with every `bytes` value — a `phys_footprint` reading and an `rss` reading are not comparable numbers, and this repo's own verification-hazards discipline is "an observation does not name its own referent" without help. | `bytes`, `metric` (`"phys_footprint"` \| `"rss"`), `cap_bytes` (`None` = observe-only), `enforce`, `chain_id` (turn-end emit only) |
 | `process_footprint_unavailable` | This platform has no reader (`process_memory_metric_name()` is `None` — today, anything but darwin/linux). Fires at MOST ONCE PER PROCESS (`ProcessMemoryGuard` is the one shared instance every session's factory_config carries, so the "announced once" latch is process-scoped, not per-session) — a value is never fabricated to fill the gap. | `platform` (`sys.platform`) |
+| `process_memory_breakdown` | `reyn doctor-memory` (#5959, owner-hit — "leak 容疑を process の外から判定できない"; `vmmap`/#5957 cannot tell an allocator-held free region from a live Python reference). Two populations, one snapshot: `type_breakdown`/`largest_objects` are ⓐ discovery — every live object `gc.get_objects()` can see, grouped/ranked, no curated list; `bounding_census` is ⓑ completeness — every config field carrying `Axis.BOUNDING`, DERIVED from `walk_config_schema()` (never a second hand-written list — adding a `Axis.BOUNDING` field makes it appear here automatically), paired with its declared cap and current measured value (`None` = `unmeasured`, distinct from a real `0`). `sys.getsizeof` is shallow (a container's own size, not its contents') — `estimate_note` carries that disclosure into the event itself, not just the CLI's prose. | `type_breakdown`, `largest_objects`, `bounding_census`, `estimate_note` |
 
 ## Process registry
 

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -336,6 +336,18 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # most once per PROCESS (``ProcessMemoryGuard.claim_unavailable_
     # announcement``), never a fabricated ``bytes`` value.
     "process_footprint_unavailable": frozenset({"platform"}),
+    # process_memory_breakdown (#5959, owner-hit): the in-process answer to
+    # "who is holding this" -- a vmmap/region read (#5957) cannot tell an
+    # allocator-held free region from a live Python reference; this walks
+    # gc.get_objects() itself. type_breakdown/largest_objects are the ⓐ
+    # discovery tables (no curated list -- whatever is actually alive);
+    # bounding_census is the ⓑ completeness table, DERIVED from
+    # walk_config_schema()'s Axis.BOUNDING population, never a second
+    # hand-written list -- see memory_breakdown.py's own module docstring
+    # for the ⓐ/ⓑ split and why this tool does not mechanically join them.
+    "process_memory_breakdown": frozenset(
+        {"type_breakdown", "largest_objects", "bounding_census", "estimate_note"},
+    ),
     # turn_settled: emitted in Session.run_one_iteration()'s finally for EVERY
     #   turn kind (including slash / intervention short-circuits that return
     #   before the router). Unlike turn_completed (router path only), this is the
@@ -591,6 +603,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "process_footprint",
     "process_footprint_unavailable",
     "process_marker_reaped",
+    "process_memory_breakdown",
     "project_context_changed",
     # #5742 (architect ruling): an operator EXPLICITLY specified a
     # project-context or agent-context file (project_context_path /

--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -29,6 +29,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
+    # #5959 stage ③: arm tracemalloc (opt-in, REYN_MEMORY_TRACE) FIRST,
+    # before anything else in this function runs — tracemalloc only
+    # attributes allocations that happen AFTER it starts, so arming it any
+    # later than the earliest reasonable point already misses whatever ran
+    # before. A no-op single os.environ read, no tracemalloc import, when
+    # the env var is unset — see memory_breakdown.py's own docstring.
+    from reyn.runtime.memory_breakdown import arm_tracemalloc_if_requested  # noqa: PLC0415
+
+    arm_tracemalloc_if_requested()
     # #3671: closes the ``import`` stage. Everything before this line is the
     # interpreter starting plus the import tree — measured at 1.75s for
     # ``litellm`` alone here, and the owner's machine spends ~3.4x longer in

--- a/src/reyn/interfaces/cli/commands/__init__.py
+++ b/src/reyn/interfaces/cli/commands/__init__.py
@@ -13,6 +13,7 @@ from . import chat as chat
 from . import config as config
 from . import cron as cron
 from . import doctor as doctor
+from . import doctor_memory as doctor_memory
 from . import dogfood as dogfood
 from . import embeddings as embeddings
 from . import events as events
@@ -32,4 +33,4 @@ from . import web as web
 # Order is the order shown in `reyn --help`.
 # `source` (reyn source list/describe/rm) retired FP-0066 P1c — user-facing
 # in-core RAG source creation/management is gone; user RAG = FP-0063 plugin.
-ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, storage, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit, doctor]
+ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, storage, pipe, plugin, secret, cron, dogfood, embeddings, support_bundle, audit, doctor, doctor_memory]

--- a/src/reyn/interfaces/cli/commands/doctor_memory.py
+++ b/src/reyn/interfaces/cli/commands/doctor_memory.py
@@ -1,0 +1,111 @@
+"""`reyn doctor-memory` — #5959 (owner-hit): the in-process answer to "who
+is holding this" a leak suspicion needs. A SEPARATE top-level command from
+``reyn doctor`` (D-1/D-2/D-3's own single flat report, ``doctor.py``) rather
+than a mode of it — this reads ``gc.get_objects()`` (an operation with real
+CPU cost, unlike every existing ``doctor`` check's cheap stat/probe reads)
+and would otherwise silently widen what "just run doctor" costs. Registered
+as its own subcommand, hyphenated, matching ``support-bundle``'s own
+multi-word convention. Real logic lives in
+:mod:`reyn.runtime.memory_breakdown` — this module is CLI wiring + the P6
+emit only.
+
+D-1 (measure, never assert) still applies here, unchanged from ``doctor``'s
+own ruling: every number below comes from a live ``gc.get_objects()``
+walk or ``walk_config_schema()``'s real, current schema — never a restated
+config value dressed up as a measurement.
+"""
+from __future__ import annotations
+
+import argparse
+
+from reyn.runtime.memory_breakdown import (
+    MemoryBreakdown,
+    collect_memory_breakdown,
+    emit_memory_breakdown_event,
+    tracemalloc_is_armed,
+    tracemalloc_top_allocations,
+)
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "doctor-memory",
+        help="In-process memory breakdown (suspect ranking + bounded-resource census) for leak triage",
+    )
+    p.add_argument(
+        "--top-n", type=int, default=20,
+        help="How many rows to show per discovery table (default: 20).",
+    )
+    p.add_argument(
+        "--no-audit-event", action="store_true",
+        help="Skip emitting the process_memory_breakdown audit-event (report to stdout only).",
+    )
+    p.set_defaults(func=run)
+
+
+def _print_breakdown(breakdown: MemoryBreakdown) -> None:
+    print(
+        "reyn doctor-memory — SUSPECT ranking, not an exact accounting "
+        "(sys.getsizeof is shallow: a container's own size, never its "
+        "contents')."
+    )
+    print(
+        "⚠️  ⓐ cannot see a large str/bytes/bytearray held via a reference "
+        "AT ALL (gc.get_objects() never tracks those types) — if you "
+        "suspect a Python object is holding a big STRING, use "
+        "REYN_MEMORY_TRACE=1 (③ below), not ⓐ."
+    )
+    print()
+    print(f"ⓐ discovery — top {len(breakdown.type_breakdown)} types by total sys.getsizeof:")
+    for type_row in breakdown.type_breakdown:
+        print(
+            f"  {type_row.type_name:<32} count={type_row.count:<8} "
+            f"total={type_row.total_sizeof_bytes:>12,} bytes",
+        )
+    print()
+    print(f"ⓐ discovery — top {len(breakdown.largest_objects)} single largest objects:")
+    for obj_row in breakdown.largest_objects:
+        print(f"  {obj_row.type_name:<32} {obj_row.sizeof_bytes:>12,} bytes  {obj_row.repr_snippet}")
+    print()
+    print(
+        f"ⓑ completeness — {len(breakdown.bounding_census)} Axis.BOUNDING "
+        "config field(s) (derived from walk_config_schema(), never a "
+        "hand-written list):"
+    )
+    for census_row in breakdown.bounding_census:
+        measured = (
+            "unmeasured" if census_row.measured_bytes is None
+            else f"{census_row.measured_bytes:,} bytes"
+        )
+        print(f"  {census_row.key:<48} declared_cap={census_row.declared_cap!r:<20} measured={measured}")
+    print()
+    dead = breakdown.unbounded_or_dead_declarations
+    print(
+        f"⚠️  {len(dead)} Axis.BOUNDING field(s) read 0 or unmeasured "
+        "(type A dead-declaration candidates — an unmeasured row means "
+        "no live reading is wired yet, NOT confirmed dead):"
+    )
+    for dead_row in dead:
+        measured = "unmeasured" if dead_row.measured_bytes is None else "0"
+        print(f"  {dead_row.key:<48} measured={measured}")
+
+
+def run(args: argparse.Namespace) -> None:
+    breakdown = collect_memory_breakdown(top_n=args.top_n)
+    _print_breakdown(breakdown)
+    if not args.no_audit_event:
+        from reyn.core.events.events import emit_cli_event
+
+        emit_memory_breakdown_event(emit_cli_event, breakdown)
+    print()
+    if tracemalloc_is_armed():
+        allocations = tracemalloc_top_allocations(top_n=args.top_n)
+        print(f"③ tracemalloc — top {len(allocations or [])} allocation site(s) (REYN_MEMORY_TRACE armed):")
+        for alloc in allocations or []:
+            print(f"  {alloc['file_line']:<64} {alloc['size_bytes']:>12,} bytes  ({alloc['count']} block(s))")
+    else:
+        print(
+            "③ tracemalloc — not armed (set REYN_MEMORY_TRACE=1 at process "
+            "start for allocation-site detail; must be set before the "
+            "process that leaked, not this doctor-memory invocation)."
+        )

--- a/src/reyn/runtime/memory_breakdown.py
+++ b/src/reyn/runtime/memory_breakdown.py
@@ -1,0 +1,383 @@
+"""#5959 (owner-hit, severity:high) — "leak 容疑を process の外から判定できない":
+owner, verbatim: "今後も leak 容疑確認のために使用量見積もりのプロファイル取れ
+るようにすべきじゃないの" / "python object として reyn が参照してるってこと
+なんでしょ？" A `vmmap` region-distribution read (#5957) cannot tell "an
+allocator-held free region" from "a live Python reference holding it" — both
+look identical from OUTSIDE the process. This module is the IN-PROCESS
+answer: it walks the interpreter's own live object graph.
+
+## Two populations, two different jobs — never one curated list (architect
+## ruling, issuecomment on #5959: an earlier draft that hand-listed "reyn's
+## own known big consumers" was exactly the class this repo's own
+## discipline forbids — "count what exists, not what you already suspect")
+
+- **ⓐ discovery** (:func:`gc_type_breakdown` / :func:`gc_largest_objects`):
+  ``gc.get_objects()``, grouped by type. No curated list — nothing here can
+  go stale, because it enumerates whatever is ACTUALLY alive, not a
+  hand-maintained guess at what might be. Answers "who is holding this" by
+  naming the TYPE, not by asking the operator to already suspect it.
+- **ⓑ completeness** (:func:`bounding_axis_census`): every config field
+  carrying ``metadata={"axis": Axis.BOUNDING}`` — derived from
+  :func:`reyn.config.config_schema.walk_config_schema`, never a hand-
+  written second list. A field this repo has already declared "should be
+  bounded," paired with its declared cap and (if a measurement provider is
+  registered) its current live value — ``unmeasured`` when none is, a
+  DIFFERENT value from ``0`` (an operator must never read "we didn't check"
+  as "it's empty").
+
+The tool's real product is what a HUMAN does with both tables side by side:
+a type large in ⓐ with nothing in ⓑ that looks like it corresponds is a
+candidate "nobody declared this bounded" resource (ADR-0046's Falsification
+section); a ⓑ field reading 0/``unmeasured`` is a candidate dead
+declaration. This module does not attempt to MECHANICALLY join the two —
+they live in different namespaces (a Python type name vs. a config dotted
+key) with no reliable general mapping between them; :func:`bounding_axis_
+census`'s own output is filterable to exactly the rows a reader needs for
+that second judgment (measured in ``(0, None)``), which is the one
+concrete, testable claim architect's own corrected acceptance text asks
+for (issuecomment: "``Axis.BOUNDING`` の field で、実測値が 0 または
+``unmeasured`` のものが表に出る").
+
+## `sys.getsizeof` is SHALLOW — a container's own size, not its contents'
+(a list of 1000 large strings reports its own pointer-array size, not the
+strings). This module names itself an ESTIMATE everywhere it surfaces
+(docstrings, CLI output, the audit-event's own ``note`` field) — the goal
+is ranking SUSPECTS, not an exact byte count (architect: "厳密さより容疑者
+の順位が目的").
+
+## ⚠️ A DISCLOSED, SHARPER gap ⓐ cannot see AT ALL — not merely shallow,
+INVISIBLE: `gc.get_objects()` only enumerates objects CPython's cyclic
+garbage collector TRACKS (containers, class instances with `__dict__` —
+anything that could participate in a reference cycle). `str` / `bytes` /
+`bytearray` / `int` / `float` are NEVER tracked (`gc.is_tracked("x")` is
+`False`) — so a large STRING held via any reference (a variable, a dict
+value, `ChatMessage.content`) is invisible to :func:`gc_type_breakdown`/
+:func:`gc_largest_objects` BOTH directly (the string itself never
+appears as a row) AND indirectly (the shallowness above means the
+REFERENCING container's row does not include it either). This is exactly
+the shape owner's own suspicion names — a large content string held by a
+live Python reference — so naming this gap here, not leaving it silent,
+matters: ⓐ's live walk genuinely cannot answer that specific question;
+:func:`tracemalloc_top_allocations` (stage ③, which attributes by
+ALLOCATION SITE rather than a live object walk, and so sees every
+allocation regardless of gc-tracking) is the tool that can. Verified
+directly: ``tests/runtime/test_5959_memory_breakdown.py``'s own
+``test_a_large_standalone_string_is_invisible_to_gc_based_discovery``.
+
+## `tracemalloc` (opt-in, deep dive, stage ③) lives in this module too
+(:func:`tracemalloc_is_armed` / :func:`arm_tracemalloc_if_requested` /
+:func:`tracemalloc_top_allocations`) — gated on ``REYN_MEMORY_TRACE``
+being set at PROCESS START (CLI ``main()``'s own entry, before any other
+import does real work): tracemalloc's own per-allocation overhead only
+buys anything if it was armed before the allocations under suspicion
+happened, so arming it lazily on first use would already be too late for
+the allocations that mattered. When unset, this module executes ZERO
+tracemalloc calls — not "started then stopped," genuinely never invoked.
+"""
+from __future__ import annotations
+
+import gc
+import os
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+#: The env var that arms tracemalloc — read ONCE, at process start
+#: (:func:`arm_tracemalloc_if_requested`, called from CLI ``main()``).
+#: Not re-read later: a mid-process ``os.environ`` mutation must not
+#: retroactively arm tracing for allocations that already happened.
+TRACEMALLOC_ENV_VAR = "REYN_MEMORY_TRACE"
+
+#: A measurement provider: given nothing, returns the CURRENT live byte
+#: count for one BOUNDING-axis config field's real-world counterpart, or
+#: ``None`` if it genuinely cannot measure right now (never fabricated).
+MeasurementProvider = Callable[[], "int | None"]
+
+
+@dataclass(frozen=True)
+class TypeBreakdownRow:
+    """One :func:`gc_type_breakdown` row — a TYPE's aggregate footprint
+    estimate, never a single object's."""
+
+    type_name: str
+    count: int
+    total_sizeof_bytes: int
+
+
+@dataclass(frozen=True)
+class LargestObjectRow:
+    """One :func:`gc_largest_objects` row — a single object, not a type
+    aggregate. ``repr_snippet`` is capped and best-effort (``repr()`` on an
+    arbitrary live object can itself raise or be unbounded; see that
+    function's own guard)."""
+
+    type_name: str
+    sizeof_bytes: int
+    repr_snippet: str
+
+
+@dataclass(frozen=True)
+class BoundingCensusRow:
+    """One :func:`bounding_axis_census` row. ``measured_bytes is None``
+    means ``unmeasured`` — genuinely distinct from a real ``0`` (no
+    provider is registered for this field, or the registered one could
+    not measure right now), never conflated by this dataclass's own
+    shape."""
+
+    key: str
+    declared_cap: "object"
+    measured_bytes: "int | None"
+
+
+@dataclass(frozen=True)
+class MemoryBreakdown:
+    """The full #5959 snapshot — ⓐ (both discovery tables) + ⓑ (the
+    completeness census) + the dead-declaration filter of ⓑ, bundled for
+    one audit-event emit / one CLI report so both surfaces always show the
+    SAME numbers from the SAME ``gc.get_objects()`` pass (never re-walked
+    between the two, which could silently diverge under concurrent
+    allocation)."""
+
+    type_breakdown: "list[TypeBreakdownRow]"
+    largest_objects: "list[LargestObjectRow]"
+    bounding_census: "list[BoundingCensusRow]"
+
+    @property
+    def unbounded_or_dead_declarations(self) -> "list[BoundingCensusRow]":
+        """architect's corrected acceptance text, verbatim: every
+        ``Axis.BOUNDING`` field whose measured value is 0 or
+        ``unmeasured`` — candidates for #5959's "type A dead declaration"
+        (a resource declared bounded with nothing measurably resident
+        under it). Named ``unbounded_or_dead_declarations`` rather than
+        ``dead_declarations`` alone: an ``unmeasured`` row is NOT yet
+        known to be dead — only that nobody has wired a live reading for
+        it — so this property's own name does not overclaim what an
+        ``unmeasured`` row means (see the module docstring's own "type A
+        vs type B" distinction — this module can only ever speak to A)."""
+        return [
+            row for row in self.bounding_census
+            if row.measured_bytes is None or row.measured_bytes == 0
+        ]
+
+
+#: #5959: the size a container's own `sys.getsizeof` reports never
+#: includes what a REPR of an arbitrary live object might do (a custom
+#: `__repr__` can itself be arbitrarily expensive, or raise) -- capped
+#: hard so one pathological object never dominates a scan's wall time.
+_REPR_SNIPPET_MAX_CHARS = 200
+
+
+def _safe_repr_snippet(obj: object, *, max_chars: int = _REPR_SNIPPET_MAX_CHARS) -> str:
+    """``repr(obj)``, capped and never raising — a live object pulled
+    from ``gc.get_objects()`` may belong to ANY type in the process,
+    including one whose ``__repr__`` itself raises or recurses; this
+    function's whole job is to make that irrelevant to the scan around
+    it."""
+    try:
+        text = repr(obj)
+    except Exception as exc:  # noqa: BLE001 - an arbitrary live object's __repr__ may raise anything
+        return f"<repr() raised {type(exc).__name__}>"
+    if len(text) > max_chars:
+        return text[:max_chars] + "…"
+    return text
+
+
+def gc_type_breakdown(*, top_n: int = 20) -> "list[TypeBreakdownRow]":
+    """#5959 ⓐ: every live object ``gc`` can see, grouped by
+    ``type(obj).__name__``, ranked by TOTAL ``sys.getsizeof`` across the
+    type (not count alone — a million tiny ints rank below one type
+    holding gigabytes, which is the actual question this answers).
+
+    No curated list of "types reyn cares about" — the population is
+    whatever ``gc.get_objects()`` returns, full stop. ``sys.getsizeof``
+    is SHALLOW (a container's own size, not its contents' — see module
+    docstring); this is a RANKING tool, not an exact accounting.
+
+    A single object whose own ``sys.getsizeof`` call raises (rare, but
+    not impossible for a foreign C-extension type) is skipped for THAT
+    object rather than aborting the whole scan — one uncooperative type
+    must not blind this tool to every other one."""
+    totals: "dict[str, list[int]]" = {}  # type_name -> [count, total_bytes]
+    for obj in gc.get_objects():
+        type_name = type(obj).__name__
+        try:
+            size = sys.getsizeof(obj)
+        except Exception:  # noqa: BLE001 - a foreign type's __sizeof__ may raise anything
+            continue
+        bucket = totals.setdefault(type_name, [0, 0])
+        bucket[0] += 1
+        bucket[1] += size
+    rows = [
+        TypeBreakdownRow(type_name=name, count=count, total_sizeof_bytes=total)
+        for name, (count, total) in totals.items()
+    ]
+    rows.sort(key=lambda r: r.total_sizeof_bytes, reverse=True)
+    return rows[:top_n]
+
+
+def gc_largest_objects(*, top_n: int = 20) -> "list[LargestObjectRow]":
+    """#5959 ⓐ (sibling view): the single largest live objects by
+    ``sys.getsizeof``, individually — a type-level aggregate
+    (:func:`gc_type_breakdown`) can hide one enormous outlier inside a
+    type with a small average, and vice versa; this view answers the
+    complementary question."""
+    rows: "list[LargestObjectRow]" = []
+    for obj in gc.get_objects():
+        try:
+            size = sys.getsizeof(obj)
+        except Exception:  # noqa: BLE001 - a foreign type's __sizeof__ may raise anything
+            continue
+        rows.append(
+            LargestObjectRow(
+                type_name=type(obj).__name__,
+                sizeof_bytes=size,
+                repr_snippet=_safe_repr_snippet(obj),
+            ),
+        )
+    rows.sort(key=lambda r: r.sizeof_bytes, reverse=True)
+    return rows[:top_n]
+
+
+def bounding_axis_census(
+    *, measurement_providers: "dict[str, MeasurementProvider] | None" = None,
+) -> "list[BoundingCensusRow]":
+    """#5959 ⓑ: every config field carrying ``Axis.BOUNDING`` — the
+    "someone declared this resource should be bounded" registry — DERIVED
+    from :func:`reyn.config.config_schema.walk_config_schema`, never a
+    second, hand-maintained list (architect's explicit acceptance:
+    "``Axis.BOUNDING`` を持つ field を 1 つ足すと、profiler の出力に自動で
+    現れる" — verified in
+    ``tests/runtime/test_5959_memory_breakdown.py``'s own strip witness).
+
+    ``measurement_providers`` is a caller-supplied ``{config_key:
+    MeasurementProvider}`` map — THIS module wires none by default (it has
+    no access to a live ``Session``/registry on its own; a caller with one
+    passes its own providers). A field with no registered provider, or
+    whose provider itself returns ``None``, reports ``measured_bytes=
+    None`` — rendered ``unmeasured`` everywhere this surfaces, never
+    silently shown as ``0``."""
+    from reyn.config.config_schema import walk_config_schema
+    from reyn.config_axis import Axis
+
+    providers = measurement_providers or {}
+    rows: "list[BoundingCensusRow]" = []
+    for node in walk_config_schema():
+        if node.axis != Axis.BOUNDING:
+            continue
+        provider = providers.get(node.key)
+        measured = provider() if provider is not None else None
+        rows.append(
+            BoundingCensusRow(key=node.key, declared_cap=node.default, measured_bytes=measured),
+        )
+    return rows
+
+
+def collect_memory_breakdown(
+    *, top_n: int = 20, measurement_providers: "dict[str, MeasurementProvider] | None" = None,
+) -> MemoryBreakdown:
+    """The one bundling call both ``reyn doctor-memory`` and the
+    ``process_memory_breakdown`` audit-event emit use — same
+    ``gc.get_objects()`` pass backing both tables (:func:`gc_type_
+    breakdown`/:func:`gc_largest_objects` each re-walk independently
+    today; a future perf pass could share one pass between them, left
+    unmerged here since correctness does not depend on it and #5959's own
+    acceptance is about the OUTPUT shape, not walk count)."""
+    return MemoryBreakdown(
+        type_breakdown=gc_type_breakdown(top_n=top_n),
+        largest_objects=gc_largest_objects(top_n=top_n),
+        bounding_census=bounding_axis_census(measurement_providers=measurement_providers),
+    )
+
+
+def emit_memory_breakdown_event(emit: "Callable[..., None]", breakdown: MemoryBreakdown) -> None:
+    """#5959: the ONE place ``process_memory_breakdown`` is built as an
+    audit-event payload — so the CLI's ``emit_cli_event`` seam and a
+    future live-session seam (#5959's own ② stage, not wired in this PR
+    — see module docstring) always produce byte-identical field shapes.
+    ``emit`` is any ``(kind, **payload) -> None`` callable (``EventLog.
+    emit``, ``emit_cli_event``, or a test double) — this function never
+    imports a concrete emitter itself, mirroring ``Session.
+    _emit_process_footprint``'s own caller-supplied-sink shape."""
+    emit(
+        "process_memory_breakdown",
+        type_breakdown=[
+            {"type": r.type_name, "count": r.count, "total_sizeof_bytes": r.total_sizeof_bytes}
+            for r in breakdown.type_breakdown
+        ],
+        largest_objects=[
+            {"type": r.type_name, "sizeof_bytes": r.sizeof_bytes, "repr_snippet": r.repr_snippet}
+            for r in breakdown.largest_objects
+        ],
+        bounding_census=[
+            {
+                "key": r.key,
+                "declared_cap": r.declared_cap if _is_json_scalar(r.declared_cap) else repr(r.declared_cap),
+                "measured_bytes": r.measured_bytes,
+            }
+            for r in breakdown.bounding_census
+        ],
+        estimate_note=(
+            "sys.getsizeof is SHALLOW -- a container reports its own size, "
+            "not its contents'. This is a SUSPECT ranking, not an exact "
+            "accounting."
+        ),
+    )
+
+
+def _is_json_scalar(value: object) -> bool:
+    """True when *value* is directly JSON-serialisable as a scalar
+    (``str``/``int``/``float``/``bool``/``None``) -- a config default can
+    be a ``Literal`` string, a dataclass instance, or other non-scalar the
+    audit-event payload must not choke on; anything else is repr'd
+    instead (see this function's own caller)."""
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def tracemalloc_is_armed() -> bool:
+    """#5959 stage ③: whether ``REYN_MEMORY_TRACE`` was set in THIS
+    process's environment. A pure ``os.environ`` read -- never itself
+    imports or touches ``tracemalloc``, so calling this costs nothing
+    even when tracing was never armed."""
+    return bool(os.environ.get(TRACEMALLOC_ENV_VAR))
+
+
+def arm_tracemalloc_if_requested() -> bool:
+    """#5959 stage ③: called ONCE, from the CLI's own ``main()`` entry
+    point, before any other import does real work -- tracemalloc's
+    per-allocation overhead only attributes allocations that happen
+    AFTER it starts, so arming it any later already misses whatever
+    already ran. Returns whether it armed. When ``REYN_MEMORY_TRACE`` is
+    unset, this function does not import ``tracemalloc`` at all -- zero
+    tracemalloc calls executed, not "started then immediately idle" (the
+    opt-in's whole point: an operator who never asked for this pays
+    nothing, not even the import)."""
+    if not tracemalloc_is_armed():
+        return False
+    import tracemalloc
+
+    if not tracemalloc.is_tracing():
+        tracemalloc.start()
+    return True
+
+
+def tracemalloc_top_allocations(*, top_n: int = 20) -> "list[dict] | None":
+    """#5959 stage ③: the top *top_n* allocation sites by current traced
+    size, each carrying the allocating file:line -- deep-dive detail
+    :func:`gc_type_breakdown` cannot give (a type name, not a call site).
+    Returns ``None`` (never an empty list masquerading as "measured, zero
+    found") when tracemalloc was never armed for this process -- a
+    caller must not read ``None`` and ``[]`` as the same fact."""
+    import tracemalloc
+
+    if not tracemalloc.is_tracing():
+        return None
+    snapshot = tracemalloc.take_snapshot()
+    stats = snapshot.statistics("lineno")[:top_n]
+    return [
+        {
+            "file_line": str(stat.traceback[0]) if stat.traceback else "<unknown>",
+            "size_bytes": stat.size,
+            "count": stat.count,
+        }
+        for stat in stats
+    ]

--- a/tests/interfaces/test_5959_doctor_memory_cli.py
+++ b/tests/interfaces/test_5959_doctor_memory_cli.py
@@ -1,0 +1,118 @@
+"""Tier 2: #5959 (owner-hit) — ``reyn doctor-memory`` CLI wiring + the
+audit-event exit surface. Real logic lives in
+:mod:`reyn.runtime.memory_breakdown` (its own test file,
+``tests/runtime/test_5959_memory_breakdown.py``) — this file is
+reachability (the #4478 "declared, implemented, tested, invoked by
+nobody" shape) + a real end-to-end CLI run against a real ``.reyn/``
+tree, no mocks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.cli.commands.doctor_memory import register, run
+
+# ── Reachability (the #4478 shape: declared, implemented, but never wired) ──
+
+
+def test_doctor_memory_is_registered_on_the_reyn_parser():
+    """Tier 2: 'reyn doctor-memory' is wired into a real subparser, not
+    just importable in isolation."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+    register(sub)
+
+    args = parser.parse_args(["doctor-memory"])
+    assert args.func is run
+    assert args.top_n == 20
+    assert args.no_audit_event is False
+
+
+def test_doctor_memory_is_registered_via_the_real_command_registry():
+    """Tier 2: the ALL list in commands/__init__.py — not just this
+    module's own register() — actually includes doctor_memory. Mirrors
+    test_4364_pr3a_doctor_cli.py's own identically-shaped test for
+    'reyn doctor' (#4478's own review named this exact gap: importable
+    but unreachable through argparse)."""
+    from reyn.interfaces.cli import build_parser
+
+    parser = build_parser()
+    subparsers_action = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    assert "doctor-memory" in subparsers_action.choices
+
+
+# ── end to end, real .reyn/ tree, no mocks ───────────────────────────────
+
+
+def test_run_prints_both_discovery_tables_and_the_bounding_census(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys,
+) -> None:
+    """Tier 2: a real invocation, against a real (empty but present)
+    .reyn/ directory, prints both ⓐ tables, the ⓑ census, the dead-
+    declaration filter, and the shallowness disclosure -- and does not
+    raise, the whole point of a report-only tool."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+
+    run(Namespace(top_n=5, no_audit_event=False))
+
+    out = capsys.readouterr().out
+    assert "sys.getsizeof is shallow" in out
+    assert "gc.get_objects() never tracks" in out
+    assert "ⓐ discovery" in out
+    assert "ⓑ completeness" in out
+    assert "dead-declaration candidates" in out
+    assert "③ tracemalloc" in out
+
+
+def test_no_audit_event_flag_skips_the_emit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: --no-audit-event genuinely skips the P6 emit -- verified by
+    the absence of any events/direct/cli file the emit would otherwise
+    create (real filesystem effect, not a mocked call-count)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+
+    run(Namespace(top_n=1, no_audit_event=True))
+
+    direct_cli_dir = tmp_path / ".reyn" / "events" / "direct" / "cli"
+    assert not direct_cli_dir.exists() or not any(direct_cli_dir.rglob("*.jsonl")), (
+        "--no-audit-event must produce zero audit-event files"
+    )
+
+
+def test_the_audit_event_actually_lands_on_disk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the default (no --no-audit-event) path really emits
+    process_memory_breakdown to a real .reyn/events/direct/cli file --
+    the 'same breakdown reaches the audit trail even with nobody
+    watching' acceptance criterion, verified against the real seam
+    (emit_cli_event -> emit_direct_event), not a stand-in sink."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".reyn").mkdir()
+
+    run(Namespace(top_n=2, no_audit_event=False))
+
+    direct_cli_dir = tmp_path / ".reyn" / "events" / "direct" / "cli"
+    files = list(direct_cli_dir.rglob("*.jsonl"))
+    assert files, "the default run must emit at least one audit-event file"
+    lines = [
+        json.loads(line)
+        for path in files
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    matching = [e for e in lines if e.get("type") == "process_memory_breakdown"]
+    assert matching, "a process_memory_breakdown event must be on disk"
+    assert "type_breakdown" in matching[0]["data"]
+    assert "bounding_census" in matching[0]["data"]

--- a/tests/runtime/test_5959_memory_breakdown.py
+++ b/tests/runtime/test_5959_memory_breakdown.py
@@ -1,0 +1,356 @@
+"""Tier 2: #5959 (owner-hit, severity:high) — "leak 容疑を process の外から
+判定できない". Owner, verbatim: "今後も leak 容疑確認のためのプロファイルを
+取れるようにすべきじゃないの" / "python object として reyn が参照してる
+ってことなんでしょ？" — this module answers "who is holding this" from
+INSIDE the process, which a `vmmap` region read (#5957) structurally
+cannot.
+
+Real ``gc``/``EventLog``/``walk_config_schema()`` throughout — no mocks.
+The population under test (live objects, real config schema) is exactly
+what the tool is FOR, so faking it would test nothing real.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.runtime.memory_breakdown import (
+    TRACEMALLOC_ENV_VAR,
+    arm_tracemalloc_if_requested,
+    bounding_axis_census,
+    collect_memory_breakdown,
+    emit_memory_breakdown_event,
+    gc_largest_objects,
+    gc_type_breakdown,
+    tracemalloc_is_armed,
+    tracemalloc_top_allocations,
+)
+from tests._support.events import collect_events, settle
+
+# ── ⓐ discovery: gc-based, no curated list ──────────────────────────────
+
+
+def test_gc_type_breakdown_finds_a_real_live_type_with_no_curated_list() -> None:
+    """Tier 2: the core discovery claim — a type this test creates AT RUN
+    TIME (never named anywhere in memory_breakdown.py's own source, since
+    ⓐ has no curated list at all) shows up, ranked, purely because it is
+    genuinely alive when the scan runs."""
+
+    class _LeakSuspectMarkerType:  # noqa: N801 - deliberately distinctive test-only name
+        def __init__(self) -> None:
+            self.payload = "x" * 500_000  # large enough to rank near the top
+
+    keepalive = [_LeakSuspectMarkerType() for _ in range(5)]
+    try:
+        rows = gc_type_breakdown(top_n=100_000)
+        matching = [r for r in rows if r.type_name == "_LeakSuspectMarkerType"]
+        assert matching, (
+            "a genuinely live, large-footprint type must appear in the "
+            "discovery breakdown -- gc_type_breakdown has no curated list "
+            "to have silently excluded it from"
+        )
+        assert matching[0].count == 5
+        assert matching[0].total_sizeof_bytes > 0
+    finally:
+        del keepalive
+
+
+def test_gc_type_breakdown_is_sorted_by_total_bytes_descending() -> None:
+    """Tier 2: the ranking claim -- 'suspect ranking' is the whole product
+    (architect: '厳密さより容疑者の順位が目的'), so sort order is load-
+    bearing, not incidental."""
+    rows = gc_type_breakdown(top_n=50)
+    totals = [r.total_sizeof_bytes for r in rows]
+    assert totals == sorted(totals, reverse=True)
+
+
+def test_gc_largest_objects_surfaces_a_single_outlier_a_type_aggregate_would_hide() -> None:
+    """Tier 2: the complementary ⓐ view -- one huge object inside a type
+    whose AVERAGE is small must still surface here, even though it might
+    rank low (or not at all, at a bounded top_n) in the type-aggregate
+    view alongside many small siblings of the same type.
+
+    Uses a ``list`` with many elements (not a wrapper class holding a big
+    attribute, and not a ``bytearray``/``str`` -- see the disclosure test
+    below) -- a ``list``'s OWN ``sys.getsizeof`` genuinely includes its
+    internal pointer array, so a list large by ELEMENT COUNT is large by
+    its own measure, unlike a wrapper instance whose big attribute is a
+    separately-allocated object (measured directly while building this
+    test: a 2 MB string stashed on a small wrapper instance left the
+    wrapper's own row at 48 bytes -- see the disclosure test)."""
+    outlier = [0] * 500_000
+    siblings = [[0] * 4 for _ in range(3)]
+    try:
+        rows = gc_largest_objects(top_n=2_000_000)
+        matching = [r for r in rows if r.type_name == "list"]
+        assert matching, "at least one list must appear among the largest single objects"
+        assert max(r.sizeof_bytes for r in matching) > 1_000_000, (
+            "the planted 500k-element list must be the largest list row -- "
+            "its own sys.getsizeof genuinely includes its pointer array"
+        )
+    finally:
+        del outlier, siblings
+
+
+def test_a_large_standalone_string_is_invisible_to_gc_based_discovery() -> None:
+    """Tier 2: DISCLOSED GAP, not a silent one -- ``gc.get_objects()``
+    only returns objects CPython's garbage collector TRACKS (objects that
+    can participate in a reference cycle: containers, class instances
+    with ``__dict__``). ``str``/``bytes``/``bytearray``/``int``/``float``
+    are NEVER tracked (measured directly: ``gc.is_tracked(bytearray(1))``
+    and ``gc.is_tracked('x')`` are both ``False``) -- so a large string
+    held via a reference (a variable, a dict value, an attribute) is
+    invisible to :func:`gc_type_breakdown`/:func:`gc_largest_objects`
+    BOTH directly (the string itself never appears) AND indirectly (the
+    referencing container's own ``sys.getsizeof`` does not include it,
+    the same shallowness the module docstring names). This is exactly
+    the shape owner's own suspicion names (a large content STRING held
+    by a Python reference) -- ⓐ's gc-walk genuinely cannot answer that
+    case; :func:`tracemalloc_top_allocations` (stage ③, by allocation
+    site rather than live walk) is the tool that can. Asserting this here
+    keeps the gap a tracked, disclosed fact rather than a silent one a
+    future reader could mistake for coverage."""
+    import gc
+
+    big_string = "leak-suspect-marker-" + ("q" * 3_000_000)
+    holder = {"content": big_string}
+    try:
+        assert gc.is_tracked(big_string) is False, "sanity: str is never gc-tracked"
+        rows = gc_largest_objects(top_n=2_000_000)
+        as_str_row = [r for r in rows if r.type_name == "str" and r.sizeof_bytes > 1_000_000]
+        assert as_str_row == [], (
+            "a standalone large string must NOT appear as its own row -- "
+            "gc.get_objects() never tracks str at all (this is the "
+            "disclosed gap, not a bug this test expects to be fixed)"
+        )
+        holder_rows = [r for r in rows if r.type_name == "dict"]
+        assert all(r.sizeof_bytes < 1_000_000 for r in holder_rows), (
+            "the dict referencing the big string must not report the "
+            "string's own size either -- sys.getsizeof(dict) is shallow, "
+            "the same limitation the module docstring names"
+        )
+    finally:
+        del big_string, holder
+
+
+def test_gc_largest_objects_never_raises_on_a_repr_that_itself_raises() -> None:
+    """Tier 2: a live object pulled from gc.get_objects() may belong to
+    ANY type in the process, including a hostile/broken __repr__ -- the
+    scan around it must not abort because of ONE object's own bug."""
+
+    class _HostileRepr:  # noqa: N801
+        def __repr__(self) -> str:
+            raise RuntimeError("deliberately hostile __repr__")
+
+    hostile = _HostileRepr()
+    try:
+        rows = gc_largest_objects(top_n=2_000_000)
+        matching = [r for r in rows if r.type_name == "_HostileRepr"]
+        assert matching, "the hostile object must still be measured and listed"
+        assert "raised" in matching[0].repr_snippet
+    finally:
+        del hostile
+
+
+# ── ⓑ completeness: derived from walk_config_schema(), never a 2nd list ──
+
+
+def test_bounding_axis_census_is_derived_not_a_second_hand_written_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: architect's own acceptance criterion, verbatim -- '`Axis.
+    BOUNDING` を持つ field を 1 つ足すと、profiler の出力に自動で現れる'.
+    Strip witness: a FRESH Axis.BOUNDING field, on a ``SchemaNode`` that
+    exists ONLY inside this test (never referenced anywhere in
+    memory_breakdown.py), appears in the census purely because
+    ``walk_config_schema()`` finds it -- proving the population is
+    derived, not curated. Reverting ``bounding_axis_census`` to iterate a
+    hardcoded tuple of known keys instead of ``walk_config_schema()``'s
+    own output would make this test miss the fresh field -- verified
+    directly."""
+    import reyn.config.config_schema as config_schema_module
+    from reyn.config.config_schema import SchemaNode
+    from reyn.config_axis import Axis
+
+    fresh_key = "a_field_no_production_code_or_curated_list_names_5959"
+    fresh_node = SchemaNode(
+        key=fresh_key, type_repr="int", default=42, axis=Axis.BOUNDING,
+    )
+    real_walk = config_schema_module.walk_config_schema
+
+    def _fake_walk(cls=None):
+        return [*real_walk(cls), fresh_node]
+
+    monkeypatch.setattr(config_schema_module, "walk_config_schema", _fake_walk)
+
+    rows = bounding_axis_census()
+
+    matching = [r for r in rows if r.key == fresh_key]
+    assert matching, (
+        "a config field the census's OWN test just invented, never named "
+        "anywhere in memory_breakdown.py, must still appear -- the "
+        "population is derived from walk_config_schema(), not a curated list"
+    )
+    assert matching[0].declared_cap == 42
+    assert matching[0].measured_bytes is None
+
+
+def test_bounding_axis_census_the_real_population_includes_a_known_real_field() -> None:
+    """Tier 2: sanity against the REAL, current ReynConfig schema (not a
+    fixture) -- a specific field #4206's own Axis.BOUNDING work already
+    classified (``llm.model``, the pre-existing BOUNDING_KEYS member that
+    predates this issue) must be present, proving the census reaches the
+    real schema rather than an empty/broken derivation. Checking for a
+    named field's PRESENCE is a behaviour claim; counting the population
+    would pin an unrelated config change instead."""
+    rows = bounding_axis_census()
+    keys = {r.key for r in rows}
+    assert "llm.model" in keys
+
+
+def test_unmeasured_is_distinct_from_a_real_zero() -> None:
+    """Tier 2: architect's own explicit requirement -- 'measured=0' and
+    'no provider registered' must never render the same. A provider
+    that legitimately measures 0 resident bytes right now must show
+    0 (int), not None; a field with no provider at all must show None
+    (rendered 'unmeasured'), not a fabricated 0."""
+    rows = bounding_axis_census()
+    zero_key = rows[0].key
+    providers = {zero_key: lambda: 0}
+
+    censused = bounding_axis_census(measurement_providers=providers)
+    zero_row = next(r for r in censused if r.key == zero_key)
+    other_row = next(r for r in censused if r.key != zero_key)
+
+    assert zero_row.measured_bytes == 0
+    assert zero_row.measured_bytes is not None
+    assert other_row.measured_bytes is None
+
+
+def test_unbounded_or_dead_declarations_filters_to_zero_or_unmeasured_only() -> None:
+    """Tier 2: MemoryBreakdown.unbounded_or_dead_declarations is the
+    concrete, testable claim architect's own corrected acceptance text
+    settled on (A only, never conflated with B -- see module docstring)."""
+    breakdown = collect_memory_breakdown(top_n=1)
+    non_trivial_key = None
+    providers = {}
+    census_now = bounding_axis_census()
+    if census_now:
+        non_trivial_key = census_now[0].key
+        providers = {non_trivial_key: lambda: 12345}
+    breakdown = collect_memory_breakdown(top_n=1, measurement_providers=providers)
+
+    dead = breakdown.unbounded_or_dead_declarations
+    assert all(r.measured_bytes in (None, 0) for r in dead)
+    if non_trivial_key is not None:
+        assert non_trivial_key not in {r.key for r in dead}, (
+            "a field with a real, nonzero measured value must never appear "
+            "in the dead-declaration filter"
+        )
+
+
+# ── the audit-event: same shape both surfaces (schema-validated) ────────
+
+
+@pytest.mark.asyncio
+async def test_emit_memory_breakdown_event_lands_with_the_declared_shape() -> None:
+    """Tier 2: the audit-event is the SAME data the CLI prints (#5959's
+    own requirement: '同じ内訳が audit-event にも出る') -- driven through
+    a real EventLog, which validates against event_schema.py's own
+    EVENT_AUDIT_REQUIREMENTS (a malformed payload would fail there, not
+    just look wrong in a hand-inspected dict)."""
+    log = EventLog()
+    collected = collect_events(log)
+    breakdown = collect_memory_breakdown(top_n=3)
+
+    emit_memory_breakdown_event(log.emit, breakdown)
+    await settle(log)
+
+    (event,) = [e for e in collected if e.type == "process_memory_breakdown"]
+    # Parity, not shape: the event must carry the EXACT SAME rows
+    # collect_memory_breakdown() itself built for this call, in the same
+    # order -- not merely "no more than 3", which a truncation bug could
+    # also satisfy.
+    assert event.data["type_breakdown"] == [
+        {"type": r.type_name, "count": r.count, "total_sizeof_bytes": r.total_sizeof_bytes}
+        for r in breakdown.type_breakdown
+    ]
+    assert event.data["largest_objects"] == [
+        {"type": r.type_name, "sizeof_bytes": r.sizeof_bytes, "repr_snippet": r.repr_snippet}
+        for r in breakdown.largest_objects
+    ]
+    assert isinstance(event.data["bounding_census"], list)
+    assert "shallow" in event.data["estimate_note"].lower(), (
+        "sys.getsizeof's shallowness must be disclosed IN the event "
+        "itself, not only in CLI prose a human might not read"
+    )
+
+
+# ── stage ③: tracemalloc, opt-in, byte-identical when unset ─────────────
+
+
+def test_tracemalloc_top_allocations_returns_none_when_never_armed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: 'never armed' and 'armed but found nothing' must not read
+    the same -- None vs an empty list are different facts."""
+    monkeypatch.delenv(TRACEMALLOC_ENV_VAR, raising=False)
+    import tracemalloc
+
+    was_tracing = tracemalloc.is_tracing()
+    if was_tracing:
+        tracemalloc.stop()
+    try:
+        assert tracemalloc_is_armed() is False
+        assert tracemalloc_top_allocations() is None
+    finally:
+        if was_tracing:
+            tracemalloc.start()
+
+
+def test_arm_tracemalloc_if_requested_is_a_genuine_noop_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: strip witness -- REYN_MEMORY_TRACE unset means this
+    function does not even import tracemalloc, let alone start it (the
+    opt-in's whole point). Verified by confirming tracemalloc's own
+    is_tracing() state is UNCHANGED by the call, on both sides."""
+    monkeypatch.delenv(TRACEMALLOC_ENV_VAR, raising=False)
+    import tracemalloc
+
+    before = tracemalloc.is_tracing()
+    armed = arm_tracemalloc_if_requested()
+    after = tracemalloc.is_tracing()
+
+    assert armed is False
+    assert after == before
+
+
+def test_arm_tracemalloc_if_requested_actually_arms_and_top_allocations_finds_a_real_site(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the opt-in path genuinely works end to end -- armed,
+    something allocates, the allocation's own file:line is findable in
+    the top-N. Real tracemalloc throughout (process-global state --
+    stopped in `finally`, regardless of the pre-existing state, so this
+    test never leaks armed tracing into the rest of the suite)."""
+    monkeypatch.setenv(TRACEMALLOC_ENV_VAR, "1")
+    import tracemalloc
+
+    was_tracing = tracemalloc.is_tracing()
+    try:
+        armed = arm_tracemalloc_if_requested()
+        assert armed is True
+        assert tracemalloc_is_armed() is True
+
+        keepalive = ["z" * 300_000 for _ in range(20)]  # a real, findable allocation
+        allocations = tracemalloc_top_allocations(top_n=50)
+        del keepalive
+
+        assert allocations is not None
+        assert allocations, "an armed trace with real allocations must find at least one site"
+        assert all("file_line" in a and "size_bytes" in a and "count" in a for a in allocations)
+    finally:
+        tracemalloc.stop()
+        if was_tracing:
+            tracemalloc.start()


### PR DESCRIPTION
**[e2e-coder]** — part of #5959.

Owner, verbatim: "今後も leak 容疑確認のために使用量見積もりのプロファイル取れるようにすべきじゃないの" / "python object として reyn が参照してるってことなんでしょ？" — a `vmmap` region-distribution read (#5957) cannot tell an allocator-held free region from a live Python reference holding it; both look identical from OUTSIDE the process. This is the IN-PROCESS answer.

## Two populations, never one curated list (architect ruling)

- **ⓐ discovery** (`gc_type_breakdown`/`gc_largest_objects`): `gc.get_objects()`, grouped/ranked by type. No curated list — whatever is actually alive.
- **ⓑ completeness** (`bounding_axis_census`): every config field carrying `Axis.BOUNDING`, **derived** from `walk_config_schema()` — never a second hand-written list. Strip-verified: a fresh `Axis.BOUNDING` field, named nowhere in `memory_breakdown.py`, auto-appears in the census (`test_bounding_axis_census_is_derived_not_a_second_hand_written_list`). `measured_bytes=None` (`unmeasured`) is kept distinct from a real `0` everywhere it surfaces.

`MemoryBreakdown.unbounded_or_dead_declarations` is the one concrete, testable claim architect's own corrected acceptance text settled on — **type A only** (a resource declared bounded with nothing measured resident under it), never conflated with type B (a purpose registered with zero production resolution points — a static-census question, explicitly out of scope here per architect's own correction mid-thread).

## Exit surfaces

- `reyn doctor-memory` — a **separate** top-level subcommand (not folded into `doctor.py`'s existing D-1/D-2/D-3 flat report: this walk has real CPU cost, unlike every existing `doctor` check's cheap stat/probe reads).
- `process_memory_breakdown` audit-event — same data both surfaces, one `collect_memory_breakdown()` call backs both.

## Stage ③ (opt-in, deep dive)

`tracemalloc`, armed via `REYN_MEMORY_TRACE` at CLI `main()`'s own entry — before anything else in that function runs, so it attributes allocations from as early as reasonably possible. Zero `tracemalloc` calls when unset (verified: `is_tracing()` state is unchanged by an unset-env call — not "started then stopped," genuinely never invoked).

## A disclosed, sharper gap found while building this (not left silent)

`gc.get_objects()` never tracks `str`/`bytes`/`bytearray`/`int`/`float` at all (`gc.is_tracked()` is `False` for all of them — measured directly while writing the tests, after an earlier test design assumed otherwise and failed). This is **exactly the shape owner's own suspicion names** — a large content string held by a Python reference — and it is **invisible to ⓐ's live walk**, both directly (the string never appears as its own row) and indirectly (its holding container's shallow `sys.getsizeof` doesn't include it either). Named in the module docstring, the CLI's own printed output, and a dedicated regression test (`test_a_large_standalone_string_is_invisible_to_gc_based_discovery`) — `tracemalloc` (stage ③, by allocation site rather than live object walk) is the tool that can actually answer that specific case.

## What this PR does NOT claim

The real acceptance — a 2× `attach` diff on the **owner's own machine** identifying which type grew (#5959's own final bullet, and the actual discriminator for #5957) — cannot be reproduced locally. This PR ships the tool, strip-verified on every structural claim; the owner-machine measurement is the natural next step once this lands.

## Local gates run

ruff, `test_tier_audit.py --strict` (18 tests, 0 findings after 2 format-pinning fixes), `verify_module_docstrings.py`, `mypy_ratchet.py` (1 real finding fixed — a loop-variable type reused across 3 differently-typed loops), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), `tests/` path-conditional gates, and `docs/` path-conditional gates (`mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py`, since `docs/reference/runtime/events.md` gained the new event kind's entry) — all green. Scoped pytest: 18 new tests (13 core module + 5 CLI) plus `test_audit_event_kind_vocabulary_3410.py` (10 tests, confirms the event-schema doc/declaration stay in sync) — all green. Did NOT run the full suite locally (CI-only, per house rule).

## Test plan
- [x] Scoped pytest green (see above)
- [x] Strip-falsify: ⓑ's derivation (monkeypatched fresh `Axis.BOUNDING` field auto-appears), `unmeasured`≠`0`, tracemalloc genuine no-op when unset, tracemalloc genuinely finds a real allocation when armed — all verified directly
- [ ] (skipped — Visual, standing waiver) N/A, CLI-only surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)