### PR TITLE
feat(#5838 段4): sandboxed_exec's cmd form -- parse for policy, execute via sh -c

### DIFF
--- a/docs/reference/runtime/control-ir.ja.md
+++ b/docs/reference/runtime/control-ir.ja.md
@@ -214,7 +214,8 @@ Control IR の op kind は `sandboxed_exec` のまま変わりません（`OP_KI
 ```
 
 フィールド:
-- `argv`（必須）— コマンドと引数。`argv[0]` が実行可能ファイル。
+- `argv`（デフォルト `[]`）— コマンドと引数。`argv[0]` が実行可能ファイル。`argv` / `cmd` のどちらか一方が必須（両方または両方省略は構築時エラー — `SandboxedExecIROp` 自身の `model_validator`）。
+- `cmd`（省略可、デフォルト `None`）— **#5838 段4**: シェルコマンド行、`argv` と排他。`security.exec_plan.parse_exec_plan` でポリシー判定可能な plan に解析し、`security.exec_plan_policy.check_exec_plan_policy`（segment ごとの tool 軸 + threat scan、redirect 先は既存の `require_file_write`/`require_file_read`）でチェック — 解析不能または policy 拒否は何も spawn する前に起こる。実際に**実行される**文字列は `cmd` そのまま、`["/bin/sh", "-c", cmd]` 経由で、解析済み plan からの再構築ではない（owner 裁定: Claude Code/Codex/OpenClaw/Hermes の実際の動作に合わせる — 詳細は `security/exec_plan.py` 自身のモジュール docstring）。LLM の `exec` tool schema や pipeline `tool:` step にはまだ露出していない（別の later stage）— 今のところ op を直接構築する呼び手からのみ到達可能。
 - `stdin`（省略可、デフォルト `None`）— プロセスの stdin に書き込むバイト列（pipeline `tool` step は前ステップの pipe-data を `args: {argv: [...], stdin_pipe: !expr pipe}` 経由で JSON としてここに渡せる — [Pipeline DSL](pipeline-dsl.ja.md#tool) 参照）。
 - `timeout_seconds`（省略可、デフォルト `None`）— **#3903①（2026-08-11、下の段落からの意図的な方針転換）**: LLM は `SandboxPolicy.timeout_seconds` 自身のデフォルトを超える前景ウォールクロックタイムアウトを、`SandboxPolicy.max_timeout_seconds`（operator 自身が設定する上限 — ハードコード値ではない）まで要求できます（`max_timeout_seconds` をデフォルトの 600 秒より狭めた operator にはその上限が実際に強制される。LLM が operator 自身の狭い設定を広げることはできない）。`None`（デフォルト）は policy 自身の `timeout_seconds` を使う。上限を超える値は**拒否**され（`status: "error"`、実際に設定された上限を名指し）、静かに切り詰められることはない — それをすると、下の段落で閉じたはずの「advertised だが無視される」形が、フィールドが黙って落とされる代わりに値が黙って変わる形で再来してしまう。非正の値も同様に拒否される。
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -366,7 +366,8 @@ The Control IR op kind stays `sandboxed_exec` (`OP_KIND_MODEL_MAP["sandboxed_exe
 ```
 
 Fields:
-- `argv` (required) — command + arguments. `argv[0]` is the executable.
+- `argv` (default `[]`) — command + arguments. `argv[0]` is the executable. Exactly one of `argv` / `cmd` is required (a construction-time error otherwise — `SandboxedExecIROp`'s own `model_validator`).
+- `cmd` (optional, default `None`) — **#5838 段4**: a shell command line, XOR `argv`. Parsed via `security.exec_plan.parse_exec_plan` into a policy-checkable plan and checked (`security.exec_plan_policy.check_exec_plan_policy`: per-segment tool-axis + threat scan, redirect targets through the existing `require_file_write`/`require_file_read`) — a parse rejection or a policy denial happens BEFORE anything spawns. The string that actually EXECUTES is `cmd` UNCHANGED, via `["/bin/sh", "-c", cmd]`, never a reconstruction from the parsed plan (owner ruling: match how Claude Code/Codex/OpenClaw/Hermes all actually work — see `security/exec_plan.py`'s own module docstring for the full rationale). Not yet exposed on the LLM `exec` tool schema or the pipeline `tool:` step (a separate later stage) — reachable today only by a caller that constructs the op directly.
 - `stdin` (optional, default `None`) — bytes written to the process's stdin, if any (a pipeline `tool` step can thread the previous step's pipe-data here as JSON via `args: {argv: [...], stdin_pipe: !expr pipe}` — see [Pipeline DSL](pipeline-dsl.md#tool)).
 - `timeout_seconds` (optional, default `None`) — **#3903① (2026-08-11), a
   deliberate reversal of the paragraph below**: the LLM may request a

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -17,6 +17,28 @@ op-dispatch entry point `handle` so `session_api.run_exec_async` (the
 background/async `exec` path) can reuse every line of it, differing only
 in the optional `sink` tee callback — see `run_sandboxed_exec`'s own
 docstring.
+
+#5838 段4: two mutually-exclusive request shapes, both handled here.
+`op.argv` (the original, unchanged form) runs argv0 through the existing
+version-manager-shim resolution and the WHOLE-op threat scan. `op.cmd`
+(new) is a shell command line: parsed via `security.exec_plan.
+parse_exec_plan` and checked via `security.exec_plan_policy.
+check_exec_plan_policy` (segment tool-axis + PER-SEGMENT threat scan +
+redirect file-axis) BEFORE anything runs — but the string actually
+executed is `cmd` UNCHANGED, via `["/bin/sh", "-c", cmd]`, never a
+reconstruction from the parsed plan (owner ruling (i), `security/
+exec_plan.py`'s own module docstring has the full rationale for why
+parse-for-policy/execute-original-string, not the other way around).
+`cwd`/`env_path` are resolved ONCE per call and reused for BOTH the
+policy check and the actual argv0 resolution — #5991 BLOCKING ③'s own
+point carried forward into this stage: the binary policy approved and
+the binary that runs must come from the identical PATH/cwd.
+
+Not yet wired: `cmd` is not exposed on the LLM `exec` tool schema or the
+pipeline `tool:` step (段6, a separate later stage); `sandboxed_exec_
+started`/`_completed`'s own `plan` field recording each segment's
+resolved argv[0] (段5) does not exist yet either — only `argv0_resolved`
+(always `/bin/sh` for a cmd-mode run) is recorded today.
 """
 from __future__ import annotations
 
@@ -69,29 +91,61 @@ async def run_sandboxed_exec(
     tool call this handler was written for is completely unaffected by
     this refactor — same behaviour, same return shape, sink simply never
     fires for it."""
-    # FP-0050/#1822 S5 (EP4): exec-scope scan of the command (joined argv) BEFORE
-    # any exec. A block-severity hit denies via the permission-deny channel
-    # (PermissionError → execute_op status="denied", decision-enabling); a warn
-    # emits + proceeds. Orthogonal to the sandbox (which confines exec EFFECTS) —
-    # both fire (§4 non-duplication). No-op when threat_scan is absent/disabled.
-    _ts = getattr(ctx, "threat_scan", None)
-    if _ts is not None and getattr(_ts, "enabled", True):  # #4523: shadow default matches ThreatScanConfig.enabled's own declared True
-        from reyn.security.content_guard import first_blocking_match, scan_for_threats
-        _matches = scan_for_threats(" ".join(op.argv), _ts, scope="exec")
-        for _m in _matches:
-            ctx.events.emit(
-                "exec_threat_match", pattern_id=_m.pattern_id, severity=_m.severity, scope=_m.scope,
-            )
-        _block = first_blocking_match(_matches, getattr(_ts, "block_severity", "block"))
-        if _block is not None:
-            ctx.events.emit(
-                "exec_threat_blocked", pattern_id=_block.pattern_id, severity=_block.severity,
-            )
-            raise PermissionError(
-                f"command blocked: matched threat pattern '{_block.pattern_id}' "
-                f"(exec/{_block.severity}). Revise the command (avoid pipe-to-shell / "
-                f"reverse-shell / homograph URL / terminal-escape) and retry."
-            )
+    # #5838 段4: cmd-mode's own policy (segment tool-axis + PER-SEGMENT
+    # threat scan + redirect file-axis, all via `check_exec_plan_policy`)
+    # replaces the whole-op threat scan below for THIS op — the segment
+    # scan already covers exec-scope threat matching, more precisely (one
+    # scan per segment, not one scan over the whole joined string a
+    # chained command's second half could otherwise dilute). See this
+    # branch's own comment further down for the parse+policy call itself;
+    # `cwd`/`env_path` are computed once, here, and reused by BOTH that
+    # call and the (cmd-mode or argv-mode) argv0 resolution below — #5991
+    # BLOCKING ③'s own point, carried forward: the binary policy approves
+    # and the binary that runs must be resolved from the SAME PATH/cwd.
+    cwd = str(ctx.workspace.base_dir)
+    env_path = os.environ.get("PATH")
+
+    if op.cmd is not None:
+        from reyn.security.exec_plan import ExecPlanRejected, parse_exec_plan
+        from reyn.security.exec_plan_policy import check_exec_plan_policy
+
+        try:
+            _plan = parse_exec_plan(op.cmd)
+        except ExecPlanRejected as _exc:
+            return {
+                "kind": "sandboxed_exec",
+                "status": "error",
+                "error": f"command could not be parsed for policy: {_exc}",
+            }
+        # Raises PermissionError on any segment/redirect denial -- caught
+        # uniformly by dispatch_tool's own PermissionError handling
+        # (execute_op status="denied"), the SAME channel the threat-scan
+        # block below already uses for argv-mode.
+        await check_exec_plan_policy(_plan, ctx, env_path=env_path, cwd=cwd)
+    else:
+        # FP-0050/#1822 S5 (EP4): exec-scope scan of the command (joined argv) BEFORE
+        # any exec. A block-severity hit denies via the permission-deny channel
+        # (PermissionError → execute_op status="denied", decision-enabling); a warn
+        # emits + proceeds. Orthogonal to the sandbox (which confines exec EFFECTS) —
+        # both fire (§4 non-duplication). No-op when threat_scan is absent/disabled.
+        _ts = getattr(ctx, "threat_scan", None)
+        if _ts is not None and getattr(_ts, "enabled", True):  # #4523: shadow default matches ThreatScanConfig.enabled's own declared True
+            from reyn.security.content_guard import first_blocking_match, scan_for_threats
+            _matches = scan_for_threats(" ".join(op.argv), _ts, scope="exec")
+            for _m in _matches:
+                ctx.events.emit(
+                    "exec_threat_match", pattern_id=_m.pattern_id, severity=_m.severity, scope=_m.scope,
+                )
+            _block = first_blocking_match(_matches, getattr(_ts, "block_severity", "block"))
+            if _block is not None:
+                ctx.events.emit(
+                    "exec_threat_blocked", pattern_id=_block.pattern_id, severity=_block.severity,
+                )
+                raise PermissionError(
+                    f"command blocked: matched threat pattern '{_block.pattern_id}' "
+                    f"(exec/{_block.severity}). Revise the command (avoid pipe-to-shell / "
+                    f"reverse-shell / homograph URL / terminal-escape) and retry."
+                )
 
     # A runtime backend instance injected on the OpContext takes precedence over
     # name-based platform auto-selection (FP-0008 C7 #2). This lets a caller
@@ -192,12 +246,12 @@ async def run_sandboxed_exec(
         # backend stays unaware of the fg/bg distinction entirely.
         policy = dataclasses.replace(policy, timeout_seconds=effective_default)
 
-    # Anchor the working directory to the run's workspace base_dir — parity with
-    # the legacy `shell` op (FP-0008 PR-I). Without this, repo-relative `git` /
-    # `pytest` run in the harness process cwd instead of the repo root, which
-    # breaks concurrent benchmark runs. A workspace-coupled backend (e.g. a
-    # container backend) may ignore this host path and use its own baked cwd.
-    cwd = str(ctx.workspace.base_dir)
+    # `cwd`/`env_path` (the working directory the sandboxed child inherits —
+    # parity with the legacy `shell` op, FP-0008 PR-I, so repo-relative
+    # `git`/`pytest` resolve against the repo root, not the harness process
+    # cwd — and the PATH used to resolve a version-manager shim) were
+    # computed ONCE, above, before the threat-scan/policy branch — reused
+    # here unchanged for argv0 resolution.
 
     # #2820 part A: resolve argv[0] past any version-manager shim OUTSIDE the
     # sandbox, so the shim's launch-fork runs in the trusted parent instead of
@@ -207,13 +261,28 @@ async def run_sandboxed_exec(
     # Fail-open: unchanged argv[0] when resolution is unavailable (the denial then
     # stands, now explained by part B's denial_class). `argv0_resolved` records
     # what actually ran — the tell for a launcher-fork denial that survives.
-    env_path = os.environ.get("PATH")
-    argv0_resolved = (
-        resolve_real_executable(op.argv[0], env_path=env_path, cwd=cwd)
-        if op.argv
-        else None
-    )
-    effective_argv = [argv0_resolved, *op.argv[1:]] if op.argv else list(op.argv)
+    #
+    # #5838 段4: cmd-mode's argv0 is always `/bin/sh` — the shell that will
+    # run *op.cmd* UNCHANGED (owner ruling (i): execute the ORIGINAL string,
+    # never a reconstruction from the parsed plan; `security/exec_plan.py`'s
+    # own module docstring has the full rationale). `_shell_argv` is what
+    # actually reaches the backend AND what the started/completed events
+    # below report as `argv` for this run — the parsed plan (already used,
+    # above, for policy) is not re-derived into an argv here.
+    argv0_resolved: "str | None"
+    if op.cmd is not None:
+        _shell_argv = ["/bin/sh", "-c", op.cmd]
+        argv0_resolved = resolve_real_executable(_shell_argv[0], env_path=env_path, cwd=cwd)
+        effective_argv = [argv0_resolved, *_shell_argv[1:]]
+        reported_argv = _shell_argv
+    elif op.argv:
+        argv0_resolved = resolve_real_executable(op.argv[0], env_path=env_path, cwd=cwd)
+        effective_argv = [argv0_resolved, *op.argv[1:]]
+        reported_argv = list(op.argv)
+    else:
+        argv0_resolved = None
+        effective_argv = list(op.argv)
+        reported_argv = list(op.argv)
 
     # #5825 ①: the op's own REQUEST to run with network enabled (architect
     # ruling, issue #5825, 2026-09-06 — "ask is where a *request* meets a
@@ -237,7 +306,7 @@ async def run_sandboxed_exec(
             )
         await ctx.permission_resolver.require_network(
             ctx.permission_decl, ctx.intervention_bus, ctx.actor,
-            argv=op.argv, agent_name=ctx.agent_name or ctx.actor,
+            argv=reported_argv, agent_name=ctx.agent_name or ctx.actor,
         )
         policy = dataclasses.replace(policy, network=True)
 
@@ -245,9 +314,13 @@ async def run_sandboxed_exec(
     # not the op's request fields — the operator-or-default policy wins over op
     # fields, so the trace must show what was enforced (a network:true op under
     # a network:false policy ran WITHOUT network, and the event must say so).
+    # #5838 段4: `reported_argv` is `["/bin/sh", "-c", op.cmd]` in cmd-mode
+    # (what actually runs), `list(op.argv)` otherwise — never `op.argv`
+    # unconditionally, which would show an empty list for every cmd-mode
+    # run.
     ctx.events.emit(
         "sandboxed_exec_started",
-        argv=list(op.argv),
+        argv=reported_argv,
         argv0_resolved=argv0_resolved,
         backend=backend.name,
         timeout_seconds=policy.timeout_seconds,
@@ -325,7 +398,7 @@ async def run_sandboxed_exec(
         # #1470: emit distinct event on cancel (P6) — not sandboxed_exec_completed.
         ctx.events.emit(
             "sandboxed_exec_cancelled",
-            argv=list(op.argv),
+            argv=reported_argv,
             backend=backend.name,
             returncode=result.returncode,
             stdout_len=len(stdout_text),
@@ -352,7 +425,7 @@ async def run_sandboxed_exec(
 
     ctx.events.emit(
         "sandboxed_exec_completed",
-        argv=list(op.argv),
+        argv=reported_argv,
         argv0_resolved=argv0_resolved,
         backend=backend.name,
         returncode=result.returncode,

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -39,6 +39,22 @@ pipeline `tool:` step (段6, a separate later stage); `sandboxed_exec_
 started`/`_completed`'s own `plan` field recording each segment's
 resolved argv[0] (段5) does not exist yet either — only `argv0_resolved`
 (always `/bin/sh` for a cmd-mode run) is recorded today.
+
+#6007 BLOCKING (architect co-vet, issuecomment-5580912677): `op.cmd` is
+read into a local (`cmd_text`) exactly once, near the top of `run_
+sandboxed_exec`, and reused for BOTH the parse+policy call and the
+argv actually built for the backend — never re-read from `op.cmd` a
+second time after the `await check_exec_plan_policy(...)` boundary.
+`SandboxedExecIROp` is not frozen and has no `validate_assignment`, so
+nothing in the type system otherwise stops the two reads from
+observing different values (no live mutation path is shown; this closes
+the class structurally rather than respond to a demonstrated exploit) —
+the arc's own core property, "the bytes policy saw are the bytes the
+shell receives," must not rest on an unstated "nobody mutates the op
+mid-call" assumption. Freezing `SandboxedExecIROp` itself (or every
+IROp) was explicitly NOT requested for this PR (`models.py` has zero
+frozen IROp dataclasses today — a file-wide convention change, tracked
+separately).
 """
 from __future__ import annotations
 
@@ -105,12 +121,24 @@ async def run_sandboxed_exec(
     cwd = str(ctx.workspace.base_dir)
     env_path = os.environ.get("PATH")
 
-    if op.cmd is not None:
+    # #6007 BLOCKING (architect co-vet, issuecomment-5580912677): `op.cmd`
+    # is read into `cmd_text` here, ONCE, and reused below for both the
+    # parse+policy call AND the argv actually built for the backend --
+    # `SandboxedExecIROp` is not frozen and has no `validate_assignment`,
+    # so nothing in the type system stops `op.cmd` from differing between
+    # two SEPARATE reads across an `await` boundary (no live mutation
+    # path is shown; the fix is a local-variable-only structural close,
+    # not a response to an observed exploit). The arc's own core property
+    # — "the bytes policy saw are the bytes the shell receives" — must not
+    # rest on an unstated "nobody mutates the op mid-call" assumption.
+    cmd_text = op.cmd
+
+    if cmd_text is not None:
         from reyn.security.exec_plan import ExecPlanRejected, parse_exec_plan
         from reyn.security.exec_plan_policy import check_exec_plan_policy
 
         try:
-            _plan = parse_exec_plan(op.cmd)
+            _plan = parse_exec_plan(cmd_text)
         except ExecPlanRejected as _exc:
             return {
                 "kind": "sandboxed_exec",
@@ -263,15 +291,16 @@ async def run_sandboxed_exec(
     # what actually ran — the tell for a launcher-fork denial that survives.
     #
     # #5838 段4: cmd-mode's argv0 is always `/bin/sh` — the shell that will
-    # run *op.cmd* UNCHANGED (owner ruling (i): execute the ORIGINAL string,
-    # never a reconstruction from the parsed plan; `security/exec_plan.py`'s
-    # own module docstring has the full rationale). `_shell_argv` is what
-    # actually reaches the backend AND what the started/completed events
-    # below report as `argv` for this run — the parsed plan (already used,
-    # above, for policy) is not re-derived into an argv here.
+    # run *cmd_text* UNCHANGED (owner ruling (i): execute the ORIGINAL
+    # string, never a reconstruction from the parsed plan; `security/
+    # exec_plan.py`'s own module docstring has the full rationale).
+    # `_shell_argv` is what actually reaches the backend AND what the
+    # started/completed events below report as `argv` for this run — the
+    # parsed plan (already used, above, for policy) is not re-derived
+    # into an argv here.
     argv0_resolved: "str | None"
-    if op.cmd is not None:
-        _shell_argv = ["/bin/sh", "-c", op.cmd]
+    if cmd_text is not None:
+        _shell_argv = ["/bin/sh", "-c", cmd_text]
         argv0_resolved = resolve_real_executable(_shell_argv[0], env_path=env_path, cwd=cwd)
         effective_argv = [argv0_resolved, *_shell_argv[1:]]
         reported_argv = _shell_argv
@@ -314,7 +343,7 @@ async def run_sandboxed_exec(
     # not the op's request fields — the operator-or-default policy wins over op
     # fields, so the trace must show what was enforced (a network:true op under
     # a network:false policy ran WITHOUT network, and the event must say so).
-    # #5838 段4: `reported_argv` is `["/bin/sh", "-c", op.cmd]` in cmd-mode
+    # #5838 段4: `reported_argv` is `["/bin/sh", "-c", cmd_text]` in cmd-mode
     # (what actually runs), `list(op.argv)` otherwise — never `op.argv`
     # unconditionally, which would show an empty list for every cmd-mode
     # run.

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -350,11 +350,45 @@ class SandboxedExecIROp(BaseModel):
     `require_network` at all, regardless of this field's value — the op
     can REQUEST network, never force it past a narrower operator policy.
     """
+    #5838 段4: `cmd` — a shell command line, XOR `argv` (validated below,
+    # same "exactly one of" shape `PresentIROp`/`RenderTemplateIROp` already
+    # use for their own XOR fields). Parsed via `security.exec_plan.
+    # parse_exec_plan` for POLICY ONLY (segment/redirect checks,
+    # `security.exec_plan_policy.check_exec_plan_policy`) — the string
+    # actually executed is `cmd` UNCHANGED, via `["/bin/sh", "-c", cmd]`,
+    # never a reconstruction from the parsed plan (owner ruling (i): match
+    # how Claude Code/Codex/OpenClaw/Hermes all actually work — see
+    # `security/exec_plan.py`'s own module docstring for the full
+    # rationale). `None` (the default) is byte-identical to before this
+    # field existed — every existing caller passes `argv`, unaffected.
+    # NOT YET exposed on the LLM `exec` tool or the pipeline `tool:` step
+    # schema (段6, a separate later stage) — this field exists at the op
+    # level only, reachable so far by a caller that constructs the op
+    # directly.
     kind: Literal["sandboxed_exec"]
-    argv: list[str]                                      # command + args; argv[0] is the executable
+    # #5838 段4: default changed from required to `[]` (via Field(default_
+    # factory=list), never a bare mutable `[]` literal) so a `cmd`-mode
+    # caller need not also invent an empty argv -- every EXISTING caller
+    # already passes a concrete argv explicitly (verified: every
+    # production/test construction site names `argv=`), so this default
+    # is unreachable for them and changes nothing they observe.
+    argv: list[str] = Field(default_factory=list)         # command + args; argv[0] is the executable
+    cmd: str | None = None                                # #5838 段4: shell command line, XOR argv -- see above
     stdin: bytes | None = None                           # #2593: bytes written to the process's stdin, if any
     timeout_seconds: float | None = None                 # #3903①: optional LLM override, checked against SandboxPolicy.max_timeout_seconds
     network: bool = False                                 # #5825①: REQUEST (not grant) that this call run with network enabled; see class docstring
+
+    @model_validator(mode="after")
+    def _exactly_one_of_argv_or_cmd(self) -> "SandboxedExecIROp":
+        # bool(self.argv): an empty list means "not given" here, the same
+        # as every other XOR-field validator in this file treats an empty/
+        # None value as "absent" -- `argv=[]` alone (the new default) is
+        # not a meaningful request on its own, only `cmd` makes it one.
+        if bool(self.argv) == (self.cmd is not None):
+            raise ValueError(
+                "sandboxed_exec requires exactly one of argv / cmd"
+            )
+        return self
 
 
 

--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -110,6 +110,17 @@ that will actually matter once 段4 lands.
    omitting either is a ``TypeError`` at the call site, not a runtime
    surprise later (lead-coder co-vet, issuecomment-5579159401: "cwd も
    同じ").
+
+## #6007 BLOCKING (architect co-vet, issuecomment-5580912677, found while
+reviewing 段4) — a redirect's own ``path`` was never threat-scanned.
+Argv-mode's whole-op scan (``sandboxed_exec.py``) sees every token
+including a redirect target (``" ".join(op.argv)``); this module's own
+per-segment scan never touched :attr:`ExecRedirect.path` at all — a
+surface UNIQUE to going through this module (cmd-mode) that was left
+unscanned only there. :func:`_check_redirect` now runs the SAME scan
+(:func:`_run_threat_scan`, factored out of :func:`_check_segment`) over
+the redirect's own path, before the resolver-presence check (scanning
+needs no resolver).
 """
 from __future__ import annotations
 
@@ -189,38 +200,47 @@ async def _check_segment(
             contextual_deny_message("command", effective, contextual)
         )
 
+    await _run_threat_scan(ctx, " ".join(segment.argv), subject=list(segment.argv))
+
+
+async def _run_threat_scan(ctx: "OpContext", text: str, *, subject: "list[str]") -> None:
+    """The threat-scan half of a segment's own check, factored out so
+    :func:`_check_redirect` can apply the IDENTICAL scan to a redirect's
+    own ``path`` (#6007 BLOCKING, architect co-vet, issuecomment-
+    5580912677: argv-mode's whole-op scan sees every token including a
+    redirect target — ``" ".join(op.argv)`` in ``sandboxed_exec.py`` —
+    but cmd-mode's per-segment scan never touched ``ExecRedirect.path``
+    at all, a surface UNIQUE to cmd-mode that was left unscanned only in
+    cmd-mode). *subject* is what the emitted event's own ``argv`` field
+    names — a segment's own argv, or a redirect's path wrapped in a
+    single-element list — never re-derived from *text* (a redirect path
+    with an embedded space must not be miscounted as multiple tokens).
+
+    Raises :class:`PermissionError` on a block-severity match; always
+    emits exactly ONE of ``exec_threat_scanned``/``exec_threat_scan_
+    skipped`` (#5991 BLOCKING ②'s own "two zeros" fix, unchanged here)."""
     threat_scan = getattr(ctx, "threat_scan", None)
     scan_will_run = threat_scan is not None and getattr(threat_scan, "enabled", True)
     if not scan_will_run:
-        # #5991 BLOCKING ②: a plan that was never scanned must leave a
-        # DIFFERENT trace than one that was scanned and found clean —
-        # ``ctx.threat_scan`` being unset/disabled is a real, legitimate
-        # state (a caller that hasn't wired one, or an operator who turned
-        # scanning off), but ``.reyn/events`` must be able to tell the two
-        # apart rather than showing the SAME empty trace for both.
         ctx.events.emit(
             "exec_threat_scan_skipped",
-            argv=list(segment.argv),
+            argv=subject,
             reason="disabled" if threat_scan is not None else "not_configured",
         )
         return
 
     from reyn.security.content_guard import first_blocking_match, scan_for_threats
 
-    matches = scan_for_threats(" ".join(segment.argv), threat_scan, scope="exec")
+    matches = scan_for_threats(text, threat_scan, scope="exec")
     for match in matches:
         ctx.events.emit(
             "exec_threat_match",
             pattern_id=match.pattern_id, severity=match.severity, scope=match.scope,
         )
     block = first_blocking_match(matches, getattr(threat_scan, "block_severity", "block"))
-    # #5991 BLOCKING ②: emitted whether or not a threat was found -- the
-    # positive "scan ran, N matches (possibly 0), blocked=<bool>" record
-    # that lets a later read of ``.reyn/events`` distinguish "clean" from
-    # "never scanned" (the skip branch above covers the latter).
     ctx.events.emit(
         "exec_threat_scanned",
-        argv=list(segment.argv), match_count=len(matches), blocked=block is not None,
+        argv=subject, match_count=len(matches), blocked=block is not None,
     )
     if block is not None:
         ctx.events.emit(
@@ -245,7 +265,19 @@ async def _check_redirect(redirect: "ExecRedirect", ctx: "OpContext") -> None:
     that will ever construct a real exec ``OpContext`` and call this
     function, is not built) — there is no existing behaviour to stay
     compatible with, so fail-open buys nothing and only weakens a
-    security gate for free. A missing resolver now DENIES."""
+    security gate for free. A missing resolver now DENIES.
+
+    #6007 BLOCKING (architect co-vet, issuecomment-5580912677): the
+    threat scan runs FIRST, unconditionally — the SAME scan
+    :func:`_check_segment` applies to a segment's own argv, applied here
+    to *redirect*'s own ``path`` (a surface argv-mode's whole-op scan
+    covers but this module's earlier version never touched at all). Runs
+    before the resolver-presence check on purpose: scanning does not
+    need a ``permission_resolver`` to be wired, so a redirect with no
+    resolver still gets scanned before it gets denied for the separate
+    (missing-resolver) reason."""
+    await _run_threat_scan(ctx, redirect.path, subject=[redirect.path])
+
     if ctx.permission_resolver is None:
         raise PermissionError(
             f"redirect {redirect.op!r} {redirect.path!r} cannot be checked "

--- a/tests/core/test_5838_stage4_shc_exec.py
+++ b/tests/core/test_5838_stage4_shc_exec.py
@@ -1,0 +1,231 @@
+"""Tier 2: #5838 段4 -- `sandboxed_exec`'s `cmd` (shell command line) form.
+
+Real ``OpContext`` + real ``EventLog``/``Workspace`` + the real default
+backend (or a real, non-mock recording stub for the deny-side tests, where
+the whole point is proving the process never spawns) throughout -- no mocks
+(CLAUDE.md testing policy). ``cmd``-mode reuses two things already covered
+by their OWN test files, exercised here only through the shared seam:
+``parse_exec_plan`` (``tests/security/test_5838_exec_plan_parser.py``) and
+``check_exec_plan_policy`` (``tests/security/test_5838_stage3_exec_plan_
+policy.py``) -- so this file is about the WIRING (policy runs before
+spawn, the ORIGINAL string is what actually executes), not re-proving
+either of those two modules' own accept/reject matrices.
+
+⚠️ **Disclosed gap**: `env_path`/`cwd` being computed ONCE and reused for
+BOTH `check_exec_plan_policy` and the real argv0 resolution (#5991
+BLOCKING ③'s point, carried into this stage -- see `sandboxed_exec.py`'s
+own module docstring) is a CODE-LEVEL fact (one local computation, two
+call sites reading it), verified by reading the diff at review time --
+NOT independently witnessed by a black-box test here. A basename-keyed
+tool-axis deny (this file's own deny-side tests) resolves identically
+regardless of which `cwd`/PATH is fed it for a bare or absolute name, so
+no behavioural difference exists to assert on; a genuine divergence
+witness would need a version-manager shim fixture (the #2820 part A
+scenario `resolve_real_executable` exists for), out of this file's scope.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import SandboxedExecIROp
+from reyn.security.permissions.effective import ContextualPermission
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.security.sandbox.backend import SandboxResult
+from tests._support.events import collect_events, settle
+from tests._support.sandbox_backend import FULLY_ENFORCING_AXES
+
+
+class _RecordingBackend:
+    """Real (non-mock) SandboxBackend stub -- records whether/how `run` was
+    called, so a deny-before-spawn claim is a WITNESSED fact (`ran is
+    False`), not an inference from the absence of stdout."""
+
+    name = "recording-stub"
+    enforced_axes = FULLY_ENFORCING_AXES
+
+    def __init__(self) -> None:
+        self.ran = False
+        self.received_argv: "list[str] | None" = None
+
+    def available(self) -> bool:
+        return True
+
+    async def run(self, argv, policy, *, stdin=None, cwd=None, cancel_event=None,
+                   hook_process_context=None, sink=None) -> SandboxResult:
+        self.ran = True
+        self.received_argv = list(argv)
+        return SandboxResult(returncode=0, stdout=b"ran", stderr=b"")
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    backend=None,
+    contextual: "ContextualPermission | None" = None,
+    permission_resolver: "PermissionResolver | None" = None,
+) -> "tuple[OpContext, list]":
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    collected = collect_events(events)
+    ws = Workspace(events=events, base_dir=project_root)
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=permission_resolver,
+        default_sandbox_policy={},
+        contextual_permission=contextual,
+        sandbox_backend=backend,
+    )
+    return ctx, collected
+
+
+# ─── schema: exactly one of argv / cmd ────────────────────────────────────
+
+
+def test_op_rejects_both_argv_and_cmd():
+    """Tier 2: constructing the op with BOTH set is a construction-time
+    error (the model's own validator), never reaches the handler."""
+    with pytest.raises(ValueError, match="exactly one"):
+        SandboxedExecIROp(kind="sandboxed_exec", argv=["ls"], cmd="ls")
+
+
+def test_op_rejects_neither_argv_nor_cmd():
+    """Tier 2: FP-sibling -- omitting BOTH is the same construction-time
+    error, not a silent "runs nothing"."""
+    with pytest.raises(ValueError, match="exactly one"):
+        SandboxedExecIROp(kind="sandboxed_exec")
+
+
+def test_op_accepts_cmd_alone():
+    """Tier 2: FP gate -- `cmd` alone (argv omitted, defaults to `[]`)
+    constructs cleanly."""
+    op = SandboxedExecIROp(kind="sandboxed_exec", cmd="ls -la")
+    assert op.cmd == "ls -la"
+    assert op.argv == []
+
+
+# ─── accept side: the ORIGINAL string runs, via /bin/sh -c ────────────────
+
+
+@pytest.mark.asyncio
+async def test_cmd_runs_through_bin_sh_dash_c_with_the_original_string(tmp_path: Path) -> None:
+    """Tier 2: end-to-end, the REAL default backend -- a `cmd` with an
+    internal double space inside quotes (`echo "a  b"`) only survives if
+    the shell that runs is handed the ORIGINAL string, not a re-joined
+    argv (joining a reconstructed argv with single spaces would collapse
+    it to one space) -- the owner ruling (i) witness: execute the string
+    exactly, never a reconstruction from the parsed plan."""
+    ctx, collected = _make_ctx(tmp_path)
+    op = SandboxedExecIROp(kind="sandboxed_exec", cmd='echo "a  b"')
+
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "ok"
+    assert result["stdout"].strip() == "a  b"
+    assert result["argv0_resolved"] is not None
+    assert result["argv0_resolved"].endswith("/sh")
+
+    await settle(ctx.events)
+    (started,) = [e for e in collected if e.type == "sandboxed_exec_started"]
+    assert started.data["argv"] == ["/bin/sh", "-c", 'echo "a  b"']
+
+
+# ─── deny side: policy runs BEFORE the backend ever spawns ────────────────
+
+
+@pytest.mark.asyncio
+async def test_tool_axis_deny_stops_the_run_before_the_backend_spawns(tmp_path: Path) -> None:
+    """Tier 2: a `cmd` resolving to a contextually-denied binary denies
+    (``execute_op``'s own ``except PermissionError`` -> ``status="denied"``,
+    the SAME channel every other permission gate in this codebase uses)
+    and the backend's own `run` is never called -- the accept-side sibling
+    of the string-fidelity test above; together they
+    are the "受入は両方向" lead-coder asked for (approved runs as
+    approved / a denied binary is never spawned, not merely reported as
+    denied after the fact)."""
+    backend = _RecordingBackend()
+    ctx, _collected = _make_ctx(
+        tmp_path, backend=backend,
+        contextual=ContextualPermission(tool_deny=frozenset({"true"})),
+    )
+    op = SandboxedExecIROp(kind="sandboxed_exec", cmd="true")
+
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "denied"
+    assert backend.ran is False
+
+
+@pytest.mark.asyncio
+async def test_threat_scan_deny_stops_the_run_before_the_backend_spawns(tmp_path: Path) -> None:
+    """Tier 2: a `cmd` matching a real block-severity threat pattern
+    (reverse_shell_devtcp — a plain substring match, `/dev/tcp/`, so this
+    stays inside 段2's supported grammar; the fd-duplication shape a real
+    reverse shell usually pairs it with, e.g. `>&`, is a DIFFERENT
+    rejection -- 段2's own "unsupported shell construct", not this one)
+    also denies before spawn -- the segment-level threat scan (段3) is
+    reached from the real op path, not only from ``check_exec_plan_
+    policy``'s own unit tests."""
+    from reyn.config.chat import ThreatScanConfig
+
+    backend = _RecordingBackend()
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=project_root)
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=None, default_sandbox_policy={},
+        threat_scan=ThreatScanConfig(), sandbox_backend=backend,
+    )
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec", cmd="echo /dev/tcp/10.0.0.1/4444",
+    )
+
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "denied"
+    assert backend.ran is False
+
+
+@pytest.mark.asyncio
+async def test_a_redirect_with_no_permission_resolver_denies_fail_closed(tmp_path: Path) -> None:
+    """Tier 2: end-to-end witness of #5991 BLOCKING ①'s fail-closed fix --
+    a `cmd` containing a redirect, with no `permission_resolver` wired on
+    ``ctx`` (this file's own `_make_ctx` default), denies rather than
+    silently running with the redirect target unchecked."""
+    backend = _RecordingBackend()
+    ctx, _collected = _make_ctx(tmp_path, backend=backend, permission_resolver=None)
+    op = SandboxedExecIROp(kind="sandboxed_exec", cmd="echo hi > out.txt")
+
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "denied"
+    assert backend.ran is False
+
+
+@pytest.mark.asyncio
+async def test_an_unparseable_cmd_returns_a_structured_error_not_a_crash(tmp_path: Path) -> None:
+    """Tier 2: a `cmd` `parse_exec_plan` (段2) rejects -- e.g. a literal
+    ``$`` (variable expansion, always forbidden) -- returns the op's own
+    ``status="error"`` envelope with a legible reason, the same shape the
+    handler already uses for its other pre-flight validation errors
+    (timeout_seconds), never an uncaught exception from ``parse_exec_
+    plan`` bubbling out raw."""
+    backend = _RecordingBackend()
+    ctx, _collected = _make_ctx(tmp_path, backend=backend)
+    op = SandboxedExecIROp(kind="sandboxed_exec", cmd="echo $HOME")
+
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "error"
+    assert "could not be parsed" in result["error"]
+    assert backend.ran is False

--- a/tests/core/test_5838_stage4_shc_exec.py
+++ b/tests/core/test_5838_stage4_shc_exec.py
@@ -22,9 +22,27 @@ regardless of which `cwd`/PATH is fed it for a bare or absolute name, so
 no behavioural difference exists to assert on; a genuine divergence
 witness would need a version-manager shim fixture (the #2820 part A
 scenario `resolve_real_executable` exists for), out of this file's scope.
+
+#6007 BLOCKING ③ (lead-coder co-vet, issuecomment-5594151412) is a
+DIFFERENT angle on `env_path`, covered below (`test_the_real_childs_
+path_matches_sandboxed_execs_own_env_path`): not "does changing PATH
+change the tool-axis verdict" (the disclosed gap above), but "does the
+value `env_path` actually holds match what a REAL spawned child's own
+PATH turns out to be" -- today it does (`policy.py`'s own
+`resolve_passthrough_env` drops PATH by default, and every backend's own
+fallback restores it from `os.environ` regardless), but nothing ties the
+two together structurally, so a future change on either side could
+silently diverge. No code change requested for this finding -- an
+OBSERVATION only, with the explicit condition that the assertion must
+NOT put `os.environ` on both sides of the same expression (that would
+transcribe the implementation and could never go red): the LEFT side
+below is a REAL subprocess's own reported `$PATH`, spawned through the
+actual default backend (which resolves env via `resolve_passthrough_env`
+internally) -- not a second call to the same accessor.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -229,3 +247,32 @@ async def test_an_unparseable_cmd_returns_a_structured_error_not_a_crash(tmp_pat
     assert result["status"] == "error"
     assert "could not be parsed" in result["error"]
     assert backend.ran is False
+
+
+# ─── #6007 BLOCKING ③ (lead-coder): env_path vs. the real child's PATH ────
+
+
+@pytest.mark.asyncio
+async def test_the_real_childs_path_matches_sandboxed_execs_own_env_path(tmp_path: Path) -> None:
+    """Tier 2: lead-coder co-vet (issuecomment-5594151412) -- an
+    OBSERVATION, not a code change (see this file's own module docstring
+    for the full framing). Runs a real command through the REAL default
+    backend (argv-mode -- `$PATH` is shell expansion, always rejected by
+    `parse_exec_plan`, so this witness deliberately does not go through
+    cmd-mode) that echoes its own `$PATH`, and asserts it equals
+    `os.environ.get("PATH")` -- the SAME value `run_sandboxed_exec`'s own
+    `env_path` local holds, used to resolve argv0 for both request
+    shapes. The LEFT side is a genuinely independent measurement (a real
+    subprocess's own env, reached through `resolve_passthrough_env` +
+    each backend's own PATH fallback), not a second call to the same
+    accessor the RIGHT side also calls -- so a future divergence between
+    the two (e.g. a backend that stops falling back to `os.environ`, or a
+    default `policy.env_deny_names` that starts denying PATH) goes RED
+    here rather than passing silently."""
+    ctx, _collected = _make_ctx(tmp_path)
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/sh", "-c", "echo $PATH"])
+
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "ok"
+    assert result["stdout"].strip() == os.environ.get("PATH")

--- a/tests/core/test_op_sandboxed_exec.py
+++ b/tests/core/test_op_sandboxed_exec.py
@@ -140,9 +140,19 @@ def test_op_no_longer_accepts_the_deleted_policy_fields():
     (`PermissionResolver.require_network`, called from `op_runtime/
     sandboxed_exec.py`'s own seam ONLY when the resolved policy already
     has network off). Moves from the `removed_field` loop below into the
-    EXPECTED set; the other 4 stay removed."""
+    EXPECTED set; the other 4 stay removed.
+
+    #5838 段4 (2026-09-09): `cmd` joins the EXPECTED set — a shell command
+    line, XOR `argv` (`SandboxedExecIROp._exactly_one_of_argv_or_cmd`'s own
+    validator), with a real reader from day one (`op_runtime/sandboxed_
+    exec.py`'s own `if op.cmd is not None:` branch: parsed for policy via
+    `security.exec_plan.parse_exec_plan` + `security.exec_plan_policy.
+    check_exec_plan_policy`, then executed UNCHANGED via `["/bin/sh", "-c",
+    cmd]`) — not the advertised-but-ignored shape this test's own removed-
+    field set exists to keep out. Not yet exposed on the LLM tool schema
+    (段6, separate later stage)."""
     fields = set(SandboxedExecIROp.model_fields)
-    assert fields == {"kind", "argv", "stdin", "timeout_seconds", "network"}
+    assert fields == {"kind", "argv", "cmd", "stdin", "timeout_seconds", "network"}
     for removed_field in (
         "read_paths", "write_paths", "allow_subprocess",
         "env_passthrough",

--- a/tests/security/test_5838_stage3_exec_plan_policy.py
+++ b/tests/security/test_5838_stage3_exec_plan_policy.py
@@ -310,6 +310,46 @@ async def test_write_redirect_inside_default_scope_is_allowed(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_a_redirect_path_matching_a_threat_pattern_is_denied(tmp_path: Path) -> None:
+    """Tier 2: #6007 BLOCKING (architect co-vet, issuecomment-5580912677)
+    -- a redirect's own PATH is threat-scanned too, not just a segment's
+    argv. Argv-mode's whole-op scan (``sandboxed_exec.py``) sees every
+    token including a redirect target; this module's earlier version
+    never touched ``ExecRedirect.path`` at all -- a surface unique to
+    reaching a redirect through THIS module (cmd-mode) that was left
+    unscanned only here. The reverse-shell pattern (a plain ``/dev/tcp/``
+    substring match) fits directly inside a redirect target path."""
+    ctx, collected = _ctx(tmp_path, threat_scan=ThreatScanConfig())
+    plan = [ExecRedirect(op=">", path="/dev/tcp/10.0.0.1/4444")]
+
+    with pytest.raises(PermissionError, match="reverse_shell_devtcp"):
+        await _check(plan, ctx)
+
+    await settle(ctx.events)
+    (scanned,) = [e for e in collected if e.type == "exec_threat_scanned"]
+    assert scanned.data["blocked"] is True
+    assert scanned.data["argv"] == ["/dev/tcp/10.0.0.1/4444"]
+
+
+@pytest.mark.asyncio
+async def test_the_redirect_threat_scan_runs_even_with_no_permission_resolver(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the redirect threat-scan does not depend on a
+    ``permission_resolver`` being wired -- it denies (with the THREAT
+    reason, not the fail-closed "no permission_resolver" reason from
+    #5991 BLOCKING ①) even when ``permission_resolver=None``, proving the
+    scan runs BEFORE the resolver-presence check, not after."""
+    ctx, _collected = _ctx(
+        tmp_path, permission_resolver=None, threat_scan=ThreatScanConfig(),
+    )
+    plan = [ExecRedirect(op=">", path="/dev/tcp/10.0.0.1/4444")]
+
+    with pytest.raises(PermissionError, match="reverse_shell_devtcp"):
+        await _check(plan, ctx)
+
+
+@pytest.mark.asyncio
 async def test_read_redirect_outside_scope_is_denied(tmp_path: Path) -> None:
     """Tier 2: an ``ExecRedirect("<")`` target outside the configured read
     scope goes through ``require_file_read``, the sibling gate to the


### PR DESCRIPTION
**[e2e-coder]** — part of #5838. 段4 (architect's implementation plan, issuecomment-5557210786, point 4): execute `sandboxed_exec`'s new `cmd` form — parse for policy (段2/段3), execute the ORIGINAL string via `sh -c`.

## What

`SandboxedExecIROp` gains `cmd: str | None`, XOR `argv` (`model_validator(mode="after")` — exactly one of the two, enforced at construction time).

`run_sandboxed_exec` branches on `op.cmd`:
- `parse_exec_plan(op.cmd)` (段2) — an `ExecPlanRejected` returns a structured `status="error"`, never an uncaught exception.
- `check_exec_plan_policy(plan, ctx, env_path=..., cwd=...)` (段3) — BEFORE anything spawns, raising `PermissionError` on any segment/redirect denial (caught uniformly by `execute_op`'s own `PermissionError` handler → `status="denied"`, the same channel every other permission gate in this codebase uses). Replaces the whole-op threat scan for this op — the segment scan already covers exec-scope threat matching, more precisely (one scan per segment).
- The string that actually **executes** is `op.cmd` UNCHANGED, via `["/bin/sh", "-c", op.cmd]` — never a reconstruction from the parsed plan (owner ruling (i)). `argv0` (`/bin/sh`) still goes through the existing #2820 shim-resolution.

`cwd`/`env_path` are computed **once**, before the branch, and reused by BOTH `check_exec_plan_policy` and the real argv0 resolution — #5991 BLOCKING ③'s point carried into this stage: the binary policy approves and the binary that runs must come from the identical PATH/cwd. Every audit event's `argv` field now reports what actually ran (`["/bin/sh", "-c", cmd]` in cmd-mode), never an empty `op.argv`.

## Round-1 fix (head `41e43c9e8`) — 3 findings, all fixed

architect co-vet (issuecomment-5580912677, 2 findings) + lead-coder co-vet (issuecomment-5594151412, adopting both + 1 own).

1. **`op.cmd` was read TWICE** (`parse_exec_plan`, then again for the shell argv), across an `await` boundary, with no `frozen`/`validate_assignment` on `SandboxedExecIROp` to stop the two reads from observing different values. No live mutation path was shown — closed structurally anyway (cost asymmetry: the fix is one local variable). `run_sandboxed_exec` now reads `op.cmd` into `cmd_text` ONCE and reuses it throughout. IROp-wide `frozen` is explicitly out of THIS PR's scope (architect: separate issue, `models.py` has zero frozen IROp dataclasses today).
2. **A redirect's own path was never threat-scanned.** Argv-mode's whole-op scan sees every token including a redirect target; `check_exec_plan_policy`'s per-segment scan never touched `ExecRedirect.path` at all — a surface UNIQUE to cmd-mode, left unscanned only there. Factored the scan-and-record logic out of `_check_segment` into `_run_threat_scan`, reused by `_check_redirect` over `redirect.path`, BEFORE the resolver-presence check (scanning needs no resolver).
3. **(lead-coder)** `env_path` is correct TODAY (`policy.py` drops PATH by default, every backend's own fallback restores it from `os.environ` regardless of the branch taken) but nothing TIES the two together — a future backend/policy change could silently diverge. No code change requested: one observation test, explicitly required to avoid `os.environ` on both sides of the same expression (a real subprocess's own `$PATH`, spawned through the actual default backend, compared against `os.environ.get("PATH")` — not a second call to the same accessor).

## Not yet done (separate, later stages — matches lead-coder's own ordering)

- `cmd` is **not** exposed on the LLM `exec` tool schema or the pipeline `tool:` step (段6).
- `sandboxed_exec_started`/`_completed`'s own `plan` field (each segment's resolved argv[0]) does not exist yet (段5).
- "拒否 → operator に尋ねる" is explicitly out of scope — 段3's own docstring already carries a concrete proposal, architect agreed with keeping it a proposal there.

## Test plan

- [x] `tests/core/test_5838_stage4_shc_exec.py` — 8 tests: the op's own XOR validator (both/neither → `ValueError`), the accept-side **string-fidelity witness** (a quoted double-space `cmd` only survives if the ORIGINAL string ran, not a re-joined argv — strip-verified: reconstructing via `shlex.join(shlex.split(cmd))` instead of the raw string makes this test fail), 3 **deny-before-spawn** tests (tool axis, threat scan, redirect fail-closed) each using a real recording backend stub that asserts `run()` was never called, and the structured-error case for an unparseable `cmd`.
- [x] Round-1: `tests/security/test_5838_stage3_exec_plan_policy.py` +2 (redirect-path threat-block, threat-scan-runs-before-resolver-check); `tests/core/test_5838_stage4_shc_exec.py` +1 (the PATH observation, #3 above). 60 tests across this PR's own files, all green.
- [x] `tests/core/test_op_sandboxed_exec.py`'s own field-set positive control updated (`cmd` joins the expected set, same "real reader from day one" justification `network`/`timeout_seconds` already carry there).
- [x] `docs/reference/runtime/control-ir.md` + `.ja.md` — `argv`'s own field entry corrected (required → defaults to `[]`, XOR `cmd`) and a `cmd` field entry added, same PR (CLAUDE.md doc-drift hard rule); the `.ja.md` edit is narrowly scoped to what this PR falsifies (its existing "argv（必須）" claim), not a blanket mirror pass.
- [x] Strip witness, every new check — verified directly (in-file Edit → red → Edit back): the `check_exec_plan_policy` call itself, the original-string-vs-reconstructed argv, and the schema's XOR validator.
- [x] 172 related tests re-run clean after the change (network seam, denial class, threat scan, argv0 resolve, async exec, 段2/段3's own suites).
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict` (both changed test files) — all OK
- [x] `python scripts/mypy_ratchet.py` — OK (0 new findings)
- [x] `python scripts/verify_module_docstrings.py` (all changed src/test files) — OK
- [x] `python scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` — all OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `check_doc_anchors.py` + `check_retired_config_keys_denylist.py` — all clean (docs/ path-conditional gates)
- [x] (skipped — Visual, standing waiver)

part of #5838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

