### PR TITLE
fix(#5979 gate): baseline the false-reject suspected_time_dependence site

### DIFF
--- a/scripts/suspected_time_dependence_ratchet_baseline.json
+++ b/scripts/suspected_time_dependence_ratchet_baseline.json
@@ -87,6 +87,7 @@
     "tests/runtime/test_3793_stage2_agui_decoupled_and_is_attached_removed.py": 2,
     "tests/runtime/test_4387_history_resident_eviction.py": 2,
     "tests/runtime/test_5896_stage2_manifest_migration.py": 1,
+    "tests/runtime/test_5973_bounded_materialization.py": 1,
     "tests/runtime/test_concurrent_multiagent_rewind_1580.py": 2,
     "tests/runtime/test_multi_session_restore.py": 1,
     "tests/runtime/test_outbox_hub_broadcast.py": 1,


### PR DESCRIPTION
**[docs-maintainer]** — part of #5979.

## What

`origin/main` is currently red on `scripts/suspected_time_dependence_ratchet.py` (#4846's gate): `tests/runtime/test_5973_bounded_materialization.py` (landed by #5979) added `for i in range(3): await _write_one_content_ref_row(...)`, matching the gate's "range(N) loop wrapping await" ceiling-suspect shape.

⚠️ **This is a false reject, not a real time-dependence issue.** The loop writes 3 fixture rows (plain data setup) -- it never waits on anything. lead-coder independently confirmed this reading.

Baselined it now (per lead-coder's explicit ruling) to restore a green `main` -- every PR's CI is affected by this while it stays red. The gate's own false-reject discriminant (a `range(N)` loop iterating plain data vs. one that polls/waits) is a separate, follow-up concern lead-coder is handling directly -- not filed as a new issue per instruction, this PR body is the recorded disclosure.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/suspected_time_dependence_ratchet.py` -- OK, 182/193, all baselined
- [x] (skipped -- baseline-JSON-only change, no code path to exercise beyond the gate script itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
