### PR TITLE
fix(#5995): _pump_frames' own supply failure no longer crashes the app, and is now visible

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2858,7 +2858,21 @@ class TextualChatApp(App):
         # docstring for the follow-up this leaves open).
         if self._read_model is not None:
             self._read_model.add_status_listener(self._on_session_status_delta)
-        self.run_worker(self._pump_frames(), name="frames", exclusive=True)
+        # #5995 (lead-coder ruling, #5978's own "a describing doc follows
+        # the code, a DECIDING doc does not" — this method's own class
+        # docstring below is the latter): `_pump_frames` re-raises its
+        # supply failure so the log/docstring's own claim is recoverable
+        # from a real traceback, but this worker must not take the whole
+        # app down over it — `exit_on_error=False` is what actually makes
+        # "the app stays open; only an explicit /quit exits" TRUE. Every
+        # other `run_worker` call site in this class keeps the Textual
+        # default (#5990's own census: 0 of 15 override it) — this is the
+        # ONE exception, and deliberately narrow: #5995 does not widen the
+        # other 5 crash-reaches-a-named-channel sites the same census
+        # found, those are tracked separately.
+        self.run_worker(
+            self._pump_frames(), name="frames", exclusive=True, exit_on_error=False,
+        )
         # #5050 ③: a SEPARATE worker, not sequenced inside ``_pump_frames``
         # itself — that loop can run forever (a live connection) or never
         # yield a single frame at all (the exact scenario this exists
@@ -7507,7 +7521,7 @@ class TextualChatApp(App):
                 "the app stays open; only an explicit /quit exits."
             )
             raise
-        except Exception:
+        except Exception as exc:
             # #5329 ②(landed, #5355): the loop's own supply,
             # ``self._transport.frames()``, was the one failure point in
             # this method with no handler — every other site above logs
@@ -7519,6 +7533,24 @@ class TextualChatApp(App):
                 ".frames()) raised (reason=supply_failed) — the app stays "
                 "open; only an explicit /quit exits."
             )
+            # #5995 (lead-coder): before this, a dead pump was reported
+            # ONLY to reyn.log — with `exit_on_error=False` (see
+            # `run_worker`'s own call site) the app no longer crashes
+            # LOUDLY over this either, so without a visible row the
+            # failure would be exactly #5990's own class: no frame ever
+            # arriving again, and nothing on screen says why. The chat
+            # pane is still alive at this point (this worker's own crash
+            # no longer takes it down), so the same `OutboxMessage` idiom
+            # #5990 used for its own round-trip couriers applies here too.
+            from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
+            self._ingest_frame(OutboxMessage(
+                kind="error",
+                text=(
+                    f"connection lost: {type(exc).__name__}: {exc} — no more "
+                    "replies will arrive; /quit and reconnect"
+                ),
+            ))
             # #5694: force ONE render here — `_refresh_live_chrome` is
             # otherwise only ever called "as frames land" (its own
             # docstring), but the frame supply just died, so no frame is

--- a/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
+++ b/tests/interfaces/test_5329_2_pump_frames_exception_not_silent.py
@@ -37,7 +37,7 @@ import logging
 from typing import AsyncIterator
 
 import pytest
-from textual.worker import WorkerFailed
+from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.transport.client_transport import ClientTransportStub
@@ -167,23 +167,46 @@ async def test_a_pump_exception_is_logged_distinguishably_before_exit(
     real frame and then hit the injected raise; CI's own ``--timeout`` is
     the only ceiling.
 
-    ``run_test``'s own pilot re-raises the worker's failure as
-    ``WorkerFailed`` on context exit — this is Textual's OWN pre-existing
-    behaviour (``Worker._run``'s ``exit_on_error`` path calls
-    ``app._handle_exception``, docstring: "Always results in the app
-    exiting"), unconditional on whether ``_pump_frames`` itself has a
-    handler. It fired identically before this fix (the bare, handler-less
-    ``try/finally`` never stopped the exception reaching the worker
-    machinery) — the fix adds the log line, not this propagation, so
-    asserting it here is not asserting the fix itself, only setting up a
-    place to observe it from."""
+    #5995 (lead-coder ruling): this test USED TO wrap the ``async with``
+    in ``pytest.raises(WorkerFailed)``, documented as Textual's own
+    pre-existing, unconditional propagation. lead-coder's own reading of
+    the method's class docstring — "the app stays open; only an explicit
+    /quit exits" — as a DECISION, not a description (CLAUDE.md: a
+    deciding doc is not falsified by an implementation that has not
+    caught up) means that propagation was itself the bug: this method's
+    own ``run_worker(..., name="frames", ...)`` call site now passes
+    ``exit_on_error=False``, so ``Worker._run`` never calls
+    ``app._handle_exception`` and ``WorkerFailed`` never reaches this
+    pilot at all — the app stays running, matching the docstring's own
+    claim for the first time. ``app.is_running`` below is this test's own
+    replacement witness for that (Textual's public, process-level
+    surface — the same one #5990's own ``return_code`` tests used).
+    Strip-falsifier for THIS half (verified by hand: the call site
+    reverted to Textual's ``exit_on_error`` default): ``app.is_running``
+    is ``False`` by the time the ``async with`` block would reach the
+    assertion — the block itself never completes normally, since the
+    pilot exits via the propagated ``WorkerFailed`` instead."""
     transport = _RaisingTransport()
     app = TextualChatApp(transport=transport)
     with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
-        with pytest.raises(WorkerFailed):
-            async with app.run_test(size=(80, 24)) as pilot:
-                await pilot.pause()
-                await pilot.pause()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert app.is_running is True, (
+                "#5995 REGRESSION: a genuine _pump_frames exception must "
+                "not take the whole app down — the app should still be "
+                "running here"
+            )
+            errors = [
+                e.item.text
+                for e in app.query_one(FlowView).entries
+                if e.item.kind == "error"
+            ]
+            assert any("connection lost" in t for t in errors), (
+                f"#5995 REGRESSION: a dead pump that no longer crashes the "
+                f"app loudly must still be visible somewhere the operator "
+                f"looks — got {errors!r}"
+            )
 
     records = [r for r in caplog.records if r.name == _LOGGER_NAME]
     messages = [r.message for r in records]
@@ -223,8 +246,6 @@ async def test_a_clean_end_of_stream_logs_nothing_new(
     drifting, ``caplog`` catching nothing. The affirmative assert below
     closes that gap: it requires the SAME pump that would carry the new
     log line to have actually run and delivered its frame."""
-    from textual_flowview import FlowView
-
     transport = _CleanEndTransport()
     app = TextualChatApp(transport=transport)
     with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):


### PR DESCRIPTION
**[tui-coder]** — fixes #5995.

lead-coder's own ruling: `_pump_frames`' class docstring ("the app stays open; only an explicit /quit exits") is a DECIDING doc (CLAUDE.md), not a describing one — the code had not caught up. The method's `except Exception:` block already logs and re-raises, but its `run_worker(...)` call site kept Textual's default `exit_on_error=True` (#5990's own census: 0 of 15 sites override it), so the re-raise reached `App._handle_exception` and crashed the whole app — the exact opposite of the docstring's own claim.

## Scope, per lead-coder's explicit instruction
Only the `"frames"` worker (`_pump_frames`' own `run_worker` call site). The other 5 sites #5990's census found reaching a named channel via a crash are a separate population, untouched here.

## The two required directions
1. **The app no longer exits.** `exit_on_error=False` on this one call site — `implementer's choice` between that and dropping the `raise`: kept the `raise` (so `Worker.error`/a future reader of a real traceback still sees it) and suppressed only the app-wide propagation, the narrower of the two changes.
2. **The failure is now visible.** With the crash gone, a dead pump would otherwise go back to silent (no more frames ever arrive, nothing on screen says why) — exactly #5990's own class. Added an `OutboxMessage` error row in the same `except` block, the idiom #5990/#6002 already established — the chat pane is still alive at this point.

## Test
`test_5329_2_pump_frames_exception_not_silent.py`'s own witness updated: it used to assert Textual's `WorkerFailed` propagation as EXPECTED (that propagation was itself the bug lead-coder found) — now asserts `app.is_running` stays `True` and the new error row appears. Strip-falsify (verified by hand, both directions): reverting `exit_on_error` goes red (app crashes mid-pilot); removing the `OutboxMessage` row goes red (`errors == []`).

Ran the broader neighborhood too (not just the touched file): `test_5329_pump_frames_supply_end_stays_open.py`, `test_5694_pump_death_flips_attach_state.py`, `test_5732_pump_swallow_visibility.py`, `test_5956_screen_timeout_diagnostics.py` — all still green.

⚠️ Not claimed as the confirmed cause of the owner's 2h45m process death — per #5995's own issue body, one more path in the same class, not confirmed as it.

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green. `suspected_time_dependence_ratchet.py` fails on an unrelated, pre-existing file (`test_5973_bounded_materialization.py`, not touched here).
- [x] Scoped pytest: `test_5329_2_pump_frames_exception_not_silent.py`, `test_5329_pump_frames_supply_end_stays_open.py`, `test_5694_pump_death_flips_attach_state.py`, `test_5732_pump_swallow_visibility.py`, `test_5956_screen_timeout_diagnostics.py` — 24 passed.
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
