### PR TITLE
fix(#5977 stage 3): reyn.log names the stall dump's actual path

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -2681,6 +2681,11 @@ class TextualChatApp(App):
                             keys_received=self._keys_received,
                             keys_delta=keys_delta,
                             turn_active=turn_active,
+                            # #5977 ③: name the dump this arm actually
+                            # writes to — None when no FileHandler was
+                            # installed for this worker (see
+                            # StallDumpArm.open's own docstring).
+                            stack_dump_at=_stack_dump.path if _stack_dump is not None else None,
                         ),
                     )
                     try:

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -196,18 +196,27 @@ async def _lifespan(app: FastAPI):
 
     _tripwire = LoopTripwire()
     app.state.loop_tripwire = _tripwire
+    # #5977 ③: bound to a name (rather than passed inline) so the on_stall
+    # lambda below can read its own .path — the same arm the dead-man's
+    # switch itself uses, never a second, independently-derived path.
+    _stack_dump = StallDumpArm.open(
+        # #5977 ②: its own single, always-overwritten file beside
+        # reyn.log — never reyn.log itself (see stall_dump_path's
+        # own docstring for why).
+        seconds=_TRIPWIRE_MS / 1000, path=stall_dump_path(find_file_handler_path()),
+        logger=logger, label="reyn:web",
+    )
     app.state.loop_tripwire_task = asyncio.create_task(
         watch_event_loop(
             _tripwire,
-            on_stall=lambda ms: logger.warning("reyn:web: %s", stall_log_line(ms)),
-            on_recovered=lambda: logger.warning("reyn:web: %s", stall_recovered_log_line()),
-            stack_dump=StallDumpArm.open(
-                # #5977 ②: its own single, always-overwritten file beside
-                # reyn.log — never reyn.log itself (see stall_dump_path's
-                # own docstring for why).
-                seconds=_TRIPWIRE_MS / 1000, path=stall_dump_path(find_file_handler_path()),
-                logger=logger, label="reyn:web",
+            on_stall=lambda ms: logger.warning(
+                "reyn:web: %s",
+                stall_log_line(
+                    ms, stack_dump_at=_stack_dump.path if _stack_dump is not None else None,
+                ),
             ),
+            on_recovered=lambda: logger.warning("reyn:web: %s", stall_recovered_log_line()),
+            stack_dump=_stack_dump,
         ),
         name="loop-tripwire",
     )

--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -489,6 +489,7 @@ def stall_log_line(
     keys_received: "int | None" = None,
     keys_delta: "int | None" = None,
     turn_active: "bool | None" = None,
+    stack_dump_at: "str | None" = None,
 ) -> str:
     """The durable record of a stall — the one that survives the operator
     looking away.
@@ -538,6 +539,19 @@ def stall_log_line(
     _watch_loop_responsiveness`) reads its own ``ActivityRow.state`` (already
     the app's existing "is a turn running" surface — see ``turn_active=`` at
     the compact-caps call site) at the same instant it reads ``pump_ticks``.
+
+    ``stack_dump_at`` (#5977 ③): the caller's own :attr:`StallDumpArm.path`
+    (never re-derived here — a second, independent call to
+    :func:`stall_dump_path` could disagree with the arm actually in use if
+    either ever changes shape). ``None`` means no stack-dump destination
+    is configured for THIS process (:func:`StallDumpArm.open` returned
+    ``None`` — no ``FileHandler`` installed), not "a dump wasn't written
+    for this particular notice" — #5977 ①'s suppression means a REPEAT
+    notice within the same still-ongoing episode has no NEW dump, but the
+    file from the episode's onset is still the current content (never
+    truncated until the NEXT distinct episode, #5992's own rule), so this
+    line still names it correctly on every notice within the episode, not
+    only the first.
     """
     ticks_note = ""
     if pump_ticks is not None:
@@ -560,10 +574,33 @@ def stall_log_line(
     turn_note = ""
     if turn_active is not None:
         turn_note = f" (turn {'active' if turn_active else 'idle'} at the time)"
+    # #5977 ③: name the ACTUAL stack-dump path when one is configured for
+    # this process (`stall_dump_path()`'s own value, passed by the caller —
+    # never re-derived here) rather than leaving an operator who reads only
+    # `reyn.log` unable to learn the dump exists at all, let alone where.
+    # The two branches below are deliberately NOT the same sentence with a
+    # value swapped in: `stack_dump_at` given means a stack dump genuinely
+    # exists already (unconditional, no env var needed) and REYN_PROF_DUMP
+    # is a SEPARATE, finer, opt-in trace on top of it; `stack_dump_at` absent
+    # means no stack-dump destination was ever configured for this process
+    # (no FileHandler installed — see `stall_dump_path`), so REYN_PROF_DUMP
+    # is the only recording this notice can point to at all. Collapsing
+    # these into one templated string is exactly the doc-drift #5977 ③
+    # itself found: "re-run with REYN_PROF_DUMP" read as the only option
+    # even once a stack dump was already being written on every stall.
+    if stack_dump_at:
+        dump_clause = (
+            f" — stack dump recorded to {stack_dump_at}; {_DUMP_ENV}=<path> is a "
+            "SEPARATE, opt-in trace for finer per-chunk wait/work timing detail"
+        )
+    else:
+        dump_clause = (
+            f" — set {_DUMP_ENV}=<path> to record per-chunk wait/work timing "
+            "detail (no stack-dump destination is configured for this process)"
+        )
     return (
         f"the interface was unresponsive for {lateness_ms / 1000:.1f}s"
-        f"{ticks_note}{keys_note}{turn_note} — re-run with {_DUMP_ENV}=<path> "
-        "to record what it was doing"
+        f"{ticks_note}{keys_note}{turn_note}{dump_clause}"
     )
 
 
@@ -704,6 +741,16 @@ class StallDumpArm:
         stand-in marker into at the exact point production code would
         have a real dump land (#5992)."""
         return self._snapshot.fd
+
+    @property
+    def path(self) -> str:
+        """This arm's dump destination — a thin passthrough to the
+        underlying :class:`~reyn.runtime.diagnostic_snapshot.
+        DiagnosticSnapshot`'s own ``path`` (#5977 ③): the caller-facing
+        surface a stall notice names in its own log line, so an operator
+        reading only ``reyn.log`` can find the dump without knowing this
+        module's internals."""
+        return self._snapshot.path
 
     def points_at_current_file(self) -> bool:
         """Whether this arm's fd points at the file CURRENTLY at its own

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -731,13 +731,44 @@ def test_stall_and_recovered_lines_carry_pump_ticks_when_given() -> None:
     without_ticks = stall_log_line(1800.0)
     assert "42" not in without_ticks
     assert without_ticks == (
-        "the interface was unresponsive for 1.8s — re-run with "
-        "REYN_PROF_DUMP=<path> to record what it was doing"
+        "the interface was unresponsive for 1.8s — set REYN_PROF_DUMP=<path> to "
+        "record per-chunk wait/work timing detail (no stack-dump destination "
+        "is configured for this process)"
     )
 
     recovered_with_ticks = stall_recovered_log_line(pump_ticks=99)
     assert "99" in recovered_with_ticks
     assert stall_recovered_log_line() == "the interface recovered from the stall reported above"
+
+
+def test_stall_log_line_names_the_actual_dump_path_when_given() -> None:
+    """Tier 2: #5977 ③ — the exact defect the issue reports: before this,
+    every notice recommended "re-run with REYN_PROF_DUMP=<path>" even once
+    a stack dump was ALREADY being written on every stall (#5977 ②) — an
+    operator reading only reyn.log could not learn the dump existed, let
+    alone where. When a real dump path is given, the line must name it
+    and must NOT tell the operator to "re-run" (the dump already
+    happened) — REYN_PROF_DUMP is presented as a separate, additional
+    trace, not the only way to see what happened.
+
+    NON-VACUITY (strip-falsified locally, in-file Edit -> run -> Edit
+    back): removing the `if stack_dump_at:` branch in `stall_log_line` (so it
+    always takes the no-destination wording) makes this assertion fail."""
+    with_dump = stall_log_line(1800.0, stack_dump_at="/tmp/reyn-logs/stall_dump.4242.log")
+    assert "/tmp/reyn-logs/stall_dump.4242.log" in with_dump
+    assert "stack dump recorded to" in with_dump
+    assert "re-run" not in with_dump
+
+
+def test_stall_log_line_without_a_dump_path_does_not_claim_one_exists() -> None:
+    """Tier 2: strip-falsify's counterpart — the no-``dump_path`` branch
+    must not claim a stack dump exists (it may genuinely not: no
+    ``FileHandler`` installed for this process, per ``StallDumpArm.open``)
+    while still pointing the operator at ``REYN_PROF_DUMP`` as the one
+    thing this notice CAN offer."""
+    without_dump = stall_log_line(1800.0)
+    assert "stack dump recorded to" not in without_dump
+    assert "REYN_PROF_DUMP" in without_dump
 
 
 def test_stall_line_carries_a_self_contained_pump_delta() -> None:
@@ -1081,8 +1112,9 @@ def test_stall_line_carries_turn_active_when_given() -> None:
     unspecified = stall_log_line(1800.0)
     assert "turn active" not in unspecified and "turn idle" not in unspecified
     assert unspecified == (
-        "the interface was unresponsive for 1.8s — re-run with "
-        "REYN_PROF_DUMP=<path> to record what it was doing"
+        "the interface was unresponsive for 1.8s — set REYN_PROF_DUMP=<path> to "
+        "record per-chunk wait/work timing detail (no stack-dump destination "
+        "is configured for this process)"
     )
 
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #5977 (stage 3, the remaining item lead-coder's accept re-verification found un-landed).

## What

After #5977② (stack dumps unconditionally written to `stall_dump.<pid>.log`, never `reyn.log`), the ONLY always-visible log line about a stall (`stall_log_line`'s "re-run with `REYN_PROF_DUMP=<path>`") kept recommending an opt-in re-run for detail that was already being recorded, every time, for free -- doc drift in a log line. An operator reading only `reyn.log` could not learn the stack dump existed, let alone where.

`stall_log_line` gains `stack_dump_at` (the caller's real dump path, from a new `StallDumpArm.path` thin passthrough property mirroring the existing `.fd` one). Two genuinely different sentences, not one template with a value swapped in:
- a path given: a stack dump already exists (unconditional, no env var needed); `REYN_PROF_DUMP` is a SEPARATE, finer, opt-in trace on top of it.
- no path: no stack-dump destination is configured for this process at all; `REYN_PROF_DUMP` is the only recording this notice can point to.

Both real call sites (`app.py`'s `_watch_loop_responsiveness`, `server.py`'s lifespan) now thread their own `StallDumpArm`'s `.path` through. `server.py`'s inline `StallDumpArm.open(...)` is bound to a name first so its own `on_stall` lambda can read it.

## Verification

Strip-falsified (disabling the `if stack_dump_at:` branch, in-file Edit -> run -> Edit back): the new tests go RED; restored byte-identical. Existing exact-string tests pinning the old default message updated to the new (still-accurate) wording. #5977②'s own "no `Thread 0x` in `reyn.log`" tests are unaffected -- this touches only the log line's text, never where dump content itself is written.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/interfaces/test_loop_probe_3539.py` -- 32/32 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/` path-conditional gates -- all green, `suspected_time_dependence_ratchet.py` OK after merging in `origin/main`'s own #5979 baseline fix
- [x] `pytest tests/interfaces/ -k "loop or stall or tripwire"` (91 passed) + `tests/web/` (4 passed) + the direct stall-mechanism suites (57 passed)
- [x] (skipped -- Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
