### PR TITLE
fix(#5989 ruling ②): sent-queue seq-gate answers "is this echo mine" by identity, not order

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -6480,20 +6480,34 @@ class TextualChatApp(App):
         local placeholder id THIS client minted at submit time, echoed back
         opaque and unread by the server — replacing the old ``has_row(msg_id)``
         GUESS (a row existing under the id this delta is ABOUT to use tells
-        you nothing about whose submission it was)."""
+        you nothing about whose submission it was).
+
+        #5989 ruling ②: ``client_ref`` matching one of THIS client's own
+        still-open pending rows is checked BEFORE calling the seq-gate, and
+        passed through as ``is_own_pending`` — a replay is BY DEFINITION an
+        echo for something NOT in this client's own pending set, so an
+        identity match can never admit a genuine replay; the gate answers
+        "is this echo mine" by IDENTITY now, not by seq order, which is what
+        #5894 (unserialized wire round-trips racing) could invert. See
+        ``RemoteQueueView.apply_user_submitted``'s own docstring for the
+        full mechanism this closes (owner-hit #5989: "pending queue に残っ
+        たまま" — the earlier of two racing submissions' echo losing the
+        seq-order race, permanently orphaning its own row)."""
         data = event.data or {}
         msg_id = data.get("msg_id")
         chain_id = data.get("chain_id")
         text = str(data.get("text", ""))
         seq = data.get("seq", 0)
+        meta = dict(data.get("meta") or {})
+        client_ref = meta.get("client_ref")
+        is_own_pending = isinstance(client_ref, str) and self._sent_queue.has_row(client_ref)
         applied = self._queue_view.apply_user_submitted(
             msg_id=msg_id, chain_id=chain_id, text=text, seq=seq,
+            is_own_pending=is_own_pending,
         )
         if applied and msg_id:
-            meta = dict(data.get("meta") or {})
             self._queue_item_meta[msg_id] = meta
-            client_ref = meta.get("client_ref")
-            if isinstance(client_ref, str) and self._sent_queue.has_row(client_ref):
+            if is_own_pending:
                 # This client's own local placeholder, identified by FACT
                 # (this echo carries the exact id THIS client minted for
                 # THIS submission) — promote in place. Never a second row,
@@ -6507,35 +6521,25 @@ class TextualChatApp(App):
                 self._sent_queue.show_item(msg_id, text)
             self._apply_compact_layout()
         elif not applied:
-            # #3688: the rejecting branch used to be pure absence — no row, no
-            # log, no trace of any kind. "The server dropped it", "the gate
-            # superseded it" and "it has not arrived yet" then look identical
-            # to the operator AND to anyone investigating, which is what made
-            # the owner's report expensive to attribute. The gate rejecting a
-            # stale delta is legitimate and stays silent to the operator; it
-            # stops being invisible to the LOG, which is the surface an
-            # investigation reads.
-            # #5886 (architect ruling ⑥): a rejection whose ``client_ref``
-            # is THIS client's own pending row is the bug's fingerprint,
-            # not routine staleness. This client minted that id moments ago
-            # for a submission it has not seen echoed yet, so "already
-            # reflected" cannot be true of it — the only way the gate says
-            # so is a baseline that is wrong. Loud, with the id, so an
-            # operator's log shows the cause instead of just the silence.
-            # Every OTHER rejection (another client's genuinely stale
-            # delta) stays debug: those are the gate doing its job.
-            _ref = (dict(data.get("meta") or {})).get("client_ref")
-            _is_own_pending = isinstance(_ref, str) and self._sent_queue.has_row(_ref)
-            (logger.warning if _is_own_pending else logger.debug)(
+            # #3688 / #5989 ③: the rejecting branch used to be pure
+            # absence — no row, no log, no trace of any kind. "The server
+            # dropped it", "the gate superseded it" and "it has not
+            # arrived yet" then look identical to the operator AND to
+            # anyone investigating — the #5989 bisection itself took 61
+            # commits partly because this WAS ``logger.debug``, invisible
+            # on the shipped default. A rejection reaching here can no
+            # longer be THIS client's own pending row (ruling ② admits
+            # every one of those above) — every rejection left is a
+            # GENUINE stale/replayed delta, the gate doing its job — but
+            # "doing its job" is still an event worth a visible trace,
+            # not silence an investigation has to reconstruct from
+            # nothing.
+            logger.warning(
                 "textual chat: sent-queue gate rejected user_submitted "
-                "msg_id=%s seq=%s client_ref=%s (already reflected by a "
-                "prior snapshot/delta)%s",
-                msg_id, seq, _ref,
-                (
-                    " — this is THIS client's own pending submission, so the "
-                    "gate's baseline is wrong (#5886), not the delta stale"
-                    if _is_own_pending else ""
-                ),
+                "msg_id=%s seq=%s client_ref=%s (stale — already reflected "
+                "by a prior snapshot/delta; not this client's own pending "
+                "row, so the rejection is correct)",
+                msg_id, seq, client_ref,
             )
 
     def _handle_turn_started_event(self, event) -> None:

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -344,13 +344,44 @@ class RemoteQueueView:
         self.turn_active = turn_active
         self._last_seq = queue_seq
 
-    def apply_user_submitted(self, *, msg_id: str, chain_id: "str | None", text: str, seq: int) -> bool:
+    def apply_user_submitted(
+        self, *, msg_id: str, chain_id: "str | None", text: str, seq: int,
+        is_own_pending: bool = False,
+    ) -> bool:
         """Apply an enqueue delta; returns False (no-op) if the seq gate
-        rejects it as already reflected by a prior snapshot/delta."""
-        if seq <= self._last_seq:
+        rejects it as already reflected by a prior snapshot/delta.
+
+        ``is_own_pending`` (#5989 ruling ②): the question this gate exists
+        to answer is IDENTITY — "is this echo the one my own pending row is
+        waiting for" — not order. #5989's own owner-hit measured what
+        answering it with ``seq`` alone costs: two submissions racing (a
+        client whose own wire round-trips can overlap — #5894, absent
+        #5907's serialization on the path that actually reproduced it)
+        can have their echoes arrive OUT of submission order; the earlier
+        one's echo then reads as ``seq <= self._last_seq`` and is rejected
+        as "stale" — except it is not stale, it is this client's OWN still-
+        pending submission, permanently orphaning its sent-queue row.
+
+        The caller (:meth:`~reyn.interfaces.inline.textual_chat.app.
+        TextualChatApp._handle_user_submitted_event`) confirms identity
+        BEFORE calling this — ``meta.client_ref`` matching one of ITS OWN
+        still-open local placeholder rows — and passes that fact through.
+        A replay is BY DEFINITION an echo for something NOT in the
+        caller's own pending set, so honoring ``is_own_pending=True`` can
+        never admit a genuine replay: replay rejection for every OTHER
+        echo (``is_own_pending=False``, the default) is unchanged.
+
+        The seq-gate's own baseline (:attr:`_last_seq`) still only ever
+        moves FORWARD here — an identity-confirmed but seq-superseded
+        echo is applied to :attr:`items` without regressing
+        :attr:`_last_seq` backward, so the ordering guarantee everything
+        ELSE (a genuine stale/replayed delta for a DIFFERENT item) relies
+        on is untouched."""
+        if seq <= self._last_seq and not is_own_pending:
             return False
         self.items[msg_id] = {"msg_id": msg_id, "chain_id": chain_id, "text": text}
-        self._last_seq = seq
+        if seq > self._last_seq:
+            self._last_seq = seq
         return True
 
     def apply_turn_started(self, *, chain_id: "str | None", seq: int) -> bool:

--- a/tests/interfaces/test_3300_p2a_queue_state_publish.py
+++ b/tests/interfaces/test_3300_p2a_queue_state_publish.py
@@ -333,6 +333,55 @@ def test_remote_queue_view_seq_gate_prevents_resurrection_after_dispatch():
     assert fresh.queue() == []
 
 
+def test_remote_queue_view_is_own_pending_promotes_despite_a_losing_seq_race():
+    """Tier 1: #5989 ruling ② — the seq-gate's own answer to "is this echo
+    mine" is IDENTITY, not order. Two submissions race (#5894, absent
+    #5907-style serialization on the path #5989 actually reproduced): B's
+    echo (seq=2) arrives FIRST and applies normally, advancing the gate's
+    baseline to 2. A's echo (seq=1) then arrives SECOND — a lower seq than
+    the baseline — but the CALLER has independently confirmed (by
+    ``client_ref`` matching A's own still-open pending row) that this is
+    NOT a replay, so it passes ``is_own_pending=True``. The gate must
+    still APPLY it (the owner-hit: without this, A's sent-queue row is
+    orphaned forever), while the baseline must NOT regress (verified via
+    a SUBSEQUENT stale, non-identity delta for a THIRD item at seq=1 —
+    genuinely stale, still correctly rejected — see the sibling replay
+    test below for the fuller replay-still-rejected coverage this
+    assertion complements).
+
+    Strip-falsify (verified by hand, both directions): dropping
+    ``is_own_pending`` from the gate's own condition (``if seq <= self.
+    _last_seq:`` unconditionally) makes A's apply return ``False`` and
+    ``view.queue()`` never contain "first" — this test's own first block
+    goes red. Making the gate move ``self._last_seq`` DOWN to A's seq (1)
+    on the identity-confirmed apply makes the THIRD item's later stale
+    check at seq=1 wrongly pass — this test's own second block goes red.
+    """
+    view = RemoteQueueView()
+
+    # B's echo (seq=2) arrives first — a completely ordinary apply.
+    assert view.apply_user_submitted(msg_id="mB", chain_id="cB", text="second", seq=2) is True
+    assert view.baseline_seq() == 2
+
+    # A's echo (seq=1) arrives second — a losing seq race against B's,
+    # but IDENTITY-confirmed as this client's own still-pending row.
+    applied = view.apply_user_submitted(
+        msg_id="mA", chain_id="cA", text="first", seq=1, is_own_pending=True,
+    )
+    assert applied is True, "an identity-confirmed echo must apply despite losing the seq race"
+    assert {"msg_id": "mA", "chain_id": "cA", "text": "first"} in view.queue(), (
+        "A's item must be present — this is the sent-queue row the owner-hit "
+        "reports as permanently stuck without this fix"
+    )
+
+    # The baseline must not have regressed to A's lower seq — a genuinely
+    # stale (non-identity) delta at the SAME seq=1 is still correctly
+    # rejected, proving replay protection for everyone else is unweakened.
+    assert view.baseline_seq() == 2, "an identity-confirmed apply must never regress the baseline"
+    stale = view.apply_user_submitted(msg_id="mC", chain_id="cC", text="unrelated", seq=1)
+    assert stale is False, "a genuinely stale, non-identity delta at the same seq must still be rejected"
+
+
 def test_remote_queue_view_snapshot_mid_stream_stays_consistent_with_redelivery():
     """Tier 1: a connection's SSE stream preserves per-connection delivery
     order (a single ordered queue, #3300 P2a emitter), so the realistic race

--- a/tests/interfaces/test_5886_own_client_ref_rejection_warns.py
+++ b/tests/interfaces/test_5886_own_client_ref_rejection_warns.py
@@ -1,25 +1,32 @@
-"""Tier 2: #5886 ruling ⑥ — the seq gate's rejection log is DISCRIMINATING.
-
-A rejection whose ``meta.client_ref`` names a row THIS client is still
-waiting on cannot be "already reflected": the client minted that id moments
-ago for a submission it has not yet seen echoed. The only way the gate says
-so is a baseline that is wrong — the fingerprint of #5886's own defect — so
-it WARNS, naming the id. Every other rejection (another client's genuinely
-stale delta) is the gate doing its job and stays ``debug``.
+"""Tier 2: #5989 ruling ② supersedes #5886 ruling ⑥ here — same fingerprint
+(a rejection whose ``client_ref`` names THIS client's own still-pending row),
+different resolution. #5886 made that case WARN, loudly naming the wrong
+baseline, but still rejected it — the row stayed stuck, only the log got
+louder. #5989's own owner-hit measured that this is not enough: the seq-gate
+should answer "is this echo mine" by IDENTITY, not by seq order, so an
+identity-confirmed echo now PROMOTES despite losing a seq race (see
+``RemoteQueueView.apply_user_submitted``'s own docstring for the full
+mechanism). What #5886 protected — the log staying discriminating, not
+turning every rejection into noise — still matters, restated for what a
+rejection means NOW that identity is handled upstream: every rejection
+reaching this branch is, by construction, NOT this client's own pending row
+(#5989 ③, replacing #5886's WARNING/DEBUG split): it is a genuine stale or
+replayed delta, and it is now ALWAYS visible (``logger.warning``, never
+``debug``) — the 61-commit #5989 bisection needed exactly this trace and did
+not have it.
 
 Both halves are tested, because either alone is satisfiable by the wrong
-build: a build that warned on EVERY rejection passes the first test and
-turns the log into noise; a build that warned on none passes the second and
-keeps the failure invisible — the shape #5886 was reported in.
+build: a build that still REJECTS the client's own pending row passes the
+second test's shape but fails the first (no promotion); a build that warns
+on nothing (silent rejection restored) passes the first but fails the
+second.
 
 Driven through a real mounted ``TextualChatApp`` on the SAME two seam
 implementations ``test_3338_tui_status_chrome_liveness.py`` established: a
 real ``ChatReadModel`` subclass whose ``snapshot()`` the test controls (so
 "the read model already carries queue_seq 5" is a fact the seed reads, not a
 private poke), and a real minimal ``ClientTransport`` fed one frame at a
-time. The verdict is read off the logger, the barrier is the rejection's own
-log record — a definite signal in BOTH tests, since the gate rejects in
-both; only the LEVEL differs, which is exactly the property under test.
+time.
 """
 from __future__ import annotations
 
@@ -36,7 +43,7 @@ from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import EventFrame, QueueSnapshot, StatusApplied
 from reyn.schemas.models import Event
 
-_TEXT = "a submission the gate will reject"
+_TEXT = "a submission the gate will now promote"
 _LOGGER = "reyn.interfaces.inline.textual_chat.app"
 
 
@@ -46,8 +53,8 @@ class _SeededReadModel(ChatReadModel):
     ``snapshot()`` deliberately reports ``queue_seq 0``: #5895 moved the
     seed's source onto the frame, so if the seed still consulted this read
     model the baseline would be 0, the stale seq-1 delta below would be
-    ADMITTED, and both tests would fail on "no rejection" — that is the
-    strip."""
+    ADMITTED regardless of identity, and both tests would fail to reach the
+    gate this file actually exercises — that is the strip."""
 
     @property
     def capabilities(self):
@@ -134,8 +141,10 @@ class _FrameTransport(ClientTransportStub):
 
 
 def _stale_user_submitted(client_ref: str) -> EventFrame:
-    """``seq 1`` against a baseline of 5 — rejected by the gate either way;
-    only WHOSE submission it is should change what gets logged."""
+    """``seq 1`` against a baseline of 5 — a losing seq race either way;
+    only WHOSE submission it is decides whether the gate now promotes it
+    (this client's own pending row, #5989 ②) or rejects it (anyone else's,
+    a genuine stale/replayed delta, #5989 ③)."""
     return EventFrame(Event(type="user_submitted", data={
         "msg_id": "m1", "chain_id": "c1", "text": _TEXT, "seq": 1,
         "meta": {"client_ref": client_ref},
@@ -146,21 +155,21 @@ def _rejections(caplog) -> "list":
     return [r for r in caplog.records if "gate rejected" in r.getMessage()]
 
 
-async def _drive(app: TextualChatApp, transport: _FrameTransport, client_ref: str, pilot, caplog) -> None:
+async def _seed_and_push(transport: _FrameTransport, client_ref: str) -> None:
     # #5895: the frame CARRIES the baseline — queue_seq 5 rides here.
     await transport.push(StatusApplied(
         kind="snapshot",
         snapshot=QueueSnapshot(queue=(), turn_active=False, queue_seq=5),
     ))
     await transport.push(_stale_user_submitted(client_ref))
-    while not _rejections(caplog):
-        await pilot.pause()
 
 
 @pytest.mark.asyncio
-async def test_rejecting_this_clients_own_pending_submission_warns(caplog) -> None:
-    """Tier 2: the fingerprint. The rejected delta's ``client_ref`` names a
-    row THIS client staged and is still waiting on → WARNING, naming it."""
+async def test_own_pending_submission_promotes_despite_losing_the_seq_race(caplog) -> None:
+    """Tier 2: #5989 ②, the fix itself. The delta's ``client_ref`` names a
+    row THIS client staged and is still waiting on — the gate must PROMOTE
+    it (the row leaves "SENDING") despite its seq losing the race against
+    the baseline, and must log NO rejection at all for it."""
     caplog.set_level("DEBUG", logger=_LOGGER)
     transport = _FrameTransport()
     app = TextualChatApp(transport=transport, read_model=_SeededReadModel())
@@ -168,28 +177,39 @@ async def test_rejecting_this_clients_own_pending_submission_warns(caplog) -> No
     async with app.run_test(size=(100, 30)) as pilot:
         # Staged exactly the way the composer stages one — the widget's
         # own public API, no private field.
-        app.query_one(SentQueue).show_item("local:mine", _TEXT, sending=True)
-        await _drive(app, transport, "local:mine", pilot, caplog)
+        sent_queue = app.query_one(SentQueue)
+        sent_queue.show_item("local:mine", _TEXT, sending=True)
+        await _seed_and_push(transport, "local:mine")
 
-        (record,) = _rejections(caplog)
-        assert record.levelname == "WARNING", (record.levelname, record.getMessage())
-        assert "local:mine" in record.getMessage()
-        assert "baseline is wrong" in record.getMessage()
+        while sent_queue.has_row("local:mine"):
+            # rekey() replaces the LOCAL key with the server msg_id — the
+            # row promoting is exactly this key disappearing.
+            await pilot.pause()
+
+        assert not sent_queue.has_row("local:mine"), "the local placeholder must have been promoted"
+        assert sent_queue.has_row("m1"), "promoted under the server's own msg_id"
+        assert _rejections(caplog) == [], "this client's own pending row must never be logged as rejected"
 
 
 @pytest.mark.asyncio
-async def test_rejecting_someone_elses_stale_delta_stays_debug(caplog) -> None:
-    """Tier 2: the control that keeps the log discriminating. The SAME
-    rejection, but the ``client_ref`` is nobody's pending row here (another
-    client's genuinely stale delta) → the gate is doing its job → ``debug``,
-    never a warning."""
+async def test_someone_elses_stale_delta_is_still_rejected_and_now_warns(caplog) -> None:
+    """Tier 2: the control that keeps ② from weakening replay protection —
+    the SAME losing seq race, but the ``client_ref`` is nobody's pending
+    row here (another client's genuinely stale delta, or a replay). The
+    gate must still reject it (#5989's own accept criterion ②: "replay が
+    今までどおり弾かれる"), and #5989 ③ requires that rejection be visible
+    — ``WARNING``, never ``debug`` (#5886's own DEBUG/WARNING split is
+    retired: every rejection reaching this branch is now, by construction,
+    a genuine one)."""
     caplog.set_level("DEBUG", logger=_LOGGER)
     transport = _FrameTransport()
     app = TextualChatApp(transport=transport, read_model=_SeededReadModel())
 
     async with app.run_test(size=(100, 30)) as pilot:
-        await _drive(app, transport, "local:someone-else", pilot, caplog)
+        await _seed_and_push(transport, "local:someone-else")
+        while not _rejections(caplog):
+            await pilot.pause()
 
         (record,) = _rejections(caplog)
-        assert record.levelname == "DEBUG", (record.levelname, record.getMessage())
-        assert "baseline is wrong" not in record.getMessage()
+        assert record.levelname == "WARNING", (record.levelname, record.getMessage())
+        assert app.query_one(SentQueue).item_count() == 0, "no row must have been resurrected"


### PR DESCRIPTION
**[tui-coder]** — P0, owner-hit live. Implements the ruling on #5989: ② (identity, not seq order, decides whether a `user_submitted` echo is this client's own pending submission) + ① kept (already present via #5907's serialization, untouched — kept for its own separate reason) + ③ (rejection always `logger.warning`, never `debug`).

## Root cause (reproduced — see `worktree-5989-repro-invest`)
`TextualChatApp._submit` can run two submissions' wire round-trips concurrently (#5894's own design). If the server answers out of submission order, `RemoteQueueView`'s seq-gate reads the earlier submission's echo — a lower seq arriving after a higher one — as "stale" and rejects it, by design, the same protection that correctly drops a genuine replay. A rejected echo never promotes; that row's sent-queue placeholder stays "SENDING" forever, silently (`logger.debug`). Matches the owner's exact report: reply renders fine, `proxy 200 OK ×3`, but the sent message never leaves the pending queue.

## Fix
`RemoteQueueView.apply_user_submitted` gains `is_own_pending: bool = False`. The caller (`_handle_user_submitted_event`) confirms identity first (`meta.client_ref` matching one of its own still-open pending rows) — a replay is *by definition* an echo for something not in the caller's own pending set, so honoring identity can never admit a genuine replay. The gate applies the item when `is_own_pending`, but never regresses its own `_last_seq` baseline backward, so replay rejection for every other echo is unweakened.

Architect's own framing: the gate's real question is "is this echo mine" (identity), not "is this in order" (seq) — substituting order for identity is exactly what #5894's concurrency can invert.

## Accept criteria (3, per the ruling)
- [x] New `RemoteQueueView`-level unit test, strip-verified both directions (drop the identity bypass → promotion reds; let the apply regress the baseline → the same test's replay-still-rejected check reds).
- [x] Existing `test_remote_queue_view_seq_gate_prevents_resurrection_after_dispatch` untouched and still green — replay is still rejected.
- [x] `test_5886_own_client_ref_rejection_warns.py` rewritten: own-pending promotes with zero rejection logged; someone else's genuinely stale delta still rejects, now `WARNING` not `DEBUG`. Strip-verified: forcing `is_own_pending=False` reproduces the owner's own symptom directly (the promotion test times out — the row never leaves SENDING).

## Separate finding, filed elsewhere (not touched here)
`_cancel_queued_over_wire`'s worker-based bookkeeping is structurally decoupled from the actual row removal (driven by the server's `inbox_cancel` echo, never the worker's return) — recorded on #5989 per lead-coder's request; lead-coder is filing it as its own follow-up issue, not mixed into this PR.

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green. `suspected_time_dependence_ratchet.py` fails on this branch, but confirmed **pre-existing on unmodified `origin/main`** (an unrelated file, `test_5973_bounded_materialization.py`, not touched by this PR) — not something this PR introduced or can fix.
- [x] Scoped pytest: `test_3300_p2a_queue_state_publish.py`, `test_5886_own_client_ref_rejection_warns.py`, `test_3300_p2b_sentqueue_render.py`, `test_3300_p3_cancel_by_id.py`, `test_4409_pre_send_indicator.py`, `test_3310_n2_reset_hydrate.py`, `test_5179_remote_own_message_seq_gate_race.py` — 58 passed.
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
