### PR TITLE
fix(#5891 (c)): tool_returned carries tool_call_id -- the real join key call_id cannot be

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -625,7 +625,7 @@ reviewer strip.
 | Kind | When | Key payload |
 |------|------|-------------|
 | `tool_called` | Before invocation, after argument validation. | `caller_kind`, `caller_id`, `tool`, `chain_id`, `call_id`, `args`, `args_hash` |
-| `tool_returned` | The invocation returned a value that does NOT declare an error (see `tool_failed`). | `caller_kind`, `caller_id`, `tool`, `chain_id`, `call_id`, `args_hash`, `result` |
+| `tool_returned` | The invocation returned a value that does NOT declare an error (see `tool_failed`). | `caller_kind`, `caller_id`, `tool`, `chain_id`, `call_id`, `tool_call_id`, `args_hash`, `result`, `result_bytes`, `result_sha256`, `result_truncated` (only when actually cut), `content_ref_unavailable`, `tool_call_id_absent_reason` (only when `tool_call_id` is `None`) |
 | `tool_failed` | The invocation was refused, raised, **or returned normally with a self-declared error** (#3450 — a handler's own `{"error": ...}` / `{"error_message": ...}` / `{"error_kind": ...}` return, plain or one level under its own `{"status": "error", "data": {...}}` self-envelope, promoted to this event instead of silently wrapped as a success). | same, plus `error_kind` (`tool_excluded` \| `permission_denied` \| `exception` \| a validation reason \| a handler-supplied kind \| `handler_error`) and `message` — `tool_excluded` (#1406/#187/#5841/#5854): the call-time TOOL-axis contextual restrict denied the (`invoke_action`-unwrapped) effective name, checked BEFORE catalog membership so an excluded-but-uncataloged name still reads truthfully rather than as `unknown_tool` |
 
 `call_id` (#4691 Phase B ①, remainder — `DispatchContext.call_id`) is the
@@ -647,6 +647,22 @@ independent invariants, and a single broken one goes unnoticed silently).
 
 `args_hash` is a stable SHA-256 prefix over the canonical-JSON arguments — the
 correlation id that pairs a `tool_called` with its outcome across the log.
+
+`tool_call_id` (#5891 (c), `DispatchContext.tool_call_id`) is the ONE tool
+call's own `tc["id"]` — distinct from `call_id` above, which identifies the
+whole litellm ROUND and is shared by every `tool_calls` entry in it, so it
+cannot by itself join a `tool_returned` event to the ONE history row a
+reader wants (the same tool called twice in one round shares a `call_id`
+but not a `tool_call_id`). This is the SAME id `RouterLoop.feedback`
+already writes onto the corresponding `{role: tool, tool_call_id: ...}`
+history row (`ChatMessage.tool_call_id`) — a reader joins `tool_returned.
+tool_call_id` to that row, then to its `meta.content_ref`, with no new
+storage. Always present as a key; `None` for a dispatch with no real
+litellm `tool_calls` entry behind it at all (a CodeAct snippet's `tool()`
+call, an `/exec`/`/tasks` slash command, a pipeline `tool:` step) — never a
+minted placeholder. `tool_call_id_absent_reason` (naming `caller_kind`) is
+added ONLY in that `None` case, the same "don't let absence and omission
+read as the same silence" discipline `content_ref_unavailable` above uses.
 
 **Remote fan-out.** `turn_started` / `llm_called` / `tool_returned` / `tool_failed`
 are the kinds the A2A and MCP progress surfaces forward to a remote peer

--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -99,17 +99,26 @@ class DispatchContext:
             omission a `TypeError`, so `None` is now ALWAYS the caller's
             own declaration, self-describing with no reason field needed).
 
-            "Which caller_kinds normally carry an id" is deliberately
-            NEVER written down as a table (#5959/#5967's own "derive the
-            population, don't curate a list" ruling, closed here a third
-            way): `caller_kind` provably cannot answer that question (the
-            CodeAct counterexample above), so there is no population to
-            enumerate in the first place. The claim "router callers have
-            an id" is instead read off REAL DATA, not a declaration: a
-            census of emitted events for `tool_returned` rows with
-            `caller_kind="router"` and `tool_call_id: null` — see
-            `tests/runtime/test_5891_tool_call_id_history_join.py`'s own
-            census test.
+            ⚠️ No gate exists for "a new caller declares `None` when it
+            actually had a real id" (architect, same review pass that
+            rejected the reason field): a declared absence cannot be
+            told apart from a wrong one by data alone, and #5960/#5959/
+            #5967's own "derive, don't curate a list" pattern does NOT
+            apply here — a first attempt at one ("`caller_kind="router"`
+            + `tool_call_id: null` events are 0" — read as data, not a
+            table) was tried and FALSIFIED by this file's own existing
+            code: CodeAct's `_os_gate` (below) is caller_kind="router"
+            AND declares `None`, by design — the exact case that census
+            would have flagged as though it were a bug. The real
+            safeguard is narrower and structural: `_dispatch_resolved`
+            is the ONE place a `DispatchContext` naming `caller_kind=
+            "router"` is ever built, so its 3 real callers are
+            enumerable by reading `router_loop.py` directly (`dispatch()`
+            — `a["tc"]["id"]`; `_os_gate` — declared `None`;
+            `_execute_tool` — `tc["id"]`, the test-only seam). A reviewer
+            adding a 4th caller must ask where ITS `tool_call_id` comes
+            from — there is no automated check standing in for that
+            question.
         completed_response_include_text: #4666 item ③b — mirrors
             ``audit_events.completed_response_include_text`` (②). Governs
             any declared tool field whose content class is "assistant"

--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -65,23 +65,51 @@ class DispatchContext:
             reader reconstructs identically, is one of four faces, and one
             skipped face goes unnoticed — not an invariant to key UI structure
             on).
-        tool_call_id: #5891 (c), architect ruling — the SAME `tc["id"]` the
-            router's own `{role: tool, tool_call_id: ...}` feedback message
-            and history row already carry (RouterLoop.feedback,
-            chat_message.py's ChatMessage.tool_call_id). `call_id` above
-            identifies the litellm ROUND (shared by every tool_calls
-            entry in it); this identifies ONE call within that round —
-            architect's own correction of the original #5891 ruling
-            ("audit event と history row は既に同じ ref を持つ" was
-            false: `call_id` alone is 1-to-many when a round calls the
-            SAME tool twice, so it cannot join `tool_returned` to the ONE
-            history row a reader wants). None for any caller with no
-            litellm tool_calls entry behind this dispatch at all — CodeAct
-            snippet `tool()` calls, `/exec`/`/tasks` slash commands
-            (`caller_kind="operator"`), and pipeline `tool:` steps
-            (`caller_kind="pipeline"`) — never a minted placeholder, the
-            same "byte-identical until threaded through" contract
-            `call_id` already established.
+        tool_call_id: #5891 (c), architect ruling (corrected twice — see
+            below) — the SAME `tc["id"]` the router's own `{role: tool,
+            tool_call_id: ...}` feedback message and history row already
+            carry (RouterLoop.feedback, chat_message.py's ChatMessage.
+            tool_call_id). `call_id` above identifies the litellm ROUND
+            (shared by every tool_calls entry in it); this identifies ONE
+            call within that round — architect's own correction of the
+            ORIGINAL #5891 ruling ("audit event と history row は既に同
+            じ ref を持つ" was false: `call_id` alone is 1-to-many when a
+            round calls the SAME tool twice, so it cannot join
+            `tool_returned` to the ONE history row a reader wants).
+
+            REQUIRED, no default (lead-coder BLOCKING + architect's
+            SECOND correction, same PR): every caller must pass this
+            EXPLICITLY — a real id, or `None` for a caller with no real
+            litellm tool_calls entry behind this dispatch at all (CodeAct
+            `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:` step).
+            The first fix gave this a `None` default plus a
+            `tool_call_id_absent_reason` field naming `caller_kind` to
+            explain a `None` — rejected: `caller_kind` cannot actually
+            distinguish "no id to give" from "one was dropped in transit",
+            since a CodeAct in-snippet `tool()` call has the SAME
+            `caller_kind="router"` an Execute-round tool_calls dispatch
+            does (same `_dispatch_resolved` construction site — the field
+            names the LOOP, not whether a litellm round backs THIS call).
+            `absent_reason: "router"` therefore repeated information the
+            event already carried (`caller_kind` itself) while claiming to
+            explain something it could not — a reason field that adds no
+            fact should not exist (#5960's own "hydrate" flip is the same
+            shape: a silently-defaultable value let a forgotten thread-
+            through pass as a declared choice; removing the default makes
+            omission a `TypeError`, so `None` is now ALWAYS the caller's
+            own declaration, self-describing with no reason field needed).
+
+            "Which caller_kinds normally carry an id" is deliberately
+            NEVER written down as a table (#5959/#5967's own "derive the
+            population, don't curate a list" ruling, closed here a third
+            way): `caller_kind` provably cannot answer that question (the
+            CodeAct counterexample above), so there is no population to
+            enumerate in the first place. The claim "router callers have
+            an id" is instead read off REAL DATA, not a declaration: a
+            census of emitted events for `tool_returned` rows with
+            `caller_kind="router"` and `tool_call_id: null` — see
+            `tests/runtime/test_5891_tool_call_id_history_join.py`'s own
+            census test.
         completed_response_include_text: #4666 item ③b — mirrors
             ``audit_events.completed_response_include_text`` (②). Governs
             any declared tool field whose content class is "assistant"
@@ -116,8 +144,8 @@ class DispatchContext:
     tool_catalog: dict[str, dict]
     events: Any  # has .emit(type: str, **data) -> None
     contextual: "ContextualPermission | None"
+    tool_call_id: str | None  # REQUIRED, no default -- see the docstring above
     call_id: str | None = None
-    tool_call_id: str | None = None
     completed_response_include_text: bool = False
     user_input_include_text: bool = False
 
@@ -173,8 +201,8 @@ async def dispatch_tool(
     Events emitted (via ctx.events.emit):
         - tool_called (caller_kind, caller_id, tool, chain_id, call_id, args, args_hash)
         - tool_returned (caller_kind, caller_id, tool, chain_id, call_id, result,
-          args_hash, tool_call_id, tool_call_id_absent_reason -- #5891 (c), see
-          below)
+          args_hash, tool_call_id -- #5891 (c), see ctx.tool_call_id's own
+          docstring above)
             on success.
         - tool_failed (caller_kind, caller_id, tool, chain_id, call_id, error_kind, message)
             on error.
@@ -360,27 +388,22 @@ async def dispatch_tool(
     # dispatch_tool hands back to the caller/LLM) is NEVER redacted —
     # only the copy that reaches the audit-event.
     #
-    # #5891 (c), architect ruling: `tool_call_id` (not `call_id`, which
+    # #5891 (c), architect ruling (corrected twice, see DispatchContext.
+    # tool_call_id's own docstring): `tool_call_id` (not `call_id`, which
     # only identifies the litellm ROUND, 1-to-many when a round calls the
     # SAME tool twice) is the key a reader joins this event to the ONE
     # history row `RouterLoop.feedback` wrote for THIS call (same
     # `tc["id"]`, ChatMessage.tool_call_id) -> that row's own
-    # `content_ref`, with no new write. `tool_call_id` itself is NEVER
-    # omitted (a missing key and "the caller forgot to thread the id
-    # through" would be the SAME observation) — `None` for a caller with
-    # no litellm tool_calls entry behind this dispatch at all (CodeAct
-    # `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:` step).
-    # `tool_call_id_absent_reason` is added ONLY in that `None` case,
-    # naming `caller_kind` — "the caller doesn't have one" and "it was
-    # forgotten" must never read as the same silence, the same discipline
-    # `_persist_tool_returned`'s own `content_ref_unavailable` uses one
-    # layer down (#5891, #5936), applied here as an only-when-needed
-    # sibling field rather than an always-set one since (unlike that
-    # field) whether an id exists varies per call, not per PR stage.
-    _extra = (
-        {} if ctx.tool_call_id is not None
-        else {"tool_call_id_absent_reason": ctx.caller_kind}
-    )
+    # `content_ref`, with no new write. `tool_call_id` is NEVER omitted
+    # (a missing key and "the caller forgot to thread the id through"
+    # would be the SAME observation) — `ctx.tool_call_id` is a REQUIRED
+    # field with no default, so `None` here is always the caller's own
+    # DECLARED absence (CodeAct `tool()`, `/exec`/`/tasks` slash, a
+    # pipeline `tool:` step), never an accidentally-omitted one; no
+    # sibling "reason" field exists because there is nothing left for one
+    # to explain (the first fix's `tool_call_id_absent_reason: caller_
+    # kind` repeated information the event already carries and was
+    # rejected for it).
     ctx.events.emit(
         "tool_returned",
         caller_kind=ctx.caller_kind,
@@ -391,7 +414,6 @@ async def dispatch_tool(
         args_hash=args_hash,
         result=_redact_content_fields(name, result, ctx),
         tool_call_id=ctx.tool_call_id,
-        **_extra,
     )
     return {"status": "ok", "data": result}
 

--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -65,6 +65,23 @@ class DispatchContext:
             reader reconstructs identically, is one of four faces, and one
             skipped face goes unnoticed — not an invariant to key UI structure
             on).
+        tool_call_id: #5891 (c), architect ruling — the SAME `tc["id"]` the
+            router's own `{role: tool, tool_call_id: ...}` feedback message
+            and history row already carry (RouterLoop.feedback,
+            chat_message.py's ChatMessage.tool_call_id). `call_id` above
+            identifies the litellm ROUND (shared by every tool_calls
+            entry in it); this identifies ONE call within that round —
+            architect's own correction of the original #5891 ruling
+            ("audit event と history row は既に同じ ref を持つ" was
+            false: `call_id` alone is 1-to-many when a round calls the
+            SAME tool twice, so it cannot join `tool_returned` to the ONE
+            history row a reader wants). None for any caller with no
+            litellm tool_calls entry behind this dispatch at all — CodeAct
+            snippet `tool()` calls, `/exec`/`/tasks` slash commands
+            (`caller_kind="operator"`), and pipeline `tool:` steps
+            (`caller_kind="pipeline"`) — never a minted placeholder, the
+            same "byte-identical until threaded through" contract
+            `call_id` already established.
         completed_response_include_text: #4666 item ③b — mirrors
             ``audit_events.completed_response_include_text`` (②). Governs
             any declared tool field whose content class is "assistant"
@@ -100,6 +117,7 @@ class DispatchContext:
     events: Any  # has .emit(type: str, **data) -> None
     contextual: "ContextualPermission | None"
     call_id: str | None = None
+    tool_call_id: str | None = None
     completed_response_include_text: bool = False
     user_input_include_text: bool = False
 
@@ -154,7 +172,9 @@ async def dispatch_tool(
 
     Events emitted (via ctx.events.emit):
         - tool_called (caller_kind, caller_id, tool, chain_id, call_id, args, args_hash)
-        - tool_returned (caller_kind, caller_id, tool, chain_id, call_id, result, args_hash)
+        - tool_returned (caller_kind, caller_id, tool, chain_id, call_id, result,
+          args_hash, tool_call_id, tool_call_id_absent_reason -- #5891 (c), see
+          below)
             on success.
         - tool_failed (caller_kind, caller_id, tool, chain_id, call_id, error_kind, message)
             on error.
@@ -339,6 +359,28 @@ async def dispatch_tool(
     # 6. Post-event: record the result. `result` itself (the return value
     # dispatch_tool hands back to the caller/LLM) is NEVER redacted —
     # only the copy that reaches the audit-event.
+    #
+    # #5891 (c), architect ruling: `tool_call_id` (not `call_id`, which
+    # only identifies the litellm ROUND, 1-to-many when a round calls the
+    # SAME tool twice) is the key a reader joins this event to the ONE
+    # history row `RouterLoop.feedback` wrote for THIS call (same
+    # `tc["id"]`, ChatMessage.tool_call_id) -> that row's own
+    # `content_ref`, with no new write. `tool_call_id` itself is NEVER
+    # omitted (a missing key and "the caller forgot to thread the id
+    # through" would be the SAME observation) — `None` for a caller with
+    # no litellm tool_calls entry behind this dispatch at all (CodeAct
+    # `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:` step).
+    # `tool_call_id_absent_reason` is added ONLY in that `None` case,
+    # naming `caller_kind` — "the caller doesn't have one" and "it was
+    # forgotten" must never read as the same silence, the same discipline
+    # `_persist_tool_returned`'s own `content_ref_unavailable` uses one
+    # layer down (#5891, #5936), applied here as an only-when-needed
+    # sibling field rather than an always-set one since (unlike that
+    # field) whether an id exists varies per call, not per PR stage.
+    _extra = (
+        {} if ctx.tool_call_id is not None
+        else {"tool_call_id_absent_reason": ctx.caller_kind}
+    )
     ctx.events.emit(
         "tool_returned",
         caller_kind=ctx.caller_kind,
@@ -348,6 +390,8 @@ async def dispatch_tool(
         call_id=ctx.call_id,
         args_hash=args_hash,
         result=_redact_content_fields(name, result, ctx),
+        tool_call_id=ctx.tool_call_id,
+        **_extra,
     )
     return {"status": "ok", "data": result}
 

--- a/src/reyn/interfaces/slash/exec.py
+++ b/src/reyn/interfaces/slash/exec.py
@@ -309,6 +309,10 @@ async def _run_exec(ctx: "SlashContext", args: str) -> "tuple[list[str], dict] |
         # still denied under the SAME session-level narrowing a hidden
         # LLM exec call is denied under.
         contextual=op_ctx.contextual_permission,
+        # #5891 (c): DispatchContext.tool_call_id is now REQUIRED (no
+        # default) -- None is the DECLARED absence, not an omission: a
+        # slash-driven /exec has no litellm tool_calls round behind it.
+        tool_call_id=None,
     )
 
     async def _invoker(call_args: dict) -> Any:

--- a/src/reyn/interfaces/slash/tasks.py
+++ b/src/reyn/interfaces/slash/tasks.py
@@ -111,6 +111,10 @@ async def _dispatch(name: str, args: dict, ctx: "SlashContext") -> dict:
         # OpContext. Without this, /tasks would be the one dispatch_tool
         # caller silently exempt from the new call-time restrict check.
         contextual=await _router_contextual_permission(tool_ctx),
+        # #5891 (c): DispatchContext.tool_call_id is now REQUIRED (no
+        # default) -- None is the DECLARED absence, not an omission: a
+        # slash-driven op has no litellm tool_calls round behind it at all.
+        tool_call_id=None,
     )
 
     async def _invoker(call_args: dict) -> Any:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3571,6 +3571,7 @@ class RouterLoop:
         # the same way it covers every other one.
         return await self._dispatch_resolved(
             name, args, raw_name=raw_name, call_id=call_id,
+            tool_call_id=tc.get("id"),
         )
 
     def _resolve_tool_call(self, tc: dict) -> "tuple[str, dict, str]":
@@ -3612,6 +3613,7 @@ class RouterLoop:
     async def _dispatch_resolved(
         self, name: str, args: dict, *,
         raw_name: "str | None" = None, call_id: "str | None" = None,
+        tool_call_id: "str | None" = None,
     ) -> dict:
         """#1593: dispatch a resolved tool call via the OS substrate
         (DispatchContext / ``dispatch_tool`` — P5). #5854: "resolved" no
@@ -3652,7 +3654,16 @@ class RouterLoop:
         ``ExecContext.extra["call_id"]`` -> the 3 delegating schemes'
         ``ops.dispatch(..., call_id=...)``; ``_run_codeblock_round``'s
         ``_os_gate`` closure captures it directly) makes a stale value
-        structurally impossible — there is no field left to go stale."""
+        structurally impossible — there is no field left to go stale.
+
+        ``tool_call_id`` (#5891 (c), architect ruling): the ONE tool call's
+        own ``tc["id"]``, distinct from ``call_id`` above (which identifies
+        the whole ROUND, shared by every tool_calls entry in it, so it
+        cannot join an audit event to the ONE history row a reader wants
+        when the same tool is called twice in one round). ``None`` for any
+        caller with no real litellm tool_calls entry to key on — the
+        CodeAct ``_os_gate`` closure below never passes one, the same
+        degrade ``call_id`` already models for that caller."""
         catalog = (
             self._dispatch_catalog
             if self._dispatch_catalog is not None
@@ -3685,6 +3696,7 @@ class RouterLoop:
             # equivalent of it.
             contextual=self._contextual_permission,
             call_id=call_id,
+            tool_call_id=tool_call_id,
             completed_response_include_text=(
                 bool(_completed_getter()) if _completed_getter else False
             ),
@@ -3955,11 +3967,21 @@ class RouterLoop:
         ``call_id`` (#4691 Phase B ①, remainder): the litellm call this batch
         of actions belongs to — forwarded verbatim to every ``_dispatch_
         resolved`` call in this batch. An explicit parameter, not a stored
-        field (see ``_dispatch_resolved``'s own docstring for why)."""
+        field (see ``_dispatch_resolved``'s own docstring for why).
+
+        ``tool_call_id`` (#5891 (c)): read from each action's own ``"tc"``
+        entry (the raw tool_calls dict, set by this method's own caller —
+        see the ``actions.append({"tc": tc, ...})`` builder above), the
+        SAME ``.get()``-defaulting posture ``raw_name`` already uses —
+        a caller that hand-builds an action dict without a ``"tc"`` key
+        (a test double, most measured instance:
+        ``test_serial_tool_dispatch_2344.py``) degrades to ``None``
+        (absent), never a ``KeyError``."""
         results: list[dict] = []
         for a in actions:
             results.append(await self._dispatch_resolved(
                 a["name"], a["args"], raw_name=a.get("raw_name"), call_id=call_id,
+                tool_call_id=(a.get("tc") or {}).get("id"),
             ))
         # FP-0050/#1822 S2: tag untrusted-source results by the EFFECTIVE resolved
         # name (``a["name"]``). feedback() iterates the raw tool_calls whose name

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3613,7 +3613,7 @@ class RouterLoop:
     async def _dispatch_resolved(
         self, name: str, args: dict, *,
         raw_name: "str | None" = None, call_id: "str | None" = None,
-        tool_call_id: "str | None" = None,
+        tool_call_id: "str | None",
     ) -> dict:
         """#1593: dispatch a resolved tool call via the OS substrate
         (DispatchContext / ``dispatch_tool`` — P5). #5854: "resolved" no
@@ -3972,16 +3972,20 @@ class RouterLoop:
         ``tool_call_id`` (#5891 (c)): read from each action's own ``"tc"``
         entry (the raw tool_calls dict, set by this method's own caller —
         see the ``actions.append({"tc": tc, ...})`` builder above), the
-        SAME ``.get()``-defaulting posture ``raw_name`` already uses —
-        a caller that hand-builds an action dict without a ``"tc"`` key
-        (a test double, most measured instance:
-        ``test_serial_tool_dispatch_2344.py``) degrades to ``None``
-        (absent), never a ``KeyError``."""
+        REQUIRES a real ``"tc"`` entry on every action (`DispatchContext.
+        tool_call_id` is itself a required field, no default — #5891 (c):
+        a caller that silently degraded here would just move the same
+        "forgot to thread it through" defect one call frame up). Every
+        production caller of ``dispatch()`` builds ``actions`` via the
+        ``actions.append({"tc": tc, ...})`` line above, so this is never
+        missing in real use; ``test_serial_tool_dispatch_2344.py`` (this
+        method's only hand-built-action caller) now seeds a synthetic
+        ``"tc"`` on every fixture action for exactly this reason."""
         results: list[dict] = []
         for a in actions:
             results.append(await self._dispatch_resolved(
                 a["name"], a["args"], raw_name=a.get("raw_name"), call_id=call_id,
-                tool_call_id=(a.get("tc") or {}).get("id"),
+                tool_call_id=a["tc"]["id"],
             ))
         # FP-0050/#1822 S2: tag untrusted-source results by the EFFECTIVE resolved
         # name (``a["name"]``). feedback() iterates the raw tool_calls whose name
@@ -4601,7 +4605,13 @@ class RouterLoop:
             # ``tool_excluded`` result from dispatch_tool's 2b — so this
             # closure no longer needs its own pre-check + emit for that
             # outcome, symmetric with the Execute arm above.
-            return await self._dispatch_resolved(name, args, call_id=call_id)
+            # #5891 (c): tool_call_id is a REQUIRED DispatchContext field
+            # (no default) -- explicit None here is CodeAct's own declared
+            # absence (an in-snippet tool() call has no litellm tool_calls
+            # entry at all), never an accidentally-omitted one.
+            return await self._dispatch_resolved(
+                name, args, call_id=call_id, tool_call_id=None,
+            )
 
         # CodeAct-safe default policy (operator-overridable in S4 via the host's
         # configured sandbox policy); the backend auto-selects per platform and the

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3569,9 +3569,18 @@ class RouterLoop:
         # restrict is the single live gate, and its own routing_decided
         # emit (this method's tail) already covers the excluded outcome
         # the same way it covers every other one.
+        #
+        # #5891 (c) architect ruling: ``tc["id"]``, not ``tc.get("id")`` —
+        # the OTHER two production arms of ``_dispatch_resolved``
+        # (``dispatch()``'s ``a["tc"]["id"]``, ``_os_gate``'s explicit
+        # ``None``) both subscript or declare; only this seam degraded.
+        # This method has no production call site (see its own docstring)
+        # -- a ``.get()`` here would let a TEST exercise a contract
+        # production can never actually hit, since a real litellm
+        # tool_calls entry always carries an ``"id"``.
         return await self._dispatch_resolved(
             name, args, raw_name=raw_name, call_id=call_id,
-            tool_call_id=tc.get("id"),
+            tool_call_id=tc["id"],
         )
 
     def _resolve_tool_call(self, tc: dict) -> "tuple[str, dict, str]":

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -447,6 +447,12 @@ def _make_tool_dispatch(
             tool_catalog={name: target.render_for_router()},
             events=ctx.events,
             contextual=cast("Any", contextual_permission),
+            # #5891 (c): DispatchContext.tool_call_id is now REQUIRED (no
+            # default) -- None is the DECLARED absence, not an omission:
+            # a pipeline `tool:` step has no litellm tool_calls round
+            # behind it (chain_id above is likewise always None for the
+            # same reason).
+            tool_call_id=None,
         )
         envelope = await dispatch_tool(
             name=name, args=target_args, ctx=dispatch_ctx, invoker=_invoker,

--- a/tests/core/test_2649_pipeline_error_envelope.py
+++ b/tests/core/test_2649_pipeline_error_envelope.py
@@ -147,6 +147,7 @@ async def _dispatch_run_pipeline(args: dict, ctx: ToolContext, events: EventLog)
         tool_catalog={"run_pipeline": {"function": {"name": "run_pipeline", "parameters": {}}}},
         events=events,
         contextual=None,  # #5841: no narrowing in play for this test
+        tool_call_id=None,  # #5891 (c): required field, this test doesn't need one
     )
     r = await dispatch_tool(name="run_pipeline", args=args, ctx=dctx, invoker=invoker)
     if isinstance(r, dict):

--- a/tests/core/test_4666_tool_content_declarations.py
+++ b/tests/core/test_4666_tool_content_declarations.py
@@ -87,6 +87,7 @@ def _make_ctx(
         tool_catalog=_CATALOG,
         events=events,
         contextual=None,  # #5841: no narrowing in play for these tests
+        tool_call_id=None,  # #5891 (c): required field, none of these tests need one
         completed_response_include_text=completed_response_include_text,
         user_input_include_text=user_input_include_text,
     )

--- a/tests/core/test_5891_tool_call_id_audit_field.py
+++ b/tests/core/test_5891_tool_call_id_audit_field.py
@@ -1,9 +1,9 @@
 """Tier 2: `tool_returned`'s `tool_call_id` field (#5891 (c), architect
-ruling) — the ONE tool call's own `tc["id"]`, distinct from `call_id`
-(which only identifies the litellm ROUND, shared by every `tool_calls`
-entry in it).
+ruling, corrected twice) — the ONE tool call's own `tc["id"]`, distinct
+from `call_id` (which only identifies the litellm ROUND, shared by every
+`tool_calls` entry in it).
 
-## Why this exists (architect's own correction)
+## Why this exists (architect's first correction)
 
 The original #5891 design ("audit event carries an excerpt/hash, the
 history row already has a `content_ref`, a reader can JOIN the two on
@@ -18,17 +18,35 @@ key that actually disambiguates them, with no new storage — see
 `tests/runtime/test_5891_tool_call_id_history_join.py` for the join
 witness through both real halves.
 
-These tests pin the dispatcher-level half only: the field is present and
-distinct across two calls, and a caller with no litellm tool_calls entry
-at all (the DispatchContext default) gets `tool_call_id: None` plus a
-NAMED absence reason — never a silently omitted key, which would make
-"the caller doesn't have one" indistinguishable from "it was forgotten"
-(the same discipline `_persist_tool_returned`'s own
-`content_ref_unavailable` already uses one layer down, #5936)."""
+## Why there is no `tool_call_id_absent_reason` field (architect's SECOND
+## correction, lead-coder BLOCKING on PR #5970)
+
+The first fix gave `tool_call_id` a `None` default and added a sibling
+`tool_call_id_absent_reason` naming `caller_kind` to explain a `None`.
+Rejected: `caller_kind` cannot actually distinguish "no id to give" from
+"one was dropped in transit", because a CodeAct in-snippet `tool()` call
+has the SAME `caller_kind="router"` an Execute-round tool_calls dispatch
+does — the reason field repeated information the event already carried
+(`caller_kind` itself) while claiming to explain something it could not.
+
+The fix instead: `tool_call_id` is a REQUIRED keyword-only field, no
+default (the SAME shape #5960's `hydrate` flip and `DispatchContext.
+contextual` already use — `test_dispatcher.py`'s own `test_dispatch_
+context_construction_without_contextual_raises_type_error` is the
+precedent this mirrors). Omitting it is a real Python `TypeError`, not a
+silent default, so `tool_call_id: None` in an emitted event is now
+ALWAYS the caller's own DECLARATION of absence — self-describing, no
+reason field needed. These tests pin the dispatcher-level half only (the
+key is never omitted either way, present or absent); the "which
+caller_kinds normally carry one" claim is answered by a CENSUS of real
+data, not a curated table — see `tests/runtime/test_5891_tool_call_id_
+history_join.py`'s own census test."""
 from __future__ import annotations
 
 import asyncio
 from typing import Any
+
+import pytest
 
 from reyn.core.dispatch import DispatchContext, dispatch_tool
 
@@ -43,7 +61,7 @@ class _FakeEventEmitter:
         self.events.append((event_type, data))
 
 
-def _make_ctx(*, tool_call_id: "str | None" = None) -> "tuple[DispatchContext, _FakeEventEmitter]":
+def _make_ctx(*, tool_call_id: "str | None") -> "tuple[DispatchContext, _FakeEventEmitter]":
     ev = _FakeEventEmitter()
     return (
         DispatchContext(
@@ -77,8 +95,8 @@ def test_tool_call_id_reaches_the_tool_returned_event():
         (returned,) = _tool_returned_events(ev)
         assert returned["tool_call_id"] == "call_abc123"
         assert "tool_call_id_absent_reason" not in returned, (
-            "the reason field must be ABSENT (not even present as None) "
-            "when a real id was supplied -- only the None case adds it"
+            "no reason field exists any more -- tool_call_id being a "
+            "required field is what makes one unnecessary"
         )
     asyncio.run(main())
 
@@ -124,36 +142,42 @@ def test_two_calls_in_one_round_get_distinct_tool_call_ids():
     asyncio.run(main())
 
 
-def test_absent_tool_call_id_is_null_with_a_named_reason_not_omitted():
-    """Tier 2: LOAD-BEARING — a caller with no litellm tool_calls entry at
-    all (CodeAct `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:`
-    step — modeled here by simply not threading one, the
-    `DispatchContext` default) gets `tool_call_id: None` PLUS
-    `tool_call_id_absent_reason` naming `caller_kind` — the key is never
-    silently dropped, which would make "no id to give" indistinguishable
-    from "a real id was forgotten"."""
-    async def main():
-        ctx, ev = _make_ctx(tool_call_id=None)
-        await dispatch_tool(name="echo", args={}, ctx=ctx, invoker=_echo_invoker)
-        (returned,) = _tool_returned_events(ev)
-        assert "tool_call_id" in returned, "the key must never be omitted"
-        assert returned["tool_call_id"] is None
-        assert returned["tool_call_id_absent_reason"] == "router"
-    asyncio.run(main())
-
-
-def test_operator_caller_kind_absence_reason_names_operator():
-    """Tier 2: accept-side variety for the absence reason — a slash-driven
-    operator call (no litellm round behind it at all, `caller_kind=
-    "operator"`) names ITS OWN caller_kind, not a hardcoded "router"."""
+def test_a_caller_that_has_no_id_declares_none_explicitly():
+    """Tier 2: a caller with no litellm tool_calls entry at all (CodeAct
+    `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:` step — modeled
+    here by an operator-kind caller, one of the real such shapes)
+    DECLARES `tool_call_id=None` explicitly. The event still carries the
+    key (never omitted -- `None` is a real, meaningful value, distinct
+    from "no key at all"), and there is no sibling reason field: the
+    None itself, on a required field, already IS the declaration."""
     async def main():
         ev = _FakeEventEmitter()
         ctx = DispatchContext(
             caller_kind="operator", caller_id="cli", chain_id=None,
             tool_catalog=_CATALOG, events=ev, contextual=None,
+            tool_call_id=None,
         )
         await dispatch_tool(name="echo", args={}, ctx=ctx, invoker=_echo_invoker)
         (returned,) = _tool_returned_events(ev)
+        assert "tool_call_id" in returned, "the key must never be omitted"
         assert returned["tool_call_id"] is None
-        assert returned["tool_call_id_absent_reason"] == "operator"
+        assert "tool_call_id_absent_reason" not in returned
     asyncio.run(main())
+
+
+def test_omitting_tool_call_id_raises_type_error_not_a_silent_default():
+    """Tier 2: LOAD-BEARING — the structural guarantee itself. Omitting
+    `tool_call_id` at DispatchContext construction is a real TypeError
+    (no default exists to silently fall back to), so a caller can no
+    longer "forget" to declare absence -- every `tool_call_id: None` an
+    event ever carries was a deliberate choice, never an accident.
+    strip: give `tool_call_id` a `None` default back in dispatcher.py --
+    this construction stops raising (see test_dispatcher.py's own
+    dedicated field-introspection test for the fuller version of this
+    witness, mirroring `contextual`'s identical precedent)."""
+    with pytest.raises(TypeError):
+        DispatchContext(
+            caller_kind="router", caller_id="test_agent", chain_id="c1",
+            tool_catalog=_CATALOG, events=_FakeEventEmitter(), contextual=None,
+            # tool_call_id= deliberately omitted
+        )

--- a/tests/core/test_5891_tool_call_id_audit_field.py
+++ b/tests/core/test_5891_tool_call_id_audit_field.py
@@ -1,0 +1,159 @@
+"""Tier 2: `tool_returned`'s `tool_call_id` field (#5891 (c), architect
+ruling) — the ONE tool call's own `tc["id"]`, distinct from `call_id`
+(which only identifies the litellm ROUND, shared by every `tool_calls`
+entry in it).
+
+## Why this exists (architect's own correction)
+
+The original #5891 design ("audit event carries an excerpt/hash, the
+history row already has a `content_ref`, a reader can JOIN the two on
+data both sides already have") turned out to rest on a false premise: a
+`tool_returned` event's `call_id` and a history row's `tool_call_id` are
+different GRANULARITIES — the former is shared by every tool call in one
+litellm round, the latter is per-call — so calling the SAME tool twice in
+one round makes `(call_id, tool)` ambiguous between the two resulting
+history rows. `DispatchContext.tool_call_id` (the SAME `tc["id"]`
+`RouterLoop.feedback` already writes onto its own history row) is the
+key that actually disambiguates them, with no new storage — see
+`tests/runtime/test_5891_tool_call_id_history_join.py` for the join
+witness through both real halves.
+
+These tests pin the dispatcher-level half only: the field is present and
+distinct across two calls, and a caller with no litellm tool_calls entry
+at all (the DispatchContext default) gets `tool_call_id: None` plus a
+NAMED absence reason — never a silently omitted key, which would make
+"the caller doesn't have one" indistinguishable from "it was forgotten"
+(the same discipline `_persist_tool_returned`'s own
+`content_ref_unavailable` already uses one layer down, #5936)."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from reyn.core.dispatch import DispatchContext, dispatch_tool
+
+_CATALOG = {"echo": {"function": {"name": "echo"}}}
+
+
+class _FakeEventEmitter:
+    def __init__(self) -> None:
+        self.events: "list[tuple[str, dict]]" = []
+
+    def emit(self, event_type: str, **data: Any) -> None:
+        self.events.append((event_type, data))
+
+
+def _make_ctx(*, tool_call_id: "str | None" = None) -> "tuple[DispatchContext, _FakeEventEmitter]":
+    ev = _FakeEventEmitter()
+    return (
+        DispatchContext(
+            caller_kind="router",
+            caller_id="test_agent",
+            chain_id="c1",
+            tool_catalog=_CATALOG,
+            events=ev,
+            contextual=None,
+            call_id="round_1",
+            tool_call_id=tool_call_id,
+        ),
+        ev,
+    )
+
+
+async def _echo_invoker(args: dict) -> dict:
+    return {"echoed": args}
+
+
+def _tool_returned_events(ev: _FakeEventEmitter) -> "list[dict]":
+    return [data for etype, data in ev.events if etype == "tool_returned"]
+
+
+def test_tool_call_id_reaches_the_tool_returned_event():
+    """Tier 2: a caller-supplied `tool_call_id` is threaded onto the
+    emitted `tool_returned` event, verbatim."""
+    async def main():
+        ctx, ev = _make_ctx(tool_call_id="call_abc123")
+        await dispatch_tool(name="echo", args={}, ctx=ctx, invoker=_echo_invoker)
+        (returned,) = _tool_returned_events(ev)
+        assert returned["tool_call_id"] == "call_abc123"
+        assert "tool_call_id_absent_reason" not in returned, (
+            "the reason field must be ABSENT (not even present as None) "
+            "when a real id was supplied -- only the None case adds it"
+        )
+    asyncio.run(main())
+
+
+def test_two_calls_in_one_round_get_distinct_tool_call_ids():
+    """Tier 2: LOAD-BEARING — the exact shape `call_id` alone cannot
+    disambiguate (architect's own falsification of the original #5891
+    design). Two dispatches sharing the SAME `call_id` (one litellm
+    round) but different `tool_call_id`s (two tool_calls entries) produce
+    two `tool_returned` events whose `tool_call_id`s are themselves
+    distinct and match their own caller-supplied id.
+
+    strip: drop `tool_call_id=ctx.tool_call_id` from dispatcher.py's emit
+    call -- both events would carry only the shared `call_id`, making them
+    indistinguishable by call identity alone."""
+    async def main():
+        # Both contexts share one emitter (one round's own event stream)
+        # and one call_id (the SAME litellm round), differing ONLY in
+        # tool_call_id -- the one variable this test isolates.
+        ev = _FakeEventEmitter()
+        ctx1 = DispatchContext(
+            caller_kind="router", caller_id="test_agent", chain_id="c1",
+            tool_catalog=_CATALOG, events=ev, contextual=None,
+            call_id="round_1", tool_call_id="call_1",
+        )
+        ctx2 = DispatchContext(
+            caller_kind="router", caller_id="test_agent", chain_id="c1",
+            tool_catalog=_CATALOG, events=ev, contextual=None,
+            call_id="round_1", tool_call_id="call_2",
+        )
+        await dispatch_tool(name="echo", args={}, ctx=ctx1, invoker=_echo_invoker)
+        await dispatch_tool(name="echo", args={}, ctx=ctx2, invoker=_echo_invoker)
+
+        first, second = _tool_returned_events(ev)  # exactly 2, or unpacking itself raises
+        returned = [first, second]
+        assert {r["call_id"] for r in returned} == {"round_1"}, (
+            "both calls really do share one round -- call_id alone cannot "
+            "tell them apart, which is exactly why tool_call_id exists"
+        )
+        assert {r["tool_call_id"] for r in returned} == {"call_1", "call_2"}, (
+            "tool_call_id must disambiguate what call_id cannot"
+        )
+    asyncio.run(main())
+
+
+def test_absent_tool_call_id_is_null_with_a_named_reason_not_omitted():
+    """Tier 2: LOAD-BEARING — a caller with no litellm tool_calls entry at
+    all (CodeAct `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:`
+    step — modeled here by simply not threading one, the
+    `DispatchContext` default) gets `tool_call_id: None` PLUS
+    `tool_call_id_absent_reason` naming `caller_kind` — the key is never
+    silently dropped, which would make "no id to give" indistinguishable
+    from "a real id was forgotten"."""
+    async def main():
+        ctx, ev = _make_ctx(tool_call_id=None)
+        await dispatch_tool(name="echo", args={}, ctx=ctx, invoker=_echo_invoker)
+        (returned,) = _tool_returned_events(ev)
+        assert "tool_call_id" in returned, "the key must never be omitted"
+        assert returned["tool_call_id"] is None
+        assert returned["tool_call_id_absent_reason"] == "router"
+    asyncio.run(main())
+
+
+def test_operator_caller_kind_absence_reason_names_operator():
+    """Tier 2: accept-side variety for the absence reason — a slash-driven
+    operator call (no litellm round behind it at all, `caller_kind=
+    "operator"`) names ITS OWN caller_kind, not a hardcoded "router"."""
+    async def main():
+        ev = _FakeEventEmitter()
+        ctx = DispatchContext(
+            caller_kind="operator", caller_id="cli", chain_id=None,
+            tool_catalog=_CATALOG, events=ev, contextual=None,
+        )
+        await dispatch_tool(name="echo", args={}, ctx=ctx, invoker=_echo_invoker)
+        (returned,) = _tool_returned_events(ev)
+        assert returned["tool_call_id"] is None
+        assert returned["tool_call_id_absent_reason"] == "operator"
+    asyncio.run(main())

--- a/tests/core/test_5891_tool_call_id_audit_field.py
+++ b/tests/core/test_5891_tool_call_id_audit_field.py
@@ -37,10 +37,19 @@ precedent this mirrors). Omitting it is a real Python `TypeError`, not a
 silent default, so `tool_call_id: None` in an emitted event is now
 ALWAYS the caller's own DECLARATION of absence — self-describing, no
 reason field needed. These tests pin the dispatcher-level half only (the
-key is never omitted either way, present or absent); the "which
-caller_kinds normally carry one" claim is answered by a CENSUS of real
-data, not a curated table — see `tests/runtime/test_5891_tool_call_id_
-history_join.py`'s own census test."""
+key is never omitted either way, present or absent).
+
+⚠️ There is deliberately no gate proving "every caller_kind='router'
+event has a real id" — architect's own first attempt at one (a census:
+"caller_kind='router' + tool_call_id: null events are 0") was proposed
+and then FALSIFIED by this codebase's own existing code: CodeAct's
+`_os_gate` (`router_loop.py`) is `caller_kind="router"` AND declares
+`None` by design, so that census would have flagged a correct, intended
+line as though it were a bug. The real safeguard is structural, not
+data-derived: `_dispatch_resolved` is the ONE place a `caller_kind=
+"router"` `DispatchContext` is ever built, so its 3 real callers are
+enumerable by reading `router_loop.py` directly — see `DispatchContext.
+tool_call_id`'s own docstring in `dispatcher.py` for the full table."""
 from __future__ import annotations
 
 import asyncio

--- a/tests/core/test_5891_tool_returned_result_cap.py
+++ b/tests/core/test_5891_tool_returned_result_cap.py
@@ -256,6 +256,7 @@ def test_excerpt_reflects_the_post_redaction_payload_dispatch_tool_hands_backend
                 tool_catalog=catalog,
                 events=events,
                 contextual=None,
+                tool_call_id=None,  # #5891 (c): required field, this test doesn't need one
                 user_input_include_text=False,
             )
 

--- a/tests/core/test_dispatcher.py
+++ b/tests/core/test_dispatcher.py
@@ -24,6 +24,7 @@ def make_ctx(
     caller_id: str = "test_agent",
     chain_id: str | None = "c1",
     call_id: str | None = None,
+    tool_call_id: str | None = None,
     catalog: dict | None = None,
     events: FakeEventEmitter | None = None,
     contextual: "object | None" = None,
@@ -40,6 +41,12 @@ def make_ctx(
             # real ContextualPermission to exercise the restrict check.
             contextual=contextual,
             call_id=call_id,
+            # #5891 (c): DispatchContext.tool_call_id is a required field
+            # (no default) -- this helper's own default of None keeps
+            # every existing call site here byte-identical (none of them
+            # care about tool_call_id), while still declaring it
+            # explicitly at the one place that matters.
+            tool_call_id=tool_call_id,
         ),
         e,
     )
@@ -734,10 +741,41 @@ def test_dispatch_context_construction_without_contextual_raises_type_error():
             chain_id="c1",
             tool_catalog={},
             events=FakeEventEmitter(),
+            tool_call_id=None,
             # contextual= deliberately omitted
         )
     # Control: the field really is declared, with no default -- so the
     # TypeError above is this field's absence, not an unrelated one.
     field = next(f for f in dataclasses.fields(DispatchContext) if f.name == "contextual")
+    assert field.default is dataclasses.MISSING
+    assert field.default_factory is dataclasses.MISSING
+
+
+def test_dispatch_context_construction_without_tool_call_id_raises_type_error():
+    """Tier 2: LOAD-BEARING (#5891 (c), architect's SECOND correction) --
+    `tool_call_id` is a REQUIRED field, no default, the same shape
+    `contextual` already has (test above) and the SAME discipline #5960's
+    `hydrate` flip established: a caller that forgets to pass it fails
+    LOUDLY at construction (a real TypeError), never silently defaults to
+    `None` and gets treated as a declared absence it never actually
+    declared. strip: give `tool_call_id` a `None` default back -- this
+    construction stops raising."""
+    import dataclasses
+
+    import pytest as _pytest
+
+    with _pytest.raises(TypeError):
+        DispatchContext(
+            caller_kind="router",
+            caller_id="test_agent",
+            chain_id="c1",
+            tool_catalog={},
+            events=FakeEventEmitter(),
+            contextual=None,
+            # tool_call_id= deliberately omitted
+        )
+    # Control: the field really is declared, with no default -- so the
+    # TypeError above is this field's absence, not an unrelated one.
+    field = next(f for f in dataclasses.fields(DispatchContext) if f.name == "tool_call_id")
     assert field.default is dataclasses.MISSING
     assert field.default_factory is dataclasses.MISSING

--- a/tests/core/test_emit_hook_event_0059_phase5_part2.py
+++ b/tests/core/test_emit_hook_event_0059_phase5_part2.py
@@ -400,6 +400,7 @@ async def test_denied_emit_via_production_router_tool_path_is_audited():
         caller_kind="router", caller_id="test-agent", chain_id="c1",
         tool_catalog=catalog, events=events,
         contextual=None,  # #5841: no narrowing in play for this test
+        tool_call_id=None,  # #5891 (c): required field, this test doesn't need one
     )
 
     result = await dispatch_tool(

--- a/tests/core/test_serial_tool_dispatch_2344.py
+++ b/tests/core/test_serial_tool_dispatch_2344.py
@@ -64,6 +64,16 @@ def _loop() -> _OrderedDispatchLoop:
     return _OrderedDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
 
 
+def _action(name: str) -> dict:
+    """One `dispatch()`-shaped action dict, including the `"tc"` entry
+    `_run_action_batch` now reads `["id"]` off unconditionally (#5891 (c):
+    `DispatchContext.tool_call_id` is a required field, no default -- a
+    caller that hand-builds an action dict without `"tc"` used to degrade
+    silently to `None`; that degrade is gone, so this fixture supplies a
+    real (synthetic) id instead of relying on it)."""
+    return {"name": name, "args": {}, "tc": {"id": f"tc_{name}"}}
+
+
 @pytest.mark.asyncio
 async def test_order_dependent_calls_execute_serially(tmp_path):
     """Tier 2: write-then-read in one round runs serially → the read OBSERVES the write.
@@ -71,7 +81,7 @@ async def test_order_dependent_calls_execute_serially(tmp_path):
     RED under the old ``asyncio.gather`` (the reader interleaves at the writer's yield and sees
     ``written=False``); GREEN with the serial for-loop (the writer completes first)."""
     loop = _loop()
-    results = await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
+    results = await loop.dispatch([_action("write"), _action("read")])
     assert results[1]["saw_write"] is True, "serial: the read must observe the preceding write"
     assert loop.trace == ["write", "read"], "completion order is strict declaration order"
 
@@ -81,7 +91,7 @@ async def test_results_returned_in_declaration_order(tmp_path):
     """Tier 2: N calls → results[i] aligns with actions[i] (tool_calls[i] ↔ tool_results[i]);
     the ordering contract is unchanged from gather's index-preservation."""
     loop = _loop()
-    actions = [{"name": f"t{i}", "args": {}} for i in range(6)]
+    actions = [_action(f"t{i}") for i in range(6)]
     results = await loop.dispatch(actions)
     assert [r["name"] for r in results] == [a["name"] for a in actions]
     assert loop.trace == [a["name"] for a in actions]
@@ -92,9 +102,7 @@ async def test_error_call_does_not_short_circuit(tmp_path):
     """Tier 2: an error result mid-round does NOT stop the rest — every call still runs
     (dispatch_tool normalizes errors, never raises), same as before."""
     loop = _loop()
-    results = await loop.dispatch(
-        [{"name": "write", "args": {}}, {"name": "boom", "args": {}}, {"name": "read", "args": {}}]
-    )
+    results = await loop.dispatch([_action("write"), _action("boom"), _action("read")])
     assert [r["status"] for r in results] == ["ok", "error", "ok"]
     assert results[2]["saw_write"] is True, "the call after the error still ran (no short-circuit)"
     assert loop.trace == ["write", "boom", "read"]
@@ -160,7 +168,7 @@ async def test_audit_event_order_is_declaration_order_contiguous(tmp_path):
     deterministic and tool-call-boundary-clean. RED under gather (interleaved), GREEN under serial.
     Drives the real dispatch_tool → real EventLog emission (no stub)."""
     loop = _RealEventDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
-    await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
+    await loop.dispatch([_action("write"), _action("read")])
     await settle(loop.event_log)
 
     assert _tool_event_seq(loop.event_log_collected) == [
@@ -180,7 +188,7 @@ async def test_replay_reproduces_declaration_order(tmp_path):
     test drives the real audit-log replay, not a WAL rewind. Serial's contiguity means the pre-cut
     prefix replays exactly the COMPLETED first call (no half-executed call straddling the cut)."""
     loop = _RealEventDispatchLoop(host=FakeRouterHost(), chain_id="chain-2344", max_iterations=5)
-    await loop.dispatch([{"name": "write", "args": {}}, {"name": "read", "args": {}}])
+    await loop.dispatch([_action("write"), _action("read")])
     await settle(loop.event_log)
 
     # replay = iterate the real EventLog in append order (P6 replay semantics for the audit log).

--- a/tests/core/test_serial_tool_dispatch_2344.py
+++ b/tests/core/test_serial_tool_dispatch_2344.py
@@ -43,6 +43,7 @@ class _OrderedDispatchLoop(RouterLoop):
     async def _dispatch_resolved(
         self, name: str, args: dict, *,
         raw_name: "str | None" = None, call_id: "str | None" = None,
+        tool_call_id: "str | None" = None,
     ) -> dict:
         if name == "write":
             await asyncio.sleep(0)  # yield: under gather the reader runs here, before the write lands
@@ -121,6 +122,7 @@ class _RealEventDispatchLoop(RouterLoop):
     async def _dispatch_resolved(
         self, name: str, args: dict, *,
         raw_name: "str | None" = None, call_id: "str | None" = None,
+        tool_call_id: "str | None" = None,
     ) -> dict:
         async def _invoker(a: dict):
             if name == "write":
@@ -133,6 +135,7 @@ class _RealEventDispatchLoop(RouterLoop):
             caller_kind="router", caller_id=self.host.agent_name,
             chain_id=self.chain_id, tool_catalog={name: {}}, events=self.event_log,
             contextual=None,  # #5841: no narrowing in play for these tests
+            call_id=call_id, tool_call_id=tool_call_id,
         )
         return await dispatch_tool(name=name, args=args, ctx=dctx, invoker=_invoker)
 

--- a/tests/runtime/test_3378_advertise_enforce_agreement.py
+++ b/tests/runtime/test_3378_advertise_enforce_agreement.py
@@ -104,7 +104,13 @@ def _advertised_names(*, contextual) -> "list[str]":
 
 def _call(loop: RouterLoop, name: str, args: dict) -> dict:
     return asyncio.run(
-        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+        loop._execute_tool({
+            # #5891 (c) architect ruling: _execute_tool now subscripts
+            # tc["id"] directly (no .get() degrade) -- production always
+            # populates it, so this fixture must too.
+            "id": f"tc_{name}",
+            "function": {"name": name, "arguments": json.dumps(args)},
+        })
     )
 
 

--- a/tests/runtime/test_5654_tasks_wiring.py
+++ b/tests/runtime/test_5654_tasks_wiring.py
@@ -102,6 +102,10 @@ async def _dispatch(name: str, args: dict, session) -> dict:
         # own local reproduction of slash/tasks.py's _dispatch needs it
         # too. No narrowing in play for these tests → None (⊤).
         contextual=None,
+        # #5891 (c): DispatchContext.tool_call_id is now REQUIRED (no
+        # default) -- None is /tasks' own declared absence, mirroring
+        # slash/tasks.py's own production DispatchContext construction.
+        tool_call_id=None,
     )
 
     async def _invoker(call_args: dict) -> "object":

--- a/tests/runtime/test_5891_tool_call_id_history_join.py
+++ b/tests/runtime/test_5891_tool_call_id_history_join.py
@@ -185,7 +185,10 @@ async def test_a_caller_with_no_tool_call_id_still_produces_a_valid_history_row(
         caller_kind="operator", caller_id=session.agent_name, chain_id=None,
         tool_catalog={"mcp": {"function": {"name": "mcp"}}},
         events=session.router_host.events, contextual=None,
-        # tool_call_id deliberately omitted -- an /exec-shaped caller.
+        # tool_call_id is a REQUIRED field (#5891 (c), no default) --
+        # None here is this /exec-shaped caller's own DECLARED absence,
+        # never an accidental omission.
+        tool_call_id=None,
     )
     result = await dispatch_tool(name="mcp", args={}, ctx=ctx, invoker=_invoker)
     result.setdefault("_canonical_source", "mcp")
@@ -193,7 +196,10 @@ async def test_a_caller_with_no_tool_call_id_still_produces_a_valid_history_row(
     await settle(session)
     (returned,) = [e for e in collected if e.type == "tool_returned"]
     assert returned.data["tool_call_id"] is None
-    assert returned.data["tool_call_id_absent_reason"] == "operator"
+    assert "tool_call_id_absent_reason" not in returned.data, (
+        "no reason field exists any more -- the required-field contract "
+        "makes one unnecessary (architect's second correction)"
+    )
 
     from reyn.tools.scheme import ExecutionResult
 

--- a/tests/runtime/test_5891_tool_call_id_history_join.py
+++ b/tests/runtime/test_5891_tool_call_id_history_join.py
@@ -1,0 +1,256 @@
+"""Tier 2: #5891 (c) — the real join, through BOTH production halves.
+
+Architect's own correction of the original #5891 design ("a reader can
+JOIN `tool_returned` to its history row on data both sides already
+have"): that premise was false — `call_id` identifies a whole litellm
+ROUND (shared by every `tool_calls` entry in it), while a history row's
+own `tool_call_id` (`ChatMessage.tool_call_id` = `tc["id"]`) is per-call,
+so the SAME tool called twice in one round produces two history rows a
+`call_id`-only join cannot tell apart. `DispatchContext.tool_call_id`
+(`tests/core/test_5891_tool_call_id_audit_field.py` pins this half in
+isolation) is meant to close that gap — THIS file proves it actually
+does, end to end: two real `dispatch_tool` calls (the SAME tool, one
+round, two different `tc["id"]`s) each emit a `tool_returned` event via
+the REAL `Session`'s own `EventLog` (`collect_events`, the production
+subscriber mechanism, #3868/#5467 — never a read-back of history, never
+a hand-rolled sink), and the SAME two `tc` dicts drive a REAL
+`RouterLoop.feedback()` + `persist_feedback()` call, the exact production
+tool-row write path #5896 stage ① built. Every `tool_returned.
+tool_call_id` names exactly one history row, and that row already has a
+real `content_ref` — the join `#5891 (c)` promises, demonstrated rather
+than argued.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config import MultimodalConfig
+from reyn.config.chat import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.core.dispatch import DispatchContext, dispatch_tool
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import CONTENT_REF_META_KEY
+from reyn.runtime.router_loop import RouterLoop
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events, settle
+
+_MODEL = "gpt-4o"
+_BODY_1 = "\n".join(f"line {i}: " + "x" * 60 for i in range(3000))
+_BODY_2 = "\n".join(f"line {i}: " + "z" * 60 for i in range(3000))
+
+
+def _session(agent_name: str, tmp_path: Path):
+    return make_session(
+        agent_name=agent_name,
+        multimodal_config=MultimodalConfig(),
+        state_log=StateLog(tmp_path / f"{agent_name}.wal"),
+        snapshot_path=tmp_path / f"{agent_name}.snap.json",
+        safety=SafetyConfig(loop=LoopConfig(), on_limit=OnLimitConfig(mode="unattended")),
+    )
+
+
+def _mcp_content(body: str) -> dict:
+    """Same shape a real MCP tool handler returns -- the `dispatch_tool`
+    invoker's own return value, wrapped by `dispatch_tool` itself into
+    `{"status": "ok", "data": <this>}` (matching
+    `test_5896_history_content_ref.py`'s own `_mcp_env` shape, minus the
+    outer wrap this test lets `dispatch_tool` perform for real instead of
+    hand-building it)."""
+    return {"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
+            "content": body, "media_blocks": []}
+
+
+@pytest.mark.asyncio
+async def test_two_tool_returned_events_join_1to1_to_two_history_rows_with_content_refs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: LOAD-BEARING — #5891 (c)'s own acceptance, items ① and ②.
+    Same tool ("mcp"), one round (`call_id="round_1"`), two calls
+    (`tc["id"]` = "call_1"/"call_2") -- the exact shape `call_id` alone
+    cannot disambiguate. Drives real `dispatch_tool` for the audit half
+    and real `RouterLoop.feedback`/`persist_feedback` for the history
+    half, using the SAME two `tc` dicts for both, then joins purely on
+    `tool_call_id` -- never on `call_id`, order, or content sniffing.
+
+    strip: dropping `tool_call_id=ctx.tool_call_id` from dispatcher.py's
+    `tool_returned` emit turns the join assertion red (no `tool_call_id`
+    key to join on at all)."""
+    monkeypatch.chdir(tmp_path)
+    session = _session("join-agent", tmp_path)
+    collected = collect_events(session)
+
+    tc1 = {"id": "call_1", "type": "function", "function": {"name": "mcp", "arguments": "{}"}}
+    tc2 = {"id": "call_2", "type": "function", "function": {"name": "mcp", "arguments": "{}"}}
+
+    async def _invoker_1(args: dict) -> dict:
+        return _mcp_content(_BODY_1)
+
+    async def _invoker_2(args: dict) -> dict:
+        return _mcp_content(_BODY_2)
+
+    def _ctx(tool_call_id: str) -> DispatchContext:
+        return DispatchContext(
+            caller_kind="router",
+            caller_id=session.agent_name,
+            chain_id="c1",
+            tool_catalog={"mcp": {"function": {"name": "mcp"}}},
+            events=session.router_host.events,
+            contextual=None,
+            call_id="round_1",
+            tool_call_id=tool_call_id,
+        )
+
+    result1 = await dispatch_tool(name="mcp", args={}, ctx=_ctx("call_1"), invoker=_invoker_1)
+    result2 = await dispatch_tool(name="mcp", args={}, ctx=_ctx("call_2"), invoker=_invoker_2)
+    # #5865/_dispatch_resolved's own tail tags the invoked identity so
+    # feedback()'s canonicalizer knows what was called -- done manually
+    # here since this test calls dispatch_tool directly, bypassing
+    # _dispatch_resolved's own plumbing.
+    result1.setdefault("_canonical_source", "mcp")
+    result2.setdefault("_canonical_source", "mcp")
+
+    await settle(session)
+    _first_event, _second_event = (  # exactly 2, or unpacking itself raises
+        e for e in collected if e.type == "tool_returned"
+    )
+    tool_returned = [_first_event, _second_event]
+    audit_ids = {e.data["tool_call_id"] for e in tool_returned}
+    assert audit_ids == {"call_1", "call_2"}, (
+        f"both events must carry their OWN, distinct tool_call_id, got {audit_ids!r}"
+    )
+    assert {e.data["call_id"] for e in tool_returned} == {"round_1"}, (
+        "both really do share one round's call_id -- the precondition "
+        "that makes tool_call_id necessary in the first place"
+    )
+
+    from reyn.tools.scheme import ExecutionResult
+
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    loop.feedback(ExecutionResult(
+        tool_calls=[tc1, tc2], tool_results=[result1, result2], assistant_content="",
+    ))
+    await loop.persist_feedback()
+
+    _first_row, _second_row = (  # exactly 2, or unpacking itself raises
+        m for m in session.history if m.role == "tool"
+    )
+    tool_rows = [_first_row, _second_row]
+    history_ids = {row.tool_call_id for row in tool_rows}
+    assert history_ids == audit_ids, (
+        "the audit events and the history rows must name the SAME set of "
+        "tool_call_ids -- the join key must not drift between the two halves"
+    )
+
+    # The join itself: each audit event's tool_call_id resolves to exactly
+    # one history row, and that row already carries a real content_ref
+    # (#5896 stage ①) -- the #5891 (c) promise, not merely both sides
+    # independently having SOME id.
+    rows_by_id = {row.tool_call_id: row for row in tool_rows}
+    bodies_by_id = {"call_1": _BODY_1, "call_2": _BODY_2}
+    for event in tool_returned:
+        tool_call_id = event.data["tool_call_id"]
+        row = rows_by_id[tool_call_id]
+        ref = row.meta.get(CONTENT_REF_META_KEY)
+        assert ref, f"history row for {tool_call_id!r} has no content_ref, meta={row.meta!r}"
+        body_file = tmp_path / ref
+        assert body_file.is_file()
+        assert body_file.read_text(encoding="utf-8") == bodies_by_id[tool_call_id], (
+            f"the file the JOIN reaches for {tool_call_id!r} must be the "
+            "SAME call's own body, not the other call's"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_caller_with_no_tool_call_id_still_produces_a_valid_history_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: accept-side control -- a dispatch with NO `tool_call_id`
+    (e.g. a CodeAct `tool()` call, modeled here by simply not threading
+    one through) must not break the history side at all; the absence is
+    an audit-event-only distinction (`RouterLoop.feedback`'s own history
+    row always carries `tc["id"]` regardless of what the audit event
+    recorded, since feedback() reads the `tc` dict directly, not the
+    audit trail)."""
+    monkeypatch.chdir(tmp_path)
+    session = _session("no-id-agent", tmp_path)
+    collected = collect_events(session)
+
+    tc = {"id": "call_only", "type": "function", "function": {"name": "mcp", "arguments": "{}"}}
+
+    async def _invoker(args: dict) -> dict:
+        return _mcp_content(_BODY_1)
+
+    ctx = DispatchContext(
+        caller_kind="operator", caller_id=session.agent_name, chain_id=None,
+        tool_catalog={"mcp": {"function": {"name": "mcp"}}},
+        events=session.router_host.events, contextual=None,
+        # tool_call_id deliberately omitted -- an /exec-shaped caller.
+    )
+    result = await dispatch_tool(name="mcp", args={}, ctx=ctx, invoker=_invoker)
+    result.setdefault("_canonical_source", "mcp")
+
+    await settle(session)
+    (returned,) = [e for e in collected if e.type == "tool_returned"]
+    assert returned.data["tool_call_id"] is None
+    assert returned.data["tool_call_id_absent_reason"] == "operator"
+
+    from reyn.tools.scheme import ExecutionResult
+
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    loop.feedback(ExecutionResult(tool_calls=[tc], tool_results=[result], assistant_content=""))
+    await loop.persist_feedback()
+
+    (row,) = [m for m in session.history if m.role == "tool"]
+    assert row.tool_call_id == "call_only", (
+        "the history row's own tool_call_id comes from tc['id'] directly "
+        "-- the audit event's absence does not propagate to it"
+    )
+    assert row.meta.get(CONTENT_REF_META_KEY)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_seam_threads_tcs_own_id_through_to_the_audit_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: LOAD-BEARING — the ACTUAL production wiring
+    (`RouterLoop._execute_tool` -> `_dispatch_resolved` ->
+    `DispatchContext(tool_call_id=...)`), not a hand-built
+    `DispatchContext` the way the tests above construct one directly.
+    Uses `_execute_tool`, the documented test-only seam for exactly this
+    (no production call site duplicates it, per that method's own
+    docstring), with `self._catalog` populated and `_invoke_router_tool`
+    overridden on the instance -- the two things a real `run()` turn
+    would otherwise populate via an LLM call this test has no need to
+    drive.
+
+    strip: remove `tool_call_id=tc.get("id")` from `_execute_tool`'s own
+    `_dispatch_resolved(...)` call -- the emitted event's `tool_call_id`
+    reverts to `None` even though `tc["id"]` was real, the exact
+    "wiring silently dropped between two correct halves" shape a
+    hand-built-context test can never catch."""
+    monkeypatch.chdir(tmp_path)
+    session = _session("wiring-agent", tmp_path)
+    collected = collect_events(session)
+
+    loop = RouterLoop(host=session.router_host, chain_id="c1", router_model=_MODEL)
+    loop._catalog = {"echo": {"function": {"name": "echo"}}}
+
+    async def _stub_invoker(name: str, args: dict) -> dict:
+        return {"echoed": args}
+
+    monkeypatch.setattr(loop, "_invoke_router_tool", _stub_invoker)
+
+    tc = {"id": "call_from_tc", "type": "function", "function": {"name": "echo", "arguments": "{}"}}
+    result = await loop._execute_tool(tc, call_id="round_x")
+    assert result["status"] == "ok"
+    assert result["data"] == {"echoed": {}}
+
+    await settle(session)
+    (returned,) = [e for e in collected if e.type == "tool_returned"]
+    assert returned.data["tool_call_id"] == "call_from_tc", (
+        "the id must reach the audit event via the REAL _execute_tool -> "
+        "_dispatch_resolved -> DispatchContext chain, not merely be "
+        "constructible by hand"
+    )
+    assert returned.data["call_id"] == "round_x"

--- a/tests/runtime/test_exclude_execution_block_1406.py
+++ b/tests/runtime/test_exclude_execution_block_1406.py
@@ -42,7 +42,13 @@ class _MiniHost:
 
 def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
     return asyncio.run(
-        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+        loop._execute_tool({
+            # #5891 (c) architect ruling: _execute_tool now subscripts
+            # tc["id"] directly (no .get() degrade) -- production always
+            # populates it, so this fixture must too.
+            "id": f"tc_{name}",
+            "function": {"name": name, "arguments": json.dumps(args)},
+        })
     )
 
 

--- a/tests/runtime/test_list_mcp_servers_canonical_shape.py
+++ b/tests/runtime/test_list_mcp_servers_canonical_shape.py
@@ -82,6 +82,7 @@ def test_end_to_end_list_mcp_servers_matches_conversation_and_llm_text(tmp_path)
         # EventLog (production wiring) — out of scope, same reason as above.
         tool_catalog=catalog, events=session._audit_events,
         contextual=None,  # #5841: no narrowing in play for this test
+        tool_call_id=None,  # #5891 (c): required field, this test doesn't need one
     )
 
     async def _dispatch():

--- a/tests/runtime/test_phase_contextual_gate_1912.py
+++ b/tests/runtime/test_phase_contextual_gate_1912.py
@@ -48,7 +48,13 @@ class _Host:
 
 def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
     return asyncio.run(
-        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+        loop._execute_tool({
+            # #5891 (c) architect ruling: _execute_tool now subscripts
+            # tc["id"] directly (no .get() degrade) -- production always
+            # populates it, so this fixture must too.
+            "id": f"tc_{name}",
+            "function": {"name": name, "arguments": json.dumps(args)},
+        })
     )
 
 

--- a/tests/runtime/test_topology_profile_binding_e2e_1827.py
+++ b/tests/runtime/test_topology_profile_binding_e2e_1827.py
@@ -59,7 +59,13 @@ class _Host:
 
 def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
     return asyncio.run(
-        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+        loop._execute_tool({
+            # #5891 (c) architect ruling: _execute_tool now subscripts
+            # tc["id"] directly (no .get() degrade) -- production always
+            # populates it, so this fixture must too.
+            "id": f"tc_{name}",
+            "function": {"name": name, "arguments": json.dumps(args)},
+        })
     )
 
 

--- a/tests/security/test_contextual_permission_1827.py
+++ b/tests/security/test_contextual_permission_1827.py
@@ -222,7 +222,13 @@ class _MiniHost:
 
 def _exec(loop: RouterLoop, name: str, args: dict) -> dict:
     return asyncio.run(
-        loop._execute_tool({"function": {"name": name, "arguments": json.dumps(args)}})
+        loop._execute_tool({
+            # #5891 (c) architect ruling: _execute_tool now subscripts
+            # tc["id"] directly (no .get() degrade) -- production always
+            # populates it, so this fixture must too.
+            "id": f"tc_{name}",
+            "function": {"name": name, "arguments": json.dumps(args)},
+        })
     )
 
 


### PR DESCRIPTION
**[tui-coder]** — #5891 (c): architect's corrected ruling. `tool_returned` now carries `tool_call_id` — the actual join key `call_id` cannot be.

## Why (architect's own correction)

The original #5891 design ("a reader can JOIN `tool_returned` to its history row on data both sides already have, no new field needed") rested on a false premise, caught before implementation: `call_id` identifies a whole litellm **ROUND** (shared by every `tool_calls` entry in it); a history row's own `tool_call_id` (`tc["id"]`) is **per-call**. The same tool called twice in one round produces two history rows a `call_id`-only join cannot disambiguate.

## What

- `DispatchContext.tool_call_id: str | None = None` — the same `tc["id"]` `RouterLoop.feedback` already writes onto its own history row.
- `dispatch_tool`'s `tool_returned` emit always carries `tool_call_id` (`None` for a caller with no real litellm `tool_calls` entry — CodeAct `tool()`, `/exec`/`/tasks` slash, a pipeline `tool:` step). `tool_call_id_absent_reason` (naming `caller_kind`) is added ONLY in that `None` case — never silently omitted, so "the caller doesn't have one" never reads as "it was forgotten" (same discipline `content_ref_unavailable` already uses one layer down, #5936).
- Wired through both real `router_loop.py` dispatch call sites plus the documented `_execute_tool` test seam.
- `docs/reference/runtime/events.md`'s `tool_returned` row updated for this AND #5936's own previously-undocumented fields.

No new audit-event kind (untouched `event_schema.py`), no new storage (no new `save_tool_result` call site).

## Tests

- `tests/core/test_5891_tool_call_id_audit_field.py` — dispatcher-level: presence, distinctness across 2 calls in 1 round, absence+reason for both `router` and `operator` callers.
- `tests/runtime/test_5891_tool_call_id_history_join.py` — end to end: 2 real `dispatch_tool` calls + `RouterLoop.feedback`/`persist_feedback`, real `Session`/`EventLog` (`collect_events`), proving each `tool_returned.tool_call_id` names exactly one history row with a real `content_ref`; plus a dedicated test driving the ACTUAL `_execute_tool` → `_dispatch_resolved` wiring, not just a hand-built `DispatchContext`.

**Regression caught and fixed while testing**: `_run_action_batch`'s `a["tc"].get("id")` KeyError'd against `test_serial_tool_dispatch_2344.py`'s hand-built action dicts (no `"tc"` key) — changed to `a.get("tc", {}).get("id")` (same defaulting posture `raw_name` already uses) and updated that file's two `_dispatch_resolved` test-double overrides to accept the new kwarg.

## Strip-verification (in-file Edit → Edit-back, no `git stash`/`checkout`)

- Removed `tool_call_id=ctx.tool_call_id` from dispatcher.py's emit → all 7 new tests fail with `KeyError`, no unrelated failures. Restored.
- Removed `tool_call_id=tc.get("id")` from `_execute_tool`'s own `_dispatch_resolved` call → only the wiring-specific test goes red (proving it actually exercises the router_loop.py plumbing, not just dispatcher.py). Restored.

## Gates (all green)

ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py`. Scoped pytest: 47 passed.

## Test plan

- [x] Scoped pytest green (47 passed)
- [x] All pre-PR + path-conditional gates green (listed above)
- [x] (skipped — Visual, standing waiver)

Closes #5891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
