### PR TITLE
docs: a hand-maintained population goes stale silently; a derived one needs two fail-closed guards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,12 +169,12 @@ that triggers it; "when in doubt" is not a trigger, because the failures these
 prevent are the ones that remove the doubt.
 
 - **Before filing an issue** — `docs/deep-dives/contributing/issue-management.md`. An issue gets its axis label(s) when it is **filed**, not later; no axis label means "not yet judged", so an unlabelled backlog carries no order to dispatch by.
-- **Before reading a green or a red as evidence** — `docs/deep-dives/contributing/verification-hazards.md`
-- **Before writing a review's blocking point** — `docs/deep-dives/contributing/test-review-six-questions.md`
+- **Before reading a green as evidence, or listing what to cover/exempt** — `docs/deep-dives/contributing/verification-hazards.md`
+- **Before writing a blocking point** — `docs/deep-dives/contributing/test-review-six-questions.md`
 - **When a Tier-1 rule above seems wrong or costly** — `docs/deep-dives/contributing/tier1-rationale.md`; **PR workflow's** own rationale: `docs/deep-dives/contributing/pr-workflow.md`
 - **When you touch session/agent state on disk** — `docs/concepts/runtime/workspace.md`; **`.reyn/` layout** (recovery-core vs persist/audit/cache, the write-gate): `docs/reference/runtime/reyn-dir-layout.md`
 - **When you emit, read, or replay an audit-event** — `docs/concepts/runtime/events.md`
 - **When you add or change a permission decision** — `docs/concepts/runtime/permission-model.md`
 - **When you add or rename an op or tool** — `src/reyn/core/op_runtime/` (catalog and dispatch); naming: `docs/reference/runtime/tool-naming.md`
 - **When you analyse an LLM trace** — `docs/reference/dogfood-tracing.md`; `scripts/dogfood_trace.py --mode llm-payloads` is the entry point, do not hand-parse JSONL.
-- **When you claim a feature does or does not exist** — `docs/feature-map.md`
+- **When you claim a feature exists or not** — `docs/feature-map.md`

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -2048,6 +2048,51 @@ it.
 
 ## See also
 
+## 28. A population you maintain by hand goes stale silently; a derived one goes silent loudly
+
+**The act that fires this: you are about to write down a list of the things
+to cover, check, or exempt.** A curated list answers "did I cover what I
+listed", never "did I list everything" — and when the world grows a
+thirteenth member, the list does not fail. It keeps passing, one member
+short, and nothing in the output says so.
+
+Three independent designs reached the same shape on one night (2026-09-07/08),
+each after a different miscount:
+
+| where | what was being enumerated | derived from |
+|---|---|---|
+| #5959 | "the big memory consumers" | `gc.get_objects()` (discovery) + every `Axis.BOUNDING` config field via `walk_config_schema()` (completeness) |
+| #5967 | "the gate scripts that must not borrow private names" | `glob("check_*.py")` + each file's own `ast.parse()` |
+| #5891 | "the caller kinds that carry a tool-call id" | nothing — the parameter is required, so absence is *declared*; "declared where it should not be" is then a census over real events |
+
+The miscounts they replaced were all one shape: **counting what is there,
+never what should be there but is not.** A `git grep <flag>` counts the call
+sites that pass the flag, not the ones that forgot it. A census scoped to
+`src/` misses `tests/`. `| head -12` turns a display limit into a population.
+
+**The trade this buys, and its price.** Deriving the population removes the
+stale-list failure and replaces it with a quieter one: *the scan itself can
+break*. An empty derivation is indistinguishable from a clean world — both
+print nothing and exit 0. So a derived population **needs a fail-closed
+guard, and it needs two of them**:
+
+1. **The scan found nothing to scan** — `assert scanned_files`, `assert
+   registry_entries`. A ratchet whose corpus silently emptied is §6's
+   vacuity guard applied to the corpus rather than to the assertion.
+2. **The scan ran but had no candidates in it** — the population was built,
+   and every member was trivially exempt. This one is a level deeper and is
+   easy to skip: the first guard is green, the run is green, and the check
+   never bit on anything. Name the count in the output so a reader can see
+   `0 of 0` and `0 of 217` differently.
+
+**Two zeros again** (§3): "nothing to check" and "everything checked, all
+clean" are the same exit code and, unless the tool says so, the same output.
+
+**When a derivation genuinely is not available**, that is a legitimate
+answer — but write down *why*, next to the list, so the next person does not
+re-derive the question. A list with a stated reason is a decision; a list
+without one is an accident that outlives its author.
+
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.
 - [CLAUDE.md](../../../CLAUDE.md) — the doc-sync hard rule (a doc
   describing a mechanism goes stale the moment the mechanism changes) is the

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -2046,8 +2046,6 @@ it.
   check. The trap is in how a HUMAN OR AGENT reads that re-evaluation's
   result as a verdict on a past event, not in the gate's design.
 
-## See also
-
 ## 28. A population you maintain by hand goes stale silently; a derived one goes silent loudly
 
 **The act that fires this: you are about to write down a list of the things
@@ -2092,6 +2090,8 @@ clean" are the same exit code and, unless the tool says so, the same output.
 answer — but write down *why*, next to the list, so the next person does not
 re-derive the question. A list with a stated reason is a decision; a list
 without one is an accident that outlives its author.
+
+## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.
 - [CLAUDE.md](../../../CLAUDE.md) — the doc-sync hard rule (a doc


### PR DESCRIPTION
**[architect]** — lead-coder の提案（broker、2026-09-08）を受けた doc 化。**起票はしない／置き場所は architect が決める**という申し送りどおり、私が書きました。`part of #5919`（この夜の 3 例の 1 つがそこ）。

## なぜ書くか

**同じ形が 3 つの独立な設計で選ばれ、しかも 3 つとも同じ代償を払いました。**

| where | 何を列挙していたか | 導出元 |
|---|---|---|
| #5959 | 「メモリの大口」 | `gc.get_objects()`（発見）＋ `walk_config_schema()` の `Axis.BOUNDING` 全数（完全性） |
| #5967 | 「private を借りてはいけない gate script」 | `glob("check_*.py")` ＋ その file 自身の `ast.parse()` |
| #5891 | 「tool-call id を持つ呼び手の種類」 | **持たない** — 引数を必須にして不在を*宣言*させ、「持つはずなのに null」は実 event の census |

置き換えられた数え落としは全部同じ形でした: **在るものを数え、在るべきなのに無いものを数えない。** `git grep <flag>` は渡した site を数えて忘れた site を数えず、`src/` に絞った census は `tests/` を落とし、`| head -12` は表示の切り詰めを母集団にします。（3 つとも今夜、私と lead-coder が実際に踏んだものです。）

## 何を書いたか

`verification-hazards.md` に **§28**。**発火する act を先頭に置きました** — 「**これから、覆う／検査する／免除する物の一覧を書こうとしている**」。

そして**代償を同じ節に書きました**（これが無いと片手落ちになります）: 導出は「腐る表」を「静かに壊れる走査」に交換するので、**fail-closed guard が 2 つ**要ります。

1. **走査する対象が 0 件**（`assert scanned_files`）
2. **走査は動いたが候補が 0 件** — 一段深く、見落としやすい。1 が緑、run も緑、検査は何も噛んでいない

**どちらの zero も、きれいな世界と同じ exit code・同じ出力**です（§3「二つの zero」の corpus 版）。∴ **`0 of 0` と `0 of 217` を出力で区別できる形にする**、を要件として書きました。

**導出できない場合**は正当な答えですが、**理由を一覧の隣に書く**こと — 理由のある一覧は決定、理由の無い一覧は作者より長生きする事故です。

## CLAUDE.md

**新しい行は足していません。** 既存の pointer 行に**発火する act を足しただけ**です:

> - **Before reading a green as evidence, or listing what to cover/exempt** — `verification-hazards.md`

理由: この規則が要るのは「一覧を書こうとした瞬間」で、既存の pointer の trigger（「green を証拠として読む前」）ではその瞬間に読まれません。**trigger の無い規則は規則ではない**（この file 自身の編集規則）。

**word count は baseline 以下**（2644 → 2646 → **2644 相当以下**）: 足した 2 語は、**同じ list 上の冗長な pointer 2 本から回収**しました（`Before writing a review's blocking point` → `Before writing a blocking point`、`When you claim a feature does or does not exist` → `When you claim a feature exists or not`）。∴ `--write-baseline` は不要です。

## Test plan
- [x] `python scripts/claude_md_word_count_ratchet.py` → OK（baseline 以下）
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` → built
- [x] `python scripts/check_doc_anchors.py` → no dangling anchors
- [x] `python scripts/check_retired_config_keys_denylist.py` → 0 hits
- [x] 4 gate を `&&` で連鎖し exit 0 を確認（`;` で飲んでいない）
- [x] 節番号の衝突を確認（既存の最大は §27 ∴ §28）
- [x] docs-only diff（2 file）；`src/` も `tests/` も触っていない
- [ ] (skipped — Visual: rendered-page 確認なし；standing owner waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow