### PR TITLE
fix(#5992): defer stall-dump truncation to the next episode; scope stall_dump_path per process

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2491,6 +2491,15 @@ class TextualChatApp(App):
         stall_dump_path`) — see ``StallDumpArm``'s own docstring for the
         full design and the truncate-timing trap ``mark_fired()`` exists
         to avoid.
+
+        **#5992 (lead-coder review of PR #5988)**: ``mark_fired()`` for
+        the episode that JUST fired is deferred (``_pending_truncate``,
+        below) — consumed right before the NEXT episode's own fire is
+        recorded, never immediately after THIS one's. Truncating right
+        away destroyed the dump before an operator could read it, with
+        every prior test still green (they counted call COUNT, not the
+        file's own content) — see ``StallDumpArm.mark_fired``'s own
+        updated docstring.
         """
         import asyncio  # noqa: PLC0415
         import time  # noqa: PLC0415
@@ -2573,6 +2582,12 @@ class TextualChatApp(App):
         # implementation each, since this loop does not call that shared
         # one — see the module docstring's own duplication note).
         _armed_last_tick = False
+        # #5992 (lead-coder review of PR #5988): whether THIS episode's
+        # own dump still needs truncating away before a FUTURE episode's
+        # own dump lands — see the block below for why this is a flag
+        # consumed on a LATER tick, never truncated the moment the fire
+        # is detected.
+        _pending_truncate = False
         if _stack_dump is not None and self._loop_tripwire.should_arm_stack_dump():
             _armed_last_tick = _stack_dump.rearm()
         try:
@@ -2589,14 +2604,29 @@ class TextualChatApp(App):
                     # (nonexistent) fired state.
                     stack_dumped = lateness_ms > _TRIPWIRE_MS
                     if stack_dumped:
-                        self._loop_tripwire.record_stack_dump()
-                        if _stack_dump is not None:
-                            # #5977 ②: truncate + reopen for the NEXT
-                            # episode NOW, right after observing this fire
-                            # — never on an ordinary re-arm (StallDumpArm.
-                            # mark_fired's own docstring: the
-                            # truncate-timing trap).
+                        # #5992 (self-caught correction, lead-coder review
+                        # of PR #5988): an EARLIER version called
+                        # mark_fired() right HERE — truncating the dump
+                        # the SAME tick it is detected, before an operator
+                        # could ever read it (a build with this exact bug
+                        # still passed every existing test, because they
+                        # counted HOW MANY TIMES mark_fired was called,
+                        # never checked what it did to the FILE). If a
+                        # PRIOR episode's dump is still owed a truncation
+                        # (deferred from that earlier episode), THIS is
+                        # the correct point to pay it — right before
+                        # recording THIS NEW episode's own dump, never
+                        # before: the old dump must survive the ENTIRE gap
+                        # between episodes (arbitrarily long, or forever
+                        # if no further stall occurs), and must be gone by
+                        # the moment a NEW one is about to replace it.
+                        if _pending_truncate and _stack_dump is not None:
                             _stack_dump.mark_fired()
+                        self._loop_tripwire.record_stack_dump()
+                        # This episode's OWN dump is now the one owed a
+                        # truncation — deferred the same way, consumed by
+                        # whichever episode (if any) comes after it.
+                        _pending_truncate = True
                 pump_history.append((now, self._pump_ticks, self._keys_received))
                 while pump_history and now - pump_history[0][0] > _PUMP_WINDOW_S:
                     pump_history.popleft()

--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -82,26 +82,56 @@ _DUMP_ENV = "REYN_PROF_DUMP"
 
 
 def stall_dump_path(reyn_log_path: "str | None") -> "str | None":
-    """The fixed, single-file destination for a stall's stack dump (#5977
-    ruling ②, #5978 ①'s ``diagnostic_snapshot`` shape) — the SAME
+    """The single-file destination for THIS PROCESS's stall stack dump
+    (#5977 ruling ②, #5978 ①'s ``diagnostic_snapshot`` shape) — the SAME
     directory ``reyn.log`` lives in, so an operator who already knows to
-    look there finds it, under a FIXED filename: no config surface at
-    all ("a limit that can be set is a limit someone can raise" —
-    architect, #5977).
+    look there finds it, under a filename derived from ``os.getpid()``:
+    no config surface (nothing here is operator-settable — "a limit that
+    can be set is a limit someone can raise," architect, #5977 — the pid
+    is read, never chosen).
+
+    **Boundedness is per-PROCESS, not per-workspace (#5992, lead-coder
+    review of PR #5988)**: a fixed, PID-less filename here would make
+    every process sharing this ``reyn.log`` directory (measured live:
+    ``reyn:web`` and ``reyn:chat`` attached to the SAME project,
+    ``lsof -a -p <pid> -d cwd`` confirming both) point their OWN
+    :class:`DiagnosticSnapshot` at the SAME inode. ``DiagnosticSnapshot``
+    opens ``O_TRUNC``, not ``O_APPEND`` — two processes would each write
+    from their OWN independent offset 0, so the LATER writer does not
+    cleanly "replace" the earlier one the way a single process's own
+    successive episodes do (architect's own "a later stall's dump is
+    never a worse sample" reasoning, #5977, is a claim about ONE
+    process's own successive stalls — it says nothing about a DIFFERENT
+    process's dump, which the current writer has no way to even know
+    exists). The two failure shapes: one process's dump silently
+    overwrites the other's (data loss with no signal), or the two writes
+    interleave into a torn, unreadable dump neither process's own
+    ``mark_fired()`` truncation ever detects. The PID suffix makes each
+    process's own destination genuinely distinct — the boundedness this
+    function's own docstring can claim is now "always exactly one dump
+    PER REYN PROCESS attached to this workspace," not "always exactly
+    one dump, full stop": N reyn processes against one workspace leave N
+    files, each individually still bounded the same way a single
+    process's own file always was. Not a config surface — nobody sets N,
+    it is simply how many reyn processes an operator happens to be
+    running against this one workspace at a time (in practice small and
+    human-driven, never something this function reasons about or bounds
+    itself).
 
     Overwritten in place rather than rotated: a dump answers "what was
-    stuck at the moment of the LAST stall," and a LATER stall's dump is
-    never a worse sample than an earlier one it replaces — there is no
-    reason to keep generations (architect's own self-correction, #5977:
-    an earlier ruling proposed rotation here, which #5977 itself exists
-    to call out — "a bound written for a mechanism this doesn't have").
+    stuck at the moment of the LAST stall," and a LATER stall's dump
+    (from the SAME process) is never a worse sample than an earlier one
+    it replaces — there is no reason to keep generations (architect's
+    own self-correction, #5977: an earlier ruling proposed rotation
+    here, which #5977 itself exists to call out — "a bound written for a
+    mechanism this doesn't have").
 
     ``None`` when there is no ``reyn.log`` path to sit beside — matches
     :meth:`StallDumpArm.open`'s own "no ``FileHandler`` installed → never
     arms" behaviour."""
     if reyn_log_path is None:
         return None
-    return str(Path(reyn_log_path).with_name("stall_dump.log"))
+    return str(Path(reyn_log_path).with_name(f"stall_dump.{os.getpid()}.log"))
 
 
 def dump_path() -> "str | None":
@@ -663,6 +693,18 @@ class StallDumpArm:
         failed reopen — the switch stays disarmed until :meth:`close`)."""
         return self._snapshot.fd is not None
 
+    @property
+    def fd(self) -> "int | None":
+        """The live fd ``faulthandler`` writes into — a thin passthrough
+        to the underlying :class:`~reyn.runtime.diagnostic_snapshot.
+        DiagnosticSnapshot`, exposed for the SAME reason that class
+        exposes its own ``fd``: a test verifying this arm's real EFFECT
+        (does the file's content actually reset between episodes, not
+        merely "was ``mark_fired`` called") needs a real fd to write a
+        stand-in marker into at the exact point production code would
+        have a real dump land (#5992)."""
+        return self._snapshot.fd
+
     def points_at_current_file(self) -> bool:
         """Whether this arm's fd points at the file CURRENTLY at its own
         destination path — a thin public passthrough to
@@ -698,12 +740,24 @@ class StallDumpArm:
         return True
 
     def mark_fired(self) -> None:
-        """Call ONCE, right after the caller has OBSERVED (via the
-        ``stack_dumped`` proxy) that a dump this arm scheduled actually
-        fired — truncates and reopens the snapshot's fd so the NEXT
-        episode's dump overwrites cleanly, ready before it is next armed.
-        Never call this on an ordinary re-arm — see the class docstring's
-        truncate-timing trap."""
+        """Truncate and reopen the snapshot's fd, clearing whatever this
+        arm most recently dumped.
+
+        #5992 (lead-coder review of PR #5988, self-caught): call this
+        ONLY when a PRIOR dump is about to be superseded by a NEW one
+        actually landing — i.e. right before recording a NEW episode's
+        own fire, never immediately after observing the PRIOR one. An
+        earlier version of this contract read "call right after
+        observing a fire," and callers that followed it literally
+        truncated their own dump on the SAME tick it landed — destroying
+        it before an operator could ever read it, with every existing
+        test still green (they counted call COUNT, never checked the
+        file's own content). The dump this arm just wrote must survive
+        the entire gap until (if ever) a NEW one is ready to replace it
+        — see :func:`watch_event_loop`'s own updated docstring for the
+        deferred-consumption shape this requires from the caller. Never
+        call this on an ordinary re-arm either — see the class
+        docstring's truncate-timing trap for why."""
         self._snapshot.reset()
 
     def close(self) -> None:
@@ -761,6 +815,11 @@ async def watch_event_loop(
     """
     last = clock()
     armed_last_tick = False
+    # #5992 (lead-coder review of PR #5988): whether THIS episode's own
+    # dump still needs truncating away before a FUTURE episode's own dump
+    # lands — see the block below for why this is a flag consumed on a
+    # LATER tick, never truncated the moment the fire is detected.
+    pending_truncate = False
     if stack_dump is not None and tripwire.should_arm_stack_dump():
         # Arm for the FIRST wait too — a stall on the very first tick would
         # otherwise go undumped (#5870 stage 1).
@@ -778,13 +837,29 @@ async def watch_event_loop(
                 # readback of faulthandler's (nonexistent) fired state.
                 stack_dumped = lateness_ms > tripwire.threshold_ms
                 if stack_dumped:
-                    tripwire.record_stack_dump()
-                    if stack_dump is not None:
-                        # #5977 ②: truncate + reopen for the NEXT episode
-                        # NOW, right after observing this fire — never on
-                        # an ordinary re-arm (StallDumpArm.mark_fired's own
-                        # docstring: the truncate-timing trap).
+                    # #5992 (self-caught correction, lead-coder review of
+                    # PR #5988): an EARLIER version of this method called
+                    # `mark_fired()` right HERE — truncating the dump the
+                    # SAME tick it is detected, before an operator could
+                    # ever read it (a build with this exact bug still
+                    # passed every existing test, because they counted
+                    # HOW MANY TIMES `mark_fired` was called, never
+                    # checked what it did to the FILE — #5992's own
+                    # finding). If a PRIOR episode's dump is still owed a
+                    # truncation (`pending_truncate`, set below by that
+                    # earlier episode), THIS is the correct point to pay
+                    # it — right before recording THIS NEW episode's own
+                    # dump, never before: the old dump must survive the
+                    # ENTIRE gap between episodes (arbitrarily long, or
+                    # forever if no further stall occurs), and must be
+                    # gone by the moment a NEW one is about to replace it.
+                    if pending_truncate and stack_dump is not None:
                         stack_dump.mark_fired()
+                    tripwire.record_stack_dump()
+                    # This episode's OWN dump is now the one owed a
+                    # truncation — deferred the same way, consumed by
+                    # whichever episode (if any) comes after it.
+                    pending_truncate = True
             if on_tick is not None:
                 on_tick(now, lateness_ms)
             active = turn_active() if turn_active is not None else None

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -249,9 +249,12 @@ async def test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists(
             "its fd number can be reused once IT closes, silently redirecting "
             "a still-pending dump)"
         )
-        expected_path = installed_file_handler.with_name("stall_dump.log")
+        # #5992: the filename carries THIS process's own pid (cross-process
+        # boundedness — two reyn processes sharing a workspace must not
+        # point at the SAME file, see stall_dump_path's own docstring).
+        expected_path = installed_file_handler.with_name(f"stall_dump.{os.getpid()}.log")
         assert os.fstat(file_arg).st_ino == expected_path.stat().st_ino, (
-            "the armed fd does not point at the derived stall-dump snapshot path"
+            "the armed fd does not point at the derived, pid-scoped stall-dump snapshot path"
         )
 
 

--- a/tests/runtime/test_5977_stall_dump_suppression.py
+++ b/tests/runtime/test_5977_stall_dump_suppression.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import pytest
 
 from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot, diagnostic_snapshot
-from reyn.runtime.loop_tripwire import LoopTripwire, StallDumpArm, watch_event_loop
+from reyn.runtime.loop_tripwire import LoopTripwire, StallDumpArm, stall_dump_path, watch_event_loop
 
 
 class _ScriptedClock:
@@ -54,11 +54,11 @@ class _ScriptedClock:
             raise asyncio.CancelledError
 
 
-def _open_arm(tmp_path: Path, *, label: str) -> StallDumpArm:
+def _open_arm(tmp_path: Path, *, label: str) -> "tuple[StallDumpArm, Path]":
     path = tmp_path / "stall_dump.log"
     arm = StallDumpArm.open(seconds=0.25, path=str(path), logger=logging.getLogger(label), label=label)
     assert arm is not None
-    return arm
+    return arm, path
 
 
 def _counting(method):
@@ -73,6 +73,34 @@ def _counting(method):
         return method(*args, **kwargs)
 
     return wrapper, calls
+
+
+def _write_a_real_marker_on_every_recorded_dump(tripwire: LoopTripwire, arm: StallDumpArm) -> "list[bytes]":
+    """Wire ``tripwire.record_stack_dump`` to write a REAL, distinguishable
+    marker into ``arm``'s own fd at the exact point production code
+    detects a fire — standing in for the real (timer-driven, unwaitable
+    in a scripted-clock test) ``faulthandler`` write that would land
+    there.
+
+    #5992 (lead-coder review of PR #5988): counting HOW MANY TIMES
+    ``mark_fired()`` was called (this file's earlier form) verifies the
+    call happened, never that it had any EFFECT — a build that truncates
+    on the WRONG tick (or never at all) can still make every one of those
+    call-count assertions pass. Checking the file's own FINAL content
+    against ``markers[-1]`` (not merely "the last marker is present" —
+    every EARLIER one must be GONE too) is the real witness."""
+    markers: "list[bytes]" = []
+    real_record = tripwire.record_stack_dump
+
+    def record_and_write() -> None:
+        assert arm.fd is not None, "the arm must still be armed when a dump is recorded"
+        marker = f"dump #{len(markers) + 1}\n".encode()
+        markers.append(marker)
+        os.write(arm.fd, marker)
+        real_record()
+
+    tripwire.record_stack_dump = record_and_write  # type: ignore[method-assign]
+    return markers
 
 
 def _many_episode_clock_instants(n: int) -> "list[float]":
@@ -109,7 +137,7 @@ async def test_watch_event_loop_dumps_at_most_once_per_stall_episode(tmp_path: P
 
     Strip-falsify (verified by hand: the ``tripwire.should_arm_stack_dump()``
     read in the post-``observe()`` re-arm decision temporarily forced to
-    ``True``): ``mark_fired`` fires twice for this exact script — the
+    ``True``): a SECOND marker gets written for this exact script — the
     issue's own accept criterion ("抑制を外すと、同じ stall で複数セット
     出ることを確認").
 
@@ -123,14 +151,13 @@ async def test_watch_event_loop_dumps_at_most_once_per_stall_episode(tmp_path: P
     ``test_watch_event_loop_never_arms_a_second_timer_before_recording_the_first_dump``
     below, which ends WHILE STILL IN THE STALL (no recovery tick), for
     the script that actually separates the two orderings."""
-    arm = _open_arm(tmp_path, label="t1")
+    arm, path = _open_arm(tmp_path, label="t1")
     rearm_wrapper, rearm_calls = _counting(arm.rearm)
     arm.rearm = rearm_wrapper  # type: ignore[method-assign]
-    fired_wrapper, mark_fired_calls = _counting(arm.mark_fired)
-    arm.mark_fired = fired_wrapper  # type: ignore[method-assign]
 
     clock = _ScriptedClock([0.0, 0.05, 0.45, 0.85, 0.90])
     tripwire = LoopTripwire(threshold_ms=250.0)
+    markers = _write_a_real_marker_on_every_recorded_dump(tripwire, arm)
     try:
         with pytest.raises(asyncio.CancelledError):
             await watch_event_loop(
@@ -141,10 +168,14 @@ async def test_watch_event_loop_dumps_at_most_once_per_stall_episode(tmp_path: P
                 clock=clock,
                 sleep=clock.sleep,
             )
+        final_content = path.read_bytes()
     finally:
         arm.close()
 
-    assert mark_fired_calls[0] == 1, "one over-threshold tick already dumped; the second must not"
+    assert markers == [b"dump #1\n"], "one over-threshold tick already dumped; the second must not"
+    assert final_content == markers[-1], (
+        "the file must hold ONLY the last dump's marker (no earlier content lingering)"
+    )
     assert rearm_calls[0] == 3, (
         "initial arm + the ONE tick that dumped — the second over-threshold "
         "tick's re-arm must be skipped, not just its readback ignored"
@@ -156,13 +187,13 @@ async def test_a_second_stall_episode_gets_its_own_fresh_dump_allowance(tmp_path
     """Tier 2: #5977 ①. Recovery must reset the per-episode gate: a
     SECOND, separate stall episode after a full recovery gets its own
     dump. Script: healthy → late(onset A, dump#1) → recovered(A) →
-    late(onset B, dump#2) → recovered(B)."""
-    arm = _open_arm(tmp_path, label="t2")
-    fired_wrapper, mark_fired_calls = _counting(arm.mark_fired)
-    arm.mark_fired = fired_wrapper  # type: ignore[method-assign]
-
+    late(onset B, dump#2) → recovered(B). #5992: the file's own FINAL
+    content must hold ONLY B's marker — A's must be gone, not sitting
+    beside it."""
+    arm, path = _open_arm(tmp_path, label="t2")
     clock = _ScriptedClock([0.0, 0.05, 0.45, 0.50, 0.90, 0.95])
     tripwire = LoopTripwire(threshold_ms=250.0)
+    markers = _write_a_real_marker_on_every_recorded_dump(tripwire, arm)
     try:
         with pytest.raises(asyncio.CancelledError):
             await watch_event_loop(
@@ -173,10 +204,12 @@ async def test_a_second_stall_episode_gets_its_own_fresh_dump_allowance(tmp_path
                 clock=clock,
                 sleep=clock.sleep,
             )
+        final_content = path.read_bytes()
     finally:
         arm.close()
 
-    assert mark_fired_calls[0] == 2, "two SEPARATE episodes each get their own one-shot dump"
+    assert markers == [b"dump #1\n", b"dump #2\n"], "two SEPARATE episodes each get their own one-shot dump"
+    assert final_content == markers[-1], "episode B's dump must have overwritten episode A's, not sat beside it"
 
 
 @pytest.mark.asyncio
@@ -191,17 +224,28 @@ async def test_no_session_cap_the_12th_episode_still_dumps(tmp_path: Path) -> No
     hiding every later one. This test runs 12 SEPARATE episodes (past the
     old cap of 10) and asserts all 12 dump.
 
-    Strip-falsify (verified by hand: re-adding ``if self._session_dump_
-    count >= 10: return False`` to ``should_arm_stack_dump``): the count
-    plateaus at 10 for this exact script instead of reaching 12 — the
+    Strip-falsify #1 (verified by hand: re-adding ``if self._session_dump_
+    count >= 10: return False`` to ``should_arm_stack_dump``): only 10
+    markers get written for this exact script instead of 12 — the
     issue's own accept criterion ("11 回目以降も dump ファイルが最新に
-    更新される")."""
-    arm = _open_arm(tmp_path, label="t3")
-    fired_wrapper, mark_fired_calls = _counting(arm.mark_fired)
-    arm.mark_fired = fired_wrapper  # type: ignore[method-assign]
+    更新される").
 
+    ⚠️ #5992 (lead-coder review of PR #5988): counting HOW MANY TIMES
+    ``mark_fired()`` was called (this test's earlier form) verifies the
+    call happened, never that it had any EFFECT — a build that truncates
+    the WRONG episode's dump (or the RIGHT one on the WRONG tick) can
+    still leave every one of those call-count assertions green. This
+    test instead checks the file's own FINAL content against the LAST
+    episode's marker alone. Strip-falsify #2 (verified by hand:
+    ``mark_fired()`` calls moved back to firing immediately upon
+    detecting EACH episode's own dump, rather than deferred to the START
+    of the NEXT episode): the file ends up EMPTY (episode 12's own
+    content gets destroyed by its OWN immediate truncation) instead of
+    holding episode 12's marker — failing the equality assertion below."""
+    arm, path = _open_arm(tmp_path, label="t3")
     clock = _ScriptedClock(_many_episode_clock_instants(12))
     tripwire = LoopTripwire(threshold_ms=250.0)
+    markers = _write_a_real_marker_on_every_recorded_dump(tripwire, arm)
     try:
         with pytest.raises(asyncio.CancelledError):
             await watch_event_loop(
@@ -212,10 +256,18 @@ async def test_no_session_cap_the_12th_episode_still_dumps(tmp_path: Path) -> No
                 clock=clock,
                 sleep=clock.sleep,
             )
+        final_content = path.read_bytes()
     finally:
         arm.close()
 
-    assert mark_fired_calls[0] == 12, "no cap — every one of 12 separate episodes must dump"
+    assert markers == [f"dump #{i}\n".encode() for i in range(1, 13)], (
+        "no cap — every one of 12 separate episodes must dump"
+    )
+    assert final_content == markers[-1], (
+        "the file must hold ONLY episode 12's marker — every earlier one must have "
+        "been truncated away by mark_fired(), not accumulated beside it, and episode "
+        "12's own marker must have survived (not destroyed by its own truncation)"
+    )
 
 
 @pytest.mark.asyncio
@@ -239,14 +291,13 @@ async def test_watch_event_loop_never_arms_a_second_timer_before_recording_the_f
     pending for no reason. Strip-falsify (verified by hand, both
     directions): swapping the re-arm decision back to before ``observe()``
     in ``watch_event_loop`` turns this 2 into 3."""
-    arm = _open_arm(tmp_path, label="t4")
+    arm, path = _open_arm(tmp_path, label="t4")
     rearm_wrapper, rearm_calls = _counting(arm.rearm)
     arm.rearm = rearm_wrapper  # type: ignore[method-assign]
-    fired_wrapper, mark_fired_calls = _counting(arm.mark_fired)
-    arm.mark_fired = fired_wrapper  # type: ignore[method-assign]
 
     clock = _ScriptedClock([0.0, 0.05, 0.45, 0.85, 1.25])
     tripwire = LoopTripwire(threshold_ms=250.0)
+    markers = _write_a_real_marker_on_every_recorded_dump(tripwire, arm)
     try:
         with pytest.raises(asyncio.CancelledError):
             await watch_event_loop(
@@ -257,10 +308,12 @@ async def test_watch_event_loop_never_arms_a_second_timer_before_recording_the_f
                 clock=clock,
                 sleep=clock.sleep,
             )
+        final_content = path.read_bytes()
     finally:
         arm.close()
 
-    assert mark_fired_calls[0] == 1
+    assert markers == [b"dump #1\n"]
+    assert final_content == markers[-1]
     assert rearm_calls[0] == 2, (
         "the tick that detects the first dump must not ALSO arm a second, "
         "uncancelled timer for the still-ongoing stall"
@@ -372,3 +425,27 @@ def test_diagnostic_snapshot_has_no_rotation_or_config_surface() -> None:
 
     params = set(inspect.signature(DiagnosticSnapshot.open).parameters)
     assert params == {"path"}, "no config surface beyond the destination itself"
+
+
+def test_stall_dump_path_is_scoped_to_this_process_not_the_workspace() -> None:
+    """Tier 1: #5992 (lead-coder review of PR #5988) — a fixed, PID-less
+    filename here would make every process sharing a ``reyn.log``
+    directory (measured live: ``reyn:web`` and ``reyn:chat`` attached to
+    the SAME project) point their own ``DiagnosticSnapshot`` at the SAME
+    inode; since ``DiagnosticSnapshot`` opens ``O_TRUNC`` (not
+    ``O_APPEND``), two processes would each write from independent
+    offset 0 — one silently overwriting the other, or the two writes
+    interleaving into a torn, unreadable dump. Embedding ``os.getpid()``
+    makes each process's own destination structurally distinct — not a
+    config surface (nobody SETS a pid; it is read, never chosen).
+
+    Non-vacuity / strip-falsify: a build that reverted to the fixed
+    ``"stall_dump.log"`` name would make this equality assertion pass
+    with an UNCHANGED path for every pid — this test's own second
+    assertion (the pid's digits appear in the result) is what a fixed
+    name fails, verified by hand (temporarily reverting the f-string to
+    the literal filename)."""
+    result = stall_dump_path("/tmp/example/.reyn/logs/reyn.log")
+    assert result is not None
+    assert result == f"/tmp/example/.reyn/logs/stall_dump.{os.getpid()}.log"
+    assert str(os.getpid()) in result, "the pid must actually appear in the derived filename"


### PR DESCRIPTION
**[tui-coder]** — part of #5992. Fixes the 3 remaining gaps from lead-coder's review of PR #5988.

## 1+2. truncate-timing had no witness, and the witness that existed watched a ledger
`mark_fired()` was called immediately on detecting a fire — truncating the dump the SAME tick it landed, before an operator could ever read it. Every existing test still passed (they counted call COUNT via `mark_fired_calls[0] == N`, never checked the FILE).

Fixed with a `pending_truncate` flag deferred to the NEXT episode: an episode's own dump now survives the entire gap until (if ever) a new one is ready to replace it, in both `watch_event_loop` and `app.py`'s own inline copy (same bug, one implementation each).

The 4 relevant tests in `test_5977_stall_dump_suppression.py` now write a real, distinguishable marker at the exact point production code detects a fire (standing in for the real, timer-driven `faulthandler` write a scripted-clock test structurally cannot wait for) and assert the file's own **final content**, not a call count. Strip-verified: reverting to immediate truncation reproduces the exact bug across all 4 — episode N's own marker destroyed on its own detecting tick.

## 3. two processes sharing a workspace wrote the same `stall_dump.log` at independent offsets
`stall_dump_path()` embeds `os.getpid()` now — not a config surface (nobody sets a pid, it's read, never chosen). Boundedness is documented precisely: "always exactly one dump **per reyn process** attached to this workspace," not "always exactly one dump, full stop" — the subject a bound protects was the finding lead-coder asked to be named explicitly.

## Test plan
- [x] New unit test confirms `stall_dump_path()` embeds the pid; updated the one existing wiring test (`test_3671_stall_trace_startup_wiring.py`) that asserted the old fixed filename.
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green. `suspected_time_dependence_ratchet.py` fails on this branch but is confirmed **pre-existing on unmodified `origin/main`** (an unrelated file, `test_5973_bounded_materialization.py`, not touched here) — not introduced or fixable by this PR.
- [x] Scoped pytest: `test_5977_stall_dump_suppression.py`, `test_5898_loop_tripwire.py`, `test_5898_web_loop_tripwire.py`, `test_loop_probe_3539.py`, `test_3671_stall_trace_startup_wiring.py` — 55 passed.
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
