### PR TITLE
fix(#5998): StallDumpArm disarms before resetting the snapshot's fd

### DIFF
--- a/src/reyn/runtime/diagnostic_snapshot.py
+++ b/src/reyn/runtime/diagnostic_snapshot.py
@@ -104,7 +104,24 @@ class DiagnosticSnapshot:
         preemptively. Sets :attr:`fd` to ``None`` on a failed reopen
         (parent directory removed mid-run, permissions changed, …) —
         every further write attempt against this instance then no-ops,
-        matching :meth:`open`'s own "cannot open → never arms" posture."""
+        matching :meth:`open`'s own "cannot open → never arms" posture.
+
+        #5998: this method closes :attr:`fd` with no notion of whether a
+        TIMER-DRIVEN writer (``faulthandler.dump_traceback_later`` is
+        this module's own first such caller, via
+        :class:`~reyn.runtime.loop_tripwire.StallDumpArm`) is currently
+        armed against that exact fd NUMBER — deliberately: this class
+        stays reusable by any future snapshot writer, including ones with
+        no such consumer at all, so it does not import or know about
+        ``stall_trace``/``faulthandler``. A caller that DOES have such a
+        consumer must quiesce (disarm) it before calling :meth:`reset`,
+        the same way it must before calling :meth:`close` — see
+        :class:`~reyn.runtime.loop_tripwire.StallDumpArm`'s own
+        ``_disarm_before_reset`` for why: closing a still-armed fd frees
+        its number back to the OS, which can hand that SAME number to an
+        unrelated file/socket/pipe opened moments later, and the pending
+        timer then writes into THAT — silently, no exception, no
+        indication anything went wrong at either end."""
         if self._fd is None:
             return
         try:

--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -723,13 +723,19 @@ class StallDumpArm:
         :meth:`~reyn.runtime.diagnostic_snapshot.DiagnosticSnapshot.
         points_at_current_file`'s own docstring for why this matters: a
         write against an orphaned fd still succeeds, silently, into a
-        file nobody can find). Returns whether a timer is now pending."""
+        file nobody can find). Returns whether a timer is now pending.
+
+        #5998 (lead-coder, real-machine hazard from #5877): the reopen
+        below disarms FIRST — see :meth:`_disarm_before_reset`'s own
+        docstring for why a plain ``self._snapshot.reset()`` here would
+        be the exact same fd-reuse hazard #5877 found and :meth:`close`
+        already guards against."""
         from reyn.runtime.stall_trace import arm as _arm
 
         if self._snapshot.fd is None:
             return False
         if not self._snapshot.points_at_current_file():
-            self._snapshot.reset()
+            self._disarm_before_reset()
             if self._snapshot.fd is None:
                 self._logger.error(
                     "%s: could not reopen the tripwire's own stall-dump snapshot after "
@@ -738,6 +744,41 @@ class StallDumpArm:
                 return False
         _arm(self._seconds, file=self._snapshot.fd, repeat=False)
         return True
+
+    def _disarm_before_reset(self) -> None:
+        """Disarm the one process-wide timer BEFORE truncating+reopening
+        the snapshot's fd — the same order :meth:`close` already uses,
+        applied to the other two places this arm ever closes an fd out
+        from under a possibly-still-pending timer (:meth:`mark_fired`,
+        and :meth:`rearm`'s own reopen-on-external-change branch).
+
+        #5998 (lead-coder, real-machine hazard #5877 found again):
+        ``faulthandler.dump_traceback_later`` commits to the fd NUMBER at
+        ARM time, not a live object (#5877's own real-machine
+        reproduction: ``open("a")`` → arm → ``close`` → ``open("b")`` —
+        the OS handed back the SAME fd number, and the pending dump
+        landed in ``"b"``). ``DiagnosticSnapshot.reset()`` itself stays
+        arm-unaware ON PURPOSE (its own module docstring: a reusable
+        primitive other future snapshot writers, with no
+        ``faulthandler``/``stall_trace`` involvement at all, can use
+        without inheriting a dependency on this module) — THIS arm is
+        the one layer that actually knows a timer might be pending
+        against the fd about to close, so disarming belongs here, not
+        pushed down into the generic primitive.
+
+        ⚠️ :func:`~reyn.runtime.stall_trace.disarm` cancels the ONE
+        process-wide ``faulthandler`` timer — safe to call even when
+        nothing is armed (idempotent), but it would also cancel a
+        DIFFERENT caller's pending timer if one existed. Today only ONE
+        arm is ever armed at a time (this module's own docstring: the
+        TUI startup bracket disarms before an interactive turn can begin,
+        and the tripwire is the PERMANENT occupant of the timer from
+        first frame onward) — this call inherits that same precondition,
+        it does not introduce a new one."""
+        from reyn.runtime.stall_trace import disarm as _disarm
+
+        _disarm()
+        self._snapshot.reset()
 
     def mark_fired(self) -> None:
         """Truncate and reopen the snapshot's fd, clearing whatever this
@@ -755,10 +796,15 @@ class StallDumpArm:
         file's own content). The dump this arm just wrote must survive
         the entire gap until (if ever) a NEW one is ready to replace it
         — see :func:`watch_event_loop`'s own updated docstring for the
-        deferred-consumption shape this requires from the caller. Never
-        call this on an ordinary re-arm either — see the class
+        deferred-consumption shape this requires from the caller.
+
+        #5998: disarms before the reset (see
+        :meth:`_disarm_before_reset`) — a re-arm always follows shortly
+        after this call in :func:`watch_event_loop`'s own tick loop
+        (:meth:`rearm`, next tick), never inside this method itself.
+        Never call this on an ordinary re-arm either — see the class
         docstring's truncate-timing trap for why."""
-        self._snapshot.reset()
+        self._disarm_before_reset()
 
     def close(self) -> None:
         """Disarm BEFORE closing the fd (#5877: the reverse order would let a

--- a/tests/runtime/test_5998_disarm_before_reset.py
+++ b/tests/runtime/test_5998_disarm_before_reset.py
@@ -1,0 +1,125 @@
+"""Tier 2: #5998 (lead-coder, real-machine hazard re-found from #5877) —
+``StallDumpArm`` must disarm the process-wide ``faulthandler`` timer BEFORE
+closing/reopening its snapshot's fd, at every call site that closes it, not
+only :meth:`~reyn.runtime.loop_tripwire.StallDumpArm.close`.
+
+``StallDumpArm.close`` already got this right (#5877's own original
+finding): ``_disarm(); self._snapshot.close()``, documented as "the reverse
+order would let a still-pending timer fire against an already-closed,
+possibly already-reused fd number" — ``faulthandler.dump_traceback_later``
+commits to the fd NUMBER at arm time, not a live object, so the OS handing
+that number to an unrelated file/socket/pipe opened moments later turns a
+stale timer into a write against THAT.
+
+lead-coder's own audit (issue #5998) found :meth:`~reyn.runtime.
+loop_tripwire.StallDumpArm.mark_fired` and the reopen-on-external-change
+branch inside :meth:`~reyn.runtime.loop_tripwire.StallDumpArm.rearm` both
+called ``self._snapshot.reset()`` directly — the SAME close-then-open shape
+``close()`` guards, without the guard. Both are fixed here to route through
+a shared ``_disarm_before_reset`` helper; this file witnesses the ORDER
+(disarm strictly before the underlying ``DiagnosticSnapshot.reset()``), not
+merely that disarm happens somewhere.
+
+Real ``StallDumpArm`` + real ``DiagnosticSnapshot``/``stall_trace`` module
+functions throughout — no mocks. The spy wraps the real, public
+``DiagnosticSnapshot.reset`` / ``stall_trace.disarm`` and still calls
+through to them (CLAUDE.md: never fake a collaborator when a real instance
+is cheaply constructible), the same idiom this file's own sibling
+(``test_5977_stall_dump_suppression.py``) already uses for ``StallDumpArm.
+rearm`` via its local ``_counting`` helper — recording call ORDER here
+instead of merely a count, since order is exactly what #5998 is about.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime import stall_trace
+from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot
+from reyn.runtime.loop_tripwire import StallDumpArm
+
+
+def _open_arm(tmp_path: Path, *, label: str) -> "tuple[StallDumpArm, Path]":
+    path = tmp_path / "stall_dump.log"
+    arm = StallDumpArm.open(seconds=60.0, path=str(path), logger=logging.getLogger(label), label=label)
+    assert arm is not None
+    return arm, path
+
+
+def _spy_on_disarm_and_reset(monkeypatch: pytest.MonkeyPatch) -> "list[str]":
+    """Wrap the real, public ``stall_trace.disarm`` and
+    ``DiagnosticSnapshot.reset`` — both still delegate to the real
+    implementation; only the call ORDER is recorded."""
+    order: "list[str]" = []
+    real_disarm = stall_trace.disarm
+    real_reset = DiagnosticSnapshot.reset
+
+    def spy_disarm() -> None:
+        order.append("disarm")
+        real_disarm()
+
+    def spy_reset(self: DiagnosticSnapshot) -> None:
+        order.append("reset")
+        real_reset(self)
+
+    monkeypatch.setattr(stall_trace, "disarm", spy_disarm)
+    monkeypatch.setattr(DiagnosticSnapshot, "reset", spy_reset)
+    return order
+
+
+def test_mark_fired_disarms_before_resetting_the_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5998 — an EARLIER version of ``mark_fired`` called
+    ``self._snapshot.reset()`` with no disarm at all — reproducing #5877's
+    own hazard (a still-armed timer's fd number freed back to the OS,
+    reusable by an unrelated file/socket/pipe opened moments later).
+
+    Strip-falsify (verified by hand: ``mark_fired`` reverted to calling
+    ``self._snapshot.reset()`` directly): ``order`` ends up ``["reset"]``
+    — disarm never runs at all — failing the assertion below."""
+    order = _spy_on_disarm_and_reset(monkeypatch)
+    arm, _path = _open_arm(tmp_path, label="t998a")
+    try:
+        arm.mark_fired()
+    finally:
+        arm.close()
+
+    assert order[:2] == ["disarm", "reset"], (
+        f"#5998 REGRESSION: mark_fired must disarm BEFORE resetting the "
+        f"snapshot's fd, not after or never — got {order!r}"
+    )
+
+
+def test_rearm_after_external_delete_disarms_before_resetting_the_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #5998 — the SAME hazard, through ``rearm``'s reopen-on-external-
+    change branch (an external tool/operator replacing the file between
+    two ticks — see ``test_5977_stall_dump_suppression.py``'s own
+    ``test_stall_dump_arm_rearms_after_an_external_delete`` for the
+    non-#5998 property this same branch already had a test for).
+
+    Strip-falsify (verified by hand: the branch reverted to calling
+    ``self._snapshot.reset()`` directly): ``order`` ends up ``["reset"]``
+    for this branch's own reopen — failing the assertion below."""
+    arm, path = _open_arm(tmp_path, label="t998b")
+    try:
+        assert arm.rearm() is True
+        pre_ino = path.stat().st_ino
+
+        path.unlink()
+        path.write_text("", encoding="utf-8")
+        assert path.stat().st_ino != pre_ino, "test setup sanity: a NEW inode"
+
+        order = _spy_on_disarm_and_reset(monkeypatch)
+        assert arm.rearm() is True
+
+        assert order[:2] == ["disarm", "reset"], (
+            f"#5998 REGRESSION: rearm's reopen-on-external-change branch "
+            f"must disarm BEFORE resetting the snapshot's fd — got {order!r}"
+        )
+    finally:
+        arm.close()


### PR DESCRIPTION
**[tui-coder]** — fixes #5998.

`DiagnosticSnapshot.reset()` closes the current fd and reopens with no notion of whether a `faulthandler` timer is currently armed against that fd number. `StallDumpArm.close()` already guards this (#5877's own real-machine finding: disarm before close, since `faulthandler.dump_traceback_later` commits to the fd NUMBER at arm time — a still-armed timer surviving a close can fire into whatever the OS hands that number to next). `mark_fired()` and `rearm()`'s reopen-on-external-change branch both called `self._snapshot.reset()` directly, without that guard.

## Design choice: fixed in `StallDumpArm`, not in `DiagnosticSnapshot.reset()` itself

lead-coder's issue asked for `reset()` to go disarm → close → open. I implemented the same *effect* one layer up instead: a new `StallDumpArm._disarm_before_reset()` (disarm, then `self._snapshot.reset()`), called from both `mark_fired()` and `rearm()`'s reopen branch.

Reason: `DiagnosticSnapshot`'s own module docstring states it's a reusable primitive for *any* future snapshot writer — it imports nothing from `stall_trace`/`faulthandler` today. `StallDumpArm` is the one layer that actually knows a timer might be pending against the fd about to close; pushing the disarm into the generic class would couple it to this one caller. Docstring on `DiagnosticSnapshot.reset()` now cross-references this so a future reader doesn't miss the requirement.

Flagging this deviation explicitly for review — happy to move it into `reset()` directly if you'd rather keep the guard co-located with the hazard regardless of layering.

## Precondition documented (per your accept criterion)
`_disarm_before_reset()`'s docstring states explicitly: `stall_trace.disarm()` cancels the ONE process-wide timer, so this is safe only because exactly one arm is ever armed at a time today (the module's own existing "PERMANENT occupant from first frame onward" claim) — not re-verified here, inherited.

## Not a causation claim
Per the issue body: the owner's SegFault predates #5988, so this is "one more path in the same class," not confirmed as the cause.

## Test plan
- [x] `test_5998_disarm_before_reset.py` — 2 new tests, each asserting call ORDER (`["disarm", "reset"]`) via a spy on the real, public `stall_trace.disarm` / `DiagnosticSnapshot.reset` (both still delegate to the real implementation — no mocks). Strip-falsify (verified by hand, both call sites reverted to a bare `self._snapshot.reset()`): each goes red (`["reset"]` / `["reset", "disarm"]`).
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green. `suspected_time_dependence_ratchet.py` fails on an unrelated, pre-existing file (`test_5973_bounded_materialization.py`, not touched here), confirmed pre-existing on unmodified `origin/main` in earlier PRs this session.
- [x] Scoped pytest: `test_5998_disarm_before_reset.py`, `test_5977_stall_dump_suppression.py`, `test_5898_loop_tripwire.py`, `test_5898_web_loop_tripwire.py`, `test_loop_probe_3539.py`, `test_3671_stall_trace_startup_wiring.py` — 57 passed.
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
