### PR TITLE
feat(#5973 裁定4): separate ResidentBytes from BodyBytes as distinct types

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -12,6 +12,13 @@ from reyn.config_axis import Axis
 # that doesn't belong in the config-only module.
 from reyn.runtime.budget.budget import CostConfig, CostLimitConfig  # noqa: E402
 
+# #5973 裁定4: HistoryResidentConfig.max_bytes is the SAME currency
+# ChatMessage.resident_bytes() measures (both count a resident row's own
+# serialized size) -- importing the NewType from its one owning module
+# rather than redeclaring it here keeps that a fact the type system
+# states, not a naming convention two files have to keep in sync by hand.
+from reyn.runtime.chat_message import ResidentBytes  # noqa: E402
+
 
 @dataclass
 class LoopConfig:
@@ -549,8 +556,16 @@ class HistoryResidentConfig:
     costs nothing but memory an operator can already afford, while a too-small
     one would make ordinary scrollback/rewind pay for reloads more often than
     necessary.
+    #5973 裁定4: ``ResidentBytes``, not a bare ``int`` — this cap and
+    ``ChatMessage.resident_bytes()`` (the value it is compared against,
+    ``session.py``'s own eviction loop) must stay the SAME currency by
+    construction; see that NewType's own module docstring in
+    ``runtime/chat_message.py`` for why the two counts drifted apart in
+    the first place.
     """
-    max_bytes: int = field(default=256 * 1024 * 1024, metadata={"axis": Axis.BOUNDING})  # 256 MiB
+    max_bytes: ResidentBytes = field(
+        default=ResidentBytes(256 * 1024 * 1024), metadata={"axis": Axis.BOUNDING},
+    )  # 256 MiB
 
 
 def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
@@ -570,7 +585,7 @@ def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
             max_bytes = defaults.max_bytes
     except (TypeError, ValueError):
         max_bytes = defaults.max_bytes
-    return HistoryResidentConfig(max_bytes=max_bytes)
+    return HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes))
 
 
 @dataclass

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -25,7 +25,36 @@ import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Literal, NewType
+
+#: #5973 裁定 4 (architect, precursor to that issue's ①②③): two byte
+#: counts this codebase measures are DIFFERENT resources that #5896's
+#: migration (inline body -> content_ref) let drift apart while both
+#: stayed a bare `int` -- nothing distinguished "how many bytes THIS ROW
+#: occupies while resident" from "how many bytes the BODY that row's ref
+#: points at is". `history_resident.max_bytes` (config/chat.py) counts
+#: the former (`ChatMessage.resident_bytes()`, this file); the file a
+#: `content_ref` names is the latter (`CONTENT_BYTES_META_KEY` below).
+#: Before #5896 a resident row WAS its body, so the two counts were the
+#: SAME number and nothing separated them; after #5896 a resident ref
+#: row can be ~400 bytes while the body it points at is hundreds of MB
+#: -- #5973's own root cause is exactly this: a bound written when the
+#: two currencies coincided kept counting the wrong one once they split.
+#:
+#: `NewType` is a STATIC-ONLY distinction (zero runtime cost, zero
+#: runtime enforcement -- both are still plain `int` at execution) that
+#: makes the TWO KINDS OF INT mypy-incompatible with each other: passing
+#: a `BodyBytes` value where a `ResidentBytes` is expected (or the
+#: reverse) is a real `[arg-type]` mypy finding, not merely a naming
+#: convention a reader has to remember to honor. This PR does that
+#: separation ONLY — no bound moves, no counting site changes what it
+#: measures, no behavior changes at all (see
+#: `tests/runtime/test_5973_resident_body_bytes_types.py` for the live
+#: mypy witness proving the distinction is enforced, and its own strip:
+#: reverting either `NewType` to a plain alias makes that witness's
+#: deliberately-wrong call type-check clean).
+ResidentBytes = NewType("ResidentBytes", int)
+BodyBytes = NewType("BodyBytes", int)
 
 
 class Spillability(StrEnum):
@@ -829,9 +858,9 @@ class ChatMessage:
         # it measures, drifting the computed size from what the pre-fix
         # `json.dumps(asdict(m))` call (still used verbatim as the
         # equivalence baseline in tests) would have produced.
-        self._resident_bytes_cache: "int | None" = None
+        self._resident_bytes_cache: "ResidentBytes | None" = None
 
-    def resident_bytes(self) -> int:
+    def resident_bytes(self) -> ResidentBytes:
         """This message's own serialized size in bytes — computed the
         FIRST time this is called, cached for the rest of this object's
         lifetime. Owner-hit incident (2026-09-07): ``Session.
@@ -875,9 +904,9 @@ class ChatMessage:
         across ``src/``, not just ``runtime/``) before trusting it
         again."""
         if self._resident_bytes_cache is None:
-            self._resident_bytes_cache = len(
+            self._resident_bytes_cache = ResidentBytes(len(
                 json.dumps(asdict(self), ensure_ascii=False).encode("utf-8"),
-            )
+            ))
         return self._resident_bytes_cache
 
     @property

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -4082,6 +4082,7 @@ class RouterLoop:
             TOOL_ERROR_MESSAGE_META_KEY,
             TOOL_STATUS_ERROR,
             TOOL_STATUS_META_KEY,
+            BodyBytes,
             LostReason,
         )
         for _result_seq, (tc, r) in enumerate(
@@ -4389,9 +4390,18 @@ class RouterLoop:
                     # no ref ever minted.
                     _write_unavailable = True
                 else:
+                    # #5973 裁定4: the body's own byte count is BodyBytes —
+                    # a DIFFERENT currency from ChatMessage.resident_bytes()
+                    # (this same row's serialized SIZE, ResidentBytes) even
+                    # though this ref row's own resident size stays tiny.
+                    # Computed here, not loaded from the type once stored:
+                    # `_tool_meta` is a plain `dict[str, Any]`, so the meta
+                    # KEY itself carries no static type -- this local is
+                    # where the distinction still holds.
+                    _body_bytes: BodyBytes = BodyBytes(len(_persist_body.encode("utf-8")))
                     _tool_meta[SPILLED_META_KEY] = False
                     _tool_meta[CONTENT_REF_META_KEY] = _block["path"]
-                    _tool_meta[CONTENT_BYTES_META_KEY] = len(_persist_body.encode("utf-8"))
+                    _tool_meta[CONTENT_BYTES_META_KEY] = _body_bytes
                     _tool_meta[CONTENT_MIME_META_KEY] = _block["mime_type"]
             # #5364 §1.5: an offload was ATTEMPTED and refused — content
             # stayed inline (never a ref to a file that doesn't exist), but

--- a/tests/runtime/test_4387_history_resident_eviction.py
+++ b/tests/runtime/test_4387_history_resident_eviction.py
@@ -35,7 +35,10 @@ from reyn.config.chat import HistoryResidentConfig
 from reyn.core.events.snapshot_generations import GLOBAL_SCOPE, REWIND_KIND, checkout
 from reyn.core.events.state_log import StateLog
 from reyn.mcp.server import _history_baseline_seq, _new_agent_history_entries
-from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.chat_message import (
+    ChatMessage,
+    ResidentBytes,  # #5973 (c)4
+)
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 
@@ -46,7 +49,7 @@ def _session(
     return make_session(
         agent_name="hist-evict-test", state_log=state_log,
         snapshot_path=tmp_path / "snap.json",
-        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+        history_resident_config=HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes)),
     )
 
 

--- a/tests/runtime/test_4468_narrowing_survives_eviction.py
+++ b/tests/runtime/test_4468_narrowing_survives_eviction.py
@@ -32,7 +32,10 @@ from pathlib import Path
 
 from reyn.config.chat import HistoryResidentConfig
 from reyn.core.events.state_log import StateLog
-from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.chat_message import (
+    ChatMessage,
+    ResidentBytes,  # #5973 (c)4
+)
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 from tests._support.untrusted_narrowing import narrowing_on
@@ -44,7 +47,7 @@ def _session(tmp_path: Path, *, max_bytes: int) -> Session:
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
         safety=narrowing_on(),
-        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+        history_resident_config=HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes)),
     )
 
 

--- a/tests/runtime/test_4470_compaction_gap_does_not_clear_narrowing.py
+++ b/tests/runtime/test_4470_compaction_gap_does_not_clear_narrowing.py
@@ -72,7 +72,10 @@ from reyn.config import CompactionConfig
 from reyn.config.chat import HistoryResidentConfig
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.chat_message import (
+    ChatMessage,
+    ResidentBytes,  # #5973 (c)4
+)
 from reyn.runtime.session import Session
 from tests._support.agent_session import make_session
 from tests._support.untrusted_narrowing import narrowing_on
@@ -125,7 +128,7 @@ def _make_session(tmp_path, monkeypatch, *, max_bytes: int) -> Session:
         ),
         snapshot_path=tmp_path / ".reyn" / "agents" / "default" / "state" / "snapshot.json",
         safety=narrowing_on(),
-        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+        history_resident_config=HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes)),
     )
 
 

--- a/tests/runtime/test_5896_p0_resident_bytes_cache.py
+++ b/tests/runtime/test_5896_p0_resident_bytes_cache.py
@@ -39,7 +39,10 @@ import pytest
 from reyn.config.chat import HistoryResidentConfig
 from reyn.core.events.state_log import StateLog
 from reyn.runtime import chat_message as chat_message_module
-from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.chat_message import (
+    ChatMessage,
+    ResidentBytes,  # #5973 (c)4
+)
 from tests._support.agent_session import make_session
 
 
@@ -149,7 +152,7 @@ def _session(tmp_path: Path, state_log: StateLog, *, max_bytes: int) -> "object"
     return make_session(
         agent_name="p0-resident-bytes-test", state_log=state_log,
         snapshot_path=tmp_path / "snap.json",
-        history_resident_config=HistoryResidentConfig(max_bytes=max_bytes),
+        history_resident_config=HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes)),
     )
 
 

--- a/tests/runtime/test_5973_resident_body_bytes_types.py
+++ b/tests/runtime/test_5973_resident_body_bytes_types.py
@@ -1,0 +1,113 @@
+"""Tier 1: `ResidentBytes` and `BodyBytes` are mypy-incompatible (#5973
+裁定4, precursor to that issue's ①②③) — passing one where the other is
+expected is a real type-checker finding, not merely a naming convention
+a reader has to remember to honor.
+
+## Why this PR exists (architect's own framing, quoted)
+
+#5973's root cause: "表現を『本体 inline』から『参照』へ変えると、それ
+まで 1 つだった『bytes』が 2 つの量に割れる — ⑴ 行そのものの常駐量と
+⑵ その行が引き寄せられる本体の量。既存の bound は全部 ⑴ を数え続け、
+痛いのは ⑵ になる." Both stayed a bare `int` throughout that migration,
+so nothing could have caught a caller that measured one and used it as
+the other. `ResidentBytes` (`ChatMessage.resident_bytes()`, a row's own
+serialized size) and `BodyBytes` (`CONTENT_BYTES_META_KEY`, the size of
+the body a `content_ref` row points AT) are the same two quantities,
+now given distinct `typing.NewType`s.
+
+**This PR moves ZERO bounds** — `history_resident.max_bytes` is still
+256 MiB, still counts the same thing it always counted (a row's
+serialized size). It only makes that thing's TYPE say what it is, so a
+future PR (#5973's own ①②③, building a "materialized BODY bytes"
+budget on top of this) cannot accidentally reuse the wrong count without
+mypy refusing to compile it.
+
+## Why this is tested via a REAL mypy subprocess, not a runtime assertion
+
+`typing.NewType` has ZERO runtime footprint — `ResidentBytes(5) == 5` is
+literally `True`, `isinstance(ResidentBytes(5), int)` is `True`, and no
+Python exception is ever raised for "wrong currency" at execution time;
+the entire guarantee lives in the type checker's own analysis. A pytest
+assertion cannot observe that guarantee — only mypy, actually invoked,
+can. This is the real collaborator here (CLAUDE.md's "never fake a
+collaborator" applied to a type checker: a hand-rolled AST scan
+pretending to be mypy would be exactly the fake this rule forbids)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_resident_bytes_and_body_bytes_are_mypy_incompatible(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
+    """Tier 1: LOAD-BEARING — the required witness (architect's own
+    acceptance for #5973's precursor PR): passing a `BodyBytes` value
+    where `ResidentBytes` is expected is a real mypy `[arg-type]`
+    finding; passing a genuine `ResidentBytes` value at the SAME call
+    shape is not.
+
+    strip: change either `NewType("...", int)` declaration in
+    `chat_message.py` to a plain type alias (`ResidentBytes = int`) —
+    the deliberately-wrong call below stops being flagged, and this
+    test goes red (`assert result.returncode != 0` fails)."""
+    probe = tmp_path / "probe_5973_resident_body_bytes.py"
+    probe.write_text(
+        textwrap.dedent("""\
+            from reyn.runtime.chat_message import BodyBytes, ResidentBytes
+
+
+            def _takes_resident(n: ResidentBytes) -> None:
+                pass
+
+
+            _wrong_currency: BodyBytes = BodyBytes(5)
+            _takes_resident(_wrong_currency)
+
+            _right_currency: ResidentBytes = ResidentBytes(5)
+            _takes_resident(_right_currency)
+        """),
+        encoding="utf-8",
+    )
+    # Line 9 (1-indexed) is the deliberately wrong call; line 12 is the
+    # correct one — asserted by position, never by re-deriving the file
+    # content, so a probe edit above cannot silently desync the numbers
+    # this test reads.
+    wrong_call_line = 9
+    right_call_line = 12
+
+    repo_root = Path(out_of_process_reyn).parent
+    env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "mypy",
+            "--cache-dir", str(tmp_path / ".mypy_cache"),
+            "--no-error-summary",
+            str(probe),
+        ],
+        capture_output=True, text=True, cwd=repo_root, env=env,
+    )
+
+    assert result.returncode != 0, (
+        "expected mypy to flag BodyBytes passed where ResidentBytes is "
+        f"required, got a clean exit.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    reported_lines = {
+        int(line.split(":", 2)[1])
+        for line in result.stdout.splitlines()
+        if line.startswith(str(probe)) and ": error:" in line
+    }
+    assert wrong_call_line in reported_lines, (
+        f"expected an error on the BodyBytes-where-ResidentBytes-expected "
+        f"line ({wrong_call_line}), got errors on {reported_lines!r} -- "
+        f"full output:\n{result.stdout}"
+    )
+    assert right_call_line not in reported_lines, (
+        f"the genuinely-correct ResidentBytes call (line {right_call_line}) "
+        f"must NOT be flagged -- got errors on {reported_lines!r}, "
+        f"full output:\n{result.stdout}"
+    )


### PR DESCRIPTION
**[tui-coder]** — #5973 裁定4: precursor PR separating `ResidentBytes` from `BodyBytes` as distinct types. **This PR moves zero bounds** — architect's own explicit constraint.

## Why this goes first (architect's ruling)

#5973's root cause: #5896's migration split ONE quantity ("a row's own byte count") into TWO — ⑴ how many bytes a resident row occupies, ⑵ how many bytes the body its `content_ref` points at is. Every existing bound kept counting the same bare `int`, blind to which currency it measured.

①②③ (the actual fix, e2e-coder) are **not** split across two people — they count the SAME resource in different places, and splitting the WORK would let two definitions drift apart, reproducing the exact class #5973 exists to close. The type separation goes first instead: once `body_bytes`/`resident_bytes` are distinct types, ①②③'s author cannot pass the wrong one without mypy refusing to compile it.

## What

- `ResidentBytes`/`BodyBytes`: `typing.NewType(..., int)` in `chat_message.py` (the file owning both concepts).
- `ChatMessage.resident_bytes() -> ResidentBytes` (was `-> int`).
- `HistoryResidentConfig.max_bytes: ResidentBytes` — **the 256 MiB default value is unchanged**, only its type.
- `router_loop.py`'s tool-result meta write: body byte count computed as an explicit `BodyBytes` local before storing (the dict itself stays `dict[str, Any]`).
- 4 existing tests constructing `HistoryResidentConfig(max_bytes=...)` with a bare int now wrap it in `ResidentBytes(...)`.

## The required witness (architect's own acceptance: passing `body_bytes` where `resident_bytes` is expected must be red)

`NewType` has zero runtime footprint, so the guarantee is only observable via a real mypy invocation. `tests/runtime/test_5973_resident_body_bytes_types.py` writes a probe module to `tmp_path` (a deliberately-wrong `BodyBytes`-where-`ResidentBytes`-expected call + a correct `ResidentBytes` call), runs the same mypy this repo's own `mypy_ratchet.py` uses, and asserts the wrong call is flagged (`[arg-type]`, exact line) while the correct one is not.

## Strip-verification (in-file Edit → Edit-back, no `git stash`/`checkout`)

Changed `ResidentBytes = NewType(...)` to a plain `ResidentBytes = int` alias → the probe's wrong call stops being flagged (mypy exits 0) → the witness test correctly goes red. Restored; `git diff --stat` confirmed clean.

## Gates (all green)

ruff, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py` (both changed-files **and** `--full` — confirmed clean under both, since a mismatch could otherwise be grandfathered under an existing same-file same-code baseline entry), `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`. Scoped pytest: 23 passed.

## Test plan

- [x] Scoped pytest green (23 passed)
- [x] All pre-PR + path-conditional gates green (listed above)
- [x] (skipped — Visual, standing waiver)

part of #5973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
