### PR TITLE
fix(#5981): give the cached Seatbelt .sb profile a real bounding subject

### DIFF
--- a/src/reyn/security/sandbox/_derivation_cache.py
+++ b/src/reyn/security/sandbox/_derivation_cache.py
@@ -28,11 +28,26 @@ SAME step, so a future object that happens to be allocated at the same
 
 #5981: eviction was in-memory only — a *compute* that writes a disk artifact
 (Seatbelt's cached ``.sb`` profile) had no exit at all, because the callback
-above dropped the dict entries and nothing else. ``on_evict`` (optional,
-below) ties a caller's own disk cleanup to the SAME weakref firing that
-already exists for the in-memory entry, rather than inventing a second,
-separate lifetime for the on-disk copy — the two were always meant to expire
-together; only one half of that was wired.
+above dropped the dict entries and nothing else. ``on_evict`` ties a caller's
+own disk cleanup to the SAME weakref firing that already exists for the
+in-memory entry, rather than inventing a second, separate lifetime for the
+on-disk copy — the two were always meant to expire together; only one half
+of that was wired.
+
+#5981 co-vet (architect): tying the on-disk lifetime SOLELY to *policy*'s own
+GC is a real fix but an incomplete contract — (1) the consumer of the derived
+artifact is whatever `compute()` produced it FOR (a running `sandbox-exec`),
+not *policy* itself, so "when does GC happen" is an implementation detail,
+not a promise this module makes; (2) `cached_derivation` is called once per
+CHECKOUT — the SAME key can have several live callers at once (two
+`wrap_command()` calls sharing one policy) — and nothing counted how many
+outstanding checkouts existed, so an eager, GC-timing-only eviction could in
+principle race a still-live SECOND checkout. ``release_derivation`` (below)
+is the fix: an EXPLICIT decrement a caller makes when it is done with its own
+checkout, independent of whether *policy* itself has died yet — the weakref
+callback remains the FLOOR (fires unconditionally, ignoring any outstanding
+count, because once *policy* itself is unreachable nothing could call
+``release_derivation`` for it ever again regardless), not the only path.
 """
 from __future__ import annotations
 
@@ -52,10 +67,25 @@ _CACHE: dict[tuple[str, int], Any] = {}
 # object itself is kept somewhere. This dict is that "somewhere" — its own
 # entry is removed by the SAME evictor callback that clears ``_CACHE``.
 _REFS: dict[tuple[str, int], "weakref.ref[SandboxPolicy]"] = {}
-# #5981: the caller-supplied cleanup for a cached VALUE, fired by the same
-# evictor that clears `_CACHE`/`_REFS` for this key — absent for callers with
-# nothing to release beyond the dict entry itself (the pre-#5981 shape).
+# #5981: the caller-supplied cleanup for a cached VALUE, fired by whichever
+# of `_evictor`/`release_derivation` empties this key first — absent for
+# callers with nothing to release beyond the dict entry itself (the
+# pre-#5981 shape).
 _ON_EVICT: dict[tuple[str, int], "Callable[[Any], None]"] = {}
+# #5981 co-vet: outstanding-checkout count per key — incremented on every
+# `cached_derivation` call (hit AND miss; each call is a NEW caller's claim
+# on the value, not just the first one that computed it), decremented by
+# `release_derivation`. A key present here is, by construction, also present
+# in `_CACHE` (both are only ever populated/cleared together under `_LOCK`)
+# — so `key in _CACHE` and `key in _REFCOUNT` never disagree about whether
+# an entry is live; nothing reads one without the other under the same lock.
+#
+# `id()` reuse against a key still IN this dict cannot happen: a caller
+# needs a live reference to *policy* to compute `key` at all (both here and
+# in `release_derivation`), and holding that reference is exactly what
+# keeps the OLD object un-collectable — so `_evictor`'s callback (the only
+# thing that would free `id(policy)` for reuse) cannot have fired yet.
+_REFCOUNT: dict[tuple[str, int], int] = {}
 _LOCK = threading.Lock()
 
 
@@ -75,32 +105,91 @@ def cached_derivation(
     two callers into computing (and, for Seatbelt, WRITING) the same
     derivation twice.
 
-    ``on_evict`` (#5981), when given, is called with the cached VALUE at the
-    exact moment *policy* is garbage-collected and its entry is dropped —
-    the hook a caller whose *compute* result is a disk artifact (a path, a
-    file handle) needs to release that artifact on the SAME lifecycle event
-    that already ends the in-memory entry, instead of the artifact outliving
-    it with no eviction event of its own. Keyword-only and optional: a
+    ``on_evict`` (#5981), when given, is called with the cached VALUE the
+    moment the LAST outstanding checkout goes away — either every caller
+    that received this value has called :func:`release_derivation`, or
+    *policy* itself is garbage-collected (whichever comes first) — the hook
+    a caller whose *compute* result is a disk artifact (a path, a file
+    handle) needs to release that artifact, instead of it outliving every
+    consumer with no eviction event of its own. Keyword-only and optional: a
     caller with nothing to release (the pre-#5981 shape) passes nothing and
     gets byte-identical behavior.
+
+    Each call — hit or miss — is its OWN checkout and increments the
+    key's live count; a caller that intends to eventually release must call
+    :func:`release_derivation` exactly once per `cached_derivation` call it
+    made (not once total) — see that function's own docstring.
     """
     key = (backend_name, id(policy))
     with _LOCK:
         if key in _CACHE:
+            _REFCOUNT[key] += 1
             return _CACHE[key]
         value = compute()
         _CACHE[key] = value
+        _REFCOUNT[key] = 1
         if on_evict is not None:
             _ON_EVICT[key] = on_evict
         _REFS[key] = weakref.ref(policy, _evictor(key))
         return value
 
 
+def release_derivation(backend_name: str, policy: SandboxPolicy) -> None:
+    """Release ONE checkout of ``(backend_name, policy)`` obtained from a
+    prior :func:`cached_derivation` call (#5981 co-vet).
+
+    Decrements the key's live-checkout count; when it reaches zero, this
+    call — not a later GC of *policy* — is what runs ``on_evict`` and drops
+    the cache entry. A key with a still-positive count after this call is
+    left fully alone: another live checkout (a second `wrap_command()` call
+    sharing the same policy, say) may still need the cached value, and NEITHER
+    this function nor the weakref evictor ever removes an entry while ANY
+    checkout of it remains outstanding.
+
+    A no-op if *policy* was never checked out under this *backend_name*, or
+    every checkout already released (idempotent from the CALLER's side —
+    but each `cached_derivation` call still needs its OWN matching release;
+    calling this twice for what was only ONE checkout under-counts and can
+    evict while a genuinely separate checkout is still live, so a caller
+    must track "have I already released THIS checkout" itself — see
+    Seatbelt's ``wrap_command._cleanup`` for the idempotency guard that
+    entails)."""
+    key = (backend_name, id(policy))
+    with _LOCK:
+        if key not in _REFCOUNT:
+            return
+        _REFCOUNT[key] -= 1
+        if _REFCOUNT[key] > 0:
+            return
+        value = _CACHE.pop(key, None)
+        _REFS.pop(key, None)
+        _REFCOUNT.pop(key, None)
+        on_evict = _ON_EVICT.pop(key, None)
+    # Outside `_LOCK` — see `_evictor`'s own comment on why.
+    if on_evict is not None:
+        on_evict(value)
+
+
 def _evictor(key: tuple[str, int]) -> "Callable[[Any], None]":
     def _evict(_ref: "Any") -> None:
         with _LOCK:
+            # #5981 co-vet: policy itself just died — this is the FLOOR, not
+            # the primary release path, so it evicts UNCONDITIONALLY, ignoring
+            # any positive `_REFCOUNT` left over. That's correct, not a race:
+            # every remaining "checkout" of this key was reachable only
+            # through *policy* (nothing else can compute this key), and
+            # *policy* just became unreachable — by definition nothing can
+            # ever call `release_derivation` for it again, so a leftover
+            # positive count here would otherwise never reach zero on its
+            # own. Real callers that DO explicitly release (Seatbelt's
+            # `_cleanup`) normally reach zero via `release_derivation` first,
+            # well before *policy* is ever collected; this path exists for
+            # whatever never got explicitly released (a crash mid-checkout,
+            # a caller that dropped everything without calling cleanup) —
+            # exactly the safety-net role this callback always had.
             value = _CACHE.pop(key, None)
             _REFS.pop(key, None)
+            _REFCOUNT.pop(key, None)
             on_evict = _ON_EVICT.pop(key, None)
         # #5981: run the caller's cleanup OUTSIDE `_LOCK` — an on_evict that
         # re-enters `cached_derivation` (a different key; the same key can't
@@ -117,11 +206,13 @@ def _reset_cache_for_tests() -> None:
 
     Does NOT fire any `on_evict` callback — this is a bookkeeping reset, not
     a real eviction; a test that needs the disk-cleanup side effect exercised
-    should let the policy it created go out of scope and be collected."""
+    should let the policy it created go out of scope and be collected, or
+    call :func:`release_derivation` to force it explicitly."""
     with _LOCK:
         _CACHE.clear()
         _REFS.clear()
         _ON_EVICT.clear()
+        _REFCOUNT.clear()
 
 
 def _cache_size_for_tests() -> int:

--- a/src/reyn/security/sandbox/_derivation_cache.py
+++ b/src/reyn/security/sandbox/_derivation_cache.py
@@ -25,6 +25,14 @@ a policy just to compute a cache key). Identity keys age out via a
 the policy object is garbage-collected, its cache entry is removed in the
 SAME step, so a future object that happens to be allocated at the same
 ``id()`` can never collide with a stale entry.
+
+#5981: eviction was in-memory only — a *compute* that writes a disk artifact
+(Seatbelt's cached ``.sb`` profile) had no exit at all, because the callback
+above dropped the dict entries and nothing else. ``on_evict`` (optional,
+below) ties a caller's own disk cleanup to the SAME weakref firing that
+already exists for the in-memory entry, rather than inventing a second,
+separate lifetime for the on-disk copy — the two were always meant to expire
+together; only one half of that was wired.
 """
 from __future__ import annotations
 
@@ -44,11 +52,19 @@ _CACHE: dict[tuple[str, int], Any] = {}
 # object itself is kept somewhere. This dict is that "somewhere" — its own
 # entry is removed by the SAME evictor callback that clears ``_CACHE``.
 _REFS: dict[tuple[str, int], "weakref.ref[SandboxPolicy]"] = {}
+# #5981: the caller-supplied cleanup for a cached VALUE, fired by the same
+# evictor that clears `_CACHE`/`_REFS` for this key — absent for callers with
+# nothing to release beyond the dict entry itself (the pre-#5981 shape).
+_ON_EVICT: dict[tuple[str, int], "Callable[[Any], None]"] = {}
 _LOCK = threading.Lock()
 
 
 def cached_derivation(
-    backend_name: str, policy: SandboxPolicy, compute: "Callable[[], T]",
+    backend_name: str,
+    policy: SandboxPolicy,
+    compute: "Callable[[], T]",
+    *,
+    on_evict: "Callable[[T], None] | None" = None,
 ) -> T:
     """Return the cached derivation for ``(backend_name, policy)``, computing
     it via *compute* exactly once per (backend, policy object) per process.
@@ -58,6 +74,15 @@ def cached_derivation(
     the lock across it trades a small amount of contention for never racing
     two callers into computing (and, for Seatbelt, WRITING) the same
     derivation twice.
+
+    ``on_evict`` (#5981), when given, is called with the cached VALUE at the
+    exact moment *policy* is garbage-collected and its entry is dropped —
+    the hook a caller whose *compute* result is a disk artifact (a path, a
+    file handle) needs to release that artifact on the SAME lifecycle event
+    that already ends the in-memory entry, instead of the artifact outliving
+    it with no eviction event of its own. Keyword-only and optional: a
+    caller with nothing to release (the pre-#5981 shape) passes nothing and
+    gets byte-identical behavior.
     """
     key = (backend_name, id(policy))
     with _LOCK:
@@ -65,6 +90,8 @@ def cached_derivation(
             return _CACHE[key]
         value = compute()
         _CACHE[key] = value
+        if on_evict is not None:
+            _ON_EVICT[key] = on_evict
         _REFS[key] = weakref.ref(policy, _evictor(key))
         return value
 
@@ -72,17 +99,29 @@ def cached_derivation(
 def _evictor(key: tuple[str, int]) -> "Callable[[Any], None]":
     def _evict(_ref: "Any") -> None:
         with _LOCK:
-            _CACHE.pop(key, None)
+            value = _CACHE.pop(key, None)
             _REFS.pop(key, None)
+            on_evict = _ON_EVICT.pop(key, None)
+        # #5981: run the caller's cleanup OUTSIDE `_LOCK` — an on_evict that
+        # re-enters `cached_derivation` (a different key; the same key can't
+        # recur, this entry is already gone) would otherwise deadlock on the
+        # same non-reentrant lock this callback was invoked from.
+        if on_evict is not None:
+            on_evict(value)
 
     return _evict
 
 
 def _reset_cache_for_tests() -> None:
-    """Test hook: drop the process-global derivation cache."""
+    """Test hook: drop the process-global derivation cache.
+
+    Does NOT fire any `on_evict` callback — this is a bookkeeping reset, not
+    a real eviction; a test that needs the disk-cleanup side effect exercised
+    should let the policy it created go out of scope and be collected."""
     with _LOCK:
         _CACHE.clear()
         _REFS.clear()
+        _ON_EVICT.clear()
 
 
 def _cache_size_for_tests() -> int:

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -430,9 +430,20 @@ class SeatbeltBackend:
         real actor: nothing in this codebase unlinks a cached ``.sb`` file
         at process exit; the file survives the process and was only ever
         removed, if at all, by whatever unrelated schedule the OS sweeps its
-        own temp directory on). ``env`` is the SAME allowlisted build
-        ``run()`` uses (#3822) — a caller launching the wrapped argv with
-        this env gets the identical env-scoping ``run()``'s callers get."""
+        own temp directory on). ⚠️ **Scope of that bounding subject (#5981
+        co-vet)**: a weakref callback only ever fires from a LIVE
+        interpreter — a crash or SIGKILL never runs it, so a `.sb` file
+        whose owning process died ungracefully outlives that process
+        indefinitely. A directory-wide sweep on the next process's startup
+        was considered and rejected: this cache directory is shared across
+        every concurrently-running reyn process on the machine (e.g. a
+        `reyn:web` and a `reyn:chat` session at once), so sweeping it would
+        delete a SIBLING process's still-live profile out from under its own
+        `sandbox-exec`. Disclosed, not closed — the crash/SIGKILL remainder
+        is real but is not this fix's scope. ``env`` is the SAME allowlisted
+        build ``run()`` uses (#3822) — a caller launching the wrapped argv
+        with this env gets the identical env-scoping ``run()``'s callers
+        get."""
         profile_text = _build_sbpl_profile(policy)
         profile_path, is_cached = _cached_profile_path(policy, profile_text)
 
@@ -441,12 +452,20 @@ class SeatbeltBackend:
             # closure) is deliberate, not dead code — it keeps *policy*
             # alive via this closure's own captured cell for as long as the
             # CALLER holds `wrapped.cleanup` (which every caller must, to
-            # call it eventually). Without this, a caller that does not
-            # separately retain *policy* itself (e.g. `wrap_command(argv,
-            # SandboxPolicy(...))` with no local binding) could see the
-            # cached `.sb` file evicted the instant `wrap_command` returns —
-            # `policy` collected, `_derivation_cache`'s on_evict firing —
-            # while `wrapped.argv` still names that now-deleted path.
+            # call it eventually). Real production call site this protects:
+            # `mcp/client.py`'s MCP stdio launch — `wrap_command(argv,
+            # self._build_mcp_sandbox_policy())` — passes an INLINE policy
+            # expression with no local binding of its own. Without this
+            # capture, the moment `wrap_command` returns there, CPython could
+            # collect that policy immediately (nothing else references it),
+            # firing `_derivation_cache`'s `on_evict` and unlinking the `.sb`
+            # profile while `wrapped.argv` still names it — the NEXT
+            # `sandbox-exec -f <path>` for that MCP stdio server would then
+            # fail with a missing profile. (lead-coder's own strip-falsify
+            # confirmed this line is gated by
+            # test_seatbelt_cached_profile_survives_while_the_wrapped_command_is_held_even_with_no_separate_policy_variable
+            # — removing it goes RED — so the stronger default-argument form
+            # first proposed here was not required after all.)
             _ = policy
             if is_cached:
                 return

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -30,7 +30,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
-from reyn.security.sandbox._derivation_cache import cached_derivation
+from reyn.security.sandbox._derivation_cache import cached_derivation, release_derivation
 from reyn.security.sandbox._subprocess_io import communicate_capped, kill_process_tree
 from reyn.security.sandbox.backend import (
     AxisEnforcement,
@@ -447,27 +447,42 @@ class SeatbeltBackend:
         profile_text = _build_sbpl_profile(policy)
         profile_path, is_cached = _cached_profile_path(policy, profile_text)
 
+        _released = False
+
         def _cleanup() -> None:
-            # #5981: reading `policy` here (never otherwise used in this
-            # closure) is deliberate, not dead code — it keeps *policy*
-            # alive via this closure's own captured cell for as long as the
-            # CALLER holds `wrapped.cleanup` (which every caller must, to
-            # call it eventually). Real production call site this protects:
-            # `mcp/client.py`'s MCP stdio launch — `wrap_command(argv,
-            # self._build_mcp_sandbox_policy())` — passes an INLINE policy
-            # expression with no local binding of its own. Without this
-            # capture, the moment `wrap_command` returns there, CPython could
-            # collect that policy immediately (nothing else references it),
-            # firing `_derivation_cache`'s `on_evict` and unlinking the `.sb`
-            # profile while `wrapped.argv` still names it — the NEXT
-            # `sandbox-exec -f <path>` for that MCP stdio server would then
-            # fail with a missing profile. (lead-coder's own strip-falsify
-            # confirmed this line is gated by
-            # test_seatbelt_cached_profile_survives_while_the_wrapped_command_is_held_even_with_no_separate_policy_variable
-            # — removing it goes RED — so the stronger default-argument form
-            # first proposed here was not required after all.)
-            _ = policy
+            # #5981 co-vet (architect): eviction is now an EXPLICIT,
+            # refcounted release (`_derivation_cache.release_derivation`),
+            # not implicit GC timing — "the consumer is exec(), the owner
+            # was GC, and GC's timing is not a contract" was the exact
+            # objection. `_cleanup` reading `policy` was ALSO still needed
+            # (confirmed by strip-falsify) to keep *policy* itself alive
+            # for as long as the caller holds `wrapped.cleanup` — the real
+            # production call site this protects is `mcp/client.py`'s MCP
+            # stdio launch, `wrap_command(argv,
+            # self._build_mcp_sandbox_policy())`, an INLINE policy
+            # expression with no local binding of its own — but that alone
+            # was NOT sufficient: `_derivation_cache`'s identity-keyed cache
+            # can have several LIVE checkouts sharing one policy (two
+            # `wrap_command()` calls for the same policy), and nothing
+            # counted how many were still outstanding before this. Each
+            # `wrap_command()` call is its own checkout;
+            # `release_derivation` releases exactly the ONE this closure
+            # owns, only unlinking when it is the LAST outstanding checkout
+            # — a second caller sharing this policy keeps its own checkout
+            # alive independently.
+            #
+            # `_released` guards `cleanup()` being called more than once on
+            # the SAME `WrappedCommand` (`test_seatbelt_wrap_command_
+            # cleanup_idempotent` calls it twice) — without this guard a
+            # double-call would release TWICE for what was only ONE
+            # checkout, under-counting and evicting while a genuinely
+            # separate checkout might still be live.
+            nonlocal _released
             if is_cached:
+                if _released:
+                    return
+                _released = True
+                release_derivation("seatbelt", policy)
                 return
             try:
                 os.unlink(profile_path)

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -291,8 +291,24 @@ def _cached_profile_path(policy: SandboxPolicy, profile_text: str) -> tuple[str,
             fh.write(profile_text)
         return path
 
-    path = cached_derivation("seatbelt", policy, _write_cached)
+    # #5981: the cached path's own disk artifact has no exit without this —
+    # `_derivation_cache`'s weakref eviction already fires when *policy* is
+    # collected; `on_evict` ties THIS file's removal to that same event
+    # instead of leaving it in `_seatbelt_cache_dir()` forever (a bare
+    # `_evict` callback only ever cleared the in-memory cache entry).
+    path = cached_derivation(
+        "seatbelt", policy, _write_cached, on_evict=_unlink_ignoring_missing,
+    )
     return path, True
+
+
+def _unlink_ignoring_missing(path: str) -> None:
+    """`on_evict` for a cached `.sb` path (#5981) — same guard shape
+    `_cleanup()` below already uses for the uncached, per-call temp file."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 class SeatbeltBackend:
@@ -404,16 +420,34 @@ class SeatbeltBackend:
         gets its own unlink-on-cleanup; a CACHED path is shared across every
         caller using this policy in the process, so ``cleanup()`` here must
         NOT unlink it — a second caller reusing the same policy would then
-        launch ``sandbox-exec -f <a path that no longer exists>``. Cached
-        files are cleaned up at process exit (OS temp-dir housekeeping),
-        matching the profile's new session-scoped lifetime rather than the
-        old per-call one. ``env`` is the SAME allowlisted build ``run()``
-        uses (#3822) — a caller launching the wrapped argv with this env
-        gets the identical env-scoping ``run()``'s callers get."""
+        launch ``sandbox-exec -f <a path that no longer exists>``. **A cached
+        file's actual bounding subject (#5981) is the SAME weakref eviction
+        that already drops its ``_derivation_cache`` entry** — when *policy*
+        itself is garbage-collected, ``cached_derivation``'s ``on_evict``
+        hook unlinks this file (``_unlink_ignoring_missing``, wired at
+        :func:`_cached_profile_path`'s call site) — NOT "process exit /
+        OS temp-dir housekeeping" (the previous claim here, which named no
+        real actor: nothing in this codebase unlinks a cached ``.sb`` file
+        at process exit; the file survives the process and was only ever
+        removed, if at all, by whatever unrelated schedule the OS sweeps its
+        own temp directory on). ``env`` is the SAME allowlisted build
+        ``run()`` uses (#3822) — a caller launching the wrapped argv with
+        this env gets the identical env-scoping ``run()``'s callers get."""
         profile_text = _build_sbpl_profile(policy)
         profile_path, is_cached = _cached_profile_path(policy, profile_text)
 
         def _cleanup() -> None:
+            # #5981: reading `policy` here (never otherwise used in this
+            # closure) is deliberate, not dead code — it keeps *policy*
+            # alive via this closure's own captured cell for as long as the
+            # CALLER holds `wrapped.cleanup` (which every caller must, to
+            # call it eventually). Without this, a caller that does not
+            # separately retain *policy* itself (e.g. `wrap_command(argv,
+            # SandboxPolicy(...))` with no local binding) could see the
+            # cached `.sb` file evicted the instant `wrap_command` returns —
+            # `policy` collected, `_derivation_cache`'s on_evict firing —
+            # while `wrapped.argv` still names that now-deleted path.
+            _ = policy
             if is_cached:
                 return
             try:

--- a/tests/security/test_codeact_runner_1593.py
+++ b/tests/security/test_codeact_runner_1593.py
@@ -258,14 +258,14 @@ def test_seatbelt_resolve_spawn_delegates_to_wrap_command(monkeypatch) -> None:
     profile_path = argv[2]
     assert os.path.exists(profile_path)
     cleanup()
-    # #4434: this policy has no write_paths, so it's safe to session-cache —
-    # cleanup() on a cached profile is a no-op (a second caller reusing the
-    # same policy object would still need the file); it does NOT unlink.
-    assert os.path.exists(profile_path)
-    os.unlink(profile_path)
-    direct.cleanup()  # no-op too (direct is also cacheable) — tidy up by hand
-    if os.path.exists(direct.argv[2]):
-        os.unlink(direct.argv[2])
+    # #4434: this policy has no write_paths, so it's safe to session-cache;
+    # #5981 co-vet: cleanup() releases THIS call's own checkout of that
+    # cached derivation, refcounted — each of `cleanup`/`direct.cleanup` is
+    # the ONLY checkout of its own (distinct) policy object here, so each
+    # release IS the last outstanding one and DOES unlink.
+    assert not os.path.exists(profile_path)
+    direct.cleanup()
+    assert not os.path.exists(direct.argv[2])
 
 
 def test_landlock_resolve_spawn_now_wraps_via_abstraction(monkeypatch) -> None:

--- a/tests/security/test_derivation_cache_5981.py
+++ b/tests/security/test_derivation_cache_5981.py
@@ -15,7 +15,7 @@ import gc
 import pytest
 
 from reyn.security.sandbox import _derivation_cache
-from reyn.security.sandbox._derivation_cache import cached_derivation
+from reyn.security.sandbox._derivation_cache import cached_derivation, release_derivation
 from reyn.security.sandbox.policy import SandboxPolicy
 
 
@@ -100,3 +100,54 @@ def test_cached_derivation_without_on_evict_is_unaffected_by_eviction():
     # module's own state was not corrupted by an eviction with no on_evict.
     later_policy = SandboxPolicy(write_paths=[])
     assert cached_derivation("test-backend", later_policy, lambda: "w") == "w"
+
+
+# ─── explicit release_derivation (#5981 co-vet: explicit refcount, not GC timing) ──
+
+
+def test_release_derivation_does_not_evict_while_another_checkout_is_outstanding():
+    """Tier 2: architect's own acceptance shape — two checkouts of the SAME
+    (backend, policy), release ONE, the value must still be retrievable (the
+    OTHER checkout's claim is still live) and `on_evict` must NOT have run
+    yet."""
+    evicted: list[str] = []
+    policy = SandboxPolicy(write_paths=[])
+
+    first = cached_derivation("test-backend", policy, lambda: "v", on_evict=evicted.append)
+    second = cached_derivation("test-backend", policy, lambda: "v", on_evict=evicted.append)
+    assert first == second == "v"
+
+    release_derivation("test-backend", policy)  # releases ONE of the two checkouts
+
+    assert evicted == []
+    # The entry is still live for the SECOND (unreleased) checkout — a third
+    # `cached_derivation` call for the same policy still hits the cache
+    # rather than recomputing.
+    third = cached_derivation("test-backend", policy, lambda: "SHOULD NOT RUN")
+    assert third == "v"
+
+
+def test_release_derivation_evicts_on_the_last_outstanding_checkout():
+    """Tier 2: strip-falsify's counterpart to the test above — releasing
+    BOTH checkouts (not just one) DOES fire `on_evict`, exactly once, with
+    the cached value. Distinguishes real reference counting from a
+    permissive "never evict via release" implementation that would also
+    pass the test above by simply doing nothing, ever."""
+    evicted: list[str] = []
+    policy = SandboxPolicy(write_paths=[])
+
+    cached_derivation("test-backend", policy, lambda: "v", on_evict=evicted.append)
+    cached_derivation("test-backend", policy, lambda: "v", on_evict=evicted.append)
+
+    release_derivation("test-backend", policy)
+    assert evicted == []  # one checkout still outstanding
+    release_derivation("test-backend", policy)
+    assert evicted == ["v"]  # the LAST release evicts
+
+
+def test_release_derivation_on_an_unreleased_key_is_a_noop():
+    """Tier 2: releasing a (backend, policy) pair that was never checked out
+    (or whose checkouts are already all released) must not raise and must
+    not fire `on_evict` — a caller cannot double-release into a crash."""
+    policy = SandboxPolicy(write_paths=[])
+    release_derivation("never-checked-out", policy)  # must not raise

--- a/tests/security/test_derivation_cache_5981.py
+++ b/tests/security/test_derivation_cache_5981.py
@@ -1,0 +1,102 @@
+"""Tier 2: `_derivation_cache.cached_derivation`'s `on_evict` hook (#5981).
+
+Before this, a cached VALUE that itself owned a resource (Seatbelt's `.sb`
+profile path) had no exit at all: the weakref callback the module already
+ran on policy collection cleared only its own bookkeeping dicts
+(`_CACHE`/`_REFS`), never anything the cached value itself pointed at. These
+tests exercise the generic hook directly — no filesystem, no SandboxPolicy —
+`_derivation_cache.py` itself takes any hashable-by-identity key and any
+`compute`/`on_evict` pair.
+"""
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+from reyn.security.sandbox import _derivation_cache
+from reyn.security.sandbox._derivation_cache import cached_derivation
+from reyn.security.sandbox.policy import SandboxPolicy
+
+
+@pytest.fixture(autouse=True)
+def _reset_derivation_cache():
+    """Isolate each test from cache state any other test (in this file or a
+    sibling like test_sandbox_seatbelt.py) may have left behind — same
+    rationale as that file's own fixture of the same name."""
+    _derivation_cache._reset_cache_for_tests()
+    yield
+    _derivation_cache._reset_cache_for_tests()
+
+
+def test_on_evict_fires_with_the_cached_value_when_the_policy_is_collected():
+    """Tier 2: the hook this issue adds — `on_evict` runs with the cached
+    VALUE (not the policy) at the exact moment the keying policy object is
+    garbage-collected, the same event that already clears the in-memory
+    cache entry."""
+    evicted: list[str] = []
+
+    def _make_policy_and_cache() -> None:
+        # Confined to its own frame so the local `policy` binding is gone
+        # the instant this function returns — CPython drops a function's
+        # locals on return, which is what makes the object collectible
+        # without an explicit `del` at the call site.
+        policy = SandboxPolicy(write_paths=[])
+        value = cached_derivation(
+            "test-backend", policy, lambda: "computed-value",
+            on_evict=evicted.append,
+        )
+        assert value == "computed-value"
+
+    _make_policy_and_cache()
+    # CPython frees a refcount-only (non-cyclic) object the instant its last
+    # reference drops — the local `policy` binding inside the confined frame
+    # above — so eviction typically already ran by this point; `gc.collect()`
+    # is the portable way to demand it regardless of that implementation
+    # detail, not a wait for something that might not have happened yet.
+    gc.collect()
+
+    assert evicted == ["computed-value"]
+
+
+def test_on_evict_does_not_fire_while_the_policy_is_still_alive():
+    """Tier 2: strip-falsify's counterpart — the SAME cache entry, but the
+    policy is kept alive by the test's own local variable. `gc.collect()`
+    must not evict a live-referenced key; if it did, this would also assert
+    a repeat `cached_derivation` call started recomputing instead of
+    hitting the cache."""
+    evicted: list[str] = []
+    calls = {"n": 0}
+
+    def _compute() -> str:
+        calls["n"] += 1
+        return f"computed-{calls['n']}"
+
+    policy = SandboxPolicy(write_paths=[])
+    first = cached_derivation("test-backend", policy, _compute, on_evict=evicted.append)
+
+    gc.collect()
+    assert evicted == []
+
+    second = cached_derivation("test-backend", policy, _compute, on_evict=evicted.append)
+    assert second == first
+    assert calls["n"] == 1  # _compute ran exactly once — the cache hit, not a re-derive
+
+
+def test_cached_derivation_without_on_evict_is_unaffected_by_eviction():
+    """Tier 2: backward-compat — a caller passing no `on_evict` (every
+    caller before #5981) gets byte-identical behavior: eviction firing with
+    nothing to call must not raise, and the module keeps working normally
+    for the NEXT policy afterward (asserted via `cached_derivation`'s own
+    return value, not `_derivation_cache`'s private dicts — #4864 Rule 8)."""
+    def _make_policy_and_cache() -> None:
+        policy = SandboxPolicy(write_paths=[])
+        cached_derivation("test-backend", policy, lambda: "v")
+
+    _make_policy_and_cache()  # eviction (on_evict=None) runs somewhere in here
+    gc.collect()  # portable demand, in case it hasn't run yet
+
+    # A later, unrelated policy still computes and caches correctly — the
+    # module's own state was not corrupted by an eviction with no on_evict.
+    later_policy = SandboxPolicy(write_paths=[])
+    assert cached_derivation("test-backend", later_policy, lambda: "w") == "w"

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -490,14 +490,17 @@ def test_seatbelt_wrap_command_reuses_the_same_profile_path_for_the_same_policy(
     with open(path1, encoding="utf-8") as fh:
         assert fh.read() == _build_sbpl_profile(policy)
 
-    # cleanup() on a cached path must be a no-op (a second caller sharing
-    # this policy still needs the file); confirmed by asserting it survives.
+    # #5981 co-vet: cleanup() on a cached path is a REFCOUNTED release, not
+    # an unconditional no-op — wrapped1 and wrapped2 are two independent
+    # checkouts of the SAME cached derivation, so releasing wrapped1's alone
+    # must not unlink a file wrapped2's own (still outstanding) checkout may
+    # still need. Confirmed by asserting it survives past the FIRST cleanup.
     wrapped1.cleanup()
     assert __import__("os").path.exists(path1)
 
-    import os
-
-    os.unlink(path1)
+    # The LAST outstanding checkout's cleanup() DOES release it.
+    wrapped2.cleanup()
+    assert not __import__("os").path.exists(path1)
 
 
 def test_seatbelt_cached_profile_is_unlinked_when_the_policy_is_collected():
@@ -558,10 +561,11 @@ def test_seatbelt_cached_profile_survives_while_the_wrapped_command_is_held_even
         "via the `_cleanup` closure for exactly this reason"
     )
 
-    wrapped.cleanup()  # no-op (cached) — the file must still be there after
-    assert os.path.exists(path)
-
-    os.unlink(path)  # tidy up the shared cache file this test wrote
+    # #5981 co-vet: cleanup() is now a refcounted release, not an
+    # unconditional no-op — this is the ONLY checkout of this policy in this
+    # test, so releasing it IS the last outstanding checkout and DOES unlink.
+    wrapped.cleanup()
+    assert not os.path.exists(path)
 
 
 def test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe():

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -500,6 +500,70 @@ def test_seatbelt_wrap_command_reuses_the_same_profile_path_for_the_same_policy(
     os.unlink(path1)
 
 
+def test_seatbelt_cached_profile_is_unlinked_when_the_policy_is_collected():
+    """Tier 2: #5981 — the cached `.sb` file's actual bounding subject.
+    Before this, `cleanup()`'s deliberate no-op on a cached path (asserted
+    just above) meant NOTHING ever unlinked it — this proves the file now
+    has a real exit: the same weakref eviction that already clears the
+    in-memory `_derivation_cache` entry when *policy* is collected."""
+    import gc
+    import os
+
+    backend = SeatbeltBackend()
+
+    def _wrap_and_get_path() -> str:
+        # Confined to its own frame — same reasoning as
+        # test_derivation_cache_5981.py's identically-shaped helper: the
+        # local `policy` binding must be gone the instant this returns for
+        # `gc.collect()` below to actually collect it.
+        policy = SandboxPolicy(write_paths=[])
+        wrapped = backend.wrap_command(["/bin/echo", "hi"], policy)
+        return wrapped.argv[wrapped.argv.index("-f") + 1]
+
+    path = _wrap_and_get_path()
+    # CPython frees the confined frame's `policy` (a refcount-only, non-
+    # cyclic object) the instant `_wrap_and_get_path` returns, so the file
+    # may already be gone by this point — `gc.collect()` below is the
+    # portable way to demand eviction, not a wait for something pending.
+    gc.collect()
+
+    assert not os.path.exists(path)
+
+
+def test_seatbelt_cached_profile_survives_while_the_wrapped_command_is_held_even_with_no_separate_policy_variable():
+    """Tier 2: #5981 strip-falsify caught this — an EARLIER version of the
+    #5981 fix evicted the file the instant `wrap_command` returned when the
+    caller passed a bare ``SandboxPolicy(...)`` inline (no local variable of
+    its own, exactly what several already-existing tests in this repo do —
+    e.g. ``test_seatbelt_wrap_command_prepends_sandbox_exec``), because
+    NOTHING kept *policy* alive once the call returned. The fix: `_cleanup`'s
+    closure captures *policy* too, so holding `wrapped` (which every caller
+    must, to call `.cleanup()` eventually) keeps the file alive regardless
+    of whether the caller ALSO kept its own reference to the policy."""
+    import os
+
+    backend = SeatbeltBackend()
+    # Deliberately no local binding for the policy — the exact inline shape
+    # that exposed the gap.
+    wrapped = backend.wrap_command(["/bin/echo", "hi"], SandboxPolicy(write_paths=[]))
+    path = wrapped.argv[wrapped.argv.index("-f") + 1]
+
+    import gc
+
+    gc.collect()  # the inline SandboxPolicy(...) has no OTHER referent now
+
+    assert os.path.exists(path), (
+        "the cached profile vanished while `wrapped` (and therefore its "
+        "cleanup()) was still held — #5981's fix must keep `policy` alive "
+        "via the `_cleanup` closure for exactly this reason"
+    )
+
+    wrapped.cleanup()  # no-op (cached) — the file must still be there after
+    assert os.path.exists(path)
+
+    os.unlink(path)  # tidy up the shared cache file this test wrote
+
+
 def test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe():
     """Tier 2: strip-falsify — a policy whose write_paths covers the cache
     directory gets an UNCACHED, per-call profile (pre-#4434 behaviour) —

--- a/tests/security/test_sandbox_wrap_command_2620.py
+++ b/tests/security/test_sandbox_wrap_command_2620.py
@@ -60,10 +60,13 @@ def test_seatbelt_wrap_command_prepends_sandbox_exec():
     original command unchanged.
 
     #4434 (stage 1): a bare ``SandboxPolicy()`` (empty write_paths) is safe
-    to session-cache, so its profile is SHARED — cleanup() on it is a no-op
-    by design (a second caller reusing this policy still needs the file);
-    see test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe
-    in test_sandbox_seatbelt.py for the DOES-unlink case."""
+    to session-cache, so its profile is SHARED — cleanup() releases this
+    call's own checkout of that shared derivation (#5981 co-vet: a real
+    refcounted release, not an unconditional no-op); see
+    test_seatbelt_wrap_command_reuses_the_same_profile_path_for_the_same_policy
+    in test_sandbox_seatbelt.py for the survives-while-a-SECOND-checkout-is-
+    outstanding case, and test_seatbelt_wrap_command_does_not_cache_when_
+    write_scope_is_unsafe for the never-cached (always unlinks) case."""
     backend = SeatbeltBackend()
     wrapped = backend.wrap_command(["my-server", "--flag"], SandboxPolicy())
     assert wrapped.argv[0] == "sandbox-exec"
@@ -77,11 +80,9 @@ def test_seatbelt_wrap_command_prepends_sandbox_exec():
     assert wrapped.cleanup is not None
     assert profile_path.exists()
     wrapped.cleanup()
-    assert profile_path.exists()  # cached (session-lifetime): cleanup() is a no-op
-
-    import os
-
-    os.unlink(profile_path)  # tidy up the shared cache file this test wrote
+    # This is the ONLY checkout of this policy in this test, so releasing it
+    # IS the last outstanding one — cleanup() unlinks.
+    assert not profile_path.exists()
 
 
 def test_seatbelt_wrap_command_cleanup_idempotent():

--- a/tests/security/test_sandbox_wrap_command_2620.py
+++ b/tests/security/test_sandbox_wrap_command_2620.py
@@ -87,14 +87,39 @@ def test_seatbelt_wrap_command_prepends_sandbox_exec():
 
 def test_seatbelt_wrap_command_cleanup_idempotent():
     """Tier 2: calling cleanup twice must not raise, on both the cached
-    (no-op) path and the uncached (best-effort unlink) path."""
+    (refcounted release, #5981) and the uncached (best-effort unlink) path.
+
+    #5981 co-vet, lead-coder's own witness demand: "not raise" alone is not
+    a witness for the cached branch's REAL contract — a `release_derivation`
+    call for an already-gone key is already a silent no-op, so "no raise"
+    would hold even with the `_released` idempotency guard removed entirely
+    (confirmed: lead-coder's own strip of that guard left every existing
+    test green, including the ORIGINAL two-line version of this test). The
+    actual invariant is that a double `cleanup()` on ONE checkout must not
+    consume a SECOND, still-outstanding checkout's release — witnessed here
+    by giving the cached case a second live checkout of the SAME policy and
+    asserting its path survives the first checkout's double-cleanup."""
     from reyn.security.sandbox.backends.seatbelt import _seatbelt_cache_dir
 
     backend = SeatbeltBackend()
+    policy = SandboxPolicy()
 
-    cached = backend.wrap_command(["cmd"], SandboxPolicy())
+    cached = backend.wrap_command(["cmd"], policy)
+    # A second, still-live checkout of the SAME policy — the thing an
+    # under-counting double-release would wrongly consume.
+    cached_second = backend.wrap_command(["cmd"], policy)
+    second_path = cached_second.argv[cached_second.argv.index("-f") + 1]
+
     cached.cleanup()
-    cached.cleanup()  # no-op both times — must not raise
+    cached.cleanup()  # must not raise, AND must not release a SECOND time
+    assert __import__("os").path.exists(second_path), (
+        "cached's own double cleanup() released cached_second's still-"
+        "outstanding checkout too — the `_released` idempotency guard is "
+        "the ONLY thing standing between a double-call and this"
+    )
+
+    cached_second.cleanup()  # the real last release — now it unlinks
+    assert not __import__("os").path.exists(second_path)
 
     uncached = backend.wrap_command(
         ["cmd"], SandboxPolicy(write_paths=[str(_seatbelt_cache_dir())]),


### PR DESCRIPTION
**[docs-maintainer]** — Closes #5981.

## What broke

`security/sandbox/backends/seatbelt.py`'s `_write_cached` creates a new `.sb` SBPL profile file under `$TMPDIR/reyn-sandbox-profiles/` per distinct `SandboxPolicy` object (keyed by `id(policy)` in `_derivation_cache.py`). `_derivation_cache`'s weakref-based `_evictor` only ever cleared its own in-memory `_CACHE`/`_REFS` dict entries when the policy was garbage-collected — the on-disk file had **no exit at all**. `wrap_command`'s own docstring falsely claimed "Cached files are cleaned up at process exit (OS temp-dir housekeeping)" — untrue; nothing unlinks them, ever, at any point.

## Fix (option ① of the 3 named in #5981)

`cached_derivation` gains an optional, keyword-only `on_evict` hook, fired with the cached VALUE at the exact moment the keying policy is collected — the same weakref lifecycle event that already existed, now doing both halves of the job instead of one. `_write_cached` passes `on_evict=_unlink_ignoring_missing`. No config knob (per the issue's own instruction — a settable bound just invites raising it).

Also corrected the false docstring claim at `wrap_command`'s own call site to name the real bounding subject.

## A second gap the strip-falsify pass caught

The first version of this fix broke 9 pre-existing tests: several construct `SandboxPolicy(...)` inline with no local variable (`wrap_command(argv, SandboxPolicy())`), so nothing kept the policy alive past the call returning — CPython's refcounting collects it immediately, firing eviction before the caller ever reads the returned path. Fixed by having `_cleanup`'s own closure also capture `policy` (previously only `is_cached`/`profile_path`) — holding `wrapped` (which every caller must, to call `.cleanup()` eventually) now keeps the file alive regardless of whether the caller separately retained the policy. Confirmed real via strip-falsify in both directions (the `on_evict` call, and the `policy` capture) — each reintroduces exactly the tests it should before being restored.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 29/29 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/` path-conditional gates (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`)
- [x] `pytest tests/security/ -k "seatbelt or derivation_cache or sandbox"` — 245 passed, 22 skipped (Darwin-only; this dev machine is not macOS — CI's own #3881 caveat applies, see test_sandbox_seatbelt.py's own module docstring)
- [x] (skipped — Visual, standing waiver 2026-08-08)

security 配下のため architect の co-vet が必要です。merge は lead-coder にお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
