### PR TITLE
fix(#5919 stage 3): consolidate marker recognition into _markers.py -- private borrow to 0

### DIFF
--- a/scripts/_markers.py
+++ b/scripts/_markers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Shared marker-detection primitives for declaration/exemption/closing-note
-gates (#5919 stage 1, extended by stage 2).
+gates (#5919 stage 1, extended by stage 2 and stage 3).
 
 ## The class this closes
 
@@ -71,6 +71,43 @@ match. Used by `check_open_blocking_checkboxes.py` and (reusing THAT
 gate's own marker regex + decoration pattern, not a second copy)
 `check_blocking_has_reread_note.py`.
 
+## `MARKER_BLOCKING`/`MARKER_CLEARED`/`NOTE_MARKER`/`DECORATION`/`undecorated`
+
+A name read across a module boundary is either RECOGNITION (belongs
+HERE — a syntax question every consumer answers identically) or
+DECISION (belongs on its OWNING gate, as a PUBLIC name — never a
+private one, regardless of who else needs it). `check_open_blocking_
+checkboxes.py`'s BLOCKING/CLEARED marker shapes and decoration
+handling, and `check_tests_read_names_its_tree.py`'s TESTS-READ marker
+shape, are all recognition — every gate that checks for a BLOCKING/
+CLEARED comment or a TESTS-READ note means the EXACT SAME syntax by it,
+so those five live here, as the ONE place each is defined. By contrast,
+`check_tests_read_names_its_tree.py`'s `note_names_head` (does a note
+name a specific head) is a decision, not a syntax question — it stays
+on that module, as a public name, never here.
+
+A gate that needs a name defined on a DIFFERENT gate for its own
+recognition step — rather than here, or as that gate's own public
+decision name — is reaching across a boundary this module and its
+sibling gates exist to keep from opening: nothing in this repo should
+ever read a leading-underscore name off a sibling module.
+
+`MARKER_BLOCKING`/`MARKER_CLEARED`/`NOTE_MARKER` are compiled,
+ready-to-use `re.Pattern` objects (not builders like
+`role_prefixed_marker` above) — every consumer of the BLOCKING/CLEARED
+or TESTS-READ shape means the exact same thing by it (RE-READ is the
+one keyword that stays genuinely gate-owned: only `check_blocking_has_
+reread_note.py` ever means it), so reusing the identical compiled
+pattern (not reconstructing a second copy from the same regex text) is
+what keeps every consumer from drifting apart the moment one of them
+changes — the same reasoning `check_blocking_has_reread_note.py` already
+relied on when it first borrowed these as private instances.
+
+`DECORATION`/`undecorated` are the UNCONDITIONAL sibling of
+`undecorated_after_role_prefix` — for text that is not itself a
+role-prefix candidate (near-miss detection's own bare-word check, which
+never anchors to a role prefix at all).
+
 ## What this module deliberately does NOT do
 
 It does not decide what counts as a declaration for any one gate — each
@@ -137,13 +174,89 @@ def undecorated_after_role_prefix(line: str, decoration: "re.Pattern[str]") -> s
     return line[:prefix_match.end()] + decoration.sub("", line[prefix_match.end():])
 
 
-def first_line(text: str) -> str:
-    """*text*'s first line, newline-delimited, no trailing newline — the
-    single line every marker in this module is matched against. A
-    document's line 2 onward (grounds, discussion, prior history) is
-    never handed to a marker pattern; the exclusion is syntactic, not a
-    matter of where a keyword happens to be more or less likely."""
-    return text.split("\n", 1)[0]
+def first_nonempty_line(text: str) -> str:
+    """*text*'s first NON-EMPTY line, stripped — the single line every
+    marker in this module is matched against. A document's line 2
+    onward (grounds, discussion, prior history) is never handed to a
+    marker pattern; the exclusion is syntactic, not a matter of where a
+    keyword happens to be more or less likely.
+
+    #5919 stage 3: replaces a bare ``text.split("\\n", 1)[0]`` (this
+    function's pre-stage-3 shape, and — independently —
+    ``check_tests_read_names_its_tree.py``'s own pre-stage-3 ``_first_
+    line``) — that shape returns an EMPTY string for a comment/body that
+    opens with a blank line before its real content, which then fails
+    every marker regex trivially, not because no marker was posted but
+    because the marker's own line was never even looked at. Verified
+    directly (not merely inferred from the two implementations'
+    difference — architect's own explicit request): a real
+    ``TESTS-READ (head <sha>)`` comment prefixed with one blank line
+    matches under this rule and was silently missed under the old
+    bare-split one — a genuine, previously-uncounted 5th fail-open
+    instance in #5919's own census (architect: the 2026-09-07 census
+    counted 4 silent-miss gates; this is the 5th, house rule 8/#5453,
+    found only once this function actually ran against a real
+    constructed input). See ``tests/scripts/test_markers_5919.py``'s own
+    witness for that exact input. House rule 7's own "識別行 = marker
+    直後の最初の非空行" definition already reads a marker's OWN position
+    by this same rule, so this is not a NEW convention — it is the
+    recognition side finally matching the decision side's own
+    definition."""
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+#: Markdown decoration this repo's own marker conventions tolerate around
+#: a keyword or SHA — backtick code-spans and `**`/`*` emphasis. Neither a
+#: SHA nor a marker keyword itself ever contains a backtick or asterisk,
+#: so stripping this cannot turn a non-marker line into a false-positive
+#: match (architect ruling, #5522: "許容側が自然" — people decorate SHAs
+#: and keywords by hand; stripping once is cheaper than asking every
+#: writer never to).
+DECORATION = re.compile(r"[`*]")
+
+
+def undecorated(line: str) -> str:
+    """*line* with every :data:`DECORATION` character stripped,
+    unconditionally.
+
+    For text that is NOT itself a role-prefix candidate — a near-miss
+    watcher's own bare-word check (which must never anchor to a role
+    prefix at all, see this module's own "What this module deliberately
+    does NOT do" section on why a watcher stays unanchored). A line that
+    DOES open with a real role prefix needs :func:`undecorated_after_
+    role_prefix` instead — a blanket strip here would erase the role
+    prefix's own literal ``**[...]**`` syntax right along with any
+    decoration around it."""
+    return DECORATION.sub("", line)
+
+
+#: The BLOCKING / BLOCKING-CLEARED marker recognition shapes (#5919 stage
+#: 3, moved from ``check_open_blocking_checkboxes.py`` — see this
+#: module's own docstring section for why these are SHARED compiled
+#: instances, not a builder each consumer calls independently). Requires
+#: the marker keyword co-located with ``(head <sha>)`` on the same
+#: anchored line — not the bare word found anywhere on it. `IGNORECASE`
+#: is dropped (``flags=0``) for the same reason the pre-#5919 regex
+#: already gave: prose is far more likely to write "blocking" lowercase
+#: than a deliberate marker is.
+MARKER_BLOCKING = role_prefixed_marker(
+    r"BLOCKING(?!-CLEARED)\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)", flags=0,
+)
+MARKER_CLEARED = role_prefixed_marker(
+    r"BLOCKING-CLEARED\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)", flags=0,
+)
+
+#: House rule 8's TESTS-READ/TESTS-READY marker (#5919 stage 3, moved from
+#: ``check_tests_read_names_its_tree.py``, which now reads THIS name —
+#: never a locally-redefined copy — so a future widening of the keyword
+#: (e.g. tolerating a further typo) cannot land in one gate and silently
+#: not the other). Tolerates the ``TESTS-READY`` typo several sessions
+#: produce, because the gate must not turn a typo into "no note landed."
+NOTE_MARKER = role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
 
 
 def html_comment_marker(tag: str, payload_pattern: str, *, flags: int = re.IGNORECASE) -> "re.Pattern[str]":

--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -52,16 +52,23 @@ marker, so a `tests/`-touching PR still clears both gates with ONE
 `TESTS-READ` comment, while a `src`-only PR can post the accurate
 `RE-READ` one instead of a claim it cannot back up.
 
-`check_tests_read_names_its_tree.py` and `check_open_blocking_checkboxes.py`
-are loaded via ``importlib.util.spec_from_file_location`` (mirroring
-`tests/scripts/test_check_tests_read_names_its_tree_5039.py`'s own
-established technique for reaching a `scripts/`-local module — this
-directory has no `__init__.py`, so a package import is not available)
-and their existing functions/regexes are called directly — the marker
-shape, the SHA-membership filter (`find_note_shas`'s own false-friend
-guard), and the "names the CURRENT head, not any past one" existential
-all come from there unchanged, so a future fix to either stays in sync
-with both gates automatically instead of drifting.
+`check_tests_read_names_its_tree.py` (for its own DECISION functions,
+`find_note_shas`'s false-friend guard and `note_names_head`'s "names the
+CURRENT head, not any past one" existential) and `_markers.py` (for
+every RECOGNITION primitive both gates need — the BLOCKING/CLEARED and
+TESTS-READ marker shapes, decoration-stripping, first-non-empty-line
+isolation) are loaded via ``importlib.util.spec_from_file_location``
+(mirroring `tests/scripts/test_check_tests_read_names_its_tree_5039.py`'s
+own established technique for reaching a `scripts/`-local module — this
+directory has no `__init__.py`, so a package import is not available).
+#5919 stage 3 (architect's boundary ruling): a name read across module
+boundaries is either recognition (`_markers.py`, this gate reads it
+DIRECTLY, never through the module that also happens to use it) or
+decision (the owning module's own PUBLIC name — never private, which is
+the exact shape that broke silently between #5919 stages 2 and 3, see
+`_has_blocking_comment`'s own docstring). `check_open_blocking_
+checkboxes.py` is no longer loaded here at all: everything this gate
+needed from it was recognition, and has moved to `_markers.py`.
 
 ## Report-only (lead-coder's own scoping, #5453)
 
@@ -104,11 +111,10 @@ def _load(module_name: str, filename: str):
 
 
 _tests_read = _load("_check_blocking_reread_tests_read", "check_tests_read_names_its_tree.py")
-_blocking = _load("_check_blocking_reread_blocking", "check_open_blocking_checkboxes.py")
 _markers = _load("_check_blocking_reread_markers", "_markers.py")
 
 #: architect's non-blocking recommendation on #5453 (quoted verbatim below,
-#: `evaluate`'s docstring) — reusing ONLY `_tests_read._NOTE_MARKER`
+#: `evaluate`'s docstring) — reusing ONLY `_markers.NOTE_MARKER`
 #: (`TESTS-READ`/`TESTS-READY`) would make a `src`-only PR's re-read
 #: comment claim "read a test that isn't in this diff at all". `RE-READ
 #: (head <sha>)` is the honest form for that case; either marker satisfies
@@ -116,10 +122,14 @@ _markers = _load("_check_blocking_reread_markers", "_markers.py")
 #: `TESTS-READ` for house rule 8) still clears both gates with ONE
 #: comment, while a `src`-only PR can post the accurate one.
 #:
-#: #5919: like `_tests_read._NOTE_MARKER`, now anchored to the CLAUDE.md
+#: #5919: like `_markers.NOTE_MARKER`, now anchored to the CLAUDE.md
 #: rule-2 role prefix via `_markers.role_prefixed_marker` — a bare
 #: `.search()` used to let a line DENYING a re-read ("No RE-READ (head
 #: start) needed here, this is a docs-only typo fix.") read as one.
+#: Unlike TESTS-READ/BLOCKING/CLEARED, RE-READ is genuinely OWNED by this
+#: gate alone — no other consumer means it — so it stays a private,
+#: locally-built instance rather than moving to `_markers.py` (see that
+#: module's own docstring for the recognition-vs-vocabulary boundary).
 _RE_READ_MARKER = _markers.role_prefixed_marker(r"RE-READ\s*\(\s*head\s")
 
 
@@ -129,41 +139,50 @@ def _is_reread_note(first_line: str) -> bool:
     `tests/`-touching PR's existing note keeps satisfying this gate too),
     or this gate's own `RE-READ (head <sha>)` (architect's #5453
     recommendation, for a PR where "TESTS-READ" would misstate what was
-    actually read)."""
+    actually read).
+
+    #5919 stage 3: reads `_markers.NOTE_MARKER` directly — NOT
+    `_tests_read._NOTE_MARKER` (the private-borrow shape this whole
+    issue exists to close) and not even `_tests_read.NOTE_MARKER` (that
+    module no longer defines its own copy at all; it too now reads
+    `_markers.NOTE_MARKER`, so there is nothing left to indirect
+    through)."""
     return bool(
-        _tests_read._NOTE_MARKER.search(first_line) or _RE_READ_MARKER.search(first_line)
+        _markers.NOTE_MARKER.search(first_line) or _RE_READ_MARKER.search(first_line)
     )
 
 
 def _has_blocking_comment(comment_bodies: "list[str]") -> bool:
     """True iff ANY comment's first non-empty line matches the `BLOCKING
-    (head <sha>)` shape (reused from `check_open_blocking_checkboxes.py`
-    — the same anchored, role-prefix-aware marker #5919 stage 2 built,
-    the same form check that excludes prose merely discussing the word,
-    #5318's own false-positive fix).
+    (head <sha>)` shape (reused from `_markers.py` — the same anchored,
+    role-prefix-aware marker #5919 stage 2 built and stage 3 promoted to
+    a shared public instance, the same form check that excludes prose
+    merely discussing the word, #5318's own false-positive fix).
 
-    #5522/#5919: reads `_blocking._first_nonempty_line`/`_blocking.
-    _MARKER_BLOCKING`/`_blocking._DECORATION`, and strips decoration via
-    `_markers.undecorated_after_role_prefix` (not `_blocking._undecorated`
-    — a blanket, role-prefix-blind strip) — this gate shares the EXACT
-    same real incidents fixed one level up, TWICE now: #5522's original
-    (a BLOCKING comment whose SHA was backtick-wrapped would make the
-    marker not match here EITHER, so THIS gate would silently conclude
-    "no BLOCKING comment on this PR" and skip its own TESTS-READ/RE-READ
-    requirement entirely), and #5919 stage 2's own (once
-    `_MARKER_BLOCKING` became role-prefix-anchored, a blanket strip would
+    #5522/#5919: reads `_markers.first_nonempty_line`/`_markers.
+    MARKER_BLOCKING`/`_markers.DECORATION` directly — NOT
+    `_blocking._first_nonempty_line`/`_blocking._MARKER_BLOCKING`/
+    `_blocking._DECORATION` (the private-borrow shape that broke silently
+    between #5919 stages 2 and 3, when `check_open_blocking_checkboxes.
+    py` renamed `_BLOCKING_MARKER` to `_MARKER_BLOCKING` and this gate's
+    own borrow of the old name went stale, unnoticed by a scoped test run
+    because the break sat outside stage 2's own diff). This gate shares
+    the EXACT same real incidents fixed one level up, TWICE now: #5522's
+    original (a BLOCKING comment whose SHA was backtick-wrapped would
+    make the marker not match here EITHER, so THIS gate would silently
+    conclude "no BLOCKING comment on this PR" and skip its own
+    TESTS-READ/RE-READ requirement entirely), and #5919 stage 2's own
+    (once the marker became role-prefix-anchored, a blanket strip would
     erase a REAL role prefix's own `**[...]** — ` literal right along
     with any decoration around the marker, breaking every role-prefixed
     BLOCKING comment — which is every real one in this repo, CLAUDE.md
-    rule 2). Reusing `check_open_blocking_checkboxes.py`'s own marker
-    regex and decoration pattern (rather than a second copy) means a
-    future change to either stays in sync with both gates automatically,
-    the same non-drift property this module's docstring already claims
-    for `_tests_read`."""
+    rule 2). Reusing the SAME shared instance (rather than a second copy)
+    means a future change to it stays in sync with every consumer
+    automatically."""
     return any(
-        _blocking._MARKER_BLOCKING.search(
+        _markers.MARKER_BLOCKING.search(
             _markers.undecorated_after_role_prefix(
-                _blocking._first_nonempty_line(body), _blocking._DECORATION,
+                _markers.first_nonempty_line(body), _markers.DECORATION,
             ),
         )
         for body in comment_bodies
@@ -186,9 +205,9 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         return 0, ["OK — this PR carries no BLOCKING comment; #5453 does not apply."]
 
     notes = [
-        _tests_read._first_line(body)
+        _markers.first_nonempty_line(body)
         for body in comment_bodies
-        if _is_reread_note(_tests_read._first_line(body))
+        if _is_reread_note(_markers.first_nonempty_line(body))
     ]
     if not notes:
         return 1, [
@@ -226,7 +245,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         if not shas:
             continue
         resolved_count += 1
-        if _tests_read._note_names_head(note, head, oids):
+        if _tests_read.note_names_head(note, head, oids):
             return 0, [f"OK — a re-read note names the current head {head}."]
         stale.append((note, shas))
 

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -65,7 +65,7 @@ names `BLOCKING`/`BLOCKING-CLEARED` but does not parse as either marker
 regex is RED — a THIRD failure mode neither A nor B could see. Real
 incident (lead-coder, 2026-08-29): a BLOCKING comment's first line read
 ``**BLOCKING (head `9862413f0`)**`` — the backtick around the SHA broke
-`_MARKER_BLOCKING`'s match, and the gate said nothing at all for 12
+`_markers.MARKER_BLOCKING`'s match, and the gate said nothing at all for 12
 minutes; the PR only stayed red by the accident of an unrelated
 BLOCKING from a different reviewer. Before #5522, "no marker on this
 comment" and "a marker written wrong" were the same silence — condition
@@ -75,7 +75,7 @@ mid-body mention, including this docstring's OWN repeated use of the
 word, must never trip it).
 
 Same PR (#5522) also strips backtick/`*` decoration from a line before
-either marker regex runs (`_undecorated`, and — #5919 stage 2 — its
+either marker regex runs (`_markers.undecorated`, and — #5919 stage 2 — its
 role-prefix-preserving sibling `_undecorated_for_marker_match`) — the
 root cause of the specific incident above, not just its silence. Aligns
 this gate with `check_tests_read_names_its_tree.py`'s own
@@ -85,13 +85,14 @@ is cheaper than asking every writer never to).
 
 ## #5919 stage 2 — anchoring the two DECIDING markers, never the WATCHER
 
-The marker regexes above (`_MARKER_BLOCKING`/`_MARKER_CLEARED`) used to
+The marker regexes above (`_markers.MARKER_BLOCKING`/`_markers.MARKER_CLEARED`) used to
 be unanchored `\b...` searches over an undecorated first line — #5919's
 census found this let 4 ordinary-prose shapes (a negating sentence, a
 backtick span, a `>` quote, mid-sentence mention) satisfy them exactly
 as `check_tests_read_names_its_tree.py`'s pre-#5919-stage-1 regex could.
 Both are now built with `scripts/_markers.role_prefixed_marker(...)`,
-column-0-anchored exactly like that gate's own `_NOTE_MARKER`.
+column-0-anchored exactly like `_markers.NOTE_MARKER` (#5919 stage 3:
+both now live there, not one per gate).
 
 `_NEAR_MISS_BARE_WORD` (condition C) is deliberately NOT anchored and
 NOT routed through `_markers.py` — see its own docstring for why
@@ -182,25 +183,26 @@ _CHECKED_BLOCK = re.compile(r"^[ \t]*[-*+][ \t]*\[[xX]\][ \t]*(?:\*\*[ \t]*)*�
 #: own IGNORECASE default) for the SAME reason the pre-#5919 regex already
 #: gave: prose is far more likely to write "blocking" lowercase than a
 #: deliberate marker is.
-_MARKER_BLOCKING = _markers.role_prefixed_marker(
-    r"BLOCKING(?!-CLEARED)\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)", flags=0,
-)
-_MARKER_CLEARED = _markers.role_prefixed_marker(
-    r"BLOCKING-CLEARED\s*\(\s*head\s+([0-9a-fA-F]{7,40})\s*\)", flags=0,
-)
+#: #5919 stage 3: moved to `_markers.py` (`MARKER_BLOCKING`/
+#: `MARKER_CLEARED`) — this gate's own logic below reads THOSE names
+#: directly (`_markers.MARKER_BLOCKING`), no local alias, so
+#: `check_blocking_has_reread_note.py` (or any future consumer) has
+#: nothing private here left to reach into; see `_markers.py`'s own
+#: docstring for why sharing the compiled instance, not reconstructing
+#: it per consumer, is what keeps every consumer from drifting apart.
 
 #: #5522 — a bare word check for NEAR-MISS DETECTION (condition C).
 #:
 #: 🔴 #5919 stage 2 (architect ruling, explicit): deliberately NOT routed
 #: through `_markers.role_prefixed_marker` and deliberately NOT anchored
 #: to column 0 or to the marker's own "(head <sha>)" shape, unlike
-#: `_MARKER_BLOCKING`/`_MARKER_CLEARED` directly above. Those two DECIDE
+#: `_markers.MARKER_BLOCKING`/`_markers.MARKER_CLEARED` directly above. Those two DECIDE
 #: ("does a real marker exist here?" — YES must be earned, so they are
 #: anchored against ordinary prose producing a false YES). This one
 #: WATCHES FOR WHAT THE DECIDERS MISSED ("did a marker attempt land here
 #: at all, even a malformed one?" — a NO-side safety net, so anchoring it
 #: would remove the exact cases it exists to catch: a decorated/malformed
-#: marker that `_MARKER_BLOCKING`/`_MARKER_CLEARED` correctly reject).
+#: marker that `_markers.MARKER_BLOCKING`/`_markers.MARKER_CLEARED` correctly reject).
 #: Anchoring this one would make it redundant with — and therefore
 #: silently subsumed by — the deciders it is supposed to be watching,
 #: which is exactly the "one incident, no signal for 12 minutes" failure
@@ -211,7 +213,7 @@ _MARKER_CLEARED = _markers.role_prefixed_marker(
 #: Matches inside "BLOCKING-CLEARED" too (the `-` after "BLOCKING" is a
 #: non-word char, satisfying `\b` on both sides of the bare word) —
 #: deliberate, not an oversight: a decorated BLOCKING-CLEARED that fails
-#: `_MARKER_CLEARED` must ALSO be caught, and this one check does both
+#: `_markers.MARKER_CLEARED` must ALSO be caught, and this one check does both
 #: without a second pattern. Case-sensitive, matching the deciding
 #: markers' own IGNORECASE-dropped posture.
 _NEAR_MISS_BARE_WORD = re.compile(r"\bBLOCKING\b")
@@ -220,7 +222,7 @@ _NEAR_MISS_BARE_WORD = re.compile(r"\bBLOCKING\b")
 #: backtick code-spans and `**`/`*` emphasis — is stripped from a line
 #: before the near-miss check (`_NEAR_MISS_BARE_WORD`) runs against it, and
 #: from whatever follows a detected role prefix before either DECIDING
-#: marker (`_MARKER_BLOCKING`/`_MARKER_CLEARED`) runs (see
+#: marker (`_markers.MARKER_BLOCKING`/`_markers.MARKER_CLEARED`) runs (see
 #: `_undecorated_for_marker_match` below — the role prefix's OWN `**...**`
 #: syntax must survive, or #5919's new anchoring could never match a
 #: decorated marker that follows a real role prefix). "Align to the
@@ -230,16 +232,14 @@ _NEAR_MISS_BARE_WORD = re.compile(r"\bBLOCKING\b")
 #: Neither a SHA nor the BLOCKING/BLOCKING-CLEARED keywords themselves
 #: ever contain a backtick or asterisk, so stripping cannot turn a
 #: non-marker line into a false-positive match.
-_DECORATION = re.compile(r"[`*]")
-
-
-def _undecorated(line: str) -> str:
-    return _DECORATION.sub("", line)
+#:
+#: #5919 stage 3: moved to `_markers.py` (`DECORATION`/`undecorated`) —
+#: this gate's own logic reads those names directly, no local alias.
 
 
 def _undecorated_for_marker_match(line: str) -> str:
-    """*line*, with :data:`_DECORATION` stripped EVERYWHERE EXCEPT a
-    leading CLAUDE.md role prefix, if one opens the line.
+    """*line*, with :data:`_markers.DECORATION` stripped EVERYWHERE
+    EXCEPT a leading CLAUDE.md role prefix, if one opens the line.
 
     #5919 stage 2: delegates to `_markers.undecorated_after_role_prefix`
     (promoted there, not left as a private helper here, once lead-coder's
@@ -251,7 +251,7 @@ def _undecorated_for_marker_match(line: str) -> str:
     own `**[...]** — ` syntax right along with any decoration AROUND the
     marker, so `_markers.role_prefixed_marker`'s anchor would never match
     a decorated, role-prefixed comment post-strip."""
-    return _markers.undecorated_after_role_prefix(line, _DECORATION)
+    return _markers.undecorated_after_role_prefix(line, _markers.DECORATION)
 
 
 def _normalize(text: str) -> str:
@@ -259,23 +259,6 @@ def _normalize(text: str) -> str:
     folding only" rule condition B (and now A) both use; never case-folded
     or punctuation-stripped, so a quote must still be a real quote."""
     return re.sub(r"\s+", " ", text).strip()
-
-
-def _first_nonempty_line(text: str) -> str:
-    """The comment's first non-empty line — the SAME scope both the
-    marker regexes and #5522's near-miss check read (architect ruling:
-    "marker規則が既に読んでいる面と同じ面に限る" — near-miss detection
-    must never widen the surface a formal marker match already uses,
-    or it would fire on prose anywhere the marker regex is not also
-    looking). A literal ``text.split("\\n", 1)[0]`` (this function's
-    pre-#5522 shape) would silently miss a comment that opens with a
-    blank line before its marker — a real gap this rename also closes,
-    not just the near-miss feature's own scoping."""
-    for line in text.split("\n"):
-        stripped = line.strip()
-        if stripped:
-            return stripped
-    return ""
 
 
 def _identifying_line(comment_body: str) -> str:
@@ -313,8 +296,8 @@ def _cleared_after(identifying_text: str, candidate_bodies: "list[str]", head: s
     if not identifying_text:
         return False
     for candidate_body in candidate_bodies:
-        first_line = _undecorated_for_marker_match(_first_nonempty_line(candidate_body))
-        cleared_match = _MARKER_CLEARED.match(first_line)
+        first_line = _undecorated_for_marker_match(_markers.first_nonempty_line(candidate_body))
+        cleared_match = _markers.MARKER_CLEARED.match(first_line)
         if not cleared_match:
             continue
         cleared_sha = cleared_match.group(1)
@@ -377,8 +360,8 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # an unresolved point with no deliberate action at all, worse than
     # the deletion bypass #5311 measured.
     for i, blocking_body in enumerate(comment_bodies):
-        blocking_first_line = _undecorated_for_marker_match(_first_nonempty_line(blocking_body))
-        blocking_match = _MARKER_BLOCKING.match(blocking_first_line)
+        blocking_first_line = _undecorated_for_marker_match(_markers.first_nonempty_line(blocking_body))
+        blocking_match = _markers.MARKER_BLOCKING.match(blocking_first_line)
         if not blocking_match:
             continue
         identifying = _identifying_line(blocking_body)
@@ -409,14 +392,14 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     # marker). A near-miss is real only when the word appears on the
     # SAME line a marker would have to be on to be read at all.
     for comment_body in comment_bodies:
-        first_line = _first_nonempty_line(comment_body)
+        first_line = _markers.first_nonempty_line(comment_body)
         if not first_line:
             continue
-        undecorated_first_line = _undecorated(first_line)
+        undecorated_first_line = _markers.undecorated(first_line)
         if not _NEAR_MISS_BARE_WORD.search(undecorated_first_line):
             continue  # no BLOCKING/BLOCKING-CLEARED word on this line at all
         marker_line = _undecorated_for_marker_match(first_line)
-        if _MARKER_BLOCKING.match(marker_line) or _MARKER_CLEARED.match(marker_line):
+        if _markers.MARKER_BLOCKING.match(marker_line) or _markers.MARKER_CLEARED.match(marker_line):
             continue  # a real marker, already handled by condition A above
         findings.append(
             "RED (near-miss) — a comment's first line names BLOCKING/"

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -34,7 +34,7 @@ the note any good" — nothing here reads the note's content. It is only:
    actually read at the time).
 
 The note's CLAIM line lives in a PR **comment**, and only its FIRST LINE is
-ever read (see ``_NOTE_MARKER`` / ``evaluate``). That comment's line 1 must
+ever read (see ``_markers.NOTE_MARKER`` / ``evaluate``). That comment's line 1 must
 carry the marker AND the head SHA together, e.g.
 ``**[e2e-coder]** — TESTS-READ (B: independent) (head 9cc100605)``. The
 GROUNDS behind the claim (six-questions answers, scope, limits) live from
@@ -58,7 +58,7 @@ first line — a one-line comment that merely DENIES a note ("This PR is not
 ready for a TESTS-READ note yet — still investigating 9cc1006.") is still
 entirely "first line" and, under a bare ``.search()`` for the keyword,
 matched exactly like a real claim, with the trailing SHA-shaped token then
-read as the tree it names. ``_NOTE_MARKER`` (:mod:`_markers`) now requires
+read as the tree it names. ``_markers.NOTE_MARKER`` now requires
 the marker to OPEN the line, immediately after the CLAUDE.md rule-2 role
 prefix every comment already carries — ordinary prose discussing the
 marker does not open a comment with a role prefix followed directly by the
@@ -121,17 +121,23 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import _markers  # noqa: E402 -- sibling module, see _markers.py's own docstring
 
 #: A TESTS-READ note's claim line is recognised by this marker ONLY when it
-#: OPENS a comment's FIRST LINE, immediately after the CLAUDE.md rule-2 role
-#: prefix (see ``_markers.role_prefixed_marker``) — never a bare `.search()`
-#: over free text (#5919: "This PR is not ready for a TESTS-READ note yet"
-#: used to match, because the keyword appeared anywhere on the line; a
-#: sentence DENYING the note is not distinguishable from one STATING it by
-#: keyword search alone). Matched case-insensitively and tolerating the
-#: ``TESTS-READY`` typo that several sessions produce, because the gate must
-#: not turn a typo into "no note landed" (that would fail the PR for the
-#: wrong reason). Required syntax: a comment's first line reading
-#: ``**[role]** — TESTS-READ (...) (head <sha>)``.
-_NOTE_MARKER = _markers.role_prefixed_marker(r"TESTS-READ(?:Y)?\b")
+#: OPENS a comment's FIRST NON-EMPTY LINE, immediately after the CLAUDE.md
+#: rule-2 role prefix (see ``_markers.role_prefixed_marker``) — never a bare
+#: `.search()` over free text (#5919: "This PR is not ready for a TESTS-READ
+#: note yet" used to match, because the keyword appeared anywhere on the
+#: line; a sentence DENYING the note is not distinguishable from one
+#: STATING it by keyword search alone). Matched case-insensitively and
+#: tolerating the ``TESTS-READY`` typo that several sessions produce,
+#: because the gate must not turn a typo into "no note landed" (that would
+#: fail the PR for the wrong reason). Required syntax: a comment's first
+#: non-empty line reading ``**[role]** — TESTS-READ (...) (head <sha>)``.
+#:
+#: #5919 stage 3: moved to ``_markers.py`` (``NOTE_MARKER``) —
+#: ``check_blocking_has_reread_note.py`` means the exact same shape when
+#: it reuses this for its own house-rule-8 acceptance, so this module now
+#: reads ``_markers.NOTE_MARKER`` directly rather than owning a private
+#: copy a second consumer would have to reach into (the shape #5919 was
+#: filed to close in the first place).
 
 #: A 7-40 char hex run, the shape `git rev-parse` prints. Bounded on both sides
 #: by a non-hex boundary so a longer word containing hex letters is not read as
@@ -144,18 +150,6 @@ _SHA = re.compile(r"(?<![0-9a-fA-F])([0-9a-fA-F]{7,40})(?![0-9a-fA-F])")
 _SHA_FALSE_FRIENDS = frozenset({
     "decade", "defaced", "faceted", "acceded", "effaced", "deface", "efface",
 })
-
-
-def _first_line(text: str) -> str:
-    """*text*'s first line, ``\\n``-delimited, with no trailing newline.
-
-    The gate's entire "read only the claim, not the grounds" boundary is
-    this one split: a comment's line 2 onward (the six-questions write-up,
-    scope, limits) is never passed to ``_NOTE_MARKER`` or ``find_note_shas``
-    at all — not filtered out after being read, but never handed to either
-    of them, which is what makes the exclusion syntactic rather than a
-    matter of degree."""
-    return text.split("\n", 1)[0]
 
 
 def find_note_shas(note_line: str, known_oids: "list[str]") -> "list[str]":
@@ -198,12 +192,22 @@ def tests_commits_after(sha: str, commits: "list[dict]") -> "list[dict]":
     return [c for c in tail if c.get("_tests_paths")]
 
 
-def _note_names_head(note: str, head: str, oids: "list[str]") -> bool:
+def note_names_head(note: str, head: str, oids: "list[str]") -> bool:
     """Does *note* (a comment's first line) name *head* specifically —
     ``head`` prefix-matched against every SHA-shaped token *note* names
     that is also a real commit of this PR (:func:`find_note_shas`'s own
     membership filter). The comparison TARGET, not merely "any commit" —
-    see :func:`evaluate`'s own docstring, #5204."""
+    see :func:`evaluate`'s own docstring, #5204.
+
+    #5919 stage 3 (architect ruling): public, not private — this is a
+    DECISION (does a note name a specific head), not a marker-recognition
+    question, so it does NOT move to ``_markers.py`` (that module holds
+    recognition only). But ``check_blocking_has_reread_note.py`` already
+    needed it, and reading it as ``_tests_read._note_names_head`` was the
+    same private-cross-module-borrow shape #5919 exists to close — the
+    fix for a decision function is to make its OWNING module's name
+    public, never to relocate the decision itself. ``find_note_shas``
+    (just above) already sets this precedent in the same module."""
     return any(
         head.startswith(sha) or sha.startswith(head)
         for sha in find_note_shas(note, oids)
@@ -218,8 +222,9 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
     '_tests_paths':}``) and ``headRefOid``. Pure — the live and fixture paths
     both build this shape first, so the decision is testable without GitHub.
 
-    A claim is a comment whose FIRST LINE (``_first_line``) matches
-    ``_NOTE_MARKER``; the SHA search (``find_note_shas``) also runs only over
+    A claim is a comment whose FIRST NON-EMPTY LINE
+    (``_markers.first_nonempty_line``) matches ``_markers.NOTE_MARKER``; the
+    SHA search (``find_note_shas``) also runs only over
     that first line, never the rest of the comment. A comment that mentions
     TESTS-READ only from its second line onward is not a claim at all — it
     falls into the same "no note" bucket as a comment that never mentions it,
@@ -273,9 +278,9 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         return 0, ["OK — this PR does not touch tests/; rule 8 does not apply."]
 
     notes = [
-        _first_line(c.get("body", ""))
+        _markers.first_nonempty_line(c.get("body", ""))
         for c in pr.get("comments", [])
-        if _NOTE_MARKER.search(_first_line(c.get("body", "")))
+        if _markers.NOTE_MARKER.search(_markers.first_nonempty_line(c.get("body", "")))
     ]
     if not notes:
         return 1, [
@@ -313,7 +318,7 @@ def evaluate(pr: dict) -> "tuple[int, list[str]]":
         if not shas:
             continue
         resolved_count += 1
-        if _note_names_head(note, head, oids):
+        if note_names_head(note, head, oids):
             return 0, [f"OK — a TESTS-READ note names the current head {head}."]
         sha = shas[0]
         other.append((note, sha, tests_commits_after(sha, commits)))

--- a/tests/scripts/test_check_blocking_has_reread_note_5453.py
+++ b/tests/scripts/test_check_blocking_has_reread_note_5453.py
@@ -242,3 +242,124 @@ def test_a_quoted_re_read_marker_is_not_a_claim():
     ))
     assert code == 1
     assert "no TESTS-READ- or RE-READ-shaped" in "\n".join(lines)
+
+
+# ── #5919 stage 3: borrow consolidation acceptance ──────────────────────────
+
+
+def test_no_private_attribute_is_read_off_tests_read_or_the_old_blocking_module():
+    """Tier 1: LOAD-BEARING acceptance (architect + lead-coder, #5919 stage
+    3) — the exact shape that broke silently between stages 2 and 3 (this
+    gate's own borrow of `_blocking._BLOCKING_MARKER` going stale the
+    moment that name was renamed to `_MARKER_BLOCKING`, unnoticed by a
+    scoped test run because the break sat outside the renaming PR's own
+    diff). AST-walks the REAL source on disk (not the loaded module's
+    ``__dict__``, which cannot tell "borrowed a private name" from "never
+    imported it at all") for any ``Attribute`` access whose base is
+    ``_tests_read`` and whose attribute name starts with ``_`` — the
+    module no longer imports ``check_open_blocking_checkboxes.py`` as
+    ``_blocking`` at all, so THAT borrow class is structurally
+    unreachable (a NameError, not merely absent today)."""
+    import ast
+
+    tree = ast.parse(
+        (REPO_ROOT / "scripts" / "check_blocking_has_reread_note.py").read_text(encoding="utf-8"),
+    )
+    offenders = [
+        f"_tests_read.{node.attr}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "_tests_read"
+        and node.attr.startswith("_")
+    ]
+    assert offenders == [], (
+        f"private attribute(s) read off _tests_read: {offenders} -- every "
+        "cross-module read must be either a PUBLIC name on the owning "
+        "module (a decision) or a name imported from _markers (a "
+        "recognition primitive), never a private one"
+    )
+    assert "_blocking" not in {
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name)
+    }, (
+        "check_open_blocking_checkboxes.py must no longer be loaded as "
+        "_blocking at all -- everything this gate needed from it was "
+        "recognition, and has moved to _markers.py"
+    )
+
+
+def test_strip_moving_marker_blocking_back_to_private_breaks_this_gate():
+    """Tier 1: strip witness for the acceptance above — reproduces the
+    EXACT failure shape #5919 stage 2->3 hit for real (11 failed CI
+    checks, lead-coder's own report): removing a name from `_markers.py`'s
+    public surface (simulating "moved back to private" / "renamed without
+    updating the borrower") must make this gate's own
+    `_has_blocking_comment` raise, not silently degrade to "no BLOCKING
+    comment found" (that direction would be the SAME fail-open class
+    #5919 exists to close, just moved one level)."""
+    original = _MOD._markers.MARKER_BLOCKING
+    del _MOD._markers.MARKER_BLOCKING
+    try:
+        import pytest
+
+        with pytest.raises(AttributeError):
+            _MOD._has_blocking_comment(["**[x]** — BLOCKING (head abc1234)"])
+    finally:
+        _MOD._markers.MARKER_BLOCKING = original
+
+
+def test_strip_moving_note_marker_back_to_private_breaks_this_gate():
+    """Tier 1: the same strip witness for `_markers.NOTE_MARKER` — the
+    OTHER name this gate reuses across the module boundary."""
+    original = _MOD._markers.NOTE_MARKER
+    del _MOD._markers.NOTE_MARKER
+    try:
+        import pytest
+
+        with pytest.raises(AttributeError):
+            _MOD._is_reread_note("**[x]** — TESTS-READ (head abc1234)")
+    finally:
+        _MOD._markers.NOTE_MARKER = original
+
+
+def test_a_blocking_comment_opening_with_a_blank_line_is_still_recognised():
+    """Tier 1: LOAD-BEARING — #5919 stage 3's own real finding (architect
+    requested direct verification, not inference from the two pre-stage-3
+    implementations' textual difference). A BLOCKING comment prefixed
+    with one blank line before its marker line must still be RAISED —
+    the exact shape `_markers.first_nonempty_line` (not the pre-stage-3
+    bare split) exists to fix. Driven through the public `evaluate()`,
+    not the private `_has_blocking_comment` directly: a PR with no
+    re-read note at all reports RED "carries a BLOCKING comment" only if
+    the blank-line-prefixed comment above was actually recognised as one
+    — if it were missed, this PR would instead report OK ("carries no
+    BLOCKING comment"), the opposite, silently-wrong verdict."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[{"body": "\n**[lead-coder]** — BLOCKING (head bbbbbbb)\n\nsome point."}],
+        commits=[_commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 1
+    assert "carries a BLOCKING comment but no" in "\n".join(lines)
+
+
+def test_a_reread_note_opening_with_a_blank_line_is_still_recognised_as_a_claim():
+    """Tier 1: LOAD-BEARING — the house-rule-8/#5453 side of the same
+    fail-open. A previously-uncounted 5th silent-miss instance in #5919's
+    own original census (architect's own self-correction on the issue
+    thread): a TESTS-READ/RE-READ note opening with a blank line used to
+    be silently treated as "no note", which this gate would then read as
+    "carries a BLOCKING comment but no note at all" -- RED for the wrong
+    reason, or worse, GREEN if some other unrelated note happened to
+    satisfy it. Verified end to end through evaluate(), not just the
+    isolated marker/line-selection primitives."""
+    code, lines = _MOD.evaluate(_pr(
+        comments=[
+            _blocking("bbbbbbb"),
+            {"body": "\n**[e2e-coder]** — TESTS-READ (head bbbbbbb)\n\ngrounds go here"},
+        ],
+        commits=[_commit("bbbbbbb")],
+        head="bbbbbbb",
+    ))
+    assert code == 0
+    assert "names the current head" in "\n".join(lines)

--- a/tests/scripts/test_check_open_blocking_checkboxes.py
+++ b/tests/scripts/test_check_open_blocking_checkboxes.py
@@ -403,7 +403,8 @@ def test_near_miss_regex_must_stay_unanchored_or_it_would_miss_real_near_misses(
     already miss, silently erasing the watcher's entire purpose (the
     same "no marker" / "marker written wrong" silence #5522 fixed, now
     for the near-miss side specifically)."""
-    from scripts.check_open_blocking_checkboxes import _NEAR_MISS_BARE_WORD, _undecorated
+    from scripts import _markers
+    from scripts.check_open_blocking_checkboxes import _NEAR_MISS_BARE_WORD
 
     real_near_miss_first_lines = [
         "**[x]** — BLOCKING, needs a fix here.",
@@ -411,7 +412,7 @@ def test_near_miss_regex_must_stay_unanchored_or_it_would_miss_real_near_misses(
     ]
     anchored_would_be = re.compile(r"^BLOCKING\b")
     for line in real_near_miss_first_lines:
-        undecorated = _undecorated(line)
+        undecorated = _markers.undecorated(line)
         assert _NEAR_MISS_BARE_WORD.search(undecorated), (
             f"the real (unanchored) near-miss regex must still catch {line!r}"
         )

--- a/tests/scripts/test_check_tests_read_names_its_tree_5039.py
+++ b/tests/scripts/test_check_tests_read_names_its_tree_5039.py
@@ -546,3 +546,27 @@ def test_a_mid_sentence_mention_is_not_a_claim():
     ))
     assert code == 1
     assert "no TESTS-READ note" in "\n".join(lines)
+
+
+# ── #5919 stage 3: a note opening with a blank line ──────────────────────
+
+
+def test_a_note_opening_with_a_blank_line_is_still_recognised_as_a_claim():
+    """Tier 1: LOAD-BEARING — #5919 stage 3's own real finding (architect
+    requested direct verification, not inference from the two pre-stage-3
+    implementations' textual difference): a comment carrying a real
+    TESTS-READ claim, but opening with a blank line before it, is a
+    previously-uncounted 5th silent-miss instance in #5919's own original
+    census (architect's own self-correction on the issue thread). Strip
+    witness: the pre-stage-3 bare ``text.split("\\n", 1)[0]`` this gate's
+    own ``_first_line`` used returns an empty string for this exact
+    input, which fails ``_NOTE_MARKER`` trivially — verified directly by
+    constructing this input and running it through the real gate."""
+    code, lines = _MOD.evaluate(_pr(
+        files=["tests/scripts/test_check_doc_drift_5003.py"],
+        comments=[{"body": "\n**[e2e-coder]** — TESTS-READ (head 9cc1006aa)"}],
+        commits=[_commit("9cc1006aa", "test: add", ("tests/scripts/test_check_doc_drift_5003.py",))],
+        head="9cc1006aa",
+    ))
+    assert code == 0
+    assert "names the current head" in "\n".join(lines)

--- a/tests/scripts/test_markers_5919.py
+++ b/tests/scripts/test_markers_5919.py
@@ -162,17 +162,111 @@ def test_undecorated_after_role_prefix_a_blanket_strip_would_break_the_role_pref
     ) is not None
 
 
-# ── first_line ────────────────────────────────────────────────────────────
+# ── first_nonempty_line ───────────────────────────────────────────────────
 
 
-def test_first_line_isolates_only_the_first_line():
+def test_first_nonempty_line_isolates_only_the_first_line():
     """Tier 1: the exclusion every marker in this module depends on — a
     document's line 2 onward must never even be handed to a pattern."""
-    assert _MOD.first_line("TESTS-READ (head abc)\n\ngrounds go here") == "TESTS-READ (head abc)"
+    assert (
+        _MOD.first_nonempty_line("TESTS-READ (head abc)\n\ngrounds go here")
+        == "TESTS-READ (head abc)"
+    )
 
 
-def test_first_line_of_a_single_line_string_is_itself():
+def test_first_nonempty_line_of_a_single_line_string_is_itself():
     """Tier 1: the no-newline case — a string with nothing to split on
     returns unchanged, so callers need no special-case for a one-line
     comment/body."""
-    assert _MOD.first_line("only one line") == "only one line"
+    assert _MOD.first_nonempty_line("only one line") == "only one line"
+
+
+def test_first_nonempty_line_skips_a_leading_blank_line():
+    """Tier 1: LOAD-BEARING — #5919 stage 3's own real finding (architect
+    requested this be verified directly, not merely inferred from the
+    two pre-stage-3 implementations' textual difference): a comment
+    opening with a blank line before its real marker must still be
+    read. Strip witness: reverting to the pre-stage-3 bare
+    ``text.split("\\n", 1)[0]`` returns an EMPTY string for this exact
+    input, which then fails every marker regex trivially — a real,
+    previously-shipping fail-open in house rule 8's own gate (a 5th
+    silent-miss instance #5919's original census undercounted),
+    confirmed empirically by constructing this input and running it
+    through the real gate before this fix landed."""
+    text = "\n**[e2e-coder]** — TESTS-READ (head abc1234)\n\ngrounds go here"
+    assert _MOD.first_nonempty_line(text) == "**[e2e-coder]** — TESTS-READ (head abc1234)"
+
+
+def test_first_nonempty_line_of_an_all_blank_string_is_empty():
+    """Tier 1: a comment with no real content at all (never a real input,
+    but a caller must not crash on it) reports no line, not a crash or a
+    stray blank string."""
+    assert _MOD.first_nonempty_line("\n\n   \n") == ""
+
+
+# ── DECORATION / undecorated ─────────────────────────────────────────────
+
+
+def test_undecorated_strips_backtick_and_asterisk_unconditionally():
+    """Tier 1: the unconditional sibling of undecorated_after_role_prefix
+    — for text that is never itself a role-prefix candidate (a near-miss
+    watcher's own bare-word check)."""
+    assert _MOD.undecorated("**BLOCKING (head `abc1234`)**") == "BLOCKING (head abc1234)"
+
+
+def test_undecorated_strips_a_role_prefixes_own_asterisks_too():
+    """Tier 1: deny-side witness for WHY undecorated_after_role_prefix
+    exists as a SEPARATE function — the unconditional undecorated() does
+    NOT preserve a role prefix's own literal syntax, unlike its
+    role-prefix-aware sibling (see that function's own tests)."""
+    line = "**[lead-coder]** — BLOCKING (head abc1234)"
+    assert _MOD.undecorated(line) == "[lead-coder] — BLOCKING (head abc1234)"
+
+
+# ── MARKER_BLOCKING / MARKER_CLEARED (#5919 stage 3) ─────────────────────
+
+
+def test_marker_blocking_matches_the_real_shape():
+    """Tier 1: accept — the exact `BLOCKING (head <sha>)` co-located shape,
+    role-prefixed, as posted in this repo today."""
+    assert _MOD.MARKER_BLOCKING.match("**[lead-coder]** — BLOCKING (head abc1234)")
+
+
+def test_marker_blocking_does_not_match_blocking_cleared():
+    """Tier 1: deny — MARKER_BLOCKING must never accept a CLEARED comment
+    (the negative lookahead this shares with the pre-stage-3 regex)."""
+    assert not _MOD.MARKER_BLOCKING.match("BLOCKING-CLEARED (head abc1234)")
+
+
+def test_marker_cleared_matches_the_real_shape():
+    """Tier 1: accept — the CLEARED counterpart."""
+    assert _MOD.MARKER_CLEARED.match("**[lead-coder]** — BLOCKING-CLEARED (head abc1234)")
+
+
+def test_marker_blocking_denies_a_negating_sentence():
+    """Tier 1: deny — #5919's own census input, applied to the moved
+    instance."""
+    assert not _MOD.MARKER_BLOCKING.match("**[x]** — my blocking is closed, thanks")
+
+
+# ── NOTE_MARKER (#5919 stage 3, moved from check_tests_read_names_its_tree.py) ──
+
+
+def test_note_marker_matches_the_real_tests_read_shape():
+    """Tier 1: accept — the exact shape house rule 8 requires, now the
+    SAME instance both check_tests_read_names_its_tree.py and
+    check_blocking_has_reread_note.py read."""
+    assert _MOD.NOTE_MARKER.match("**[e2e-coder]** — TESTS-READ (head abc1234)")
+
+
+def test_note_marker_tolerates_the_testsready_typo():
+    """Tier 1: accept — TESTS-READY, the typo several sessions produce."""
+    assert _MOD.NOTE_MARKER.match("TESTS-READY (head abc1234)")
+
+
+def test_note_marker_denies_a_denying_sentence():
+    """Tier 1: deny — the exact #5919 census input this marker exists to
+    reject."""
+    assert not _MOD.NOTE_MARKER.match(
+        "This PR is not ready for a TESTS-READ note yet — still investigating 9cc1006.",
+    )


### PR DESCRIPTION
**[e2e-coder]** — part of #5919.

## What broke, twice, in the same shape

`check_blocking_has_reread_note.py` reached into private module-level names on 2 sibling gates. Between stage 2 (#5961) and this stage, `_BLOCKING_MARKER` was renamed to `_MARKER_BLOCKING` and the borrow went stale — the exact class #5919 was filed to close, recurring one level up because the recognition primitives it moved for TESTS-READ/RE-READ/exemption/closing-intent were still private, gate-local names for BLOCKING/CLEARED.

## Architect's boundary ruling (applied)

A name read across module boundaries is either **RECOGNITION** (moves to `_markers.py` — every consumer means the exact same syntax) or **DECISION** (stays a **PUBLIC** name on its OWNING module — never a private one, regardless of who else needs it).

- `_markers.py` gains `MARKER_BLOCKING`/`MARKER_CLEARED` (from `check_open_blocking_checkboxes.py`), `NOTE_MARKER` (from `check_tests_read_names_its_tree.py`), `DECORATION`/`undecorated` (the unconditional sibling of the existing `undecorated_after_role_prefix`), and `first_nonempty_line` (replacing `first_line` — see below).
- `check_tests_read_names_its_tree.py`'s `_note_names_head` → public `note_names_head` on that SAME module — a decision, so it does NOT move to `_markers.py`, but a private cross-module read of it is exactly as wrong as a private read of a recognition primitive (architect's own correction after I initially read it as simply "out of scope").
- `check_blocking_has_reread_note.py` no longer loads `check_open_blocking_checkboxes.py` at all — every real dependency it had there was recognition, now read from `_markers.py` directly, never re-exported through the old owning module.

## `first_line` → `first_nonempty_line` — a genuine, previously-shipping fail-open

`_markers.py`'s own `first_line` (zero production callers — confirmed by full enumeration before touching anything) used a bare `text.split("\n", 1)[0]`, differing from `check_tests_read_names_its_tree.py`'s OWN (also pre-stage-3) identically-shaped `_first_line` — **both** returned `""` for a comment opening with a blank line, silently failing every marker regex against it.

Architect explicitly asked this be **verified directly**, not inferred from the two implementations' textual difference. Constructed a real input and ran it through the live gate:

```python
comment = "\n**[e2e-coder]** — TESTS-READ (head abc1234)\n\ngrounds go here"
tr._first_line(comment)                          # -> "" (old)
tr._NOTE_MARKER.search(tr._first_line(comment))  # -> False (note silently missed)
first_nonempty_line(comment)                      # -> "**[e2e-coder]** — TESTS-READ (head abc1234)" (new)
```

**Confirmed: they diverge, and the old rule silently drops a real TESTS-READ note.** This is a genuine, previously-uncounted **5th** fail-open instance in #5919's own original census — architect's own self-correction on the issue thread (the original count was 4).

## Per-caller rule table (posted to #5919, reproduced here)

| caller | scope object | rule before this PR |
|---|---|---|
| `check_open_blocking_checkboxes.py` (condition A/C) | comment | first non-empty line |
| `check_tests_read_names_its_tree.py` (house rule 8) | comment | **first line as-is** (bug) |
| `check_blocking_has_reread_note.py` (TESTS-READ/RE-READ check) | comment | inherited house-rule-8's bug |
| `check_blocking_has_reread_note.py` (BLOCKING check) | comment | first non-empty line |

Only house rule 8 (and its #5453 borrower) used the buggy rule — everyone else already used first-non-empty-line. All 4 now share ONE implementation.

## Acceptance (lead-coder's explicit 4, all met)

- [x] Private borrow → **0** real code sites (AST-verified against the source on disk, not just `git grep` text matching — `test_no_private_attribute_is_read_off_tests_read_or_the_old_blocking_module`). 4 remaining `git grep` hits are historical prose in docstrings/comments, not code.
- [x] Strip: removing a name from `_markers.py`'s public surface (simulating the exact stage-2→3 break) makes the borrowing gate raise loudly (`AttributeError`), not silently degrade — `test_strip_moving_marker_blocking_back_to_private_breaks_this_gate` / `..._note_marker_...`.
- [x] The blank-first-line divergence, verified **directly**, on both house-rule-8's own gate and its #5453 borrower, end-to-end through `evaluate()`.
- [x] Near-miss detector (`_NEAR_MISS_BARE_WORD`) stays unanchored — pre-existing deny-side test still green, untouched by this PR.

## Local gates run

ruff, `test_tier_audit.py --strict` (94 tests, 1 Tier-4 finding fixed — a private-state assert rewritten to drive the public `evaluate()` API instead), `verify_module_docstrings.py` (1 refactor-narrative finding fixed — rewrote the "moved from X" module-docstring section to describe current-state reasoning, not history), `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), and the `tests/` path-conditional gates — all green. Scoped pytest: 94 tests across the 4 touched files plus the 5th (untouched) sibling gate's own 60 tests for regression safety — 154 total, all green. Did NOT run the full suite locally (CI-only, per house rule).

## Test plan
- [x] Scoped pytest green (154 tests, see above)
- [x] Strip-falsify: both the private-borrow-break and the blank-first-line-fix claims verified directly, not inferred
- [ ] (skipped — Visual, standing waiver) N/A, no UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)