### PR TITLE
fix(#5973 2-d): estimate_tokens never hands litellm the whole text at once

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -107,6 +107,23 @@ _token_counter_fallback_warned: bool = False
 _TOKEN_COUNTER_COOLDOWN_SECONDS = 60.0
 _token_counter_cooldown_until: float = 0.0
 
+# #5973 2-d (owner-hit P0, architect's measured finding, issuecomment-
+# 5577627693): litellm.token_counter tokenizes via tiktoken internally and
+# returns len() of the list[int] it built — that transient list, not the
+# int estimate_tokens() actually returns, was the real driver of a 16 GB
+# peak this issue traces (measured ~32-35 bytes/int; a 597 MB / ~150M-token
+# body built a ~5 GB list in ONE call). Materialization itself measured
+# ~1x (Japanese BMP text even smaller, ~0.92x — no per-language multiplier
+# concern this constant needs to account for). Chunking the call bounds
+# that transient list to one chunk's own size, discarded (GC'd, nothing
+# holds a reference past the chunk's own `litellm.token_counter` call)
+# before the next chunk starts — see `_chunked_token_count`'s own
+# docstring for the accuracy trade-off this introduces. ~50k tokens/chunk
+# at a ~4 chars/token rule of thumb -> a ~1.6-1.75 MB transient list per
+# chunk, not a user-facing knob (an internal bound on litellm's own
+# tokenizer call shape, not a budget or a cap a caller ever chooses).
+_TOKENIZE_CHUNK_CHARS = 200_000
+
 # Process-lifetime cache: (model, text_hash) -> int. Keyed by a hash, not the
 # raw text, so an entry stays tiny regardless of the source message's length
 # (a long tool-output turn costs the same few bytes as a short one).
@@ -182,12 +199,63 @@ def _text_hash(text: str) -> str:
     return hashlib.md5(text.encode("utf-8", errors="replace"), usedforsecurity=False).hexdigest()
 
 
+def _chunked_token_count(litellm: Any, model: str, text: str) -> int:
+    """#5973 2-d: sum ``litellm.token_counter`` over fixed-size chunks of
+    *text* instead of one call on the whole thing.
+
+    ``litellm.token_counter`` tokenizes via tiktoken internally and returns
+    ``len()`` of the ``list[int]`` it built — that transient list is what
+    this function exists to bound, not what any caller here wants (they
+    all want the integer). Un-chunked, a 597 MB / ~150M-token tool-result
+    body built a ~5 GB transient list in ONE call (measured: ~32-35
+    bytes/token; architect, issuecomment-5577627693) — the actual driver
+    of a 16 GB resident peak this issue traces, not materializing the body
+    itself (measured ~1x, Japanese BMP text included at ~0.92x). Chunking
+    bounds the transient to one chunk's own list (~1.6-1.75 MB at
+    ``_TOKENIZE_CHUNK_CHARS``), which is discarded — nothing holds a
+    reference to it past this function's own ``litellm.token_counter``
+    call — before the next chunk starts.
+
+    Approximate, not exact, for a text this function actually chunks: a
+    BPE tokenizer can tokenize a span differently depending on what comes
+    right before/after it, so a token that would have straddled a chunk
+    boundary in one un-chunked call counts as two (or merges differently)
+    once the boundary falls inside it — a small, bounded over/under-count
+    at each of ``len(text) // _TOKENIZE_CHUNK_CHARS`` boundaries, not a
+    per-character or per-language drift. Every caller of
+    :func:`estimate_tokens` already treats its non-``use_chars4`` return as
+    a BUDGET estimate (head/tail/shortfall math throughout
+    ``compaction_controller.py``/``router_history_buffer.py``), never a
+    wire-exact count reproduced bit-for-bit against the provider's own
+    tokenizer — this trade-off changes no caller's contract.
+
+    A short *text* (the overwhelming majority of calls — most turns are
+    far under ``_TOKENIZE_CHUNK_CHARS``) makes exactly one
+    ``litellm.token_counter`` call, byte-identical to before this
+    function existed."""
+    if len(text) <= _TOKENIZE_CHUNK_CHARS:
+        return litellm.token_counter(model=model, text=text)
+    total = 0
+    for start in range(0, len(text), _TOKENIZE_CHUNK_CHARS):
+        chunk = text[start : start + _TOKENIZE_CHUNK_CHARS]
+        total += litellm.token_counter(model=model, text=chunk)
+    return total
+
+
 def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
     """Estimate tokens for a text string.
 
     Axis 10: uses litellm.token_counter by default; falls back to chars//4
     when litellm.token_counter itself raises (a genuine failure), and emits
     ``token_counter_fallback`` the first time that happens in this process.
+
+    #5973 2-d: the non-``use_chars4`` path never hands the WHOLE *text* to
+    litellm.token_counter in one call — :func:`_chunked_token_count` sums
+    it over fixed-size chunks, bounding the transient ``list[int]``
+    litellm's own tokenizer builds internally (see that function's own
+    docstring for the measured cause and the accuracy trade-off this
+    introduces for a text large enough to actually chunk). ``use_chars4=
+    True`` already never built that list at all — unaffected.
 
     ``count == 0`` (e.g. estimating an empty string) is a valid litellm
     result, not a failure, and does NOT trigger the fallback path (#2961).
@@ -232,7 +300,7 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
             # part of PR-1's diff).
             litellm = ensure_litellm_ready_or_defer()
             m = model or "gpt-3.5-turbo"
-            count = litellm.token_counter(model=m, text=text or "")
+            count = _chunked_token_count(litellm, m, text or "")
             # #2961: litellm.token_counter returns 0 (not an exception) for
             # an empty string — that is the correct answer, not a failure.
             # Only a raised exception (the `except` below) is a genuine

--- a/tests/llm/test_chat_compaction_engine_11axis.py
+++ b/tests/llm/test_chat_compaction_engine_11axis.py
@@ -592,6 +592,122 @@ def test_estimate_tokens_for_turn_chars4_opt_out_multimodal() -> None:
 
 
 # ---------------------------------------------------------------------------
+# #5973 2-d: estimate_tokens' exact-count path never hands litellm.
+# token_counter the WHOLE text in one call — it chunks, so the transient
+# list[int] litellm builds internally stays bounded per chunk instead of
+# scaling with the whole body (the measured driver of a 16 GB peak, not
+# materialization itself — architect, issuecomment-5577627693).
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTokenizer:
+    """A real, deterministic ``litellm.token_counter``-shaped collaborator
+    — not a patch of litellm itself, and not a fake standing in for a
+    reyn object: this is the exact seam :func:`_chunked_token_count` is
+    written against (any object with ``.token_counter(model=, text=)``),
+    used here to make its OWN chunking behaviour directly observable
+    without depending on litellm's internal tokenizer implementation
+    (which this test is not about). Returns ``len(text) // 4`` — a
+    stable, deterministic count with no real tokenization involved."""
+
+    def __init__(self) -> None:
+        self.call_lengths: "list[int]" = []
+
+    def token_counter(self, *, model: str, text: str) -> int:
+        del model
+        self.call_lengths.append(len(text))
+        return max(1, len(text) // 4)
+
+
+def test_chunked_token_count_never_hands_one_call_the_whole_oversized_text() -> None:
+    """Tier 1: the core #5973 2-d claim — a text well over
+    ``_TOKENIZE_CHUNK_CHARS`` is counted via MULTIPLE calls, each bounded
+    to at most ``_TOKENIZE_CHUNK_CHARS`` chars, never one call carrying
+    the whole text (which is what let litellm's own tokenizer build one
+    huge transient ``list[int]``).
+
+    Strip witness: replacing the chunking loop with a single
+    ``litellm.token_counter(model=model, text=text)`` call (the pre-2-d
+    shape) turns this red — ``call_lengths`` would hold exactly one
+    entry equal to the full (over-bound) text length."""
+    from reyn.services.compaction.engine import (
+        _TOKENIZE_CHUNK_CHARS,
+        _chunked_token_count,
+    )
+
+    text = "z" * (_TOKENIZE_CHUNK_CHARS * 3 + 137)  # over the bound, on purpose
+    tok = _RecordingTokenizer()
+
+    total = _chunked_token_count(tok, "model", text)
+
+    assert tok.call_lengths[1:], (
+        f"an oversized text must be split into MULTIPLE calls, not handed "
+        f"to litellm.token_counter whole — got {tok.call_lengths}"
+    )
+    assert all(n <= _TOKENIZE_CHUNK_CHARS for n in tok.call_lengths), (
+        f"no single call may carry more than _TOKENIZE_CHUNK_CHARS chars "
+        f"— this is the whole point (bounding the transient list[int] "
+        f"litellm's own tokenizer builds per call); got {tok.call_lengths}"
+    )
+    assert sum(tok.call_lengths) == len(text), (
+        "every character of the input must be covered by exactly the "
+        "chunk calls made — no chunk dropped or double-counted"
+    )
+    assert total == sum(max(1, n // 4) for n in tok.call_lengths), (
+        "the returned count must be the SUM of every chunk's own count"
+    )
+
+
+def test_chunked_token_count_short_text_makes_exactly_one_call() -> None:
+    """Tier 1: a text at or under ``_TOKENIZE_CHUNK_CHARS`` (the
+    overwhelming majority of real turns) is byte-identical to the pre-2-d
+    behaviour — exactly one ``litellm.token_counter`` call, carrying the
+    whole text unchanged."""
+    from reyn.services.compaction.engine import (
+        _TOKENIZE_CHUNK_CHARS,
+        _chunked_token_count,
+    )
+
+    text = "y" * _TOKENIZE_CHUNK_CHARS
+    tok = _RecordingTokenizer()
+
+    total = _chunked_token_count(tok, "model", text)
+
+    assert tok.call_lengths == [len(text)], (
+        f"a text at the chunk bound must make exactly one call carrying "
+        f"the whole text; got {tok.call_lengths}"
+    )
+    assert total == len(text) // 4
+
+
+def test_estimate_tokens_exact_path_agrees_with_chars4_within_bpe_slack() -> None:
+    """Tier 2: :func:`estimate_tokens`'s real (non-``use_chars4``) path,
+    driven with the SAME ``_RecordingTokenizer`` double via
+    :func:`_chunked_token_count` directly (isolating the chunking claim
+    from litellm's own real tokenizer, which is not what this test is
+    about) — an oversized text's summed count must equal the sum of each
+    chunk's own ``len(text)//4``, proving the sum is genuinely built from
+    the per-chunk calls this module makes, not from a single whole-text
+    call this test would not have caught."""
+    from reyn.services.compaction.engine import (
+        _TOKENIZE_CHUNK_CHARS,
+        _chunked_token_count,
+    )
+
+    text = "橋" * (_TOKENIZE_CHUNK_CHARS + 500)  # multibyte text, still just chars
+    tok = _RecordingTokenizer()
+
+    total = _chunked_token_count(tok, "model", text)
+
+    assert tok.call_lengths[1:], (
+        "a text past the bound must still be split for non-ASCII content, "
+        f"got {tok.call_lengths}"
+    )
+    assert sum(tok.call_lengths) == len(text)
+    assert total == sum(max(1, n // 4) for n in tok.call_lengths)
+
+
+# ---------------------------------------------------------------------------
 # ISSUE #4: recompute_budgets() — dynamic system_prompt_provider
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**[e2e-coder]** — part of #5973.

## What

`litellm.token_counter` tokenizes via tiktoken internally and returns `len()` of the `list[int]` it built. That transient list — not the int `estimate_tokens()` actually returns — cost ~32-35 bytes/token (architect, measured: https://github.com/tya5/reyn/issues/5973#issuecomment-5577627693): a 597 MB / ~150M-token tool-result body built a ~5 GB list in ONE call, the real driver behind a 16 GB resident peak this issue traces (materialization itself measured ~1x, including Japanese BMP text at 0.92x — no per-language multiplier concern, so the byte-based approach is safe to use elsewhere in #5973).

`_chunked_token_count` sums `litellm.token_counter` over fixed-size chunks of text instead of one call on the whole thing, bounding the transient list to one chunk's own size (~1.6 MB at `_TOKENIZE_CHUNK_CHARS = 200_000`), discarded before the next chunk starts. A text at or under the bound (the overwhelming majority of real turns) makes exactly one call, byte-identical to before this PR.

Approximate (not exact) for a text large enough to actually chunk — a BPE tokenizer can count a boundary-straddling span differently once split — disclosed in the docstring. Every existing caller already treats `estimate_tokens()`'s non-`use_chars4` return as a budget estimate, never a wire-exact count, so this changes no caller's contract.

## Scope confirmation (lead-coder's request before starting)

Confirmed no file/line overlap with #5973's ①②③ (`history_resident` bound / wire-construction budget / recovery-path budget) — this PR is confined entirely to `estimate_tokens()` in `engine.py`; every caller (session.py, router_history_buffer.py, compaction_controller.py, context_budget_advisor.py) is unchanged, they just call the fixed function.

## Test plan

- [x] `tests/llm/test_chat_compaction_engine_11axis.py` — 3 new tests (37/37 pass): oversized text splits into multiple bounded calls covering the input exactly once each; short text makes exactly one call (byte-identical to pre-fix); multibyte (Japanese) text still chunks correctly.
- [x] Strip witness: reverting the chunking loop to a single `litellm.token_counter(model=model, text=text)` call turns the new tests red (call_lengths would hold one entry equal to the full text length) — verified directly during authoring.
- [x] `ruff check` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/llm/test_chat_compaction_engine_11axis.py` — 37/37 OK
- [x] `python scripts/mypy_ratchet.py` — OK (changed-files)
- [x] `python scripts/verify_module_docstrings.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` — all OK
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)