### PR TITLE
fix(#5996): ThreadedTransportProxy's pump task delivers its death to frames()'s waiter

### DIFF
--- a/src/reyn/interfaces/transport/threaded.py
+++ b/src/reyn/interfaces/transport/threaded.py
@@ -90,6 +90,32 @@ if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
 
 
+class ThreadedPumpFailed(RuntimeError):
+    """Raised from :meth:`ThreadedTransportProxy.frames` when the worker
+    thread's own frame-pump task (:meth:`ThreadedTransportProxy._pump_
+    frames`) died from an unhandled exception nobody else observed
+    (#5996). The original exception is chained as ``__cause__`` — this
+    class exists only to give the caller a type this module's own name
+    is attached to (a bare re-raise of, say, a transport-internal
+    ``RemoteProtocolError`` would look identical to one raised on the
+    caller's OWN thread, losing the "this crossed a thread boundary"
+    fact); the real cause is always still reachable via ``__cause__``."""
+
+
+class _PumpDied:
+    """The sentinel :meth:`ThreadedTransportProxy._on_pump_task_done`
+    pushes onto ``_caller_queue`` in place of a frame — #5996. Not a
+    ``Frame``/``BacklogBatch`` (the queue's own declared element types),
+    deliberately: :meth:`ThreadedTransportProxy.frames` checks for this
+    exact type before treating a queue item as a frame to yield, so a
+    real ``Frame`` can never be mistaken for this sentinel or vice versa
+    (a shared base/marker attribute on ``Frame`` itself would risk a
+    FUTURE frame variant accidentally satisfying it)."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+
+
 @dataclass(frozen=True)
 class _ThreadedSnapshot:
     """The frozen, single-slot value the caller (TUI) thread reads — every
@@ -201,7 +227,7 @@ class ThreadedTransportProxy(ClientTransport):
         self._thread: "threading.Thread | None" = None
         self._worker_thread_ident: "int | None" = None
         self._caller_loop: "asyncio.AbstractEventLoop | None" = None
-        self._caller_queue: "asyncio.Queue[Frame | BacklogBatch] | None" = None
+        self._caller_queue: "asyncio.Queue[Frame | BacklogBatch | _PumpDied] | None" = None
         # Single overwriting slot (#4995's own settled design, see module
         # docstring) — a plain attribute, not a queue: only the LATEST
         # snapshot is ever meaningful, so an older one is safe to discard
@@ -241,8 +267,49 @@ class ThreadedTransportProxy(ClientTransport):
         self._inner = self._transport_factory()
         self._inner.start()
         self._pump_task = loop.create_task(self._pump_frames())
+        # #5996: without this, a `_pump_frames` task that dies from an
+        # unhandled exception is simply GONE — asyncio's own default
+        # handler only logs "Task exception was never retrieved" at
+        # teardown/GC (never to this app's own logger), and the caller's
+        # own `frames()` waits on `_caller_queue.get()` forever, since
+        # nothing else will ever put anything there again. Runs on THIS
+        # (the worker) loop — `add_done_callback` always schedules its
+        # callback via the loop that owns the task, never synchronously.
+        self._pump_task.add_done_callback(self._on_pump_task_done)
         self._ready.set()
         loop.run_forever()
+
+    def _on_pump_task_done(self, task: "asyncio.Task") -> None:
+        """The callback :meth:`_run_worker` attaches to ``_pump_task`` —
+        #5996. Fires for EVERY way the task can end; only a genuine
+        unhandled exception gets forwarded:
+
+        - Cancelled (:meth:`_cancel_pump_on_worker`'s own doing, the
+          ``shutdown()`` path) — not a death, nothing to report.
+        - Ended with no exception (the inner stream's own async
+          generator returned normally) — also not a death; whatever the
+          inner transport wanted the caller to know about a clean end
+          already rode through as an ordinary frame before this fired
+          (e.g. a ``kind="__end__"`` sentinel), the SAME channel a live
+          frame uses, so this callback adds nothing for that case.
+        - Ended with a real exception — the ONLY case this pushes
+          anything: a :class:`_PumpDied` sentinel, carrying the real
+          exception, onto ``_caller_queue`` via ``call_soon_threadsafe``
+          (the SAME cross-thread handoff every real frame already uses
+          — no second mechanism introduced). :meth:`frames` on the
+          caller side raises :class:`ThreadedPumpFailed` the moment it
+          reads this sentinel back off the queue, unblocking the
+          ``await self._caller_queue.get()`` that would otherwise wait
+          forever."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return
+        assert self._caller_loop is not None and self._caller_queue is not None
+        self._caller_loop.call_soon_threadsafe(
+            self._caller_queue.put_nowait, _PumpDied(exc),
+        )
 
     async def _pump_frames(self) -> None:
         """Runs ON THE WORKER LOOP. Drains the inner transport's own frame
@@ -283,6 +350,16 @@ class ThreadedTransportProxy(ClientTransport):
         assert self._caller_queue is not None
         while True:
             frame = await self._caller_queue.get()
+            # #5996: the ONE non-frame item this queue can ever carry —
+            # see :meth:`_on_pump_task_done`'s own docstring for when it
+            # is pushed. Raising here is what unblocks a caller that
+            # would otherwise wait on this same ``get()`` forever; every
+            # OTHER item is a real frame and falls through unchanged.
+            if isinstance(frame, _PumpDied):
+                raise ThreadedPumpFailed(
+                    f"the worker thread's frame pump died: "
+                    f"{type(frame.exc).__name__}: {frame.exc}"
+                ) from frame.exc
             # #3570: unconditional suspension point, once per frame — same
             # reasoning as ``InProcessTransport.frames``'s own identical
             # line (see ``drain.py``'s own docstring): ``Queue.get()``
@@ -507,4 +584,4 @@ class ThreadedTransportProxy(ClientTransport):
         await asyncio.to_thread(self._thread.join)
 
 
-__all__ = ["ThreadedTransportProxy"]
+__all__ = ["ThreadedPumpFailed", "ThreadedTransportProxy"]

--- a/tests/interfaces/test_5996_pump_task_death_reaches_caller.py
+++ b/tests/interfaces/test_5996_pump_task_death_reaches_caller.py
@@ -1,0 +1,199 @@
+"""Tier 2: #5996 — ``ThreadedTransportProxy``'s own worker-thread pump task
+(``_pump_frames``, run on a dedicated OS thread's own event loop) used to
+die UNTRACKED on an unhandled exception: no ``add_done_callback``, so
+asyncio's own default handler only logs "Task exception was never
+retrieved" at teardown/GC — never to this app's own logger — and the
+caller's own :meth:`ThreadedTransportProxy.frames` waited on
+``self._caller_queue.get()`` forever, since nothing else would ever put
+anything there again.
+
+lead-coder's own ruling (issue #5996): keep the task, and deliver the
+exception to ``frames()``'s own waiter — not "make the pump not die",
+which is a different, unrelated question this issue does not answer.
+Scope: ``ThreadedTransportProxy`` only, per lead-coder's explicit
+instruction — this issue was surfaced by #5990's own census as a
+structurally similar (but NOT identical, and NOT fixed by) shape to
+#5989/#5990/#5995.
+
+Real ``ThreadedTransportProxy`` + a real worker thread + a real, minimal
+``ClientTransport`` throughout (mirrors #5329's own ``_RaisingTransport``
+idiom for injecting a wire-layer failure) — no mocks. No duration
+anywhere: the caller-side ``await proxy.frames().__anext__()`` genuinely
+blocks on a real ``asyncio.Queue.get()`` until the worker thread's own
+``call_soon_threadsafe`` wakes it — CI's own ``--timeout`` is the only
+ceiling, matching every other unbounded-wait test in this file's own
+sibling (``test_4995_threaded_transport_proxy.py``).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, AsyncIterator
+
+import pytest
+
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.threaded import ThreadedPumpFailed, ThreadedTransportProxy
+
+if TYPE_CHECKING:
+    from reyn.runtime.outbox import OutboxMessage
+
+
+class _InjectedPumpFailure(RuntimeError):
+    """Stands in for a real inner-transport failure — what actually raises
+    is irrelevant to the property under test (#5329's own explicit
+    scoping, reused here for the same reason)."""
+
+
+class _RaisingAfterOneFrameTransport(ClientTransportStub):
+    """A real, minimal ``ClientTransport`` whose ``frames()`` yields ONE
+    genuine frame (proving normal flow still works — accept criterion ②)
+    then raises (accept criterion ①'s own trigger)."""
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        from reyn.interfaces.transport.frames import DisplayFrame
+        from reyn.runtime.outbox import OutboxMessage
+
+        yield DisplayFrame(OutboxMessage(kind="agent", text="before the failure"))
+        raise _InjectedPumpFailure("simulated inner-transport failure")
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover
+        return ""
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _NeverYieldsTransport(ClientTransportStub):
+    """Regression-guard sibling: ``frames()`` never yields anything and
+    never raises on its own — the pump task only ever ends via a real
+    ``shutdown()``/cancel, never a death. Confirms
+    :meth:`ThreadedTransportProxy._on_pump_task_done`'s cancellation
+    branch (``task.cancelled()`` → return, no forwarding) — the
+    LEGITIMATE shutdown path must never be mistaken for a death."""
+
+    def __init__(self) -> None:
+        self._never = asyncio.Event()
+        self.shutdown_calls = 0
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        await self._never.wait()
+        return
+        yield  # pragma: no cover - unreachable, satisfies the generator shape
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover
+        return ""
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_pump_task_death_unblocks_frames_with_a_typed_exception() -> None:
+    """Tier 2: #5996's own accept criterion ① — when the worker thread's
+    pump task dies, the caller's ``await`` on ``frames()`` resolves via a
+    raised exception, not a permanent hang.
+
+    Strip-falsifier (verified by hand: ``_on_pump_task_done`` never
+    attached via ``add_done_callback``, matching the pre-fix shape): this
+    test hangs — the assertion below is never reached, and CI's own
+    ``--timeout`` is what would eventually kill it (per CLAUDE.md's own
+    "wait on the condition unboundedly" ceiling policy — a stripped fix
+    correctly manifests as an unbounded wait that never resolves, not as
+    a quick red)."""
+    proxy = ThreadedTransportProxy(lambda: _RaisingAfterOneFrameTransport())
+    proxy.start()
+    try:
+        stream = proxy.frames()
+        first = await stream.__anext__()
+        assert first.message.text == "before the failure", (
+            "accept criterion ②: a real frame must flow normally BEFORE "
+            "the failure — proves this is testing the real pump, not a "
+            "pump that never started"
+        )
+        with pytest.raises(ThreadedPumpFailed) as excinfo:
+            await stream.__anext__()
+        assert isinstance(excinfo.value.__cause__, _InjectedPumpFailure), (
+            "the real exception must be chained as __cause__, not lost — "
+            f"got {excinfo.value.__cause__!r}"
+        )
+    finally:
+        proxy.close()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_of_a_never_finishing_pump_does_not_raise_threaded_pump_failed() -> None:
+    """Tier 2: regression guard — #5996's own accept criterion, the OTHER
+    direction: :meth:`ThreadedTransportProxy._cancel_pump_on_worker`
+    (the ``shutdown()`` path) cancels a still-running pump task, and that
+    CANCELLATION must not be mistaken for a death by the new
+    ``_on_pump_task_done`` callback. A build that forwarded on
+    cancellation too would make a completely ordinary ``/quit`` raise
+    ``ThreadedPumpFailed`` out of ``shutdown()`` itself.
+
+    No duration: this transport's own ``frames()`` awaits a real
+    ``asyncio.Event`` that never fires on its own — the pump task is
+    genuinely, indefinitely alive until ``shutdown()``'s own real
+    ``task.cancel()`` ends it; nothing here is a timed wait."""
+    transport = _NeverYieldsTransport()
+    proxy = ThreadedTransportProxy(lambda: transport)
+    proxy.start()
+    await proxy.shutdown()
+    assert transport.shutdown_calls == 1, (
+        "sanity: shutdown must have actually reached the inner transport"
+    )

--- a/tests/interfaces/test_5996_pump_task_death_reaches_caller.py
+++ b/tests/interfaces/test_5996_pump_task_death_reaches_caller.py
@@ -182,18 +182,67 @@ async def test_shutdown_of_a_never_finishing_pump_does_not_raise_threaded_pump_f
     direction: :meth:`ThreadedTransportProxy._cancel_pump_on_worker`
     (the ``shutdown()`` path) cancels a still-running pump task, and that
     CANCELLATION must not be mistaken for a death by the new
-    ``_on_pump_task_done`` callback. A build that forwarded on
-    cancellation too would make a completely ordinary ``/quit`` raise
-    ``ThreadedPumpFailed`` out of ``shutdown()`` itself.
+    ``_on_pump_task_done`` callback.
 
-    No duration: this transport's own ``frames()`` awaits a real
-    ``asyncio.Event`` that never fires on its own — the pump task is
-    genuinely, indefinitely alive until ``shutdown()``'s own real
-    ``task.cancel()`` ends it; nothing here is a timed wait."""
+    #5996 (lead-coder review, BLOCKING on PR #6004, self-corrected here):
+    an earlier version of this test called ``shutdown()`` WITHOUT ever
+    consuming ``frames()`` — ``ThreadedPumpFailed`` is only ever raised
+    from INSIDE ``frames()``'s own ``isinstance`` check (see that
+    method's own docstring), never from ``shutdown()`` itself, which
+    never reads the queue at all. A build that forwarded on cancellation
+    too would have merely left an unread ``_PumpDied`` sentinel sitting
+    in ``_caller_queue`` — the old test stayed green regardless, since
+    nothing ever looked. Fixed: a real consumer task is started on
+    ``frames()`` BEFORE ``shutdown()`` runs, so a wrongly-forwarded
+    sentinel has a real reader to reach.
+
+    No arbitrary wait: ``shutdown()`` itself is the real synchronization
+    point, not a chosen duration — it structurally requires several real
+    cross-thread round trips (``_call_on_worker("shutdown")``, then
+    ``_cancel_pump_on_worker`` via ``wrap_future``, then
+    ``asyncio.to_thread(self._thread.join)``), each of which yields the
+    CALLER loop back to the scheduler. ``_on_pump_task_done`` is
+    registered via ``add_done_callback`` at ``_run_worker`` time — before
+    ``_cancel_pump_on_worker``'s own ``await self._pump_task`` is ever
+    reached — so in a build that forwards on cancellation, the sentinel
+    would already have been pushed AND already have been read by
+    ``consumer`` by the time ``await proxy.shutdown()`` returns; nothing
+    here depends on picking a sleep long enough.
+
+    Strip-falsifier, verified by hand — NOT a bare deletion of ``if
+    task.cancelled(): return``: ``Task.exception()`` on an already-
+    CANCELLED task raises ``CancelledError`` itself (confirmed
+    interactively), so simply removing that guard makes
+    ``_on_pump_task_done`` raise INSIDE the ``add_done_callback``
+    machinery instead — asyncio's own callback invocation swallows that
+    (logged via the loop's default exception handler, never reaching
+    ``call_soon_threadsafe``), so a bare deletion leaves this test green
+    for an unrelated reason (nothing forwards, but also nothing is
+    diagnosed — a real, distinct gap, just not the one this test
+    targets). The strip that DOES turn this test red, and the one
+    verified by hand: replacing the cancellation guard with a mistake a
+    careless rewrite could plausibly make —
+    ``try: exc = task.exception() except asyncio.CancelledError as ce:
+    exc = ce`` — which treats the cancellation itself as a forwardable
+    failure. That reproduces the exact "an ordinary /quit raises
+    ThreadedPumpFailed" shape this test exists to catch."""
     transport = _NeverYieldsTransport()
     proxy = ThreadedTransportProxy(lambda: transport)
     proxy.start()
-    await proxy.shutdown()
-    assert transport.shutdown_calls == 1, (
-        "sanity: shutdown must have actually reached the inner transport"
-    )
+    consumer = asyncio.ensure_future(proxy.frames().__anext__())
+    try:
+        await proxy.shutdown()
+        assert transport.shutdown_calls == 1, (
+            "sanity: shutdown must have actually reached the inner transport"
+        )
+        assert not consumer.done(), (
+            "#5996 REGRESSION: an ordinary /quit must not deliver "
+            "ThreadedPumpFailed to a live frames() consumer — got "
+            f"{consumer.exception() if consumer.done() else 'n/a'!r}"
+        )
+    finally:
+        consumer.cancel()
+        try:
+            await consumer
+        except asyncio.CancelledError:
+            pass


### PR DESCRIPTION
**[tui-coder]** — fixes #5996.

`ThreadedTransportProxy`'s worker-thread pump task (`_pump_frames`, on its own dedicated event loop) used to die UNTRACKED on an unhandled exception: no `add_done_callback`, so asyncio's own default handler only logs "Task exception was never retrieved" at teardown/GC — never to this app's own logger — and the caller's own `frames()` waited on `self._caller_queue.get()` forever, since nothing would ever put anything there again. Structurally the closest thing in this codebase to #5989's own reported shape (worker dies, transport says nothing, queue never resolves) — **not confirmed as its cause**, per the issue body's own explicit caveat; this class still has no production call site.

## Design, per the ruling ("task を保持して例外を frames() の待ち手に届ける")
- `_run_worker` attaches `_on_pump_task_done` via `add_done_callback` on the worker loop.
- The callback distinguishes 3 end states:
  - **cancelled** (the legitimate `shutdown()`/`_cancel_pump_on_worker` path) — nothing to report.
  - **ended, no exception** (a clean end) — whatever the inner transport wanted known already rode through as an ordinary frame (e.g. a `kind="__end__"` sentinel) before this fired — no second channel needed for that case.
  - **ended with a real exception** — the ONLY case that pushes a `_PumpDied` sentinel onto `_caller_queue`, via the SAME `call_soon_threadsafe` handoff every real frame already uses (no second cross-thread mechanism introduced).
- `frames()` checks for the sentinel and raises `ThreadedPumpFailed` (chaining the real exception as `__cause__`) the instant it reads it back — unblocking the `get()` that would otherwise wait forever.

## Both accept-criteria directions
- ① a dead pump resolves the caller's `await` via a raised exception.
- ② normal frame flow is untouched — the test yields a real frame first, asserts it flows, THEN triggers the failure.

## Test
`test_5996_pump_task_death_reaches_caller.py` — real `ThreadedTransportProxy` + a real worker thread + a real, minimal `ClientTransport` (mirrors #5329's own `_RaisingTransport` idiom), no mocks, no duration (the caller-side `await` genuinely blocks on a real cross-thread wakeup; CI's own `--timeout` is the only ceiling). Strip-falsify (verified by hand, in-file Edit then Edit back, both directions): dropping `add_done_callback` hangs (confirmed via a local `timeout` wrapper, exit 124); dropping the `isinstance` check in `frames()` lets the sentinel leak through as a malformed "frame" instead of raising. A second test confirms the legitimate `shutdown()` cancellation path does not get mistaken for a death.

Also ran the broader neighborhood (not just the touched files): `test_4995_threaded_transport_proxy.py`, `test_4995_registry_owner_thread.py`, `test_5048_threaded_proxy_pending_head_not_live_object.py`, `test_5895_threaded_proxy_forwards_seed_frame.py`, `test_3595_s4_slash_handler_seam.py`, `test_threaded_transport_proxy_total_delegation_5048.py` — all still green. (`test_stall_dump_4986.py` hangs under this sandbox's local run — confirmed, via `git stash`, that it hangs IDENTICALLY on unmodified `origin/main`, unrelated to this diff — it only mentions `ThreadedTransportProxy` in a comment.)

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green. `suspected_time_dependence_ratchet.py` fails on an unrelated, pre-existing file (`test_5973_bounded_materialization.py`, not touched here).
- [x] Scoped pytest: `test_5996_pump_task_death_reaches_caller.py`, `test_4995_threaded_transport_proxy.py`, plus the broader neighborhood above — 9+ passed (see above).
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
