### PR TITLE
feat(#5956): #4986 variant C's armed observer -- catch WaitForScreenTimeout with 3 diagnostics attached

### DIFF
--- a/tests/_support/screen_timeout_diagnostics.py
+++ b/tests/_support/screen_timeout_diagnostics.py
@@ -1,0 +1,148 @@
+"""#5956 (#4986 variant C's own armed observer) — the FIRST real diagnostic
+data a `textual.pilot.WaitForScreenTimeout` occurrence gives this repo.
+
+Owner-hit incident recap (#4986): a `WaitForScreenTimeout` fired once, in
+`tests/interfaces/test_textual_chat_intervention_panel_3299.py`, on an
+unrelated PR's CI run (#5331). Structurally different from variants A/B (a
+Textual-internal timeout, not `pytest-timeout`/an `asyncio` event-loop
+stall) — #4051/#4052 do not explain it (verified directly against that
+run's own log, not inferred). Architect's own closing condition for this
+issue (quoted at #5956's own filing): "catch it and attach ①a pending
+Textual worker ②the pump's own last-processed tick ③whether the loop
+tripwire fired — that trio settles the mechanism on the NEXT occurrence."
+
+## Why THIS shape, not a duration
+
+CLAUDE.md's own testing policy forbids writing a duration a test's
+assertion depends on, in EITHER direction — and this issue's own dispatch
+repeats it explicitly ("duration は書かない — timeout を待つ形の issue な
+ので最も流れやすい"). Nothing here measures HOW LONG the timeout took, or
+waits for one to happen: :func:`diagnosed_screen_wait` is a passive catch
+around an exception `textual.pilot._wait_for_screen` already raises on its
+OWN internal 30s clock — this module never starts a clock of its own,
+never asserts a magnitude, and adds nothing to the wait itself (the
+`except`/`add_note`/`raise` path costs nothing on the healthy path, which
+never executes it).
+
+## The three diagnostics, and where each one comes from
+
+① **pending Textual worker(s)** — `app.workers` (Textual's own
+`WorkerManager`, already tracking every `run_worker()` call), filtered to
+`not worker.is_finished`. A worker still running (or merely PENDING) at
+the moment `_wait_for_screen` gave up is a live candidate for what it was
+actually waiting on — Textual's own `call_later`/message-pump completion
+tracking (`_wait_for_screen`'s internal counter) is a DIFFERENT mechanism
+from the Worker API, so a stuck worker would not itself block the pump
+directly, but a widget's `on_mount`/message handler blocking ON a worker
+result (`await worker.wait()`) would show up here as "pump still has
+something outstanding" with no `call_later` counterpart to explain it.
+
+② **the pump's own last-processed tick** — `TextualChatApp._pump_ticks`
+(#4761 ②'s own message-pump heartbeat counter, already built and already
+armed by the loop tripwire machinery this app carries by construction —
+reused here, not reinvented). A snapshot at catch time, nothing more; a
+LATER occurrence comparing this value against activity elsewhere in the
+same CI log is what would show whether the pump was still advancing.
+
+③ **whether the loop tripwire fired** — `TextualChatApp._loop_tripwire`
+(:class:`reyn.runtime.loop_tripwire.LoopTripwire`, #3539/#5870/#5898),
+already watching this app's own event-loop responsiveness on every tick.
+If it had already fired (or its own worst-observed lateness is nonzero)
+at the moment `_wait_for_screen` gave up, the SAME event loop this pilot
+call needed was independently already flagged as unresponsive — variant
+B's own mechanism (#5445), reused as a cross-check for variant C rather
+than asserted to be the SAME issue (#4986's own repeated discipline:
+never merge two incidents on symptom-resemblance alone).
+
+## What this does NOT claim
+
+A record here does not prove causation — it is the primary data #4986's
+own closing condition asked for, to be read against whatever the NEXT
+real occurrence's own log shows. `collect_screen_timeout_diagnostics` is
+exposed separately from :func:`diagnosed_screen_wait` so a test can
+assert on the DATA it collects directly, without needing to force a real
+Textual-internal timeout to do it.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any, AsyncGenerator
+
+
+def collect_screen_timeout_diagnostics(app: Any) -> "dict[str, Any]":
+    """Snapshot ①②③ off *app* right now — best-effort, never raising: a
+    diagnostic collector that can itself fail would destroy the exception
+    it was trying to annotate (the same "an instrument that can break the
+    thing it measures is worse than no instrument" rule
+    ``loop_tripwire.write_record`` already follows).
+
+    Returns a plain dict (JSON-shaped values only) so the caller can
+    render it into an exception note, a log line, or a durable record
+    with no further translation."""
+    diagnostics: "dict[str, Any]" = {}
+
+    try:
+        workers = getattr(app, "workers", None)
+        pending = [
+            {
+                "name": worker.name or "",
+                "group": worker.group,
+                "description": worker.description,
+                "state": worker.state.name,
+            }
+            for worker in (workers or [])
+            if not worker.is_finished
+        ]
+        diagnostics["pending_workers"] = pending
+    except Exception as exc:  # noqa: BLE001 - collecting context must never itself raise
+        diagnostics["pending_workers_error"] = repr(exc)
+
+    try:
+        diagnostics["pump_ticks"] = getattr(app, "_pump_ticks", None)
+    except Exception as exc:  # noqa: BLE001
+        diagnostics["pump_ticks_error"] = repr(exc)
+
+    try:
+        tripwire = getattr(app, "_loop_tripwire", None)
+        if tripwire is not None:
+            diagnostics["loop_tripwire"] = {
+                "fired": tripwire.fired,
+                "max_lateness_ms": tripwire.max_lateness_ms,
+                "threshold_ms": tripwire.threshold_ms,
+            }
+        else:
+            diagnostics["loop_tripwire"] = None
+    except Exception as exc:  # noqa: BLE001
+        diagnostics["loop_tripwire_error"] = repr(exc)
+
+    return diagnostics
+
+
+@asynccontextmanager
+async def diagnosed_screen_wait(app: Any) -> "AsyncGenerator[None, None]":
+    """Wrap a block that awaits Pilot calls (``pilot.pause()``/``pilot.
+    press()``/etc.) that can raise ``textual.pilot.WaitForScreenTimeout``.
+
+    On that SPECIFIC exception, attaches :func:`collect_screen_timeout_
+    diagnostics`'s own snapshot as a note (``BaseException.add_note``,
+    stdlib, Python 3.11+ — both CI legs this repo runs) and re-raises the
+    SAME exception object — never swallowed, never replaced with a
+    different type, so pytest's own failure report, and anything else
+    that inspects the exception, sees exactly what Textual raised, plus
+    the note.
+
+    Any OTHER exception (including one Textual itself raises for a
+    different reason) passes through completely untouched — this context
+    manager's only job is to recognise ONE specific exception type and
+    attach data to it; it must never become a general-purpose except-and-
+    reraise wrapper (that would risk the #5909 shape lead-coder's own
+    dispatch named: an observer that fires on cases it was never meant to
+    watch)."""
+    from textual.pilot import WaitForScreenTimeout
+
+    try:
+        yield
+    except WaitForScreenTimeout as exc:
+        diagnostics = collect_screen_timeout_diagnostics(app)
+        exc.add_note(f"#5956 diagnostics (variant C observer): {diagnostics!r}")
+        raise

--- a/tests/interfaces/test_5956_screen_timeout_diagnostics.py
+++ b/tests/interfaces/test_5956_screen_timeout_diagnostics.py
@@ -1,0 +1,173 @@
+"""Tier 2: #5956 (#4986 variant C's own armed observer) — the diagnostic
+collector + catch/re-raise wrapper this issue's own closing condition asks
+for. Real ``TextualChatApp`` + real ``Worker``/``LoopTripwire`` state
+throughout — no mocks; the whole point is that the 3 diagnostics are read
+off a genuinely running app, not synthesised.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from textual.pilot import WaitForScreenTimeout
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from tests._support.screen_timeout_diagnostics import (
+    collect_screen_timeout_diagnostics,
+    diagnosed_screen_wait,
+)
+from tests.interfaces.test_textual_chat_intervention_panel_3299 import RecordingTransport
+
+
+def _empty_transport() -> RecordingTransport:
+    """A real transport with no messages, stream kept open (``end=False``)
+    so the app stays mounted — this file needs nothing from the
+    intervention flow itself, only a real, minimal, already-established
+    transport double."""
+    return RecordingTransport([], end=False)
+
+
+# ── collect_screen_timeout_diagnostics: real app, real values ───────────
+
+
+@pytest.mark.asyncio
+async def test_collects_real_pump_ticks_and_loop_tripwire_state() -> None:
+    """Tier 2: ② and ③ read real, live values off a real running app — not
+    placeholders. ``pump_ticks`` is the app's OWN heartbeat-timer counter
+    (``TextualChatApp.on_timer``, incremented only when that specific
+    timer fires — not on every pump pass), so this asserts it is a real,
+    present int (distinguishing it from the ``None`` a broken/absent app
+    would report — see ``test_collector_never_raises_...`` below), not
+    that it has already advanced past zero on this specific short-lived
+    run. The loop tripwire (armed by construction on every
+    ``TextualChatApp``) must report its real, healthy (never-fired)
+    state on an app that never stalled."""
+    app = TextualChatApp(transport=_empty_transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        diagnostics = collect_screen_timeout_diagnostics(app)
+
+        assert isinstance(diagnostics["pump_ticks"], int)
+        tripwire = diagnostics["loop_tripwire"]
+        assert tripwire["fired"] is False, "a healthy run must not report an active stall"
+        assert tripwire["max_lateness_ms"] < tripwire["threshold_ms"], (
+            "a healthy run's worst observed lateness must stay under its "
+            "own threshold -- both real values, read off the app's own "
+            "LoopTripwire, not pinned to an exact synthetic number"
+        )
+        # A fresh TextualChatApp already runs its own real internal worker
+        # (e.g. `_pump_frames`) -- this asserts the SHAPE is right, not
+        # emptiness, which would be false on a real app (measured directly
+        # while writing this test: it is not "no workers ever," it is
+        # "this app's own known-real worker(s), correctly enumerated").
+        assert isinstance(diagnostics["pending_workers"], list)
+        assert all(
+            {"name", "group", "description", "state"} <= w.keys()
+            for w in diagnostics["pending_workers"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_collects_a_real_pending_worker_by_name() -> None:
+    """Tier 2: ① — a worker genuinely still running (never finishing on
+    its own within the test) must be named in the collected diagnostics,
+    by the SAME name it was started with — proving this reads Textual's
+    real ``WorkerManager``, not a stand-in."""
+    app = TextualChatApp(transport=_empty_transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        never_finishes = asyncio.Event()
+        app.run_worker(never_finishes.wait(), name="e2e-5956-marker-worker")
+        await pilot.pause()
+
+        diagnostics = collect_screen_timeout_diagnostics(app)
+
+        names = [w["name"] for w in diagnostics["pending_workers"]]
+        assert "e2e-5956-marker-worker" in names, (
+            f"a genuinely still-running worker must appear by name; got {names!r}"
+        )
+        never_finishes.set()  # let it finish so the test's own teardown is clean
+
+
+# ── diagnosed_screen_wait: catch, attach, re-raise -- never swallow ──────
+
+
+@pytest.mark.asyncio
+async def test_a_real_screen_timeout_is_re_raised_with_the_diagnostics_attached() -> None:
+    """Tier 2: LOAD-BEARING — the exception is NEVER swallowed (the
+    #5909-shaped false-positive risk lead-coder's own dispatch named: an
+    observer that fires on ordinary completion, or that eats the real
+    signal, is worse than none). Drives a REAL WaitForScreenTimeout by
+    raising it from inside the wrapped block -- the correct way to test
+    an exception handler's own behaviour, not by forcing Textual's
+    internal 30s clock to genuinely expire."""
+    app = TextualChatApp(transport=_empty_transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.run_worker(asyncio.Event().wait(), name="e2e-5956-witness-worker")
+        await pilot.pause()
+
+        with pytest.raises(WaitForScreenTimeout) as excinfo:
+            async with diagnosed_screen_wait(app):
+                raise WaitForScreenTimeout("Timed out while waiting for widgets to process pending messages.")
+
+        notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+        assert "#5956 diagnostics" in notes, "the note must actually be attached"
+        assert "e2e-5956-witness-worker" in notes, (
+            "① the real pending worker's name must appear in the record"
+        )
+        assert "pump_ticks" in notes, "② the pump-tick snapshot must appear in the record"
+        assert "loop_tripwire" in notes, "③ the loop-tripwire state must appear in the record"
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_exception_passes_through_completely_untouched() -> None:
+    """Tier 2: deny side (#5909's own lesson, applied here) — the wrapper
+    must recognise ONLY ``WaitForScreenTimeout``. Any other exception
+    (including a plain bug in the wrapped block) must propagate
+    byte-identical, no note attached, no type change -- an observer that
+    reacts to cases outside its own named scope is exactly the shape
+    that produced #5909's 12 false positives."""
+    app = TextualChatApp(transport=_empty_transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+
+        with pytest.raises(ValueError) as excinfo:
+            async with diagnosed_screen_wait(app):
+                raise ValueError("unrelated bug, not a screen timeout")
+
+        assert str(excinfo.value) == "unrelated bug, not a screen timeout"
+        assert not getattr(excinfo.value, "__notes__", []), (
+            "an unrelated exception must carry no diagnostics note at all"
+        )
+
+
+@pytest.mark.asyncio
+async def test_ordinary_completion_never_fires_the_observer() -> None:
+    """Tier 2: the #5909 false-positive shape, directly -- an ORDINARY,
+    successful pass through the wrapped block must produce no note, no
+    side effect, nothing collected. The observer's cost on the healthy
+    path is exactly the ``except`` clause never running."""
+    app = TextualChatApp(transport=_empty_transport())
+    async with app.run_test(size=(100, 30)) as pilot:
+        async with diagnosed_screen_wait(app):
+            await pilot.pause()
+        # No exception at all -- nothing to assert on notes because there
+        # is no exception object; the absence of a raise IS the witness.
+
+
+# ── collect_screen_timeout_diagnostics never raises on a broken app ─────
+
+
+def test_collector_never_raises_even_given_a_broken_app_stand_in() -> None:
+    """Tier 1: 'an instrument that can break the thing it measures is
+    worse than no instrument' (this module's own docstring, mirroring
+    loop_tripwire.write_record's rule). An object missing every expected
+    attribute must still yield a usable dict, never raise."""
+
+    class _Broken:
+        pass
+
+    diagnostics = collect_screen_timeout_diagnostics(_Broken())
+    assert diagnostics["pending_workers"] == []
+    assert diagnostics["pump_ticks"] is None
+    assert diagnostics["loop_tripwire"] is None

--- a/tests/interfaces/test_textual_chat_intervention_panel_3299.py
+++ b/tests/interfaces/test_textual_chat_intervention_panel_3299.py
@@ -290,9 +290,20 @@ async def _settle_until(pilot, until) -> None:
     ``pilot.pause()`` runs BEFORE every check, unconditionally -- it is
     not just a delay, it is the pump that flushes pending UI messages, so
     an already-true predicate must still get one pass before returning
-    (lead-coder review: checking first would silently skip that flush)."""
+    (lead-coder review: checking first must not silently skip that flush).
+
+    #5956 (#4986 variant C's own armed observer): the ONE real occurrence
+    of ``textual.pilot.WaitForScreenTimeout`` this repo has seen (#5331,
+    an unrelated PR's CI run) fired from exactly this ``pilot.pause()``
+    call, inside this exact loop. Wrapped so a recurrence carries ①②③
+    (pending workers / pump ticks / loop-tripwire state) as an exception
+    note -- see ``tests/_support/screen_timeout_diagnostics.py``'s own
+    module docstring for what each one is and why."""
+    from tests._support.screen_timeout_diagnostics import diagnosed_screen_wait
+
     while True:
-        await pilot.pause()
+        async with diagnosed_screen_wait(pilot.app):
+            await pilot.pause()
         if until():
             return
         await asyncio.sleep(0.01)


### PR DESCRIPTION
**[e2e-coder]** — Closes #5956.

Architect's own closing condition for this issue, verbatim: catch `textual.pilot.WaitForScreenTimeout` and, on re-raise, attach **①a pending Textual worker ②the pump's own last-processed tick ③whether the loop tripwire fired**. This is "build the observer first" work, not "await recurrence" — #4986's own repeated discipline: armed-observer-present-vs-absent is the exact discriminator lead-coder used to close #4986 tonight, carving variant C out into this issue for that reason.

## The 3 diagnostics, where each comes from

- **① pending worker(s)** — `app.workers` (Textual's own `WorkerManager`, already tracking every `run_worker()` call), filtered to `not worker.is_finished`.
- **② the pump's last-processed tick** — `TextualChatApp._pump_ticks`, the #4761 ② message-pump heartbeat counter already built for the loop-tripwire machinery. Reused, not reinvented.
- **③ whether the loop tripwire fired** — `TextualChatApp._loop_tripwire` (#3539/#5870/#5898's `LoopTripwire`), already watching this app's own event-loop responsiveness on every tick. A cross-check against variant B's own mechanism (#5445) — read, never asserted to be the same issue (#4986's own discipline: never merge on symptom-resemblance alone).

## No duration, anywhere

`diagnosed_screen_wait` is a passive catch around an exception Textual's own `_wait_for_screen` already raises on its own internal 30s clock — this module never starts a clock, never waits for one, never asserts a magnitude. Flagged explicitly in the dispatch as the easiest place to drift on a "catch a timeout" ticket, so calling it out here too.

## Deployed at the real, confirmed occurrence — not a guess

`tests/interfaces/test_textual_chat_intervention_panel_3299.py`'s `_settle_until` is the EXACT call site #5331's CI run hit (confirmed by pulling that run's own job log, not assumed — `pilot.pause()` inside this loop, line-for-line).

## Strip-verified: the observer does not false-positive (#5909's own lesson, executed not just cited)

Broadened `diagnosed_screen_wait`'s `except WaitForScreenTimeout` to bare `except Exception` and re-ran the deny-side test ("an unrelated `ValueError` must carry no diagnostics note") — **it failed**, confirming the narrow except clause is load-bearing, not incidental. Reverted after confirming red.

4 tests cover the acceptance directly:
- a real `WaitForScreenTimeout`, raised from inside the wrapped block, comes back out with all 3 diagnostics readable in its note (not merely "no exception raised" — the actual record is checked).
- an unrelated exception passes through completely untouched (no type change, no note).
- ordinary, successful completion produces no note, no side effect at all.
- the collector itself never raises, even given a broken/absent app.

## Local gates run

ruff, `test_tier_audit.py --strict` (36 tests, 0 findings), `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` (re-run right before push), and the `tests/` path-conditional gates — all green. Scoped pytest: 6 new tests + the full 25-test `test_textual_chat_intervention_panel_3299.py` suite (confirming the `_settle_until` wrap doesn't change behaviour on the healthy path) — 31 total, all green. Did NOT run the full suite locally (CI-only, per house rule).

## Test plan
- [x] Scoped pytest green (31 tests, see above)
- [x] Strip-falsify: broadening the except clause makes the deny-side test fail — verified directly, reverted
- [ ] (skipped — Visual, standing waiver) N/A, test-infrastructure only

🤖 Generated with [Claude Code](https://claude.com/claude-code)