### PR TITLE
feat(#5838 段2): ExecPlan parser -- shlex + chain ops + redirects

### DIFF
--- a/src/reyn/security/exec_plan.py
+++ b/src/reyn/security/exec_plan.py
@@ -68,13 +68,16 @@ parser saw — the parse/execute gap class above:
   segment-level policy (段3) was never designed to scan.
 - Background execution: a bare ``&`` (not part of ``&&``) — changes
   process lifecycle in a way #5838's plan never modeled.
-- Variable/glob/home-directory expansion: any token containing ``$``,
-  a glob metacharacter (``* ? [``), or starting with ``~`` — resolves
-  to something DIFFERENT at real execution time than the literal text
-  this parser saw (measured bypasses: a redirect target check would
-  see the literal string ``"$HOME/out.txt"``, never the real expanded
-  path; a threat scan over ``rm *.txt`` would see the literal glob,
-  never the files it actually matches).
+- Variable/glob/brace/home-directory expansion: any token containing
+  ``$``, a glob metacharacter (``* ? [``), an opening brace ``{``
+  (macOS ``/bin/sh`` expands ``{a,b}`` even in POSIX mode), or starting
+  with ``~`` — resolves to something DIFFERENT at real execution time
+  than the literal text this parser saw (measured bypasses: a redirect
+  target check would see the literal string ``"$HOME/out.txt"``, never
+  the real expanded path; a threat scan over ``rm *.txt`` would see the
+  literal glob rather than whatever files actually match; ``cp
+  file{1,2} /tmp/`` would see ONE argv token while the real shell
+  operates on TWO files).
 - A leading ``NAME=value`` environment-assignment prefix — would become
   the segment's ``argv[0]``, hiding the REAL command from tool-axis
   policy entirely (``FOO=bar rm -rf /tmp/x`` → this parser's ``argv[0]``
@@ -133,23 +136,28 @@ _REDIRECT_OPS_SINGLE = frozenset({">", "<"})
 _CHAIN_OPS_DOUBLE = frozenset({"&&", "||"})
 _REDIRECT_OPS_DOUBLE = frozenset({">>"})
 
-# #5838 BLOCKING (architect co-vet, issuecomment-5578395294, real-machine
-# measurement against this module): a token containing ``$`` (variable
-# expansion), a glob metacharacter (``* ? [``), or starting with ``~``
-# (home-directory expansion) resolves to something DIFFERENT at real
-# `sh -c` execution time than the literal text this parser sees --
-# exactly the same "parser saw one thing, shell runs another" class this
-# module's own docstring names for `$(...)`/backtick, just via expansion
-# instead of substitution. Measured real bypasses: `echo hi >
-# $HOME/out.txt` let a redirect-target permission check (段3's future
-# `require_file_write`) see the literal string `"$HOME/out.txt"` instead
-# of the real path; `rm *.txt` let a threat scan see `"*.txt"` instead of
-# whatever files actually match at execution time. The SAME
-# "no way to know what this really is" gap a quoted operator-shaped
-# token (_iter_tokens's own docstring) is rejected for -- this closes
-# the inconsistency architect's own co-vet named: that gap was closed
-# for quoting and left open for expansion.
-_EXPANSION_CHARS = frozenset("$*?[")
+# #5838 BLOCKING (architect co-vet, issuecomment-5578395294 /
+# issuecomment-5578436446, real-machine measurement against this
+# module): a token containing ``$`` (variable expansion), a glob
+# metacharacter (``* ? [``), ``{`` (brace expansion -- macOS `/bin/sh`
+# expands `{a,b}` even in POSIX mode, measured: `cp file{1,2} /tmp/`
+# parses to ONE argv token `"file{1,2}"` while the real shell operates
+# on TWO files), or starting with ``~`` (home-directory expansion)
+# resolves to something DIFFERENT at real `sh -c` execution time than
+# the literal text this parser sees -- exactly the same "parser saw one
+# thing, shell runs another" class this module's own docstring names
+# for `$(...)`/backtick, just via expansion instead of substitution.
+# Measured real bypasses: `echo hi > $HOME/out.txt` let a redirect-
+# target permission check (段3's future `require_file_write`) see the
+# literal string `"$HOME/out.txt"` instead of the real path; `rm
+# *.txt` let a threat scan see `"*.txt"` instead of whatever files
+# actually match at execution time. The SAME "no way to know what this
+# really is" gap a quoted operator-shaped token (_iter_tokens's own
+# docstring) is rejected for -- one consistent judgement, not "safe
+# side for operators, open for expansion." Only the OPENING brace is
+# checked (architect's own ruling): a stray `}` alone (`echo a}b`) is
+# not a brace-expansion pattern and stays accepted, no divergence risk.
+_EXPANSION_CHARS = frozenset("$*?[{")
 
 # #5838 BLOCKING (same co-vet): `FOO=bar rm -rf /tmp/x` -- a leading
 # `NAME=value` environment-assignment prefix -- is not stripped by this

--- a/src/reyn/security/exec_plan.py
+++ b/src/reyn/security/exec_plan.py
@@ -90,6 +90,13 @@ parser saw — the parse/execute gap class above:
   parser cannot verify which the shell would really do; see
   :func:`_iter_tokens`'s own docstring for how this is detected and why
   it is refused rather than guessed either way.
+- A LITERAL NEWLINE anywhere in the input, checked BEFORE tokenizing —
+  the worst of this class measured: ``shlex`` folds a newline into
+  ordinary whitespace, so ``"ls\nrm -rf /tmp/x"`` parses as ONE segment
+  whose ``argv[0]`` is the ordinary, likely-allowed ``"ls"``, while a
+  real shell runs the newline as a command SEPARATOR — two commands,
+  the second never seen by policy at all. See :func:`parse_exec_plan`'s
+  own docstring for why this check runs first, unconditionally.
 - Any other unsupported punctuation sequence (``;;``, ``<>``, an
   isolated stray operator character, etc.).
 - An empty command line, an empty segment (a leading/trailing/doubled
@@ -333,7 +340,32 @@ def parse_exec_plan(text: str) -> "ExecPlan":
     (execution) runs the ORIGINAL *text* through ``sh -c``, never a
     reconstruction from this function's return value (architect's own
     ruling: "実行は... 元の文字列を渡す" — see this module's docstring
-    for why)."""
+    for why).
+
+    #5838 BLOCKING (architect co-vet, issuecomment-5578466297, real-
+    machine measurement — the worst of the class found so far): a
+    LITERAL NEWLINE in *text* is checked BEFORE tokenizing at all,
+    unconditionally, and rejected if present. ``shlex`` folds a newline
+    into ordinary whitespace, so ``"ls\\nrm -rf /tmp/x"`` parsed as ONE
+    segment (``argv=('ls','rm','-rf','/tmp/x')``) while a real
+    ``sh -c`` runs a newline as a COMMAND SEPARATOR — TWO commands,
+    ``ls`` then ``rm -rf /tmp/x``. Worse than every other bypass this
+    module closes: ``argv[0]`` here is ``"ls"`` — a real, ordinary,
+    almost-certainly-allowed tool — so a future tool-axis policy (段3)
+    would PASS this plan, and the shell would then run a command policy
+    never saw at all. A newline inside a quote is a legitimate single
+    argument (multi-line quoted text) that this blanket check also
+    rejects — the SAME "cannot distinguish quoted from unquoted ∴
+    reject either way" judgement :func:`_iter_tokens` already applies
+    to a quoted operator-shaped token, not a new exception to it."""
+    if "\n" in text or "\r" in text:
+        raise ExecPlanRejected(
+            "a newline is not supported here — shlex folds it into "
+            "ordinary whitespace, but a real shell treats it as a "
+            "command separator; this parser cannot tell a newline "
+            "inside quotes from one that would start a second, "
+            "unreviewed command, and refuses to guess"
+        )
     tokens = _iter_tokens(text)
     if not tokens:
         raise ExecPlanRejected("no command given")

--- a/src/reyn/security/exec_plan.py
+++ b/src/reyn/security/exec_plan.py
@@ -40,46 +40,104 @@ Codex incidents architect's research names (a `./sed` basename bypass,
 a zsh-fork sandbox-wrapper bypass). This parser's rejection list below
 exists specifically to keep that gap as narrow as competitors' own.
 
-## Denylist -> allowlist (architect's structural ruling, PR #5984
-BLOCKING, after 4 independent bypasses surfaced in ~40 minutes of
-review: ``$``/glob/``~``, brace ``{a,b}``, a literal newline, ``!``)
+## Denylist -> two-tier allowlist (architect's TWO rulings, PR #5984
+BLOCKING — the second a self-correction of the first)
 
 This module's FIRST version enumerated dangerous characters/constructs
 and rejected each one it found (a denylist). That denylist did not
 converge — a THIRD PARTY's shell (`/bin/sh`, whichever binary that
 resolves to on whatever machine this runs) decides what is special, and
 that population is not something this module's own source code can
-read and enumerate exhaustively; each review pass found one more
-character this parser had never considered. A denylist ALSO fails in
-the dangerous direction on anything it has not yet enumerated (unknown
--> accepted), the opposite of what a front-end whose only job is
-"policy's reading matches the shell's reading" needs (unknown -> must
-be refused).
+read and enumerate exhaustively; 4 independent bypasses surfaced in
+~40 minutes of review (`$`/glob/`~`, brace `{a,b}`, a literal newline,
+`!` negation), each via a different probing approach.
 
-This module now does the reverse: :data:`_ALLOWED_RAW_CHARS` is an
-ALLOWLIST checked against the RAW input string, before any tokenizing
-— not the per-token denylist checks the first version used (a
-per-token check misses a literal newline entirely: ``shlex`` folds it
-into ordinary whitespace before this module ever sees a token). Any
-character not in the allowed set — known dangerous or not yet
-discovered — is refused. See :func:`_reject_disallowed_raw_characters`
-for the set itself and the per-character justification (never "looks
-harmless" — "unquoted, ``shlex``'s posix tokenizer and ``sh`` agree on
-what this character means").
+The SECOND ruling (issuecomment-5578535394) corrected the first: a
+raw-string-wide allowlist checked EVERY character the same way and
+over-rejected real, benign commands (`python -c "print(1)"`,
+`curl "http://x/a?b=1"`). Real-machine measurement found the actual
+boundary was never "which characters are dangerous" — it was "which
+characters does ``shlex``'s own ``punctuation_chars`` distinguish by
+quoting":
+
+- ``python -c "print(1)"`` -> ``['python','-c','print(1)']`` — QUOTED,
+  ``shlex`` keeps the parens inside the WORD token, exactly like ``sh``
+  would treat them (literal).
+- ``python -c print(1)`` -> ``['python','-c','print','(','1',')']`` —
+  UNQUOTED, ``shlex`` splits them into their OWN punctuation tokens.
+- ``curl "...?b=1"`` and ``curl ...?b=1`` tokenize IDENTICALLY either
+  way — ``?`` is not in ``shlex``'s ``punctuation_chars``, so quoting
+  changes nothing observable, and this parser genuinely cannot recover
+  which the caller meant.
+
+So this module now runs TWO different checks, for two different
+reasons, not one blanket allowlist:
+
+1. :data:`_PUNCTUATION_CHARS` (`( ) | & ; < >` and backtick) — ``shlex``
+   DOES distinguish quoted from unquoted for these, so they are checked
+   per TOKEN, quote-aware: an unquoted occurrence becomes its own
+   operator token (checked for a SUPPORTED shape below); a quoted one
+   stays inside a word, accepted as literal text.
+2. :data:`_ALWAYS_FORBIDDEN_CHARS` (`$ * ? [ ] { } ~ !`) — ``shlex``
+   tokenizes these THE SAME WAY whether quoted or not, so there is no
+   recoverable signal; every occurrence is rejected, quoted or not (see
+   :func:`_reject_always_forbidden_characters`).
+
+Only ONE check still runs against the RAW string before any tokenizing
+(:func:`_reject_raw_newline`) — a literal newline, which never reaches
+a per-token check at all: ``shlex`` folds it into ordinary whitespace
+before producing a token.
+
+## This is an approximation, not the industry's own unit (owner
+directive "調べて" — architect's follow-up research, #5987)
+
+A CHARACTER allowlist is not what competitors do. Claude Code / Codex
+parse a real grammar (a tree-sitter AST) and allowlist NODE TYPES;
+OpenClaw allowlists a resolved path + argument pattern over its own
+execution plan. Both escalate what they cannot resolve (heredoc,
+expansion) TO THE OPERATOR rather than refusing outright — architect's
+own competitive research already recorded "人に回す" (hand it to a
+human) for exactly this case, and this module does not do that (段3's
+job, not this one — see :class:`ExecPlanRejected`'s own docstring). All
+4 bypasses this module closes (a newline, `!`, `$`/glob/`~`, brace)
+would show up structurally in a real AST — a separator node, a
+negation node, an expansion node — not as a character to notice by
+counting.
+
+This module makes NO claim of completeness. Those 4 were each found by
+real-machine MEASUREMENT (a live `sh -c` run compared against this
+parser's own output), one probing pass at a time — there is no evidence
+the enumeration in :data:`_ALWAYS_FORBIDDEN_CHARS`/
+:data:`_PUNCTUATION_CHARS` is a copy of the true population of
+characters/constructs a real shell treats specially, only that these 4
+are covered. A 5th is not ruled out by anything this module's own
+source can verify (see the module docstring's own denylist/allowlist
+history above for why that is a structural limit of counting
+characters, not a bug in THIS enumeration specifically).
+
+``shlex`` has no grammar to allowlist nodes OF, so counting characters
+was the only mechanism available here, not a considered design choice
+matching the field's own unit. #5987 tracks re-evaluating the parser
+itself (measured against real ``bash`` on one corpus, not "because it's
+the standard" — the two obvious alternatives each have their own
+measured failure modes: ``bashlex`` breaks on heredoc/arrays/arithmetic,
+``tree-sitter-bash`` has carried real bugs in Codex's own use of it).
+This module's own character-level approach stays as-is until that
+lands.
 
 ## What this parser accepts
 
-- The allowed literal characters (:data:`_ALLOWED_RAW_CHARS`) —
-  letters, digits, and a short list of punctuation ``shlex`` and ``sh``
-  read identically when unquoted (see that constant's own table).
+- Ordinary word characters — letters, digits, and punctuation neither
+  :data:`_PUNCTUATION_CHARS` nor :data:`_ALWAYS_FORBIDDEN_CHARS` claims
+  (e.g. ``- _ . / , : = + @ % #``) — literal to both ``shlex`` and
+  ``sh`` in every position, quoted or not.
 - ``shlex``-quoted words — single/double quotes, backslash escapes;
   the SAME primitive #5837's own (now-superseded) ``tokenize_exec_
-  cmdline`` used for the no-shell argv form. Quoting lets a word
-  contain a SPACE (already allowed raw) but does NOT let it contain a
-  character outside the allowlist — quoting is not an escape hatch
-  around the allowlist here (see :func:`_reject_disallowed_raw_
-  characters`'s own docstring for why the check runs on raw text,
-  quote-position-blind).
+  cmdline`` used for the no-shell argv form. Quoting DOES let a word
+  contain one of :data:`_PUNCTUATION_CHARS`'s own characters as literal
+  text (``"print(1)"``) — it does NOT rescue a character from
+  :data:`_ALWAYS_FORBIDDEN_CHARS` (see the section above for why those
+  two groups are treated differently).
 - Chain operators: ``|`` (pipe), ``&&`` (AND), ``||`` (OR), ``;``
   (sequence).
 - Redirects: ``>`` (truncate), ``>>`` (append), ``<`` (input) — each
@@ -90,30 +148,34 @@ what this character means").
 
 ## What this parser rejects
 
-Any character outside the allowlist above (this is now the primary
-defense, not an enumerated list — see the denylist/allowlist section),
-PLUS two things a character allowlist cannot express because they are
-about POSITION and CONTEXT, not individual characters:
-
+- A literal newline anywhere in the input (:func:`_reject_raw_newline`).
+- Any of :data:`_ALWAYS_FORBIDDEN_CHARS`, quoted or not
+  (:func:`_reject_always_forbidden_characters`).
+- An UNQUOTED occurrence of one of :data:`_PUNCTUATION_CHARS` that is
+  not a supported operator/redirect shape — command substitution
+  (backtick), subshell grouping (``(...)``), process substitution
+  (``<(...)``/``>(...)``), heredoc (``<<``), a bare ``&`` (background,
+  not part of ``&&``), or an unrecognised punctuation run (``;;``,
+  ``<>``).
 - A leading ``NAME=value`` environment-assignment prefix — every
-  character in ``FOO=bar`` is individually allowed (letters, ``=``),
-  but in the LEADING position of a segment it would become that
-  segment's ``argv[0]``, hiding the REAL command from tool-axis policy
-  entirely (``FOO=bar rm -rf /tmp/x`` → this parser's ``argv[0]`` would
-  be ``"FOO=bar"``, never ``"rm"`` — the same basename-bypass class
-  Codex #28732 named, reached through assignment instead of a relative
-  path). A LATER argument shaped like ``NAME=value`` (``docker run -e
-  FOO=bar image``) is unaffected.
-- A QUOTED token whose dequoted value happens to consist entirely of
-  operator characters (e.g. ``grep '|' file``) — string-identical to a
-  real unquoted operator once ``shlex`` strips the quotes, so this
-  parser cannot verify which the shell would really do; see
-  :func:`_iter_tokens`'s own docstring for how this is detected and why
-  it is refused rather than guessed either way.
-- Malformed operator/redirect placement (an empty segment, a redirect
-  with no target, an argument after a redirect's target, an
-  unrecognised punctuation run) or an unterminated quote (``shlex``
-  itself raises for the last one).
+  character in ``FOO=bar`` is individually allowed, but in the LEADING
+  position of a segment it would become that segment's ``argv[0]``,
+  hiding the REAL command from tool-axis policy entirely (``FOO=bar
+  rm -rf /tmp/x`` → this parser's ``argv[0]`` would be ``"FOO=bar"``,
+  never ``"rm"`` — the same basename-bypass class Codex #28732 named,
+  reached through assignment instead of a relative path). A LATER
+  argument shaped like ``NAME=value`` (``docker run -e FOO=bar image``)
+  is unaffected.
+- A QUOTED token whose dequoted value happens to consist ENTIRELY of
+  :data:`_PUNCTUATION_CHARS` characters (e.g. ``grep '|' file``) —
+  string-identical to a real unquoted operator once ``shlex`` strips
+  the quotes, so this parser cannot verify which the shell would really
+  do; see :func:`_iter_tokens`'s own docstring for how this is detected
+  and why it is refused rather than guessed either way.
+- An empty command line, an empty segment (a leading/trailing/doubled
+  chain operator), a redirect with no following path, an argument after
+  a redirect's target, or an unterminated quote (``shlex`` itself
+  raises for the last one).
 
 Rejection is LOUD (a raised exception with a human-readable reason),
 never a silent pass-through — matching Claude Code's "解析不能なら
@@ -124,16 +186,19 @@ competitive summary): every competitor's shape is "refuse, don't guess."
 ## If your command gets rejected
 
 This parser accepts a narrower set of commands than a real shell does
-— a real, benign command using a character outside the allowlist (a
-literal ``$``, a glob, brace expansion, home-directory ``~``, or a
-character this module has not yet allowlisted) is refused rather than
-guessed at. Two ways forward, once #5838's later stages land: (1) the
-no-shell argv form (#5837 — quote nothing, no operators, exactly the
-literal words to run) stays available wherever this parser's caller
-also offers it; (2) if you genuinely need one of these characters in a
-shell command, that character can be added to :data:`_ALLOWED_RAW_CHARS`
-with the SAME justification every existing entry carries ("unquoted,
-shlex and sh agree") — file it rather than working around this parser.
+— a real, benign command using one of :data:`_ALWAYS_FORBIDDEN_CHARS`
+(a literal ``$``, a glob, brace expansion, home-directory ``~``, a
+literal ``!``) is refused rather than guessed at, quoted or not — for
+example ``curl "http://x/a?b=1"`` cannot be accepted here: ``?`` is not
+distinguishable by quoting, the same reason a genuinely benign use is
+indistinguishable from a glob. Two ways forward, once #5838's later
+stages land: (1) the no-shell argv form (#5837 — quote nothing, no
+operators, exactly the literal words to run) stays available wherever
+this parser's caller also offers it; (2) if a specific character
+genuinely needs support, it can be added to :data:`_PUNCTUATION_CHARS`
+(if quote-aware handling is possible for it) with the same measured
+justification every existing entry carries — file it rather than
+working around this parser.
 """
 from __future__ import annotations
 
@@ -143,15 +208,28 @@ import shlex
 from dataclasses import dataclass
 from typing import cast
 
-# The operator characters this parser recognises — the ONE source of
-# truth for both the raw-string allowlist (_ALLOWED_RAW_CHARS, below)
-# and shlex's own tokenizing (_iter_tokens passes this as
-# punctuation_chars). A token whose dequoted VALUE is entirely made of
-# these characters is either a real operator (unquoted) or, if it was
-# quoted, rejected outright (_iter_tokens's own docstring — this parser
-# cannot tell the two apart by value alone, and refuses to guess).
-_OPERATOR_CHARS = "|&;><"
-_PUNCTUATION_CHARS = _OPERATOR_CHARS
+# #5838 BLOCKING (architect's SECOND ruling, issuecomment-5578535394 --
+# a self-correction of the first allowlist, issuecomment-5578494687):
+# the raw-string-wide allowlist over-rejected. Real-machine measurement
+# against 16 real commands found 2 false rejections and a boundary that
+# was never "which characters are dangerous" -- it was "which
+# characters shlex's own `punctuation_chars` distinguishes by quoting":
+#
+#   'python -c "print(1)"' -> ['python','-c','print(1)']       (quoted: shlex keeps the parens in the WORD)
+#   'python -c print(1)'   -> ['python','-c','print','(','1',')']  (unquoted: shlex splits them into their OWN tokens)
+#
+# For `( ) | & ; < >` (and backtick, added to punctuation_chars the
+# same way), `shlex` genuinely tells quoted from unquoted apart --
+# quoted, they land inside a WORD token exactly like sh would treat
+# them (literal); unquoted, they become their OWN punctuation token,
+# checked below for a SUPPORTED shape (a pipe, a chain op, a redirect)
+# and rejected otherwise (an unsupported one, e.g. a bare `(` subshell
+# open, still raises). `curl "...?b=1"` and `curl ...?b=1` tokenize
+# IDENTICALLY either way (`?` is not in punctuation_chars) -- for THAT
+# class of character, quoting changes nothing shlex can see, so this
+# parser genuinely cannot recover intent and rejects unconditionally,
+# quoted or not (see `_ALWAYS_FORBIDDEN_CHARS` below).
+_PUNCTUATION_CHARS = "();<>|&`"
 
 # Single-character operator tokens this parser accepts standalone.
 _CHAIN_OPS_SINGLE = frozenset({"|", ";"})
@@ -167,91 +245,53 @@ _REDIRECT_OPS_SINGLE = frozenset({">", "<"})
 _CHAIN_OPS_DOUBLE = frozenset({"&&", "||"})
 _REDIRECT_OPS_DOUBLE = frozenset({">>"})
 
-# #5838 BLOCKING (architect's structural ruling, issuecomment-5578494687,
-# after 4 independent bypasses in ~40 minutes of denylist review: $/
-# glob/~, brace {a,b}, a literal newline, ! negation) -- see this
-# module's own docstring, "Denylist -> allowlist," for why this replaced
-# a per-character denylist. Every character below is admitted for the
-# SAME reason (architect's own required criterion, never "looks
-# harmless"): unquoted, shlex's posix tokenizer and sh's own
-# interpretation agree on what this character means.
-#
-# | chars              | why unquoted shlex and sh agree                |
-# |--------------------|-------------------------------------------------|
-# | A-Z a-z 0-9         | ordinary word characters to both; no operator/  |
-# |                     | expansion meaning either side                    |
-# | ``-``               | option-flag marker to both; not a shell          |
-# |                     | metacharacter to either                          |
-# | ``_``               | ordinary identifier/word character to both       |
-# | ``.``               | literal in both -- NOT a glob metacharacter by   |
-# |                     | itself (only ``* ? [`` are)                      |
-# | ``/``               | path separator, literal to both                  |
-# | ``,``               | literal to both UNLESS paired with ``{``/``}``   |
-# |                     | (brace expansion) -- those two are NOT in this   |
-# |                     | set, so a lone ``,`` has no special sh meaning   |
-# | ``:``               | literal to both -- PATH-list-separator is a      |
-# |                     | convention programs read, not shell syntax       |
-# | ``=``               | ordinary word character to both -- its only      |
-# |                     | special meaning is POSITIONAL (a leading         |
-# |                     | ``NAME=`` prefix), a separate check below, not a |
-# |                     | per-character concern                            |
-# | ``+``               | literal to both                                  |
-# | ``@``               | literal to both for non-interactive ``sh -c``    |
-# | ``%``               | literal to both for non-interactive ``sh -c``    |
-# |                     | (job-control ``%`` is an interactive-shell-only  |
-# |                     | feature, not reachable through this front-end)   |
-# | ``#``               | agree even though it IS special to both: shlex's |
-# |                     | own default `commenters` is `#` (rest-of-line    |
-# |                     | ignored), matching `sh`'s own comment syntax     |
-# |                     | exactly -- `ls # rm -rf /` reads identically on  |
-# |                     | both sides (architect's own confirmed-safe case) |
-#
-# Quote characters (`'`/`"`) let a WORD contain a space (already
-# allowed raw) but do not admit any character outside this set --
-# quoting is not an escape hatch around the allowlist (module docstring,
-# "What this parser accepts"). Whitespace (space/tab) separates words;
-# a NEWLINE is deliberately excluded (module docstring's own newline
-# section) -- `shlex` folds it into ordinary whitespace, but a real
-# shell reads it as a command separator. Recognised operators
-# (_OPERATOR_CHARS) are admitted as themselves, checked for a supported
-# shape by the main parse loop below (an unrecognised punctuation run,
-# e.g. `;;`, still raises there).
-_LITERAL_CHARS = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    "-_./,:=+@%#"
-)
-_QUOTE_CHARS = frozenset("'\"")
-_RAW_WHITESPACE_CHARS = frozenset(" \t")
-_ALLOWED_RAW_CHARS = (
-    _LITERAL_CHARS | _QUOTE_CHARS | frozenset(_OPERATOR_CHARS) | _RAW_WHITESPACE_CHARS
-)
+# #5838 BLOCKING (architect's second ruling, same comment as above): a
+# character shlex does NOT distinguish by quoting -- `$` (variable
+# expansion), `*`/`?`/`[`/`]` (glob), `{`/`}` (brace expansion, macOS
+# `/bin/sh` expands `{a,b}` even in POSIX mode), `~` (home-directory
+# expansion), `!` (negation operator -- `! ls` reads as negation to a
+# real shell, never a command name). None of these are in
+# `_PUNCTUATION_CHARS`, so `shlex` tokenizes a quoted and an unquoted
+# occurrence THE SAME WAY (unlike `( ) | & ; < >`, above) -- there is no
+# recoverable signal to tell "the caller quoted this deliberately" from
+# "this is about to expand," so every occurrence is rejected, quoted or
+# not (`curl "...?b=1"` cannot be saved this way -- architect's own
+# explicit acceptance of that loss, see the module docstring's own
+# "If your command gets rejected" section for the escape hatch).
+_ALWAYS_FORBIDDEN_CHARS = frozenset("$*?[]{}~!")
 
 
-def _reject_disallowed_raw_characters(text: str) -> None:
-    """The primary defense (architect's structural ruling, replacing a
-    per-character denylist — see this module's own docstring): raises
-    :class:`ExecPlanRejected` if *text* contains ANY character outside
-    :data:`_ALLOWED_RAW_CHARS`, checked against the RAW string, before
-    any tokenizing.
-
-    Raw, not per-token, on purpose: a per-token check cannot see a
-    NEWLINE at all — ``shlex`` folds it into ordinary whitespace before
-    ever producing a token, which is exactly how the newline bypass
-    (module docstring) reached this module's own denylist-era version.
-    Quote-position-blind, also on purpose: this does not attempt to
-    special-case a disallowed character that happens to sit inside a
-    quoted region — the SAME "cannot verify, so refuse" judgement
-    :func:`_iter_tokens` already applies to a quoted operator-shaped
-    token, applied here to every other character too, not a second,
-    narrower rule."""
-    disallowed = sorted(set(text) - _ALLOWED_RAW_CHARS)
-    if disallowed:
+def _reject_always_forbidden_characters(token: str) -> None:
+    """Raises :class:`ExecPlanRejected` if *token* contains any
+    character from :data:`_ALWAYS_FORBIDDEN_CHARS` — see that constant's
+    own module-level comment for why these, specifically, are rejected
+    regardless of quoting (unlike the operator characters in
+    :data:`_PUNCTUATION_CHARS`, which ARE quote-aware)."""
+    hit = _ALWAYS_FORBIDDEN_CHARS.intersection(token)
+    if hit:
         raise ExecPlanRejected(
-            f"character(s) not supported here: {disallowed!r} — this "
-            "parser only accepts a fixed allowlist of characters whose "
-            "meaning is guaranteed to match between shlex and a real "
-            "shell (see the module's own docstring, \"If your command "
-            "gets rejected,\" for what to do next)"
+            f"character(s) not supported here (token: {token!r}, "
+            f"character(s): {sorted(hit)!r}) — this parser cannot predict "
+            "what these resolve to at execution time, quoted or not (see "
+            "the module's own docstring, \"If your command gets "
+            "rejected,\" for what to do next)"
+        )
+
+
+def _reject_raw_newline(text: str) -> None:
+    """Raises :class:`ExecPlanRejected` if *text* contains a literal
+    newline — the ONE check this parser still runs against the RAW
+    string, before any tokenizing (module docstring's own newline
+    section): ``shlex`` folds a newline into ordinary whitespace, so it
+    never reaches a per-token check like
+    :func:`_reject_always_forbidden_characters` at all."""
+    if "\n" in text or "\r" in text:
+        raise ExecPlanRejected(
+            "a newline is not supported here — shlex folds it into "
+            "ordinary whitespace, but a real shell treats it as a "
+            "command separator; this parser cannot tell a newline "
+            "inside quotes from one that would start a second, "
+            "unreviewed command, and refuses to guess"
         )
 
 
@@ -282,10 +322,12 @@ def _looks_like_leading_assignment(token: str) -> bool:
 
 class ExecPlanRejected(Exception):
     """Raised by :func:`parse_exec_plan` when *text* contains a
-    character outside :data:`_ALLOWED_RAW_CHARS`, or a shell construct
-    this parser cannot safely decompose into policy-checkable segments
-    (#5838 段2) — see this module's own docstring, "What this parser
-    rejects" and "Denylist -> allowlist," for the reasoning.
+    character it cannot resolve safely (:data:`_ALWAYS_FORBIDDEN_CHARS`,
+    a raw newline, or an unquoted :data:`_PUNCTUATION_CHARS` occurrence
+    in an unsupported shape), or a shell construct this parser cannot
+    safely decompose into policy-checkable segments (#5838 段2) — see
+    this module's own docstring, "What this parser rejects" and
+    "Denylist -> two-tier allowlist," for the reasoning.
 
     This is a v1 narrowing, disclosed, not a claim of covering every
     legitimate shell command: a real, benign command using a character
@@ -374,9 +416,12 @@ def _iter_tokens(text: str) -> "list[tuple[str, bool]]":
     parser cannot verify which the real shell would do (treat it as
     literal text, per the quoting, or — if some future construct this
     parser does not yet know about defeats the quote — as the operator
-    it resembles) and refuses to guess, the SAME judgement
-    :func:`_reject_disallowed_raw_characters` applies to every other
-    character outside the allowlist.
+    it resembles) and refuses to guess. NOT the same situation
+    :func:`_reject_always_forbidden_characters` handles — those
+    characters are rejected because ``shlex`` gives NO quoting signal at
+    all; this one exists because ``shlex`` gives a signal
+    (:data:`_PUNCTUATION_CHARS`) that this specific case cannot fully
+    trust either.
 
     Raises :class:`ExecPlanRejected` for an unterminated quote (``shlex``
     itself raises ``ValueError``) or for a quoted operator-shaped token
@@ -430,19 +475,19 @@ def parse_exec_plan(text: str) -> "ExecPlan":
     ruling: "実行は... 元の文字列を渡す" — see this module's docstring
     for why).
 
-    The FIRST check (architect's structural ruling — see the module
-    docstring's own "Denylist -> allowlist" section) is
-    :func:`_reject_disallowed_raw_characters`, run against *text* BEFORE
-    any tokenizing: this is what catches a literal newline (``shlex``
-    folds it into ordinary whitespace, so a per-token check would never
-    see it — ``"ls\\nrm -rf /tmp/x"`` would otherwise parse as ONE
-    segment whose ``argv[0]`` is the ordinary, almost-certainly-allowed
-    ``"ls"``, while a real shell runs the newline as a command
-    SEPARATOR, running ``rm -rf /tmp/x`` as a second command policy
-    never saw at all) and every other character this parser does not
-    yet accept, in ONE place, by construction, rather than by
-    enumerating each dangerous case as it is found."""
-    _reject_disallowed_raw_characters(text)
+    The FIRST check (module docstring's own "Denylist -> two-tier
+    allowlist" section) is :func:`_reject_raw_newline`, run against
+    *text* BEFORE any tokenizing: ``shlex`` folds a newline into
+    ordinary whitespace, so a per-token check would never see it —
+    ``"ls\\nrm -rf /tmp/x"`` would otherwise parse as ONE segment whose
+    ``argv[0]`` is the ordinary, almost-certainly-allowed ``"ls"``,
+    while a real shell runs the newline as a command SEPARATOR, running
+    ``rm -rf /tmp/x`` as a second command policy never saw at all.
+    Every other rejection (:func:`_reject_always_forbidden_characters`,
+    the leading-assignment check, an unsupported operator shape) runs
+    per TOKEN, once tokenizing has happened — see the module docstring
+    for why these two checks are not merged into one."""
+    _reject_raw_newline(text)
     tokens = _iter_tokens(text)
     if not tokens:
         raise ExecPlanRejected("no command given")
@@ -471,6 +516,7 @@ def parse_exec_plan(text: str) -> "ExecPlan":
                     f"parser (token: {token!r}) — put every argument before "
                     "the redirect"
                 )
+            _reject_always_forbidden_characters(token)
             if not current_argv and _looks_like_leading_assignment(token):
                 raise ExecPlanRejected(
                     f"a leading NAME=value environment assignment is not "
@@ -496,6 +542,7 @@ def parse_exec_plan(text: str) -> "ExecPlan":
             nxt = tokens[i + 1] if i + 1 < len(tokens) else None
             if nxt is None or nxt[1]:
                 raise ExecPlanRejected(f"redirect {token!r} has no target path")
+            _reject_always_forbidden_characters(nxt[0])
             plan.append(ExecRedirect(op=token, path=nxt[0]))
             redirect_closed_segment = True
             i += 2
@@ -509,13 +556,14 @@ def parse_exec_plan(text: str) -> "ExecPlan":
                 "segment-level check was designed to scan."
             )
 
-        # A punctuation token that survived _iter_tokens but is not one
-        # of #5838's supported operators/redirects -- a lone "&", or an
-        # unrecognised run like "<>"/";;" (built entirely from allowed
-        # operator characters, just not a recognised COMBINATION of
-        # them -- "(", ")", "`" and everything else this branch used to
-        # need to name are now unreachable, blocked earlier by
-        # _reject_disallowed_raw_characters).
+        # An unquoted _PUNCTUATION_CHARS token that survived _iter_tokens
+        # but is not one of #5838's supported operators/redirects --
+        # "(" / ")" / "`" (subshell / command substitution -- see the
+        # module docstring for why these hide a second command), a lone
+        # "&" (background, not part of "&&"), or an unrecognised run
+        # like "<>"/";;". A QUOTED occurrence of any of these never
+        # reaches here at all -- it stays inside a WORD token
+        # (_iter_tokens's own classification), accepted as literal text.
         raise ExecPlanRejected(
             f"unsupported shell construct (token: {token!r}) — this parser "
             "only supports pipes/chains (| && || ;) and redirects (> >> <), "

--- a/src/reyn/security/exec_plan.py
+++ b/src/reyn/security/exec_plan.py
@@ -40,11 +40,46 @@ Codex incidents architect's research names (a `./sed` basename bypass,
 a zsh-fork sandbox-wrapper bypass). This parser's rejection list below
 exists specifically to keep that gap as narrow as competitors' own.
 
+## Denylist -> allowlist (architect's structural ruling, PR #5984
+BLOCKING, after 4 independent bypasses surfaced in ~40 minutes of
+review: ``$``/glob/``~``, brace ``{a,b}``, a literal newline, ``!``)
+
+This module's FIRST version enumerated dangerous characters/constructs
+and rejected each one it found (a denylist). That denylist did not
+converge — a THIRD PARTY's shell (`/bin/sh`, whichever binary that
+resolves to on whatever machine this runs) decides what is special, and
+that population is not something this module's own source code can
+read and enumerate exhaustively; each review pass found one more
+character this parser had never considered. A denylist ALSO fails in
+the dangerous direction on anything it has not yet enumerated (unknown
+-> accepted), the opposite of what a front-end whose only job is
+"policy's reading matches the shell's reading" needs (unknown -> must
+be refused).
+
+This module now does the reverse: :data:`_ALLOWED_RAW_CHARS` is an
+ALLOWLIST checked against the RAW input string, before any tokenizing
+— not the per-token denylist checks the first version used (a
+per-token check misses a literal newline entirely: ``shlex`` folds it
+into ordinary whitespace before this module ever sees a token). Any
+character not in the allowed set — known dangerous or not yet
+discovered — is refused. See :func:`_reject_disallowed_raw_characters`
+for the set itself and the per-character justification (never "looks
+harmless" — "unquoted, ``shlex``'s posix tokenizer and ``sh`` agree on
+what this character means").
+
 ## What this parser accepts
 
+- The allowed literal characters (:data:`_ALLOWED_RAW_CHARS`) —
+  letters, digits, and a short list of punctuation ``shlex`` and ``sh``
+  read identically when unquoted (see that constant's own table).
 - ``shlex``-quoted words — single/double quotes, backslash escapes;
   the SAME primitive #5837's own (now-superseded) ``tokenize_exec_
-  cmdline`` used for the no-shell argv form.
+  cmdline`` used for the no-shell argv form. Quoting lets a word
+  contain a SPACE (already allowed raw) but does NOT let it contain a
+  character outside the allowlist — quoting is not an escape hatch
+  around the allowlist here (see :func:`_reject_disallowed_raw_
+  characters`'s own docstring for why the check runs on raw text,
+  quote-position-blind).
 - Chain operators: ``|`` (pipe), ``&&`` (AND), ``||`` (OR), ``;``
   (sequence).
 - Redirects: ``>`` (truncate), ``>>`` (append), ``<`` (input) — each
@@ -53,61 +88,52 @@ exists specifically to keep that gap as narrow as competitors' own.
   :class:`ExecPlanRejected`'s own docstring for why this is a
   deliberate v1 narrowing, not an oversight).
 
-## What this parser REJECTS (raises :class:`ExecPlanRejected`)
+## What this parser rejects
 
-Anything that would let a segment's real argv[0] diverge from what this
-parser saw — the parse/execute gap class above:
+Any character outside the allowlist above (this is now the primary
+defense, not an enumerated list — see the denylist/allowlist section),
+PLUS two things a character allowlist cannot express because they are
+about POSITION and CONTEXT, not individual characters:
 
-- Command substitution: ``$(...)`` or backtick ```cmd```` — a nested
-  command this parser would never see, exactly the "解析器が見ない
-  第2の経路" shape.
-- Subshell grouping: ``(...)``  / process substitution: ``<(...)``,
-  ``>(...)`` — same reason; a parenthesized group can hide a whole
-  second pipeline.
-- Heredoc: ``<<`` (and ``<<-``) — arbitrary multi-line content the
-  segment-level policy (段3) was never designed to scan.
-- Background execution: a bare ``&`` (not part of ``&&``) — changes
-  process lifecycle in a way #5838's plan never modeled.
-- Variable/glob/brace/home-directory expansion: any token containing
-  ``$``, a glob metacharacter (``* ? [``), an opening brace ``{``
-  (macOS ``/bin/sh`` expands ``{a,b}`` even in POSIX mode), or starting
-  with ``~`` — resolves to something DIFFERENT at real execution time
-  than the literal text this parser saw (measured bypasses: a redirect
-  target check would see the literal string ``"$HOME/out.txt"``, never
-  the real expanded path; a threat scan over ``rm *.txt`` would see the
-  literal glob rather than whatever files actually match; ``cp
-  file{1,2} /tmp/`` would see ONE argv token while the real shell
-  operates on TWO files).
-- A leading ``NAME=value`` environment-assignment prefix — would become
-  the segment's ``argv[0]``, hiding the REAL command from tool-axis
-  policy entirely (``FOO=bar rm -rf /tmp/x`` → this parser's ``argv[0]``
-  would be ``"FOO=bar"``, never ``"rm"`` — the same basename-bypass
-  class Codex #28732 named, reached through assignment instead of a
-  relative path).
+- A leading ``NAME=value`` environment-assignment prefix — every
+  character in ``FOO=bar`` is individually allowed (letters, ``=``),
+  but in the LEADING position of a segment it would become that
+  segment's ``argv[0]``, hiding the REAL command from tool-axis policy
+  entirely (``FOO=bar rm -rf /tmp/x`` → this parser's ``argv[0]`` would
+  be ``"FOO=bar"``, never ``"rm"`` — the same basename-bypass class
+  Codex #28732 named, reached through assignment instead of a relative
+  path). A LATER argument shaped like ``NAME=value`` (``docker run -e
+  FOO=bar image``) is unaffected.
 - A QUOTED token whose dequoted value happens to consist entirely of
   operator characters (e.g. ``grep '|' file``) — string-identical to a
   real unquoted operator once ``shlex`` strips the quotes, so this
   parser cannot verify which the shell would really do; see
   :func:`_iter_tokens`'s own docstring for how this is detected and why
   it is refused rather than guessed either way.
-- A LITERAL NEWLINE anywhere in the input, checked BEFORE tokenizing —
-  the worst of this class measured: ``shlex`` folds a newline into
-  ordinary whitespace, so ``"ls\nrm -rf /tmp/x"`` parses as ONE segment
-  whose ``argv[0]`` is the ordinary, likely-allowed ``"ls"``, while a
-  real shell runs the newline as a command SEPARATOR — two commands,
-  the second never seen by policy at all. See :func:`parse_exec_plan`'s
-  own docstring for why this check runs first, unconditionally.
-- Any other unsupported punctuation sequence (``;;``, ``<>``, an
-  isolated stray operator character, etc.).
-- An empty command line, an empty segment (a leading/trailing/doubled
-  chain operator), a redirect with no following path, or an unterminated
-  quote (``shlex`` itself raises for the last one).
+- Malformed operator/redirect placement (an empty segment, a redirect
+  with no target, an argument after a redirect's target, an
+  unrecognised punctuation run) or an unterminated quote (``shlex``
+  itself raises for the last one).
 
 Rejection is LOUD (a raised exception with a human-readable reason),
 never a silent pass-through — matching Claude Code's "解析不能なら
 プロンプトへ" / Codex's ``used_complex_parsing`` escalation / OpenClaw's
 "chain/redirect は全 segment が通らない限り拒否" (architect's own
 competitive summary): every competitor's shape is "refuse, don't guess."
+
+## If your command gets rejected
+
+This parser accepts a narrower set of commands than a real shell does
+— a real, benign command using a character outside the allowlist (a
+literal ``$``, a glob, brace expansion, home-directory ``~``, or a
+character this module has not yet allowlisted) is refused rather than
+guessed at. Two ways forward, once #5838's later stages land: (1) the
+no-shell argv form (#5837 — quote nothing, no operators, exactly the
+literal words to run) stays available wherever this parser's caller
+also offers it; (2) if you genuinely need one of these characters in a
+shell command, that character can be added to :data:`_ALLOWED_RAW_CHARS`
+with the SAME justification every existing entry carries ("unquoted,
+shlex and sh agree") — file it rather than working around this parser.
 """
 from __future__ import annotations
 
@@ -117,17 +143,15 @@ import shlex
 from dataclasses import dataclass
 from typing import cast
 
-# The operator/redirect characters this parser understands as
-# standalone tokens — a token whose dequoted VALUE is entirely made of
+# The operator characters this parser recognises — the ONE source of
+# truth for both the raw-string allowlist (_ALLOWED_RAW_CHARS, below)
+# and shlex's own tokenizing (_iter_tokens passes this as
+# punctuation_chars). A token whose dequoted VALUE is entirely made of
 # these characters is either a real operator (unquoted) or, if it was
 # quoted, rejected outright (_iter_tokens's own docstring — this parser
 # cannot tell the two apart by value alone, and refuses to guess).
-# Backtick is added to shlex's own default punctuation set
-# (`shlex.punctuation_chars = True` gives ``();<>|&`` per the stdlib
-# docs) specifically so command substitution's backtick form is caught
-# by the SAME "not a recognised operator" rule as ``$(...)``'s own
-# ``(``/``)`` — one rejection path, not two.
-_PUNCTUATION_CHARS = "();<>|&`"
+_OPERATOR_CHARS = "|&;><"
+_PUNCTUATION_CHARS = _OPERATOR_CHARS
 
 # Single-character operator tokens this parser accepts standalone.
 _CHAIN_OPS_SINGLE = frozenset({"|", ";"})
@@ -143,49 +167,109 @@ _REDIRECT_OPS_SINGLE = frozenset({">", "<"})
 _CHAIN_OPS_DOUBLE = frozenset({"&&", "||"})
 _REDIRECT_OPS_DOUBLE = frozenset({">>"})
 
-# #5838 BLOCKING (architect co-vet, issuecomment-5578395294 /
-# issuecomment-5578436446, real-machine measurement against this
-# module): a token containing ``$`` (variable expansion), a glob
-# metacharacter (``* ? [``), ``{`` (brace expansion -- macOS `/bin/sh`
-# expands `{a,b}` even in POSIX mode, measured: `cp file{1,2} /tmp/`
-# parses to ONE argv token `"file{1,2}"` while the real shell operates
-# on TWO files), or starting with ``~`` (home-directory expansion)
-# resolves to something DIFFERENT at real `sh -c` execution time than
-# the literal text this parser sees -- exactly the same "parser saw one
-# thing, shell runs another" class this module's own docstring names
-# for `$(...)`/backtick, just via expansion instead of substitution.
-# Measured real bypasses: `echo hi > $HOME/out.txt` let a redirect-
-# target permission check (段3's future `require_file_write`) see the
-# literal string `"$HOME/out.txt"` instead of the real path; `rm
-# *.txt` let a threat scan see `"*.txt"` instead of whatever files
-# actually match at execution time. The SAME "no way to know what this
-# really is" gap a quoted operator-shaped token (_iter_tokens's own
-# docstring) is rejected for -- one consistent judgement, not "safe
-# side for operators, open for expansion." Only the OPENING brace is
-# checked (architect's own ruling): a stray `}` alone (`echo a}b`) is
-# not a brace-expansion pattern and stays accepted, no divergence risk.
-_EXPANSION_CHARS = frozenset("$*?[{")
+# #5838 BLOCKING (architect's structural ruling, issuecomment-5578494687,
+# after 4 independent bypasses in ~40 minutes of denylist review: $/
+# glob/~, brace {a,b}, a literal newline, ! negation) -- see this
+# module's own docstring, "Denylist -> allowlist," for why this replaced
+# a per-character denylist. Every character below is admitted for the
+# SAME reason (architect's own required criterion, never "looks
+# harmless"): unquoted, shlex's posix tokenizer and sh's own
+# interpretation agree on what this character means.
+#
+# | chars              | why unquoted shlex and sh agree                |
+# |--------------------|-------------------------------------------------|
+# | A-Z a-z 0-9         | ordinary word characters to both; no operator/  |
+# |                     | expansion meaning either side                    |
+# | ``-``               | option-flag marker to both; not a shell          |
+# |                     | metacharacter to either                          |
+# | ``_``               | ordinary identifier/word character to both       |
+# | ``.``               | literal in both -- NOT a glob metacharacter by   |
+# |                     | itself (only ``* ? [`` are)                      |
+# | ``/``               | path separator, literal to both                  |
+# | ``,``               | literal to both UNLESS paired with ``{``/``}``   |
+# |                     | (brace expansion) -- those two are NOT in this   |
+# |                     | set, so a lone ``,`` has no special sh meaning   |
+# | ``:``               | literal to both -- PATH-list-separator is a      |
+# |                     | convention programs read, not shell syntax       |
+# | ``=``               | ordinary word character to both -- its only      |
+# |                     | special meaning is POSITIONAL (a leading         |
+# |                     | ``NAME=`` prefix), a separate check below, not a |
+# |                     | per-character concern                            |
+# | ``+``               | literal to both                                  |
+# | ``@``               | literal to both for non-interactive ``sh -c``    |
+# | ``%``               | literal to both for non-interactive ``sh -c``    |
+# |                     | (job-control ``%`` is an interactive-shell-only  |
+# |                     | feature, not reachable through this front-end)   |
+# | ``#``               | agree even though it IS special to both: shlex's |
+# |                     | own default `commenters` is `#` (rest-of-line    |
+# |                     | ignored), matching `sh`'s own comment syntax     |
+# |                     | exactly -- `ls # rm -rf /` reads identically on  |
+# |                     | both sides (architect's own confirmed-safe case) |
+#
+# Quote characters (`'`/`"`) let a WORD contain a space (already
+# allowed raw) but do not admit any character outside this set --
+# quoting is not an escape hatch around the allowlist (module docstring,
+# "What this parser accepts"). Whitespace (space/tab) separates words;
+# a NEWLINE is deliberately excluded (module docstring's own newline
+# section) -- `shlex` folds it into ordinary whitespace, but a real
+# shell reads it as a command separator. Recognised operators
+# (_OPERATOR_CHARS) are admitted as themselves, checked for a supported
+# shape by the main parse loop below (an unrecognised punctuation run,
+# e.g. `;;`, still raises there).
+_LITERAL_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    "-_./,:=+@%#"
+)
+_QUOTE_CHARS = frozenset("'\"")
+_RAW_WHITESPACE_CHARS = frozenset(" \t")
+_ALLOWED_RAW_CHARS = (
+    _LITERAL_CHARS | _QUOTE_CHARS | frozenset(_OPERATOR_CHARS) | _RAW_WHITESPACE_CHARS
+)
 
-# #5838 BLOCKING (same co-vet): `FOO=bar rm -rf /tmp/x` -- a leading
-# `NAME=value` environment-assignment prefix -- is not stripped by this
-# parser, so `argv[0]` becomes the literal string `"FOO=bar"`, never
-# `"rm"`. Any future tool-axis policy (段3) reading `argv[0]` would
-# check the WRONG binary entirely; the real `rm` never reaches policy at
-# all -- the exact `./sed` basename-bypass class architect's own
-# competitive research (Codex #28732) names, reached through a different
-# door. Matched only in LEADING position (before the first real word of
-# a segment — see `_looks_like_leading_assignment`'s own caller) so a
+
+def _reject_disallowed_raw_characters(text: str) -> None:
+    """The primary defense (architect's structural ruling, replacing a
+    per-character denylist — see this module's own docstring): raises
+    :class:`ExecPlanRejected` if *text* contains ANY character outside
+    :data:`_ALLOWED_RAW_CHARS`, checked against the RAW string, before
+    any tokenizing.
+
+    Raw, not per-token, on purpose: a per-token check cannot see a
+    NEWLINE at all — ``shlex`` folds it into ordinary whitespace before
+    ever producing a token, which is exactly how the newline bypass
+    (module docstring) reached this module's own denylist-era version.
+    Quote-position-blind, also on purpose: this does not attempt to
+    special-case a disallowed character that happens to sit inside a
+    quoted region — the SAME "cannot verify, so refuse" judgement
+    :func:`_iter_tokens` already applies to a quoted operator-shaped
+    token, applied here to every other character too, not a second,
+    narrower rule."""
+    disallowed = sorted(set(text) - _ALLOWED_RAW_CHARS)
+    if disallowed:
+        raise ExecPlanRejected(
+            f"character(s) not supported here: {disallowed!r} — this "
+            "parser only accepts a fixed allowlist of characters whose "
+            "meaning is guaranteed to match between shlex and a real "
+            "shell (see the module's own docstring, \"If your command "
+            "gets rejected,\" for what to do next)"
+        )
+
+
+# #5838 BLOCKING: `FOO=bar rm -rf /tmp/x` -- a leading `NAME=value`
+# environment-assignment prefix -- is not stripped by this parser, so
+# `argv[0]` becomes the literal string `"FOO=bar"`, never `"rm"`. Any
+# future tool-axis policy (段3) reading `argv[0]` would check the WRONG
+# binary entirely; the real `rm` never reaches policy at all -- the
+# exact `./sed` basename-bypass class architect's own competitive
+# research (Codex #28732) names, reached through a different door. Not
+# expressible as a character allowlist entry (every character in
+# `FOO=bar` is individually allowed) -- this is a POSITIONAL check.
+# Matched only in LEADING position (before the first real word of a
+# segment — see `_looks_like_leading_assignment`'s own caller) so a
 # legitimate later argument shaped like `NAME=value` (e.g. `docker run
 # -e FOO=bar image`) is unaffected: `docker` already satisfied "a real
 # word was seen" before `FOO=bar` appears.
 _ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-
-
-def _contains_expansion(token: str) -> bool:
-    """True if *token* would resolve to something this parser cannot
-    predict at real shell execution time — see ``_EXPANSION_CHARS``'s
-    own module-level comment for the measured bypasses this closes."""
-    return bool(_EXPANSION_CHARS.intersection(token)) or token.startswith("~")
 
 
 def _looks_like_leading_assignment(token: str) -> bool:
@@ -197,17 +281,20 @@ def _looks_like_leading_assignment(token: str) -> bool:
 
 
 class ExecPlanRejected(Exception):
-    """Raised by :func:`parse_exec_plan` when *text* contains a shell
-    construct this parser cannot safely decompose into policy-checkable
-    segments (#5838 段2) — see this module's own docstring for the full
-    rejection list and why each one is there.
+    """Raised by :func:`parse_exec_plan` when *text* contains a
+    character outside :data:`_ALLOWED_RAW_CHARS`, or a shell construct
+    this parser cannot safely decompose into policy-checkable segments
+    (#5838 段2) — see this module's own docstring, "What this parser
+    rejects" and "Denylist -> allowlist," for the reasoning.
 
     This is a v1 narrowing, disclosed, not a claim of covering every
-    legitimate shell command: a real, benign command using a rejected
-    construct (a heredoc, a subshell, `2>` fd-numbered redirects, argv
-    tokens after a redirect) is refused with a reason, the same
-    "refuse, don't guess" shape every competitor #5838's own research
-    found already takes."""
+    legitimate shell command: a real, benign command using a character
+    or construct this parser does not yet accept (a heredoc, a
+    subshell, `2>` fd-numbered redirects, argv tokens after a redirect)
+    is refused with a reason, the same "refuse, don't guess" shape
+    every competitor #5838's own research found already takes — see the
+    module docstring's own "If your command gets rejected" section for
+    what to do next."""
 
 
 @dataclass(frozen=True)
@@ -288,7 +375,8 @@ def _iter_tokens(text: str) -> "list[tuple[str, bool]]":
     literal text, per the quoting, or — if some future construct this
     parser does not yet know about defeats the quote — as the operator
     it resembles) and refuses to guess, the SAME judgement
-    :data:`_EXPANSION_CHARS` applies to ``$``/glob/``~``.
+    :func:`_reject_disallowed_raw_characters` applies to every other
+    character outside the allowlist.
 
     Raises :class:`ExecPlanRejected` for an unterminated quote (``shlex``
     itself raises ``ValueError``) or for a quoted operator-shaped token
@@ -342,30 +430,19 @@ def parse_exec_plan(text: str) -> "ExecPlan":
     ruling: "実行は... 元の文字列を渡す" — see this module's docstring
     for why).
 
-    #5838 BLOCKING (architect co-vet, issuecomment-5578466297, real-
-    machine measurement — the worst of the class found so far): a
-    LITERAL NEWLINE in *text* is checked BEFORE tokenizing at all,
-    unconditionally, and rejected if present. ``shlex`` folds a newline
-    into ordinary whitespace, so ``"ls\\nrm -rf /tmp/x"`` parsed as ONE
-    segment (``argv=('ls','rm','-rf','/tmp/x')``) while a real
-    ``sh -c`` runs a newline as a COMMAND SEPARATOR — TWO commands,
-    ``ls`` then ``rm -rf /tmp/x``. Worse than every other bypass this
-    module closes: ``argv[0]`` here is ``"ls"`` — a real, ordinary,
-    almost-certainly-allowed tool — so a future tool-axis policy (段3)
-    would PASS this plan, and the shell would then run a command policy
-    never saw at all. A newline inside a quote is a legitimate single
-    argument (multi-line quoted text) that this blanket check also
-    rejects — the SAME "cannot distinguish quoted from unquoted ∴
-    reject either way" judgement :func:`_iter_tokens` already applies
-    to a quoted operator-shaped token, not a new exception to it."""
-    if "\n" in text or "\r" in text:
-        raise ExecPlanRejected(
-            "a newline is not supported here — shlex folds it into "
-            "ordinary whitespace, but a real shell treats it as a "
-            "command separator; this parser cannot tell a newline "
-            "inside quotes from one that would start a second, "
-            "unreviewed command, and refuses to guess"
-        )
+    The FIRST check (architect's structural ruling — see the module
+    docstring's own "Denylist -> allowlist" section) is
+    :func:`_reject_disallowed_raw_characters`, run against *text* BEFORE
+    any tokenizing: this is what catches a literal newline (``shlex``
+    folds it into ordinary whitespace, so a per-token check would never
+    see it — ``"ls\\nrm -rf /tmp/x"`` would otherwise parse as ONE
+    segment whose ``argv[0]`` is the ordinary, almost-certainly-allowed
+    ``"ls"``, while a real shell runs the newline as a command
+    SEPARATOR, running ``rm -rf /tmp/x`` as a second command policy
+    never saw at all) and every other character this parser does not
+    yet accept, in ONE place, by construction, rather than by
+    enumerating each dangerous case as it is found."""
+    _reject_disallowed_raw_characters(text)
     tokens = _iter_tokens(text)
     if not tokens:
         raise ExecPlanRejected("no command given")
@@ -394,13 +471,6 @@ def parse_exec_plan(text: str) -> "ExecPlan":
                     f"parser (token: {token!r}) — put every argument before "
                     "the redirect"
                 )
-            if _contains_expansion(token):
-                raise ExecPlanRejected(
-                    f"variable/glob/home-directory expansion is not supported "
-                    f"here (token: {token!r}) — this parser cannot predict "
-                    "what it resolves to at execution time, the same "
-                    "uncertainty a quoted operator is rejected for"
-                )
             if not current_argv and _looks_like_leading_assignment(token):
                 raise ExecPlanRejected(
                     f"a leading NAME=value environment assignment is not "
@@ -426,13 +496,6 @@ def parse_exec_plan(text: str) -> "ExecPlan":
             nxt = tokens[i + 1] if i + 1 < len(tokens) else None
             if nxt is None or nxt[1]:
                 raise ExecPlanRejected(f"redirect {token!r} has no target path")
-            if _contains_expansion(nxt[0]):
-                raise ExecPlanRejected(
-                    f"variable/glob/home-directory expansion is not "
-                    f"supported in a redirect target (token: {nxt[0]!r}) — "
-                    "a future file-permission check would see this literal "
-                    "text, never the real expanded path"
-                )
             plan.append(ExecRedirect(op=token, path=nxt[0]))
             redirect_closed_segment = True
             i += 2
@@ -447,8 +510,12 @@ def parse_exec_plan(text: str) -> "ExecPlan":
             )
 
         # A punctuation token that survived _iter_tokens but is not one
-        # of #5838's supported operators/redirects -- "(", ")", "`", a
-        # lone "&", or an unrecognised run like "<>"/";;".
+        # of #5838's supported operators/redirects -- a lone "&", or an
+        # unrecognised run like "<>"/";;" (built entirely from allowed
+        # operator characters, just not a recognised COMBINATION of
+        # them -- "(", ")", "`" and everything else this branch used to
+        # need to name are now unreachable, blocked earlier by
+        # _reject_disallowed_raw_characters).
         raise ExecPlanRejected(
             f"unsupported shell construct (token: {token!r}) — this parser "
             "only supports pipes/chains (| && || ;) and redirects (> >> <), "

--- a/src/reyn/security/exec_plan.py
+++ b/src/reyn/security/exec_plan.py
@@ -68,6 +68,25 @@ parser saw — the parse/execute gap class above:
   segment-level policy (段3) was never designed to scan.
 - Background execution: a bare ``&`` (not part of ``&&``) — changes
   process lifecycle in a way #5838's plan never modeled.
+- Variable/glob/home-directory expansion: any token containing ``$``,
+  a glob metacharacter (``* ? [``), or starting with ``~`` — resolves
+  to something DIFFERENT at real execution time than the literal text
+  this parser saw (measured bypasses: a redirect target check would
+  see the literal string ``"$HOME/out.txt"``, never the real expanded
+  path; a threat scan over ``rm *.txt`` would see the literal glob,
+  never the files it actually matches).
+- A leading ``NAME=value`` environment-assignment prefix — would become
+  the segment's ``argv[0]``, hiding the REAL command from tool-axis
+  policy entirely (``FOO=bar rm -rf /tmp/x`` → this parser's ``argv[0]``
+  would be ``"FOO=bar"``, never ``"rm"`` — the same basename-bypass
+  class Codex #28732 named, reached through assignment instead of a
+  relative path).
+- A QUOTED token whose dequoted value happens to consist entirely of
+  operator characters (e.g. ``grep '|' file``) — string-identical to a
+  real unquoted operator once ``shlex`` strips the quotes, so this
+  parser cannot verify which the shell would really do; see
+  :func:`_iter_tokens`'s own docstring for how this is detected and why
+  it is refused rather than guessed either way.
 - Any other unsupported punctuation sequence (``;;``, ``<>``, an
   isolated stray operator character, etc.).
 - An empty command line, an empty segment (a leading/trailing/doubled
@@ -79,34 +98,25 @@ never a silent pass-through — matching Claude Code's "解析不能なら
 プロンプトへ" / Codex's ``used_complex_parsing`` escalation / OpenClaw's
 "chain/redirect は全 segment が通らない限り拒否" (architect's own
 competitive summary): every competitor's shape is "refuse, don't guess."
-
-## Disclosed v1 limitation — a QUOTED operator-only token
-
-``shlex`` strips quotes before this module ever sees the resulting
-token value, so ``grep '|' file`` (a literal pipe character as an
-argument, quoted) is currently indistinguishable from an unquoted ``|``
-by VALUE alone once tokenizing is done — this parser rejects it as an
-operator. This is the SAFE direction (a false rejection, never a false
-acceptance that could misread a real operator as literal text) —
-"refuse, don't guess" holds even where the guess would have been
-right. Fixing it needs per-token quoting metadata ``shlex``'s public
-iterator does not expose; tracked as a known follow-up, not solved
-here.
 """
 from __future__ import annotations
 
+import io
+import re
 import shlex
 from dataclasses import dataclass
+from typing import cast
 
 # The operator/redirect characters this parser understands as
-# standalone tokens — everything else that shlex would otherwise fold
-# into a plain word stays a word (e.g. a quoted "|" is protected by
-# shlex's own quote handling, never reaches here as a punctuation
-# token at all). Backtick is added to shlex's own default punctuation
-# set (`shlex.punctuation_chars = True` gives ``();<>|&`` per the
-# stdlib docs) specifically so command substitution's backtick form is
-# caught by the SAME "not a recognised operator" rule as ``$(...)``'s
-# own ``(``/``)`` — one rejection path, not two.
+# standalone tokens — a token whose dequoted VALUE is entirely made of
+# these characters is either a real operator (unquoted) or, if it was
+# quoted, rejected outright (_iter_tokens's own docstring — this parser
+# cannot tell the two apart by value alone, and refuses to guess).
+# Backtick is added to shlex's own default punctuation set
+# (`shlex.punctuation_chars = True` gives ``();<>|&`` per the stdlib
+# docs) specifically so command substitution's backtick form is caught
+# by the SAME "not a recognised operator" rule as ``$(...)``'s own
+# ``(``/``)`` — one rejection path, not two.
 _PUNCTUATION_CHARS = "();<>|&`"
 
 # Single-character operator tokens this parser accepts standalone.
@@ -122,6 +132,53 @@ _REDIRECT_OPS_SINGLE = frozenset({">", "<"})
 # operator here.
 _CHAIN_OPS_DOUBLE = frozenset({"&&", "||"})
 _REDIRECT_OPS_DOUBLE = frozenset({">>"})
+
+# #5838 BLOCKING (architect co-vet, issuecomment-5578395294, real-machine
+# measurement against this module): a token containing ``$`` (variable
+# expansion), a glob metacharacter (``* ? [``), or starting with ``~``
+# (home-directory expansion) resolves to something DIFFERENT at real
+# `sh -c` execution time than the literal text this parser sees --
+# exactly the same "parser saw one thing, shell runs another" class this
+# module's own docstring names for `$(...)`/backtick, just via expansion
+# instead of substitution. Measured real bypasses: `echo hi >
+# $HOME/out.txt` let a redirect-target permission check (段3's future
+# `require_file_write`) see the literal string `"$HOME/out.txt"` instead
+# of the real path; `rm *.txt` let a threat scan see `"*.txt"` instead of
+# whatever files actually match at execution time. The SAME
+# "no way to know what this really is" gap a quoted operator-shaped
+# token (_iter_tokens's own docstring) is rejected for -- this closes
+# the inconsistency architect's own co-vet named: that gap was closed
+# for quoting and left open for expansion.
+_EXPANSION_CHARS = frozenset("$*?[")
+
+# #5838 BLOCKING (same co-vet): `FOO=bar rm -rf /tmp/x` -- a leading
+# `NAME=value` environment-assignment prefix -- is not stripped by this
+# parser, so `argv[0]` becomes the literal string `"FOO=bar"`, never
+# `"rm"`. Any future tool-axis policy (段3) reading `argv[0]` would
+# check the WRONG binary entirely; the real `rm` never reaches policy at
+# all -- the exact `./sed` basename-bypass class architect's own
+# competitive research (Codex #28732) names, reached through a different
+# door. Matched only in LEADING position (before the first real word of
+# a segment — see `_looks_like_leading_assignment`'s own caller) so a
+# legitimate later argument shaped like `NAME=value` (e.g. `docker run
+# -e FOO=bar image`) is unaffected: `docker` already satisfied "a real
+# word was seen" before `FOO=bar` appears.
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _contains_expansion(token: str) -> bool:
+    """True if *token* would resolve to something this parser cannot
+    predict at real shell execution time — see ``_EXPANSION_CHARS``'s
+    own module-level comment for the measured bypasses this closes."""
+    return bool(_EXPANSION_CHARS.intersection(token)) or token.startswith("~")
+
+
+def _looks_like_leading_assignment(token: str) -> bool:
+    """True if *token* has the ``NAME=value`` shape of a shell
+    environment-assignment prefix — see ``_ASSIGNMENT_RE``'s own
+    module-level comment for the measured bypass this closes. Callers
+    apply this ONLY while still in a segment's leading position."""
+    return bool(_ASSIGNMENT_RE.match(token))
 
 
 class ExecPlanRejected(Exception):
@@ -194,26 +251,65 @@ def _iter_tokens(text: str) -> "list[tuple[str, bool]]":
     groups such a run into ONE token when ``punctuation_chars`` is set
     (e.g. ``"a && b"`` tokenizes to ``["a", "&&", "b"]`` directly, never
     ``["a", "&", "&", "b"]``) — this function does no merging of its
-    own, only classifies what ``shlex`` already produced. A quoted
-    ``'|'`` is never one of these: ``shlex``'s own quote handling keeps
-    it as part of a plain WORD token, so quoting something is exactly
-    what protects it from being read as an operator here — the same
-    guarantee real POSIX shell quoting gives.
+    own, only classifies what ``shlex`` already produced.
+
+    #5838 BLOCKING (lead-coder co-vet, issuecomment-5578405655, real
+    measurement): a QUOTED token whose dequoted VALUE happens to consist
+    entirely of punctuation characters (e.g. ``grep '|' file``) is
+    string-identical to a real unquoted operator once ``shlex`` strips
+    the quotes — ``list(shlex.shlex(...))``'s public iterator throws
+    that distinction away, and treating such a token as a literal word
+    (the earlier, WRONG assumption this docstring used to state) let
+    ``grep '|' file`` silently misparse into TWO piped commands instead
+    of one ``grep`` call with a literal ``|`` argument. Tracked here
+    instead by reading ``lexer.instream.tell()`` before/after each
+    ``get_token()`` call to recover the RAW source substring for that
+    token (``shlex``'s own scanner consumes a plain ``str`` through an
+    internal ``io.StringIO``, whose ``tell()`` is character-position-
+    accurate for this purpose) and checking whether that raw substring
+    contains a quote character. A token that is BOTH punctuation-only
+    AND was quoted raises :class:`ExecPlanRejected` outright — this
+    parser cannot verify which the real shell would do (treat it as
+    literal text, per the quoting, or — if some future construct this
+    parser does not yet know about defeats the quote — as the operator
+    it resembles) and refuses to guess, the SAME judgement
+    :data:`_EXPANSION_CHARS` applies to ``$``/glob/``~``.
 
     Raises :class:`ExecPlanRejected` for an unterminated quote (``shlex``
-    itself raises ``ValueError``)."""
+    itself raises ``ValueError``) or for a quoted operator-shaped token
+    (above)."""
     lexer = shlex.shlex(text, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
     lexer.whitespace_split = True
+    # shlex.shlex(str, ...) wraps a plain str argument in an io.StringIO
+    # internally (stdlib source) -- typeshed's own instream type is a
+    # narrower read-only Protocol that doesn't declare .tell(), so this
+    # cast documents what is actually there rather than silencing an
+    # unrelated mypy finding.
+    instream = cast("io.StringIO", lexer.instream)
+    operator_chars = frozenset(_PUNCTUATION_CHARS)
+    tokens: "list[tuple[str, bool]]" = []
     try:
-        raw_tokens = list(lexer)
+        while True:
+            start = instream.tell()
+            token = lexer.get_token()
+            if token is None:
+                break
+            end = instream.tell()
+            raw = text[start:end]
+            quoted = "'" in raw or '"' in raw
+            is_operator = bool(token) and all(c in operator_chars for c in token)
+            if is_operator and quoted:
+                raise ExecPlanRejected(
+                    f"a quoted token that looks like an operator (token: "
+                    f"{token!r}) is not supported here — this parser cannot "
+                    "verify whether a real shell would treat it as literal "
+                    "text or as the operator it resembles, and refuses to "
+                    "guess"
+                )
+            tokens.append((token, is_operator))
     except ValueError as exc:
         raise ExecPlanRejected(f"could not parse arguments: {exc}") from exc
-
-    operator_chars = frozenset(_PUNCTUATION_CHARS)
-    return [
-        (token, all(c in operator_chars for c in token))
-        for token in raw_tokens
-    ]
+    return tokens
 
 
 def parse_exec_plan(text: str) -> "ExecPlan":
@@ -258,6 +354,20 @@ def parse_exec_plan(text: str) -> "ExecPlan":
                     f"parser (token: {token!r}) — put every argument before "
                     "the redirect"
                 )
+            if _contains_expansion(token):
+                raise ExecPlanRejected(
+                    f"variable/glob/home-directory expansion is not supported "
+                    f"here (token: {token!r}) — this parser cannot predict "
+                    "what it resolves to at execution time, the same "
+                    "uncertainty a quoted operator is rejected for"
+                )
+            if not current_argv and _looks_like_leading_assignment(token):
+                raise ExecPlanRejected(
+                    f"a leading NAME=value environment assignment is not "
+                    f"supported here (token: {token!r}) — it would become "
+                    "this segment's argv[0], hiding the real command from "
+                    "policy"
+                )
             current_argv.append(token)
             i += 1
             continue
@@ -276,6 +386,13 @@ def parse_exec_plan(text: str) -> "ExecPlan":
             nxt = tokens[i + 1] if i + 1 < len(tokens) else None
             if nxt is None or nxt[1]:
                 raise ExecPlanRejected(f"redirect {token!r} has no target path")
+            if _contains_expansion(nxt[0]):
+                raise ExecPlanRejected(
+                    f"variable/glob/home-directory expansion is not "
+                    f"supported in a redirect target (token: {nxt[0]!r}) — "
+                    "a future file-permission check would see this literal "
+                    "text, never the real expanded path"
+                )
             plan.append(ExecRedirect(op=token, path=nxt[0]))
             redirect_closed_segment = True
             i += 2

--- a/src/reyn/security/exec_plan.py
+++ b/src/reyn/security/exec_plan.py
@@ -1,0 +1,304 @@
+"""``ExecPlan`` — the parser front-end for #5838 (owner decision: "shell
+文字列を受け、解析した実行計画にポリシーを掛け、実行は sandbox 内の
+`sh -c` に元の文字列を渡す。LLM の exec・pipeline の exec step・
+`/exec`・`!`/`!!` すべて同じ front-end").
+
+This module is 段2 of #5838's implementation plan (architect,
+issuecomment-5557210786): the ONE parser every caller shares. It does
+NOT check policy and does NOT execute anything — 段3 (segment policy:
+tool axis + threat scan per segment's resolved argv[0], redirect targets
+through the existing ``require_file_write``/``require_file_read``) and
+段4 (``sh -c`` execution of the ORIGINAL string, never a reconstruction
+from this parse) are separate, later stages. This module's only job:
+turn a shell-looking command line into a policy-checkable
+:data:`ExecPlan`, or reject it outright when it cannot be safely
+decomposed.
+
+Placed here (not ``interfaces/``, per architect's explicit ruling: "LLM
+経路も呼ぶ") because the LLM ``exec`` tool path (``tools/exec.py``,
+段4/6) and the operator ``/exec``/``!``/``!!`` path
+(``interfaces/slash/exec.py``, 段7) both need the SAME parser — one
+function, one place, matching #5837's own isolation of
+``tokenize_exec_cmdline`` this module replaces.
+
+## Why "解析して policy、実行は元の文字列" (parse for policy, execute
+the ORIGINAL string) rather than executing this module's own parsed
+segments
+
+Owner picked option (i) — matching how Claude Code / Codex / OpenClaw /
+Hermes all actually work (architect's competitive research,
+``docs/deep-dives/research/competitive/shell-interpretation.md``):
+policy reads the PARSED plan, but the shell that actually runs gets the
+ORIGINAL string, unparsed. architect's own (ii) proposal (execute the
+parsed segments directly via the backend, never start a real shell) was
+explicitly NOT chosen — "私の提案でしたが競合に無い一歩なので採りません"
+— because the owner's request was to move CLOSER to what competitors
+do, and (ii) would have been a step none of them take. The known cost of
+(i) (real audit-event trace will show this once 段4/5 land): a
+parse/execute semantic gap can exist — the exact class of two real
+Codex incidents architect's research names (a `./sed` basename bypass,
+a zsh-fork sandbox-wrapper bypass). This parser's rejection list below
+exists specifically to keep that gap as narrow as competitors' own.
+
+## What this parser accepts
+
+- ``shlex``-quoted words — single/double quotes, backslash escapes;
+  the SAME primitive #5837's own (now-superseded) ``tokenize_exec_
+  cmdline`` used for the no-shell argv form.
+- Chain operators: ``|`` (pipe), ``&&`` (AND), ``||`` (OR), ``;``
+  (sequence).
+- Redirects: ``>`` (truncate), ``>>`` (append), ``<`` (input) — each
+  followed by exactly one path token, and each must be the LAST thing
+  in its segment (no argv token after a redirect's path — see
+  :class:`ExecPlanRejected`'s own docstring for why this is a
+  deliberate v1 narrowing, not an oversight).
+
+## What this parser REJECTS (raises :class:`ExecPlanRejected`)
+
+Anything that would let a segment's real argv[0] diverge from what this
+parser saw — the parse/execute gap class above:
+
+- Command substitution: ``$(...)`` or backtick ```cmd```` — a nested
+  command this parser would never see, exactly the "解析器が見ない
+  第2の経路" shape.
+- Subshell grouping: ``(...)``  / process substitution: ``<(...)``,
+  ``>(...)`` — same reason; a parenthesized group can hide a whole
+  second pipeline.
+- Heredoc: ``<<`` (and ``<<-``) — arbitrary multi-line content the
+  segment-level policy (段3) was never designed to scan.
+- Background execution: a bare ``&`` (not part of ``&&``) — changes
+  process lifecycle in a way #5838's plan never modeled.
+- Any other unsupported punctuation sequence (``;;``, ``<>``, an
+  isolated stray operator character, etc.).
+- An empty command line, an empty segment (a leading/trailing/doubled
+  chain operator), a redirect with no following path, or an unterminated
+  quote (``shlex`` itself raises for the last one).
+
+Rejection is LOUD (a raised exception with a human-readable reason),
+never a silent pass-through — matching Claude Code's "解析不能なら
+プロンプトへ" / Codex's ``used_complex_parsing`` escalation / OpenClaw's
+"chain/redirect は全 segment が通らない限り拒否" (architect's own
+competitive summary): every competitor's shape is "refuse, don't guess."
+
+## Disclosed v1 limitation — a QUOTED operator-only token
+
+``shlex`` strips quotes before this module ever sees the resulting
+token value, so ``grep '|' file`` (a literal pipe character as an
+argument, quoted) is currently indistinguishable from an unquoted ``|``
+by VALUE alone once tokenizing is done — this parser rejects it as an
+operator. This is the SAFE direction (a false rejection, never a false
+acceptance that could misread a real operator as literal text) —
+"refuse, don't guess" holds even where the guess would have been
+right. Fixing it needs per-token quoting metadata ``shlex``'s public
+iterator does not expose; tracked as a known follow-up, not solved
+here.
+"""
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+# The operator/redirect characters this parser understands as
+# standalone tokens — everything else that shlex would otherwise fold
+# into a plain word stays a word (e.g. a quoted "|" is protected by
+# shlex's own quote handling, never reaches here as a punctuation
+# token at all). Backtick is added to shlex's own default punctuation
+# set (`shlex.punctuation_chars = True` gives ``();<>|&`` per the
+# stdlib docs) specifically so command substitution's backtick form is
+# caught by the SAME "not a recognised operator" rule as ``$(...)``'s
+# own ``(``/``)`` — one rejection path, not two.
+_PUNCTUATION_CHARS = "();<>|&`"
+
+# Single-character operator tokens this parser accepts standalone.
+_CHAIN_OPS_SINGLE = frozenset({"|", ";"})
+_REDIRECT_OPS_SINGLE = frozenset({">", "<"})
+# Two-character operator tokens -- shlex itself already emits these as
+# ONE token when the two characters are adjacent in *text* with no
+# whitespace between them (punctuation_chars mode groups a run of
+# consecutive punctuation characters; see _iter_tokens's own
+# docstring), so no merging happens in this module. "&&"/"||"/">>" are
+# the only doubled forms #5838's plan supports; "<<" is heredoc,
+# rejected explicitly in the main parse loop, never treated as a usable
+# operator here.
+_CHAIN_OPS_DOUBLE = frozenset({"&&", "||"})
+_REDIRECT_OPS_DOUBLE = frozenset({">>"})
+
+
+class ExecPlanRejected(Exception):
+    """Raised by :func:`parse_exec_plan` when *text* contains a shell
+    construct this parser cannot safely decompose into policy-checkable
+    segments (#5838 段2) — see this module's own docstring for the full
+    rejection list and why each one is there.
+
+    This is a v1 narrowing, disclosed, not a claim of covering every
+    legitimate shell command: a real, benign command using a rejected
+    construct (a heredoc, a subshell, `2>` fd-numbered redirects, argv
+    tokens after a redirect) is refused with a reason, the same
+    "refuse, don't guess" shape every competitor #5838's own research
+    found already takes."""
+
+
+@dataclass(frozen=True)
+class ExecSegment:
+    """One command in the plan — the SAME argv shape #5837's own
+    (pre-#5838) ``tokenize_exec_cmdline`` returned, now one element of a
+    larger :data:`ExecPlan` instead of the whole result. 段3's own
+    segment-level policy (tool axis, threat scan) reads ``argv[0]``
+    from here."""
+
+    argv: "tuple[str, ...]"
+
+
+@dataclass(frozen=True)
+class ExecChainOp:
+    """A chain operator between two segments — ``op`` is one of
+    ``"|"``, ``"&&"``, ``"||"``, ``";"``."""
+
+    op: str
+
+
+@dataclass(frozen=True)
+class ExecRedirect:
+    """A redirect attached to the segment immediately before it in the
+    plan — ``op`` is one of ``">"``, ``">>"``, ``"<"``. 段3's own policy
+    routes ``path`` through the existing ``require_file_write``/
+    ``require_file_read`` (the same file-axis primitives production
+    already uses in 8 other places, per architect's own plan) — this
+    module makes no permission decision of its own."""
+
+    op: str
+    path: str
+
+
+#: One item of an :data:`ExecPlan` — a command, a chain operator, or a
+#: redirect, in the SAME left-to-right order they appeared in the
+#: original text (architect's own worked example: ``"ls -la | grep foo
+#: > out.txt"`` -> ``[segment(["ls","-la"]), "|",
+#: segment(["grep","foo"]), redirect(">", "out.txt")]``).
+ExecPlanItem = ExecSegment | ExecChainOp | ExecRedirect
+
+#: The full parsed plan for one command line — a flat, ordered list of
+#: :data:`ExecPlanItem`. Never nested (a subshell/group would need
+#: nesting, and #5838's plan rejects those constructs outright — see
+#: this module's own docstring).
+ExecPlan = list[ExecPlanItem]
+
+
+def _iter_tokens(text: str) -> "list[tuple[str, bool]]":
+    """Tokenize *text* with ``shlex`` (posix quoting rules, the SAME
+    engine #5837's own ``tokenize_exec_cmdline`` used).
+
+    Returns ``[(token, is_operator), ...]`` — ``is_operator=True`` means
+    *token* is a run of one or more consecutive, UNQUOTED
+    :data:`_PUNCTUATION_CHARS` characters. ``shlex`` itself already
+    groups such a run into ONE token when ``punctuation_chars`` is set
+    (e.g. ``"a && b"`` tokenizes to ``["a", "&&", "b"]`` directly, never
+    ``["a", "&", "&", "b"]``) — this function does no merging of its
+    own, only classifies what ``shlex`` already produced. A quoted
+    ``'|'`` is never one of these: ``shlex``'s own quote handling keeps
+    it as part of a plain WORD token, so quoting something is exactly
+    what protects it from being read as an operator here — the same
+    guarantee real POSIX shell quoting gives.
+
+    Raises :class:`ExecPlanRejected` for an unterminated quote (``shlex``
+    itself raises ``ValueError``)."""
+    lexer = shlex.shlex(text, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
+    lexer.whitespace_split = True
+    try:
+        raw_tokens = list(lexer)
+    except ValueError as exc:
+        raise ExecPlanRejected(f"could not parse arguments: {exc}") from exc
+
+    operator_chars = frozenset(_PUNCTUATION_CHARS)
+    return [
+        (token, all(c in operator_chars for c in token))
+        for token in raw_tokens
+    ]
+
+
+def parse_exec_plan(text: str) -> "ExecPlan":
+    """The ONE parser #5838's plan uses everywhere (LLM ``exec`` tool,
+    pipeline exec step, ``/exec``/``!``/``!!`` — see this module's own
+    docstring). Turns *text* into an ordered list of
+    :class:`ExecSegment`/:class:`ExecChainOp`/:class:`ExecRedirect`, or
+    raises :class:`ExecPlanRejected` when *text* contains a construct
+    this parser cannot safely decompose (see this module's own docstring
+    for the full list).
+
+    Never executes anything, never checks policy — purely a parse. 段4
+    (execution) runs the ORIGINAL *text* through ``sh -c``, never a
+    reconstruction from this function's return value (architect's own
+    ruling: "実行は... 元の文字列を渡す" — see this module's docstring
+    for why)."""
+    tokens = _iter_tokens(text)
+    if not tokens:
+        raise ExecPlanRejected("no command given")
+
+    plan: "list[ExecPlanItem]" = []
+    current_argv: "list[str]" = []
+    redirect_closed_segment = False  # True once a redirect's path lands -- no more argv for this segment
+
+    def _flush_segment(*, require_nonempty: bool, context: str) -> None:
+        nonlocal current_argv, redirect_closed_segment
+        if not current_argv:
+            if require_nonempty:
+                raise ExecPlanRejected(f"empty command {context}")
+            return
+        plan.append(ExecSegment(argv=tuple(current_argv)))
+        current_argv = []
+        redirect_closed_segment = False
+
+    i = 0
+    while i < len(tokens):
+        token, is_op = tokens[i]
+        if not is_op:
+            if redirect_closed_segment:
+                raise ExecPlanRejected(
+                    "an argument cannot follow a redirect's target in this "
+                    f"parser (token: {token!r}) — put every argument before "
+                    "the redirect"
+                )
+            current_argv.append(token)
+            i += 1
+            continue
+
+        if token in _CHAIN_OPS_SINGLE or token in _CHAIN_OPS_DOUBLE:
+            _flush_segment(require_nonempty=True, context=f"before {token!r}")
+            plan.append(ExecChainOp(op=token))
+            i += 1
+            continue
+
+        if token in _REDIRECT_OPS_SINGLE or token in _REDIRECT_OPS_DOUBLE:
+            if not current_argv and not (plan and isinstance(plan[-1], ExecRedirect)):
+                raise ExecPlanRejected(f"redirect {token!r} with no preceding command")
+            if current_argv:
+                _flush_segment(require_nonempty=False, context=f"before {token!r}")
+            nxt = tokens[i + 1] if i + 1 < len(tokens) else None
+            if nxt is None or nxt[1]:
+                raise ExecPlanRejected(f"redirect {token!r} has no target path")
+            plan.append(ExecRedirect(op=token, path=nxt[0]))
+            redirect_closed_segment = True
+            i += 2
+            continue
+
+        if token.startswith("<<"):
+            raise ExecPlanRejected(
+                "heredoc (\"<<\") is not supported here — this parser only "
+                "decomposes a command line into policy-checkable segments, "
+                "and a heredoc's body is arbitrary multi-line content no "
+                "segment-level check was designed to scan."
+            )
+
+        # A punctuation token that survived _iter_tokens but is not one
+        # of #5838's supported operators/redirects -- "(", ")", "`", a
+        # lone "&", or an unrecognised run like "<>"/";;".
+        raise ExecPlanRejected(
+            f"unsupported shell construct (token: {token!r}) — this parser "
+            "only supports pipes/chains (| && || ;) and redirects (> >> <), "
+            "see the module docstring for the full rejection list"
+        )
+
+    _flush_segment(require_nonempty=not redirect_closed_segment, context="at end of input")
+    if not plan or not any(isinstance(item, ExecSegment) for item in plan):
+        raise ExecPlanRejected("no command given")
+    return plan

--- a/tests/security/test_5838_exec_plan_parser.py
+++ b/tests/security/test_5838_exec_plan_parser.py
@@ -279,11 +279,16 @@ def test_variable_glob_or_home_expansion_is_rejected(text: str) -> None:
     literal text this parser sees (measured: a redirect-target
     permission check would see the literal string ``"$HOME/out.txt"``,
     never the real expanded path; a threat scan over ``rm *.txt`` would
-    see the literal glob, never the files it actually matches).
+    see the literal glob, never the files it actually matches). Closed
+    by the allowlist reversal below (issuecomment-5578494687) — none of
+    ``$ * ? [ ~`` are admitted characters, so every one of these is
+    caught by :func:`_reject_disallowed_raw_characters` alone, before
+    any of the (now-removed) per-character checks this test's docstring
+    originally described.
 
-    Strip witness: emptying ``_EXPANSION_CHARS`` turns the ``$``/glob
-    cases here red (5 of 6 — the ``~`` case is a separate
-    ``token.startswith("~")`` check, unaffected by that one); verified
+    Strip witness: adding these characters to ``_ALLOWED_RAW_CHARS``
+    makes each case parse successfully with the literal expansion
+    syntax as a plain argv/path token instead of raising — verified
     directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan(text)
@@ -299,21 +304,80 @@ def test_brace_expansion_is_rejected(text: str) -> None:
     even in POSIX mode, so ``cp file{1,2} /tmp/`` parses to ONE argv
     token (``"file{1,2}"``) while the real shell operates on TWO files
     — the same "cannot predict what this resolves to" class as ``$``/
-    glob/``~``, closed the same way.
+    glob/``~``, closed the same way (neither ``{`` nor ``}`` is in
+    ``_ALLOWED_RAW_CHARS``).
 
-    Strip witness: dropping ``{`` from ``_EXPANSION_CHARS`` makes both
-    of these parse successfully with the literal brace syntax instead
-    of raising — verified directly, restored after."""
+    Strip witness: adding ``{``/``}`` to ``_ALLOWED_RAW_CHARS`` makes
+    both of these parse successfully with the literal brace syntax
+    instead of raising — verified directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan(text)
 
 
-def test_a_stray_closing_brace_alone_is_accepted() -> None:
-    """Tier 1: architect's own explicit carve-out — only the OPENING
-    brace signals a brace-expansion pattern; a stray ``}`` alone is not
-    one and stays accepted (no divergence risk, over-rejecting it would
-    be an unjustified narrowing)."""
-    assert parse_exec_plan("echo a}b") == [ExecSegment(argv=("echo", "a}b"))]
+# ── the allowlist itself (architect's structural reversal, replacing ────
+#    the per-character denylist above — issuecomment-5578494687) ────────
+
+
+@pytest.mark.parametrize("text", ["! ls", "ls; ! rm -rf /tmp/x", "ls && ! rm -rf /tmp/x"])
+def test_negation_operator_is_rejected(text: str) -> None:
+    """Tier 1: architect's own real-machine measurement while writing
+    the allowlist ruling — a real shell reads a leading ``!`` as the
+    NEGATION operator (``! false; echo $?`` -> ``0``), never a command
+    name, but this parser (pre-allowlist) read ``argv[0]='!'`` and let
+    the real command after it (``rm -rf /tmp/x``) ride along unseen by
+    any future policy. ``!`` is simply not in ``_ALLOWED_RAW_CHARS`` —
+    no per-construct check was ever added for it, the allowlist alone
+    closes it.
+
+    Strip witness: adding ``!`` to ``_ALLOWED_RAW_CHARS`` makes each of
+    these parse successfully with ``'!'`` as a literal argv token
+    instead of raising — verified directly, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_a_disallowed_character_inside_quotes_is_still_rejected() -> None:
+    """Tier 1: the allowlist check runs against the RAW string, quote-
+    position-blind, on purpose (module docstring, "What this parser
+    accepts" — quoting is not an escape hatch around it) — a disallowed
+    character does not become safe by being quoted, since this parser
+    cannot verify a real shell would treat it as literal either (the
+    same judgement already applied to a quoted operator-shaped token)."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("echo '$HOME'")
+
+
+def test_every_allowed_literal_character_is_individually_accepted() -> None:
+    """Tier 1: a direct, positive test of ``_ALLOWED_RAW_CHARS`` itself
+    — every literal character the module docstring's own justification
+    table lists must actually parse as a plain argv token, not merely
+    "not explicitly denied." Catches an allowlist that accidentally
+    narrows (a typo dropping a character) as surely as one that
+    accidentally widens.
+
+    ``#`` is tested separately (``test_shell_style_comment_stays_
+    accepted``) — it is a real ``shlex`` comment character, so embedding
+    it inside this test's own concatenated word would truncate
+    everything after it, which is correct behavior, not something this
+    test is about."""
+    from reyn.security.exec_plan import _LITERAL_CHARS
+
+    literal_word = "".join(sorted(_LITERAL_CHARS - {"#"}))
+    plan = parse_exec_plan(f"echo {literal_word}")
+    assert plan == [ExecSegment(argv=("echo", literal_word))]
+
+
+def test_a_stray_closing_brace_alone_is_now_rejected_under_the_allowlist() -> None:
+    """Tier 1: superseded by the allowlist reversal (issuecomment-
+    5578494687) — under the earlier denylist, a stray ``}`` alone was
+    deliberately accepted (no brace-expansion pattern, no divergence
+    risk). The allowlist has no per-construct carve-out mechanism: ``}``
+    is simply not one of the admitted characters, so this now rejects
+    too. architect's own explicit acceptance of this exact regression:
+    "allowlist を採る場合は `}` も落ちますが、それは安全側の偽陽性とし
+    て受け入れます" (a safe-side false positive, accepted)."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("echo a}b")
 
 
 def test_quoted_operator_shaped_token_is_rejected_not_silently_split() -> None:

--- a/tests/security/test_5838_exec_plan_parser.py
+++ b/tests/security/test_5838_exec_plan_parser.py
@@ -254,6 +254,16 @@ def test_environment_assignment_as_a_later_argument_is_accepted() -> None:
     ]
 
 
+@pytest.mark.parametrize("text", ["ls | FOO=bar rm", "ls && FOO=bar rm"])
+def test_leading_assignment_is_rejected_in_every_segment_not_just_the_first(text: str) -> None:
+    """Tier 1: architect's own explicit re-check (issuecomment-5578436446)
+    — the leading-assignment guard must re-apply at the START OF EVERY
+    segment, not just the plan's first one; a chain operator resets
+    "leading position" for the segment that follows it."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
 @pytest.mark.parametrize("text", [
     "echo hi > $HOME/out.txt",
     "echo hi > ~/out.txt",
@@ -277,6 +287,33 @@ def test_variable_glob_or_home_expansion_is_rejected(text: str) -> None:
     directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan(text)
+
+
+@pytest.mark.parametrize("text", [
+    "cp file{1,2} /tmp/",
+    "echo {a,b}.txt",
+])
+def test_brace_expansion_is_rejected(text: str) -> None:
+    """Tier 1: architect's own follow-up real-machine measurement
+    (issuecomment-5578436446) — macOS ``/bin/sh`` expands ``{a,b}``
+    even in POSIX mode, so ``cp file{1,2} /tmp/`` parses to ONE argv
+    token (``"file{1,2}"``) while the real shell operates on TWO files
+    — the same "cannot predict what this resolves to" class as ``$``/
+    glob/``~``, closed the same way.
+
+    Strip witness: dropping ``{`` from ``_EXPANSION_CHARS`` makes both
+    of these parse successfully with the literal brace syntax instead
+    of raising — verified directly, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_a_stray_closing_brace_alone_is_accepted() -> None:
+    """Tier 1: architect's own explicit carve-out — only the OPENING
+    brace signals a brace-expansion pattern; a stray ``}`` alone is not
+    one and stays accepted (no divergence risk, over-rejecting it would
+    be an unjustified narrowing)."""
+    assert parse_exec_plan("echo a}b") == [ExecSegment(argv=("echo", "a}b"))]
 
 
 def test_quoted_operator_shaped_token_is_rejected_not_silently_split() -> None:

--- a/tests/security/test_5838_exec_plan_parser.py
+++ b/tests/security/test_5838_exec_plan_parser.py
@@ -280,16 +280,14 @@ def test_variable_glob_or_home_expansion_is_rejected(text: str) -> None:
     permission check would see the literal string ``"$HOME/out.txt"``,
     never the real expanded path; a threat scan over ``rm *.txt`` would
     see the literal glob, never the files it actually matches). Closed
-    by the allowlist reversal below (issuecomment-5578494687) — none of
-    ``$ * ? [ ~`` are admitted characters, so every one of these is
-    caught by :func:`_reject_disallowed_raw_characters` alone, before
-    any of the (now-removed) per-character checks this test's docstring
-    originally described.
+    by :data:`_ALWAYS_FORBIDDEN_CHARS` — ``shlex`` tokenizes these THE
+    SAME regardless of quoting, so there is no signal to recover intent
+    from, unlike :data:`_PUNCTUATION_CHARS`'s own quote-aware group.
 
-    Strip witness: adding these characters to ``_ALLOWED_RAW_CHARS``
-    makes each case parse successfully with the literal expansion
-    syntax as a plain argv/path token instead of raising — verified
-    directly, restored after."""
+    Strip witness: dropping these characters from
+    ``_ALWAYS_FORBIDDEN_CHARS`` makes each case parse successfully with
+    the literal expansion syntax as a plain argv/path token instead of
+    raising — verified directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan(text)
 
@@ -304,18 +302,18 @@ def test_brace_expansion_is_rejected(text: str) -> None:
     even in POSIX mode, so ``cp file{1,2} /tmp/`` parses to ONE argv
     token (``"file{1,2}"``) while the real shell operates on TWO files
     — the same "cannot predict what this resolves to" class as ``$``/
-    glob/``~``, closed the same way (neither ``{`` nor ``}`` is in
-    ``_ALLOWED_RAW_CHARS``).
+    glob/``~``, closed the same way (``{``/``}`` are both in
+    :data:`_ALWAYS_FORBIDDEN_CHARS`).
 
-    Strip witness: adding ``{``/``}`` to ``_ALLOWED_RAW_CHARS`` makes
-    both of these parse successfully with the literal brace syntax
-    instead of raising — verified directly, restored after."""
+    Strip witness: dropping ``{``/``}`` from ``_ALWAYS_FORBIDDEN_CHARS``
+    makes both of these parse successfully with the literal brace
+    syntax instead of raising — verified directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan(text)
 
 
-# ── the allowlist itself (architect's structural reversal, replacing ────
-#    the per-character denylist above — issuecomment-5578494687) ────────
+# ── the two-tier check itself (architect's SECOND ruling, correcting ────
+#    the first raw-string-wide allowlist — issuecomment-5578535394) ─────
 
 
 @pytest.mark.parametrize("text", ["! ls", "ls; ! rm -rf /tmp/x", "ls && ! rm -rf /tmp/x"])
@@ -323,59 +321,85 @@ def test_negation_operator_is_rejected(text: str) -> None:
     """Tier 1: architect's own real-machine measurement while writing
     the allowlist ruling — a real shell reads a leading ``!`` as the
     NEGATION operator (``! false; echo $?`` -> ``0``), never a command
-    name, but this parser (pre-allowlist) read ``argv[0]='!'`` and let
-    the real command after it (``rm -rf /tmp/x``) ride along unseen by
-    any future policy. ``!`` is simply not in ``_ALLOWED_RAW_CHARS`` —
-    no per-construct check was ever added for it, the allowlist alone
-    closes it.
+    name, but this parser (pre-fix) read ``argv[0]='!'`` and let the
+    real command after it (``rm -rf /tmp/x``) ride along unseen by any
+    future policy. ``!`` is in :data:`_ALWAYS_FORBIDDEN_CHARS` — no
+    per-construct check was ever added for it specifically.
 
-    Strip witness: adding ``!`` to ``_ALLOWED_RAW_CHARS`` makes each of
-    these parse successfully with ``'!'`` as a literal argv token
-    instead of raising — verified directly, restored after."""
+    Strip witness: dropping ``!`` from ``_ALWAYS_FORBIDDEN_CHARS`` makes
+    each of these parse successfully with ``'!'`` as a literal argv
+    token instead of raising — verified directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan(text)
 
 
-def test_a_disallowed_character_inside_quotes_is_still_rejected() -> None:
-    """Tier 1: the allowlist check runs against the RAW string, quote-
-    position-blind, on purpose (module docstring, "What this parser
-    accepts" — quoting is not an escape hatch around it) — a disallowed
-    character does not become safe by being quoted, since this parser
-    cannot verify a real shell would treat it as literal either (the
-    same judgement already applied to a quoted operator-shaped token)."""
+def test_an_always_forbidden_character_inside_quotes_is_still_rejected() -> None:
+    """Tier 1: :data:`_ALWAYS_FORBIDDEN_CHARS` is checked per-token,
+    quote-position-blind, on purpose — ``shlex`` tokenizes ``'$HOME'``
+    and ``$HOME`` identically (``$`` is not in ``_PUNCTUATION_CHARS``),
+    so there is no signal this parser could use to trust the quoting
+    even if it wanted to (module docstring's own "Denylist -> two-tier
+    allowlist" section, the `curl "...?b=1"` example)."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan("echo '$HOME'")
 
 
-def test_every_allowed_literal_character_is_individually_accepted() -> None:
-    """Tier 1: a direct, positive test of ``_ALLOWED_RAW_CHARS`` itself
-    — every literal character the module docstring's own justification
-    table lists must actually parse as a plain argv token, not merely
-    "not explicitly denied." Catches an allowlist that accidentally
-    narrows (a typo dropping a character) as surely as one that
-    accidentally widens.
-
-    ``#`` is tested separately (``test_shell_style_comment_stays_
-    accepted``) — it is a real ``shlex`` comment character, so embedding
-    it inside this test's own concatenated word would truncate
-    everything after it, which is correct behavior, not something this
-    test is about."""
-    from reyn.security.exec_plan import _LITERAL_CHARS
-
-    literal_word = "".join(sorted(_LITERAL_CHARS - {"#"}))
-    plan = parse_exec_plan(f"echo {literal_word}")
-    assert plan == [ExecSegment(argv=("echo", literal_word))]
+def test_a_punctuation_char_becomes_literal_only_when_quoted() -> None:
+    """Tier 1: architect's OWN corrected worked example (issuecomment-
+    5578535394) — the exact case the first (raw-string) allowlist got
+    wrong. ``python -c "print(1)"`` must be ACCEPTED (``shlex`` keeps
+    the parens inside the quoted WORD token, matching how ``sh`` itself
+    would read them: literal); ``python -c print(1)`` — the SAME
+    characters, unquoted — must be REJECTED (``shlex`` splits them into
+    their own punctuation tokens, an unsupported "(" construct). Only
+    testing ONE direction would not be a witness for this: the design's
+    entire claim is that quoting changes the outcome for
+    :data:`_PUNCTUATION_CHARS` characters specifically."""
+    assert parse_exec_plan('python -c "print(1)"') == [
+        ExecSegment(argv=("python", "-c", "print(1)")),
+    ]
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("python -c print(1)")
 
 
-def test_a_stray_closing_brace_alone_is_now_rejected_under_the_allowlist() -> None:
-    """Tier 1: superseded by the allowlist reversal (issuecomment-
-    5578494687) — under the earlier denylist, a stray ``}`` alone was
-    deliberately accepted (no brace-expansion pattern, no divergence
-    risk). The allowlist has no per-construct carve-out mechanism: ``}``
-    is simply not one of the admitted characters, so this now rejects
-    too. architect's own explicit acceptance of this exact regression:
-    "allowlist を採る場合は `}` も落ちますが、それは安全側の偽陽性とし
-    て受け入れます" (a safe-side false positive, accepted)."""
+def test_a_non_punctuation_forbidden_char_stays_rejected_even_quoted() -> None:
+    """Tier 1: the sibling contrast to the test above — for
+    :data:`_ALWAYS_FORBIDDEN_CHARS` (unlike :data:`_PUNCTUATION_CHARS`),
+    quoting changes NOTHING ``shlex`` can see, so
+    ``curl "http://x/a?b=1"`` and ``curl http://x/a?b=1`` must BOTH
+    reject — architect's own explicit acceptance of this loss (module
+    docstring's own "If your command gets rejected" section)."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan('curl "http://x/a?b=1"')
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("curl http://x/a?b=1")
+
+
+def test_every_always_forbidden_character_is_individually_rejected() -> None:
+    """Tier 1: a direct, positive-population test of
+    :data:`_ALWAYS_FORBIDDEN_CHARS` itself — every character it lists
+    must actually cause a rejection on its own, not merely "happen to
+    be caught by some other check." Catches an accidentally-narrowed set
+    (a typo dropping a character) as surely as one that widened."""
+    from reyn.security.exec_plan import _ALWAYS_FORBIDDEN_CHARS
+
+    assert _ALWAYS_FORBIDDEN_CHARS, (
+        "sanity: an empty set here would make the loop below vacuously "
+        "pass without checking anything"
+    )
+    for char in sorted(_ALWAYS_FORBIDDEN_CHARS):
+        with pytest.raises(ExecPlanRejected):
+            parse_exec_plan(f"echo x{char}y")
+
+
+def test_a_stray_closing_brace_alone_is_rejected() -> None:
+    """Tier 1: ``}`` is a member of :data:`_ALWAYS_FORBIDDEN_CHARS`
+    (unlike the earlier denylist, which only checked the OPENING brace)
+    — a stray ``}`` alone (``echo a}b``) is not a real brace-expansion
+    pattern and carries no divergence risk on its own, but the two-tier
+    check has no per-construct carve-out mechanism for it. architect's
+    own explicit acceptance of this exact over-rejection: a safe-side
+    false positive."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan("echo a}b")
 

--- a/tests/security/test_5838_exec_plan_parser.py
+++ b/tests/security/test_5838_exec_plan_parser.py
@@ -217,3 +217,82 @@ def test_chained_redirects_on_the_same_segment_are_accepted() -> None:
         ExecRedirect(op=">", path="out.txt"),
         ExecRedirect(op="<", path="in.txt"),
     ]
+
+
+# ── reject: real-machine measured bypasses (lead-coder/architect co-vet,
+#    issuecomment-5578395294 / issuecomment-5578405655) ──────────────────
+
+
+@pytest.mark.parametrize("text", [
+    "FOO=bar rm -rf /tmp/x",
+    "PATH=/tmp/evil ls",
+])
+def test_leading_environment_assignment_is_rejected(text: str) -> None:
+    """Tier 1: architect's own real-machine measurement against this
+    module before this fix — a leading ``NAME=value`` prefix became
+    this parser's ``argv[0]``, hiding the real command (``rm``/``ls``)
+    from any future tool-axis policy entirely, the same basename-bypass
+    class Codex #28732 named.
+
+    Strip witness: removing the leading-assignment check in
+    ``parse_exec_plan``'s word-token branch makes ``argv[0]`` equal the
+    literal ``"FOO=bar"``/``"PATH=/tmp/evil"`` string instead of raising
+    — verified directly, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_environment_assignment_as_a_later_argument_is_accepted() -> None:
+    """Tier 1: the leading-only scope of the check above — a
+    ``NAME=value``-shaped token appearing AFTER a real command word
+    (``docker`` here) is a legitimate argument (``docker run -e
+    FOO=bar image``), not an environment-assignment prefix, and must
+    stay accepted."""
+    plan = parse_exec_plan("docker run -e FOO=bar image")
+    assert plan == [
+        ExecSegment(argv=("docker", "run", "-e", "FOO=bar", "image")),
+    ]
+
+
+@pytest.mark.parametrize("text", [
+    "echo hi > $HOME/out.txt",
+    "echo hi > ~/out.txt",
+    "rm *.txt",
+    "echo $FOO",
+    "echo a?b",
+    "echo [ab]",
+])
+def test_variable_glob_or_home_expansion_is_rejected(text: str) -> None:
+    """Tier 1: architect's own real-machine measurement — a token
+    containing ``$``/glob metacharacters/leading ``~`` resolves to
+    something DIFFERENT at real ``sh -c`` execution time than the
+    literal text this parser sees (measured: a redirect-target
+    permission check would see the literal string ``"$HOME/out.txt"``,
+    never the real expanded path; a threat scan over ``rm *.txt`` would
+    see the literal glob, never the files it actually matches).
+
+    Strip witness: emptying ``_EXPANSION_CHARS`` turns the ``$``/glob
+    cases here red (5 of 6 — the ``~`` case is a separate
+    ``token.startswith("~")`` check, unaffected by that one); verified
+    directly, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_quoted_operator_shaped_token_is_rejected_not_silently_split() -> None:
+    """Tier 1: lead-coder's own additional real-machine measurement —
+    ``grep '|' file`` (a literal pipe character as a quoted argument)
+    used to be silently accepted and split into TWO piped commands
+    (``grep`` | ``file``) instead of the one ``grep`` call the caller
+    actually wrote, because a quoted token's dequoted value is
+    string-identical to a real unquoted operator once shlex strips the
+    quotes. Now rejected outright — this parser cannot verify which the
+    real shell would do, and refuses to guess (the same judgement
+    ``_EXPANSION_CHARS`` above applies).
+
+    Strip witness: reverting ``_iter_tokens`` to classify purely by
+    token VALUE (dropping the raw-substring quote check) makes this
+    silently return a 2-segment plan (``grep`` piped to ``file``)
+    instead of raising — verified directly, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("grep '|' file")

--- a/tests/security/test_5838_exec_plan_parser.py
+++ b/tests/security/test_5838_exec_plan_parser.py
@@ -333,3 +333,44 @@ def test_quoted_operator_shaped_token_is_rejected_not_silently_split() -> None:
     instead of raising — verified directly, restored after."""
     with pytest.raises(ExecPlanRejected):
         parse_exec_plan("grep '|' file")
+
+
+# ── reject: a literal newline (worst of the class, architect co-vet) ────
+
+
+@pytest.mark.parametrize("text", ["ls\nrm -rf /tmp/x", "echo a\necho b", "ls\r\nrm -rf /"])
+def test_a_literal_newline_is_rejected(text: str) -> None:
+    """Tier 1: architect's own real-machine measurement
+    (issuecomment-5578466297) — the worst bypass this module closes.
+    ``shlex`` folds a newline into ordinary whitespace, so
+    ``"ls\\nrm -rf /tmp/x"`` parsed as ONE segment whose ``argv[0]`` is
+    the ordinary, almost-certainly-allowed ``"ls"`` — while a real
+    shell runs the newline as a command SEPARATOR, executing ``rm -rf
+    /tmp/x`` as a SECOND command policy never saw at all. Unlike every
+    other bypass this module closes, ``argv[0]`` here is completely
+    unremarkable, so a future tool-axis policy (段3) would PASS this
+    plan outright.
+
+    Strip witness: removing the newline pre-check at the top of
+    ``parse_exec_plan`` makes this parse successfully into ONE segment
+    (``('ls', 'rm', '-rf', '/tmp/x')``) instead of raising — verified
+    directly, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_redirect_fd_duplication_stays_rejected() -> None:
+    """Tier 1: architect's own confirmed-safe case — ``2>&1`` (fd
+    duplication, not in this parser's supported redirect set) was
+    already rejected before the newline fix and must stay that way."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("2>&1")
+
+
+def test_shell_style_comment_stays_accepted() -> None:
+    """Tier 1: architect's own confirmed-safe case — ``shlex``'s
+    default comment handling (``#`` to end of line) already matches
+    real shell behavior, so ``ls # rm -rf /`` correctly parses to just
+    ``('ls',)`` — the comment is not silently smuggling a second
+    command past this parser, it genuinely is inert on both sides."""
+    assert parse_exec_plan("ls # rm -rf /") == [ExecSegment(argv=("ls",))]

--- a/tests/security/test_5838_exec_plan_parser.py
+++ b/tests/security/test_5838_exec_plan_parser.py
@@ -1,0 +1,219 @@
+"""Tier 1: #5838 段2 — ``ExecPlan`` parser (owner decision: parse a shell
+command line into policy-checkable segments, execute the ORIGINAL string
+via ``sh -c`` in a later stage). Covers:
+
+- Accept: plain argv, quoted words, every supported chain operator
+  (``| && || ;``), every supported redirect (``> >> <``), and
+  architect's own worked example (multi-segment pipe + redirect).
+- Reject: empty input, unterminated quotes, command substitution
+  (``$(...)``/backtick), subshell grouping (``(...)``), heredoc
+  (``<<``), a bare ``&``, an empty segment (leading/trailing/doubled
+  operator), a redirect with no target, an argv token after a
+  redirect's target.
+- The plan's own shape matches architect's example exactly (real data,
+  not a paraphrase of the docstring).
+
+No mocking — ``parse_exec_plan`` is a pure function over a string;
+every test drives it directly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.security.exec_plan import (
+    ExecChainOp,
+    ExecPlanRejected,
+    ExecRedirect,
+    ExecSegment,
+    parse_exec_plan,
+)
+
+# ── accept ────────────────────────────────────────────────────────────
+
+
+def test_plain_argv_is_one_segment() -> None:
+    """Tier 1: no operators at all -> a single ExecSegment, argv order
+    preserved exactly."""
+    assert parse_exec_plan("ls -la /tmp") == [ExecSegment(argv=("ls", "-la", "/tmp"))]
+
+
+def test_quoted_word_with_space_stays_one_argv_token() -> None:
+    """Tier 1: shlex quoting behaves identically to #5837's own
+    (now-superseded) tokenize_exec_cmdline for this case."""
+    assert parse_exec_plan("ls 'my dir'") == [ExecSegment(argv=("ls", "my dir"))]
+
+
+@pytest.mark.parametrize("op", ["|", "&&", "||", ";"])
+def test_each_chain_operator_splits_into_two_segments(op: str) -> None:
+    """Tier 1: every one of #5838's 4 supported chain operators produces
+    exactly [segment, ExecChainOp(op), segment] — the SAME shape for
+    all 4, not special-cased per operator."""
+    plan = parse_exec_plan(f"a {op} b")
+    assert plan == [
+        ExecSegment(argv=("a",)),
+        ExecChainOp(op=op),
+        ExecSegment(argv=("b",)),
+    ]
+
+
+@pytest.mark.parametrize("op", ["|", "&&", "||", ";"])
+def test_each_chain_operator_works_unspaced(op: str) -> None:
+    """Tier 1: real shells don't require whitespace around an operator
+    (``a|b`` pipes exactly like ``a | b``) — this parser must match
+    that, not just the spaced form."""
+    plan = parse_exec_plan(f"a{op}b")
+    assert plan == [
+        ExecSegment(argv=("a",)),
+        ExecChainOp(op=op),
+        ExecSegment(argv=("b",)),
+    ]
+
+
+@pytest.mark.parametrize("op", [">", ">>", "<"])
+def test_each_redirect_attaches_after_its_segment(op: str) -> None:
+    """Tier 1: every one of #5838's 3 supported redirects produces
+    [segment, ExecRedirect(op, path)] — the redirect is its own plan
+    item, not folded into the segment's own argv."""
+    plan = parse_exec_plan(f"cat {op} out.txt")
+    assert plan == [
+        ExecSegment(argv=("cat",)),
+        ExecRedirect(op=op, path="out.txt"),
+    ]
+
+
+def test_architects_own_worked_example_matches_exactly() -> None:
+    """Tier 1: the literal example from #5838's own implementation plan
+    (architect, issuecomment-5557091059) — pinned as the acceptance
+    shape, not re-derived from this parser's own internals."""
+    plan = parse_exec_plan("ls -la | grep foo > out.txt")
+    assert plan == [
+        ExecSegment(argv=("ls", "-la")),
+        ExecChainOp(op="|"),
+        ExecSegment(argv=("grep", "foo")),
+        ExecRedirect(op=">", path="out.txt"),
+    ]
+
+
+def test_multiple_chained_segments() -> None:
+    """Tier 1: three segments joined by ``;`` — not just the 2-segment
+    minimal case."""
+    plan = parse_exec_plan("a ; b ; c")
+    assert plan == [
+        ExecSegment(argv=("a",)),
+        ExecChainOp(op=";"),
+        ExecSegment(argv=("b",)),
+        ExecChainOp(op=";"),
+        ExecSegment(argv=("c",)),
+    ]
+
+
+# ── reject: empty / malformed input ──────────────────────────────────
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\t\n"])
+def test_empty_or_whitespace_only_is_rejected(text: str) -> None:
+    """Tier 1: no command at all — never a silent no-op plan."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_unterminated_quote_is_rejected() -> None:
+    """Tier 1: shlex's own ValueError is folded into ExecPlanRejected,
+    not left to propagate as a different exception type callers would
+    need a second catch clause for."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("ls 'unterminated")
+
+
+# ── reject: constructs that could hide a segment from policy ─────────
+
+
+@pytest.mark.parametrize("text", [
+    "echo $(date)",
+    "echo `date`",
+    "echo $(rm -rf /)",
+])
+def test_command_substitution_is_rejected(text: str) -> None:
+    """Tier 1: #5838's own core rejection reason — a nested command this
+    parser would never see is exactly the parse/execute-gap class
+    architect's own competitive research (Codex #28732 basename bypass)
+    names.
+
+    Strip witness: removing ``(``/``)``/backtick from
+    ``_PUNCTUATION_CHARS`` makes ``$(...)``'s contents parse as an
+    ordinary argv word instead of raising — verified directly during
+    authoring, restored after."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+@pytest.mark.parametrize("text", ["(ls)", "( ls; pwd )"])
+def test_subshell_grouping_is_rejected(text: str) -> None:
+    """Tier 1: a parenthesized group can hide a whole second pipeline
+    this parser would never see — same class as command substitution."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_heredoc_is_rejected_with_a_specific_reason() -> None:
+    """Tier 1: heredoc gets its OWN rejection message (distinguishable
+    from the generic "unsupported construct" reason) — its body is
+    arbitrary multi-line content, a different hazard shape from a
+    single-token construct like ``$(...)``."""
+    with pytest.raises(ExecPlanRejected, match="heredoc"):
+        parse_exec_plan("cat << EOF")
+
+
+def test_bare_background_ampersand_is_rejected() -> None:
+    """Tier 1: only ``&&`` is a supported operator — a lone ``&``
+    (background execution) is not in #5838's plan."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("ls &")
+
+
+# ── reject: malformed operator/redirect placement ─────────────────────
+
+
+@pytest.mark.parametrize("text", ["| ls", "ls |", "a || | b", "a | | b"])
+def test_an_empty_segment_around_a_chain_operator_is_rejected(text: str) -> None:
+    """Tier 1: a leading, trailing, or doubled chain operator leaves an
+    empty command on one side — never silently dropped/treated as a
+    no-op segment. Includes ``"a | | b"`` (spaced double pipe, a real
+    POSIX shell syntax error) alongside ``"a || | b"``."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan(text)
+
+
+def test_redirect_with_no_target_is_rejected() -> None:
+    """Tier 1: a redirect operator with nothing after it — never a
+    silent no-op redirect."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("ls >")
+
+
+def test_redirect_with_no_preceding_command_is_rejected() -> None:
+    """Tier 1: a redirect with no command before it — there is nothing
+    for the redirect to attach to."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("> out.txt")
+
+
+def test_argument_after_a_redirect_target_is_rejected() -> None:
+    """Tier 1: a deliberate v1 narrowing (module docstring) — redirects
+    must be the last thing in a segment here, even though real shells
+    allow ``cmd arg1 > file arg2`` (equivalent to ``cmd arg1 arg2 >
+    file``). Rejecting rather than silently mis-attributing ``arg2``."""
+    with pytest.raises(ExecPlanRejected):
+        parse_exec_plan("ls > out.txt -la")
+
+
+def test_chained_redirects_on_the_same_segment_are_accepted() -> None:
+    """Tier 1: ``cmd > out.txt < in.txt`` — two redirects, no argv
+    between them, on the same command — must not be confused with the
+    "argument after a redirect" rejection above."""
+    plan = parse_exec_plan("cat > out.txt < in.txt")
+    assert plan == [
+        ExecSegment(argv=("cat",)),
+        ExecRedirect(op=">", path="out.txt"),
+        ExecRedirect(op="<", path="in.txt"),
+    ]


### PR DESCRIPTION
**[e2e-coder]** — part of #5838. 段2 (architect's implementation plan, issuecomment-5557210786). **Corrected twice after co-vet**: first denylist → allowlist (issuecomment-5578494687), then self-corrected to a two-tier, quote-aware check (issuecomment-5578535394) — see below.

## What

The ONE parser #5838's plan shares across every future caller (LLM `exec` tool, pipeline exec step, `/exec`, `!`/`!!`) — owner decision (i): parse a shell command line into policy-checkable segments, but **execute the ORIGINAL string via `sh -c`** in later stages, never a reconstruction from this parsed plan. This module does neither policy nor execution — purely `text -> ExecPlan | raise ExecPlanRejected`.

Placed in `security/` (not `interfaces/` — the LLM `exec` path uses it too), matching #5837's own isolation of `tokenize_exec_cmdline`, the function this eventually replaces in a **later, separate stage (段7)**. Segment policy (段3) and `sh -c` execution (段4) are also separate PRs.

## Denylist → two-tier allowlist (the structural history)

**First**: an enumerated denylist. Co-vet found 4 independent bypasses in ~40 minutes, each a different probing approach: `$`/glob/`~`, brace `{a,b}` (macOS `/bin/sh` expands it even in POSIX mode), a **literal newline** (the worst — `shlex` folds `\n` into whitespace, so `"ls\nrm -rf /tmp/x"` parsed as one segment with an ordinary `argv[0]="ls"`, while a real shell runs the newline as a command separator), and `!` (negation — `! ls` read `argv[0]='!'` here while a real shell treats `!` as negation and runs `ls` unseen).

**Second**: a raw-string-wide allowlist (reject any character not on a fixed list). This over-rejected real commands: `python -c "print(1)"` and `curl "http://x/a?b=1"`. Real-machine measurement found the true boundary was never "dangerous vs safe" — it was **whether `shlex`'s own `punctuation_chars` distinguishes quoted from unquoted for that character**:

```
python -c "print(1)" -> ['python','-c','print(1)']       (quoted: shlex keeps the parens in the WORD)
python -c print(1)   -> ['python','-c','print','(','1',')']  (unquoted: split into their own tokens)
curl "...?b=1" and curl ...?b=1 tokenize IDENTICALLY either way — ? isn't in punctuation_chars, no recoverable signal
```

**Current (third) design** — two checks, for two different reasons:
1. `_PUNCTUATION_CHARS` (`( ) | & ; < >` + backtick) — quote-aware, checked per TOKEN: unquoted becomes its own operator token (checked for a supported shape — pipe/chain/redirect, else rejected); quoted stays inside a word, accepted as literal.
2. `_ALWAYS_FORBIDDEN_CHARS` (`$ * ? [ ] { } ~ !`) — `shlex` tokenizes these identically whether quoted or not, so every occurrence is rejected, quoted or not (`curl "...?b=1"` cannot be saved — explicitly accepted loss).

Only `_reject_raw_newline` still runs against the raw string before tokenizing — the one thing `shlex` never surfaces as a token at all.

One accepted regression from the original denylist (explicitly blessed): a stray `}` alone (`echo a}b`) is now rejected too — no per-construct carve-out mechanism in either allowlist tier.

## Disclosure required by owner directive ("調べて industry standard before inventing your own")

architect's follow-up research (#5987, filed separately): a **character**-level check is not what competitors use — Claude Code/Codex allowlist **tree-sitter AST node types**; OpenClaw allowlists a resolved path + argument pattern, and both **escalate what they can't resolve to a human** rather than refusing outright (this module refuses — escalation is 段3's subject, out of scope here). `shlex` has no grammar to allowlist nodes of, so counting characters was the only mechanism available, not a considered match to the field's own unit. The module docstring now states this plainly, states **no completeness claim** (the 4 bypasses were found by measurement, not by enumerating a verified-complete population), and points to #5987 for the future parser re-evaluation (measured against real `bash` on a corpus, not "because it's the standard").

## Test plan

- [x] `tests/security/test_5838_exec_plan_parser.py` — 61 tests: full accept/reject matrix, architect's own worked example pinned as data, every measured bypass, the exact quoted/unquoted contrast pair (`python -c "print(1)"` accepts, `python -c print(1)` rejects — testing only one direction would not be a witness), and non-regression cases (`docker run -e FOO=bar image`, `2>&1`, `ls # rm -rf /`).
- [x] Strip witness, every check — verified directly (in-file Edit → red → Edit back). One self-caught bug during authoring: a strip witness that iterated an emptied set vacuously passed with zero assertions run — fixed with a non-empty sanity assert, re-verified against the same strip.
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_5838_exec_plan_parser.py` — 33/33 OK
- [x] `python scripts/mypy_ratchet.py` — OK (0 findings)
- [x] `python -m mypy src/reyn/security/exec_plan.py` — clean, standalone
- [x] `verify_module_docstrings.py` / `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
