### PR TITLE
fix(#5985): bound crash/SIGKILL-leftover .sb profiles with a pid subdir + dead-pid sweep

### DIFF
--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -301,9 +301,15 @@ def _sweep_dead_pid_cache_dirs() -> None:
     try:
         entries = list(root.iterdir())
     except (FileNotFoundError, NotADirectoryError):
-        return  # nothing to sweep yet — this process will create root itself
+        # Nothing to sweep yet (this process will create root itself) — still
+        # logged, for the same "ran" vs "never ran" reason as the loop's own
+        # summary line below.
+        _logger.info("sandbox profile cache sweep: cache root does not exist yet")
+        return
 
     own_pid = os.getpid()
+    removed = 0
+    failed = 0
     for entry in entries:
         if not entry.is_dir():
             continue  # a stray non-directory at this level is not ours to touch
@@ -316,6 +322,24 @@ def _sweep_dead_pid_cache_dirs() -> None:
         if pid_alive(pid):
             continue  # a live sibling's cache — the whole reason this isn't a blanket sweep
         shutil.rmtree(entry, ignore_errors=True)
+        if entry.exists():
+            failed += 1
+        else:
+            removed += 1
+
+    # #5985 co-vet (architect ⑵, lead-coder ruling): `ignore_errors=True`
+    # makes "removed" / "couldn't remove" / "nothing to sweep" indistinguishable
+    # from each other — exactly the same silent-outcome shape #5991② closed
+    # earlier the same night, and #5985's own subject IS "a leftover nobody
+    # notices accumulating", so a sweep that silently no-ops or silently
+    # fails would defeat the fix while looking identical to it working.
+    # Logged unconditionally (including the 0/0 case) so "this ran" is
+    # observable on its own, not only inferable from the absence of a line.
+    _logger.info(
+        "sandbox profile cache sweep: removed %d dead-pid dir(s), "
+        "%d failed to remove",
+        removed, failed,
+    )
 
 
 def _profile_is_safe_to_cache(policy: SandboxPolicy) -> bool:

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -30,6 +30,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
+from reyn.data.index.build_lock import pid_alive
 from reyn.security.sandbox._derivation_cache import cached_derivation, release_derivation
 from reyn.security.sandbox._subprocess_io import communicate_capped, kill_process_tree
 from reyn.security.sandbox.backend import (
@@ -214,16 +215,96 @@ def _build_sbpl_profile(policy: SandboxPolicy) -> str:
 # distinguishable from other processes' temp files.
 _CACHE_SUBDIR_NAME = "reyn-sandbox-profiles"
 
+# #5985: has THIS process already swept `_seatbelt_cache_root()` for dead-pid
+# siblings? Module-level, not per-call — the sweep only needs to run once per
+# process (repeating it on every cache-miss would just re-scan a directory
+# that hasn't changed since the last scan, in the same process).
+_swept_dead_pid_dirs = False
+
+
+def _seatbelt_cache_root() -> Path:
+    """Return the directory ALL processes' pid-scoped SBPL profile caches
+    live under — the sweep target for :func:`_sweep_dead_pid_cache_dirs`,
+    never written to directly (see :func:`_seatbelt_cache_dir` for the
+    per-process subdirectory that actually is)."""
+    return Path(tempfile.gettempdir()) / _CACHE_SUBDIR_NAME
+
 
 def _seatbelt_cache_dir() -> Path:
-    """Return the directory session-cached SBPL profiles are written under.
+    """Return the directory THIS process's session-cached SBPL profiles are
+    written under — a pid-scoped subdirectory of :func:`_seatbelt_cache_root`
+    (#5985), not the shared root itself.
 
     A function, not a module-level constant, so :func:`_profile_is_safe_to_cache`
     below always re-derives the CURRENT value rather than a value captured at
     import time — ``tempfile.gettempdir()`` itself never changes within a
     process, but this keeps the two functions symmetric and re-testable.
+
+    #5985: pid-scoped so a crashed/SIGKILLed process's leftover `.sb` files
+    are structurally isolated from every OTHER (including currently live)
+    process's own cache — sweeping dead entries (below) never has to touch
+    a directory a live process might still be reading from, because a live
+    process's own entries live under a DIFFERENT pid subdirectory entirely.
     """
-    return Path(tempfile.gettempdir()) / _CACHE_SUBDIR_NAME
+    return _seatbelt_cache_root() / str(os.getpid())
+
+
+def _sweep_dead_pid_cache_dirs() -> None:
+    """Remove every SIBLING pid-subdirectory of :func:`_seatbelt_cache_dir`
+    whose owning process is no longer alive (#5985).
+
+    Runs at most once per process (guarded by the module-level
+    ``_swept_dead_pid_dirs`` flag) — called right before this process
+    creates its OWN cache subdirectory, so it never races its own not-yet-
+    created directory.
+
+    ⚠️ Deliberately NOT a size/age-based or blanket sweep: this repo's own
+    #5981 investigation found a directory-wide sweep unsafe (owner runs
+    `reyn:web` and `reyn:chat` concurrently — sweeping on ANY process's
+    startup would delete a SIBLING's still-live `.sb` file out from under
+    its own `sandbox-exec`). Liveness, not age, is the only safe
+    discriminant a startup-time sweep can use here: an age threshold would
+    be an unearned constant (how old is "definitely dead"?), while a
+    liveness check has NO constant to get wrong — a pid subdir either has a
+    living owner or it does not, on the machine's own authority (``os.kill``
+    signal-0), not this module's guess. A REUSED pid reads as "alive" and
+    is therefore left alone — the failure mode of pid reuse here is "an
+    unrelated, unreapable dir lingers a little longer", never "a live
+    process's cache gets deleted out from under it".
+
+    Uses :func:`reyn.data.index.build_lock.pid_alive` (`os.kill(pid, 0)`),
+    NOT :func:`reyn.api.safe.process.pid_alive` — semantically identical
+    today, but the latter is the curated surface exposed to SANDBOXED
+    safe-mode python steps specifically (see that module's own docstring);
+    pulling it into trusted sandbox-backend code blurs the boundary it
+    exists to keep. `process_registry.py` (#5296) already established this
+    exact substitution for the identical reason — reused here, not
+    reinvented.
+    """
+    global _swept_dead_pid_dirs
+    if _swept_dead_pid_dirs:
+        return
+    _swept_dead_pid_dirs = True
+
+    root = _seatbelt_cache_root()
+    try:
+        entries = list(root.iterdir())
+    except (FileNotFoundError, NotADirectoryError):
+        return  # nothing to sweep yet — this process will create root itself
+
+    own_pid = os.getpid()
+    for entry in entries:
+        if not entry.is_dir():
+            continue  # a stray non-directory at this level is not ours to touch
+        try:
+            pid = int(entry.name)
+        except ValueError:
+            continue  # not a pid-shaped name — not this sweep's population
+        if pid == own_pid:
+            continue  # never our own, not-yet-fully-created directory
+        if pid_alive(pid):
+            continue  # a live sibling's cache — the whole reason this isn't a blanket sweep
+        shutil.rmtree(entry, ignore_errors=True)
 
 
 def _profile_is_safe_to_cache(policy: SandboxPolicy) -> bool:
@@ -245,7 +326,7 @@ def _profile_is_safe_to_cache(policy: SandboxPolicy) -> bool:
     Only the SUBPATH direction is unsafe: a write grant on ``write_paths``
     makes that path and everything BELOW it writable, never anything above
     it, so the cache dir being an *ancestor* of a write_paths entry is fine
-    (e.g. cache dir ``/tmp/reyn-sandbox-profiles`` and a write grant on
+    (e.g. cache dir ``/tmp/reyn-sandbox-profiles/<pid>`` and a write grant on
     ``/tmp/reyn-sandbox-profiles/../workspace`` never overlaps the cache
     dir's own files).
     """
@@ -284,6 +365,12 @@ def _cached_profile_path(policy: SandboxPolicy, profile_text: str) -> tuple[str,
             return fh.name, False
 
     def _write_cached() -> str:
+        # #5985: sweep dead-pid siblings BEFORE creating our own subdirectory
+        # — see _sweep_dead_pid_cache_dirs's own docstring for why this is
+        # liveness-gated, not a blanket sweep, and why "before" (not "after")
+        # matters (our own dir doesn't exist yet, so there's nothing of ours
+        # for the sweep to even consider).
+        _sweep_dead_pid_cache_dirs()
         cache_dir = _seatbelt_cache_dir()
         cache_dir.mkdir(parents=True, exist_ok=True)
         fd, path = tempfile.mkstemp(suffix=".sb", dir=str(cache_dir))

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -280,6 +280,17 @@ def _sweep_dead_pid_cache_dirs() -> None:
     exists to keep. `process_registry.py` (#5296) already established this
     exact substitution for the identical reason — reused here, not
     reinvented.
+
+    ⚠️ Theoretical race (architect co-vet, #6005): a parent dies right after
+    spawning its own ``sandbox-exec -f <profile>``, and a LATER reyn process
+    starts and sweeps the now-dead parent's pid subdir before that
+    ``sandbox-exec`` has finished reading the profile — a window measured
+    in milliseconds, requiring another process's startup to land inside it.
+    Considered unlikely enough not to warrant closing. **Do not "fix" this
+    by adding a fallback that runs the command WITHOUT a sandbox profile**:
+    the correct behaviour here is fail-CLOSED — ``sandbox-exec`` given a
+    missing profile path fails to launch at all, it does not silently run
+    unsandboxed. That failure mode is the point, not a bug to route around.
     """
     global _swept_dead_pid_dirs
     if _swept_dead_pid_dirs:

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -647,6 +647,38 @@ def test_sweep_removes_a_dead_pids_subdirectory():
     assert not dead.exists()
 
 
+def test_sweep_logs_the_removed_count(caplog):
+    """Tier 2: #5985 co-vet (architect ⑵, lead-coder ruling) — the sweep's
+    outcome must be OBSERVABLE, not silent on every branch the way a bare
+    `shutil.rmtree(ignore_errors=True)` is. This is the exact shape #5991②
+    closed the same night for a different mechanism: "ran and found
+    nothing" / "didn't run" / "ran and failed" must not all look identical.
+
+    NON-VACUITY (strip-falsified locally, in-file Edit -> run -> Edit
+    back): removing the `_logger.info(...)` call in
+    `_sweep_dead_pid_cache_dirs` makes this assertion fail — there would be
+    nothing in the log to assert on."""
+    import logging
+
+    from reyn.security.sandbox.backends.seatbelt import (
+        _seatbelt_cache_root,
+        _sweep_dead_pid_cache_dirs,
+    )
+
+    root = _seatbelt_cache_root()
+    dead = root / str(_dead_pid())
+    dead.mkdir(parents=True, exist_ok=True)
+
+    with caplog.at_level(logging.INFO, logger="reyn.security.sandbox.backends.seatbelt"):
+        _sweep_dead_pid_cache_dirs()
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("removed 1 dead-pid dir" in m for m in messages), (
+        "the sweep's own outcome (1 dir removed) left no observable trace — "
+        f"records were: {messages}"
+    )
+
+
 def test_sweep_does_not_remove_a_live_pids_subdirectory():
     """Tier 2: strip-falsify's counterpart — a sibling pid-subdirectory
     whose owning process is ALIVE (this test's own parent process, a real,

--- a/tests/security/test_sandbox_seatbelt.py
+++ b/tests/security/test_sandbox_seatbelt.py
@@ -417,6 +417,21 @@ def _reset_derivation_cache():
     _derivation_cache._reset_cache_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _reset_dead_pid_sweep_flag():
+    """#5985: `_sweep_dead_pid_cache_dirs` runs at most ONCE per process (a
+    module-level flag, not per-call) — without resetting it, whichever test
+    in the WHOLE pytest session first triggers a Seatbelt cache-miss
+    consumes that "once" for every other test that runs after it in the
+    SAME process, silently no-opping the sweep in every test that actually
+    means to exercise it."""
+    import reyn.security.sandbox.backends.seatbelt as _seatbelt_module
+
+    _seatbelt_module._swept_dead_pid_dirs = False
+    yield
+    _seatbelt_module._swept_dead_pid_dirs = False
+
+
 def test_seatbelt_cache_dir_is_outside_a_realistic_write_scope():
     """Tier 2: #4434's load-bearing precondition, derived from the policy
     object (via the same expand_policy_path + resolve every emitted SBPL
@@ -592,3 +607,152 @@ def test_seatbelt_wrap_command_does_not_cache_when_write_scope_is_unsafe():
     wrapped1.cleanup()
     assert not os.path.exists(path1)
     wrapped2.cleanup()
+
+
+# ─── 7. Dead-pid cache-dir sweep (#5985) ────────────────────────────────────
+
+
+def _dead_pid() -> int:
+    """A real, guaranteed-not-alive pid — spawn a trivial subprocess and let
+    it exit, then use its own pid. Cheaper and more honest than guessing a
+    large integer that MIGHT collide with something real on a busy
+    machine — this is an ACTUAL process that ACTUALLY exited, not a faked
+    liveness answer."""
+    import subprocess
+    import sys as _sys
+
+    proc = subprocess.Popen([_sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def test_sweep_removes_a_dead_pids_subdirectory():
+    """Tier 2: a sibling pid-subdirectory whose owning process has already
+    exited IS removed by the sweep — the "band question 1" answer #5985
+    exists to provide (crash/SIGKILL leftovers had no bounding subject
+    before this)."""
+
+    from reyn.security.sandbox.backends.seatbelt import (
+        _seatbelt_cache_root,
+        _sweep_dead_pid_cache_dirs,
+    )
+
+    root = _seatbelt_cache_root()
+    dead = root / str(_dead_pid())
+    dead.mkdir(parents=True, exist_ok=True)
+    (dead / "leftover.sb").write_text("stale", encoding="utf-8")
+
+    _sweep_dead_pid_cache_dirs()
+
+    assert not dead.exists()
+
+
+def test_sweep_does_not_remove_a_live_pids_subdirectory():
+    """Tier 2: strip-falsify's counterpart — a sibling pid-subdirectory
+    whose owning process is ALIVE (this test's own parent process, a real,
+    distinct, genuinely-running pid — not the test's own pid, which the
+    sweep already skips unconditionally) survives the sweep untouched.
+
+    NON-VACUITY (strip-falsified locally, in-file Edit → run → Edit back):
+    replacing the ``pid_alive(pid)`` check in ``_sweep_dead_pid_cache_dirs``
+    with an unconditional False makes THIS assertion fail — the
+    false-reject half of #5985's own "both directions" acceptance
+    criterion (the false-accept half is
+    ``test_sweep_removes_a_dead_pids_subdirectory`` above)."""
+    import os
+
+    from reyn.security.sandbox.backends.seatbelt import (
+        _seatbelt_cache_root,
+        _sweep_dead_pid_cache_dirs,
+    )
+
+    root = _seatbelt_cache_root()
+    live_pid = os.getppid()  # the pytest runner's own parent — really alive
+    live = root / str(live_pid)
+    live.mkdir(parents=True, exist_ok=True)
+    (live / "still-needed.sb").write_text("in use", encoding="utf-8")
+
+    try:
+        _sweep_dead_pid_cache_dirs()
+        assert live.exists(), (
+            "a LIVE sibling's cache dir was removed — this is exactly the "
+            "failure #5981's own investigation ruled out a blanket sweep "
+            "over: a concurrently-running process's sandbox-exec would now "
+            "reference a deleted profile"
+        )
+    finally:
+        import shutil as _shutil
+
+        _shutil.rmtree(live, ignore_errors=True)  # tidy up regardless of outcome
+
+
+def test_sweep_ignores_non_pid_shaped_and_non_directory_entries():
+    """Tier 2: a stray file or a non-numeric-named directory under the cache
+    root (never written by this module, but the population isn't
+    guaranteed-pure — it's a real, shared OS temp subdirectory) is left
+    alone rather than raising or being swept as if it were a pid."""
+    from reyn.security.sandbox.backends.seatbelt import (
+        _seatbelt_cache_root,
+        _sweep_dead_pid_cache_dirs,
+    )
+
+    root = _seatbelt_cache_root()
+    root.mkdir(parents=True, exist_ok=True)
+    stray_file = root / "not-a-pid-dir.txt"
+    stray_file.write_text("x", encoding="utf-8")
+    stray_dir = root / "not-numeric"
+    stray_dir.mkdir(exist_ok=True)
+
+    try:
+        _sweep_dead_pid_cache_dirs()  # must not raise
+        assert stray_file.exists()
+        assert stray_dir.exists()
+    finally:
+        stray_file.unlink(missing_ok=True)
+        stray_dir.rmdir()
+
+
+def test_sweep_runs_at_most_once_per_process():
+    """Tier 2: the module-level guard — a second call in the same process
+    is a no-op even if a fresh dead-pid subdirectory appears in between,
+    matching the docstring's own "at most once per process" claim."""
+    from reyn.security.sandbox.backends.seatbelt import (
+        _seatbelt_cache_root,
+        _sweep_dead_pid_cache_dirs,
+    )
+
+    _sweep_dead_pid_cache_dirs()  # first call — consumes the "once"
+
+    root = _seatbelt_cache_root()
+    dead = root / str(_dead_pid())
+    dead.mkdir(parents=True, exist_ok=True)
+
+    try:
+        _sweep_dead_pid_cache_dirs()  # second call — must be a no-op
+        assert dead.exists(), (
+            "the sweep ran a second time in the same process — the "
+            "module-level guard is not doing its job"
+        )
+    finally:
+        import shutil as _shutil
+
+        _shutil.rmtree(dead, ignore_errors=True)
+
+
+def test_wrap_command_triggers_the_sweep_before_creating_its_own_pid_dir():
+    """Tier 2: integration — a real ``wrap_command()`` cache-miss call
+    triggers the sweep as a side effect (not just the unit-level direct
+    call above), and a dead-pid sibling planted beforehand is gone
+    afterward."""
+    from reyn.security.sandbox.backends.seatbelt import _seatbelt_cache_root
+
+    root = _seatbelt_cache_root()
+    dead = root / str(_dead_pid())
+    dead.mkdir(parents=True, exist_ok=True)
+
+    backend = SeatbeltBackend()
+    wrapped = backend.wrap_command(["/bin/echo", "hi"], SandboxPolicy(write_paths=[]))
+
+    assert not dead.exists()
+
+    wrapped.cleanup()


### PR DESCRIPTION
**[docs-maintainer]** — part of #5985.

## What

`_seatbelt_cache_dir()` is now pid-scoped (`$TMPDIR/reyn-sandbox-profiles/<pid>/`), and the first cache-dir creation per process sweeps sibling pid-subdirectories whose owning process is no longer alive. Liveness (`os.kill(pid, 0)` via `reyn.data.index.build_lock.pid_alive`), not age, is the only discriminant -- structurally can't have an unearned constant, and a reused pid reads as "alive" (safe-side failure: a stale dir lingers, never a live one deleted). No config knob.

`pid_alive` deliberately sourced from `reyn.data.index.build_lock`, not `reyn.api.safe.process` (semantically identical `os.kill(pid, 0)` probe, but that module is the curated surface for SANDBOXED safe-mode python steps specifically -- `runtime/process_registry.py` (#5296) already established this exact substitution for the identical cross-boundary reason; reused here, not reinvented).

## Verification (both directions, strip-falsified independently)

- `test_sweep_removes_a_dead_pids_subdirectory` -- a dead pid's sibling IS removed. Strip (disable the `shutil.rmtree` call): RED.
- `test_sweep_does_not_remove_a_live_pids_subdirectory` -- a LIVE pid's sibling (the test's own real parent process, `os.getppid()` -- not a faked answer) is NOT removed. Strip (disable the `pid_alive` check): RED.
- `test_sweep_ignores_non_pid_shaped_and_non_directory_entries`, `test_sweep_runs_at_most_once_per_process`, `test_wrap_command_triggers_the_sweep_before_creating_its_own_pid_dir` (integration path).

## Remaining #5985 scope (not this PR -- after #5977③)

#5985's population is not only `.sb` -- lead-coder found `stall_dump.<pid>.log` (added by #5997, pid now in the path) is the same unbounded-leftover class, with zero `unlink`/`glob`/`rmtree` in `loop_tripwire.py`. Same shape this PR uses (pid-scoped dir + liveness-gated dead-pid sweep) should apply directly. Picking this up after #5977③, per lead-coder's ordering.

## Note: an unrelated, pre-existing gate failure on `main`

`scripts/suspected_time_dependence_ratchet.py` currently fails on `origin/main` independent of this PR (`tests/runtime/test_5973_bounded_materialization.py`, landed by #5979) -- confirmed by running the gate against a clean `origin/main` with none of this branch's changes applied. Reported to lead-coder separately over broker; not this PR's scope, and CI here may show it too through no fault of this diff.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_sandbox_seatbelt.py` -- 31/31 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/` path-conditional gates (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`) -- all green; `suspected_time_dependence_ratchet.py` shows the pre-existing unrelated failure noted above, not a new site from this diff
- [x] `pytest tests/security/ -k "seatbelt or derivation_cache or sandbox"` -- 253 passed, 22 skipped (Darwin-only); `test_mcp_client_sandbox_wrap.py`/`test_codeact_runner_1593.py`/`test_sandbox_wrap_command_2620.py` -- 40 passed
- [x] (skipped -- Visual, standing waiver 2026-08-08)

security 配下のため architect の co-vet が必要です。merge は lead-coder にお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7

