### PR TITLE
fix(#5990): the 4 (A)-classified run_worker sites now report failure somewhere

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -5115,13 +5115,33 @@ class TextualChatApp(App):
 
     async def _clear_pending_command_ui_over_wire(self) -> None:
         """The round-trip half of the two ``clear_pending_command_ui`` calls
-        in :meth:`_handle_rewind_request` (#5894 ①-2) — a worker. The clear
-        is a courtesy to the server's read model (the picker is already
-        showing); a failure is logged exactly as the inline call logged it."""
+        in :meth:`_handle_rewind_request` (#5894 ①-2) — a worker.
+
+        #5990: a failure used to be ``logger.exception`` only — nothing
+        downstream ever reads it, so a real failure here was silent to the
+        operator (the picker they are already looking at is the only place
+        that could show it). Now draws an error row, the same idiom
+        :meth:`_cancel_turn_over_wire` and :meth:`_cancel_queued_over_wire`
+        use for their own round-trip couriers: the clear is a courtesy to
+        the server's read model, so a failed clear cannot corrupt this
+        client's own state — but a NEXT unrelated rewind could replay the
+        stale request if the server never got the clear, which is worth
+        naming rather than leaving to a log file nobody is tailing."""
+        from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
         try:
             await self._transport.clear_pending_command_ui()
-        except Exception:
+        except Exception as exc:
             logger.exception("textual chat: command-UI clear failed")
+            self._ingest_frame(
+                OutboxMessage(
+                    kind="error",
+                    text=(
+                        f"command-UI clear failed: {type(exc).__name__}: {exc}"
+                        " — a stale rewind request may replay later"
+                    ),
+                )
+            )
 
     async def _handle_rewind_request(self, msg: "OutboxMessage") -> None:
         """Consume a ``__rewind_list__`` sentinel: show the picker, or the text
@@ -7146,12 +7166,32 @@ class TextualChatApp(App):
         ①-2) — a worker. Same bookkeeping as the inline call had: a raise or
         a no-op removal forgets the restore entry, so a later, unrelated
         ``inbox_cancel`` delta cannot restore text this client never
-        cancelled."""
+        cancelled.
+
+        #5990: the raise branch used to be ``logger.exception`` plus the
+        bookkeeping pop — the pop is internal accounting nobody reads as a
+        signal, so a genuine transport failure here was invisible: the
+        operator pressed Enter on a queued row expecting it gone, and it
+        may not be. Now draws an error row too. The ``not removed`` branch
+        (below) stays silent on purpose — that is the server's own
+        legitimate "already dispatched, nothing to cancel" answer, not a
+        failure; :class:`SentQueue`'s row removal already told that story."""
+        from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
         try:
             removed = await self._transport.cancel_queued(msg_id)
-        except Exception:
+        except Exception as exc:
             logger.exception("textual chat: cancel_queued failed")
             self._pending_own_cancels.pop(msg_id, None)
+            self._ingest_frame(
+                OutboxMessage(
+                    kind="error",
+                    text=(
+                        f"cancel failed: {type(exc).__name__}: {exc}"
+                        " — the queued item may still be sent"
+                    ),
+                )
+            )
             return
         if not removed:
             self._pending_own_cancels.pop(msg_id, None)
@@ -7856,11 +7896,30 @@ class TextualChatApp(App):
         await self._submit(text, local_id=local_id)
 
     async def _shutdown_then_exit(self) -> None:
-        """``/quit``'s detach-then-exit, off the pump (#5894 ①-2)."""
+        """``/quit``'s detach-then-exit, off the pump (#5894 ①-2).
+
+        #5990: ``self.exit()`` used to run unconditionally after the
+        ``except`` — a shutdown failure was logged, then the app closed
+        the exact same way a clean shutdown does, so the operator's
+        terminal looked identical either way. The TUI itself is gone by
+        the time this would matter, so an ``OutboxMessage`` row (the idiom
+        the other ``_over_wire`` couriers use) cannot be the channel here —
+        nothing is left on screen to show it. Textual's own
+        ``App.exit(message=..., return_code=...)`` prints ``message`` to
+        the console AFTER the screen is torn down and sets the process's
+        real exit code, so both a human watching the terminal and a script
+        checking ``$?`` see the failure without any setting changed."""
         try:
             await self._transport.shutdown()
-        except Exception:
+        except Exception as exc:
             logger.exception("textual chat: transport shutdown failed on /quit")
+            self.exit(
+                return_code=1,
+                message=(
+                    f"reyn: shutdown failed on /quit: {type(exc).__name__}: {exc}"
+                ),
+            )
+            return
         self.exit()
 
     def _notify_blocked_on_attach(self) -> None:

--- a/tests/interfaces/test_5990_over_wire_failure_reporting.py
+++ b/tests/interfaces/test_5990_over_wire_failure_reporting.py
@@ -1,0 +1,252 @@
+"""Tier 2: #5990 — the 4 ``run_worker(...)`` call sites lead-coder's own
+census classified (A) ("nobody would notice if this failed") in
+``TextualChatApp``: a raise from the courier's own wire call was logged via
+``logger.exception`` and nothing else — no UI signal, no audit-event, no
+distinguishable process exit. Scope is exactly the 4 sites named in the
+issue, confirmed by lead-coder after the census (comment on #5990): the
+other 11 ``run_worker`` sites already reach a named channel (an
+``OutboxMessage`` row, or — for 6 of them — crashing the whole app, tracked
+separately as #5995) and Q2's 98 broader ``except`` sites are explicitly
+out of scope for this issue.
+
+- :meth:`_clear_pending_command_ui_over_wire` (2 call sites, same callee,
+  app.py:5186/:5220 in the census)
+- :meth:`_cancel_queued_over_wire` (app.py:7131)
+- :meth:`_shutdown_then_exit` (app.py:7822)
+
+Real ``TextualChatApp`` + a real, minimal ``ClientTransport`` throughout
+(``ClientTransportStub`` supplies every abstract method's default; each
+transport below overrides only the ONE method whose failure is under test)
+— no ``unittest.mock``, matching #5329 ②'s own idiom for injecting a wire
+failure. Observed via the PUBLIC surface only: ``FlowView.entries`` for the
+error-row sites, ``TextualChatApp.return_code``/``is_running`` for the exit
+site — never a private attribute.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.chrome import Composer
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.runtime.outbox import OutboxMessage
+
+
+class _FailAsInstructedTransport(ClientTransportStub):
+    """A real, minimal :class:`ClientTransport` whose
+    ``clear_pending_command_ui`` / ``cancel_queued`` / ``shutdown`` each
+    raise ONLY when told to — a real attribute per call, never a mock, so a
+    test can drive exactly one failure at a time and use the SAME
+    transport's other methods (``has_session``, ``pending_intervention_head``,
+    …) via ``ClientTransportStub``'s own real defaults."""
+
+    def __init__(
+        self,
+        *,
+        fail_clear: bool = False,
+        fail_cancel: bool = False,
+        fail_shutdown: bool = False,
+    ) -> None:
+        self._fail_clear = fail_clear
+        self._fail_cancel = fail_cancel
+        self._fail_shutdown = fail_shutdown
+        self.clear_calls = 0
+        self.cancel_calls: "list[str]" = []
+        self.shutdown_calls = 0
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":  # pragma: no cover - unused here
+        if False:
+            yield None  # makes this a real (empty) async generator
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover
+        return ""
+
+    async def clear_pending_command_ui(self) -> None:
+        self.clear_calls += 1
+        if self._fail_clear:
+            raise RuntimeError("simulated clear failure")
+
+    async def cancel_queued(self, msg_id: str) -> bool:
+        self.cancel_calls.append(msg_id)
+        if self._fail_cancel:
+            raise RuntimeError("simulated cancel failure")
+        return True
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        if self._fail_shutdown:
+            raise RuntimeError("simulated shutdown failure")
+
+
+def _error_texts(app: TextualChatApp) -> "list[str]":
+    return [
+        e.item.text
+        for e in app.query_one(FlowView).entries
+        if e.item.kind == "error"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. _clear_pending_command_ui_over_wire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_command_ui_failure_draws_an_error_row() -> None:
+    """Tier 2: a raise from the courier's own wire call must reach an
+    ``error`` row on the flow — not merely ``logger.exception``, which
+    nobody in the running app ever reads."""
+    transport = _FailAsInstructedTransport(fail_clear=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await app._clear_pending_command_ui_over_wire()
+        while transport.clear_calls == 0 or not _error_texts(app):
+            await pilot.pause()
+        assert transport.clear_calls == 1
+        assert any("command-UI clear failed" in t for t in _error_texts(app)), (
+            f"#5990 REGRESSION: a failed command-UI clear must be visible "
+            f"on the flow — got {_error_texts(app)!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_command_ui_success_draws_no_error_row() -> None:
+    """Tier 2: regression guard — a clean clear stays exactly as silent as
+    it always was — the fix adds a signal on the failure path, not noise
+    on the normal one."""
+    transport = _FailAsInstructedTransport(fail_clear=False)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await app._clear_pending_command_ui_over_wire()
+        while transport.clear_calls == 0:
+            await pilot.pause()
+        await pilot.pause()
+        assert _error_texts(app) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. _cancel_queued_over_wire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_failure_draws_an_error_row() -> None:
+    """Tier 2: a raise from ``cancel_queued`` itself (not the server's own
+    legitimate "already dispatched" no-op — see the next test) must reach
+    an error row: the operator pressed Enter expecting the row gone, and
+    without this it silently might not be."""
+    transport = _FailAsInstructedTransport(fail_cancel=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await app._cancel_queued_over_wire("m1")
+        while not transport.cancel_calls or not _error_texts(app):
+            await pilot.pause()
+        assert transport.cancel_calls == ["m1"]
+        assert any("cancel failed" in t for t in _error_texts(app)), (
+            f"#5990 REGRESSION: a failed cancel_queued must be visible on "
+            f"the flow — got {_error_texts(app)!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_already_dispatched_noop_draws_no_error_row() -> None:
+    """Tier 2: regression guard — the server's own legitimate
+    ``removed=False`` answer (already dispatched, nothing to cancel) is
+    not a failure — :class:`SentQueue`'s own row state already tells that
+    story, and this path must stay exactly as silent as before."""
+
+    class _AlreadyDispatchedTransport(_FailAsInstructedTransport):
+        async def cancel_queued(self, msg_id: str) -> bool:
+            self.cancel_calls.append(msg_id)
+            return False
+
+    transport = _AlreadyDispatchedTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await app._cancel_queued_over_wire("m1")
+        while not transport.cancel_calls:
+            await pilot.pause()
+        await pilot.pause()
+        assert _error_texts(app) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. _shutdown_then_exit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quit_after_shutdown_failure_exits_with_nonzero_return_code() -> None:
+    """Tier 2: #5990's own headline gap — ``self.exit()`` used to run
+    unconditionally after a shutdown failure, so a genuine transport-
+    shutdown failure and a clean ``/quit`` looked identical to the
+    operator. ``return_code`` is Textual's own PUBLIC, process-level
+    signal (``App.return_code`` / ``sys.exit(app.return_code)`` in its own
+    docs) — checkable by a script without opening any log."""
+    transport = _FailAsInstructedTransport(fail_shutdown=True)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("/quit"))
+        while app.is_running:
+            await pilot.pause()
+    assert transport.shutdown_calls == 1
+    assert app.return_code == 1, (
+        f"#5990 REGRESSION: a shutdown failure must exit with a nonzero "
+        f"return_code, distinguishable from a clean /quit — got "
+        f"{app.return_code!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quit_after_clean_shutdown_exits_with_zero_return_code() -> None:
+    """Tier 2: regression guard — an ordinary, successful ``/quit`` keeps
+    exiting the same way it always did — ``return_code`` 0, the default
+    Textual gives a plain ``self.exit()`` call with no arguments."""
+    transport = _FailAsInstructedTransport(fail_shutdown=False)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await app.on_composer_submitted(Composer.Submitted("/quit"))
+        while app.is_running:
+            await pilot.pause()
+    assert transport.shutdown_calls == 1
+    assert app.return_code == 0, (
+        f"a clean /quit must keep exiting with return_code 0 — got "
+        f"{app.return_code!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5990. backlog-watcher's census classified 15 `run_worker` sites in `TextualChatApp`: 0 (B), 11 (C) (already reach a named channel — an `OutboxMessage` row, or a crash tracked separately as #5995), 4 (A) — a raise reached `logger.exception` and nothing else. Scope confirmed by lead-coder: exactly these 4; Q2's 98 broader `except` sites are out of scope for this issue.

## The 4 sites
- `_clear_pending_command_ui_over_wire` (2 call sites, same callee) — failure now draws an `OutboxMessage` error row, the idiom `_cancel_turn_over_wire` already uses for its own round-trip courier.
- `_cancel_queued_over_wire` — same, on the genuine transport-exception branch only. The server's own legitimate `removed=False` ("already dispatched") answer stays silent — `SentQueue`'s own row state already tells that story, it's not a failure.
- `_shutdown_then_exit` — `self.exit()` ran unconditionally after a shutdown failure, so a genuine failure and a clean `/quit` looked identical to the operator. The TUI is gone by the time this runs, so an `OutboxMessage` row can't be the channel — now uses `self.exit(return_code=1, message=...)`, Textual's own public exit-message/return-code channel (printed to the console after teardown; `return_code` is checkable by a script via `$?`, no setting changed).

## Test plan
- [x] `test_5990_over_wire_failure_reporting.py` — 6 tests (failure + regression-guard pair per site), real `TextualChatApp` + a real minimal `ClientTransport` throughout, no mocks. Observed via `FlowView.entries` (error-row sites) / `TextualChatApp.return_code`/`is_running` (exit site) — public surface only.
- [x] Strip-falsify (verified by hand, each of the 3 fixes reverted in turn): each relevant test goes red — the `/quit` case hangs to CI's own timeout (not a hung wait bug: no error row is ever drawn without the fix, so the loop's own wait condition never becomes true — the expected shape for a stripped fix, per CLAUDE.md's ceiling policy).
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green. `suspected_time_dependence_ratchet.py` fails on an unrelated, pre-existing file (`test_5973_bounded_materialization.py`, not touched here), confirmed pre-existing on unmodified `origin/main` in earlier PRs this session.
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
