### PR TITLE
fix(#5985 remainder): sweep dead-pid stall_dump.<pid>.log files, same shape as the .sb cache

### DIFF
--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -48,10 +48,12 @@ import asyncio
 import json
 import logging
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any, Callable
 
+from reyn.data.index.build_lock import pid_alive
 from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot, diagnostic_snapshot
 
 #: A loop tick later than this is worth telling someone about. Set well above
@@ -132,6 +134,80 @@ def stall_dump_path(reyn_log_path: "str | None") -> "str | None":
     if reyn_log_path is None:
         return None
     return str(Path(reyn_log_path).with_name(f"stall_dump.{os.getpid()}.log"))
+
+
+_STALL_DUMP_NAME_RE = re.compile(r"^stall_dump\.(\d+)\.log$")
+
+#: Has THIS process already swept dead-pid sibling ``stall_dump.<pid>.log``
+#: files? Module-level, at-most-once-per-process guard — same shape as
+#: `security/sandbox/backends/seatbelt.py`'s `_swept_dead_pid_dirs` (#5985),
+#: this mechanism's own precedent for the identical reason: repeating the
+#: scan on every dump-arm open would just re-scan a directory that hasn't
+#: changed since the last scan, in the same process.
+_swept_dead_pid_stall_dumps = False
+
+
+def _sweep_dead_pid_stall_dumps(own_path: str, *, logger: logging.Logger) -> None:
+    """Remove every SIBLING ``stall_dump.<pid>.log`` beside *own_path*
+    whose owning process is no longer alive (#5985, remainder of the
+    ``.sb`` cache fix — lead-coder's own finding: #5997 put a pid in this
+    file's name too, reproducing the identical unbounded-leftover class a
+    crash/SIGKILL leaves behind, with no sweep of its own).
+
+    Deliberately the SAME shape as `_sweep_dead_pid_cache_dirs`
+    (`backends/seatbelt.py`, #5985) — liveness, not age, is the only safe
+    discriminant a startup-time sweep can use here for the identical
+    reason: an age threshold needs a constant nobody can justify ("how old
+    is definitely dead?"), while liveness has none — the machine answers
+    (`os.kill` signal-0), not this module's guess. A REUSED pid reads as
+    "alive" and is left alone, so pid reuse fails toward "an unrelated file
+    lingers a little longer," never toward deleting a live process's own
+    dump. No config knob, for the same reason.
+
+    Runs at most once per process (`_swept_dead_pid_stall_dumps`) — called
+    right before THIS process opens its own dump file, so it never
+    considers its own not-yet-created destination."""
+    global _swept_dead_pid_stall_dumps
+    if _swept_dead_pid_stall_dumps:
+        return
+    _swept_dead_pid_stall_dumps = True
+
+    directory = Path(own_path).parent
+    try:
+        entries = list(directory.iterdir())
+    except (FileNotFoundError, NotADirectoryError):
+        logger.info("stall dump sweep: destination directory does not exist yet")
+        return
+
+    own_pid = os.getpid()
+    removed = 0
+    failed = 0
+    for entry in entries:
+        if not entry.is_file():
+            continue  # a directory or other stray entry is not this sweep's population
+        match = _STALL_DUMP_NAME_RE.match(entry.name)
+        if match is None:
+            continue  # not a stall-dump-shaped name — not this sweep's population
+        pid = int(match.group(1))
+        if pid == own_pid:
+            continue  # never our own, not-yet-fully-created destination
+        if pid_alive(pid):
+            continue  # a live sibling's dump — the whole reason this isn't a blanket sweep
+        try:
+            entry.unlink()
+        except OSError:
+            failed += 1
+        else:
+            removed += 1
+
+    # #5985 co-vet precedent (architect/lead-coder, PR #6005): the
+    # sweep's outcome must be observable on every branch — logged
+    # unconditionally, including the 0/0 case, so "this ran" is visible
+    # from the log line's presence, not only inferable from its absence.
+    logger.info(
+        "stall dump sweep: removed %d dead-pid file(s), %d failed to remove",
+        removed, failed,
+    )
 
 
 def dump_path() -> "str | None":
@@ -681,6 +757,12 @@ class StallDumpArm:
         the dead-man's switch simply never arms for this watcher."""
         if path is None:
             return None
+        # #5985: sweep dead-pid sibling dumps BEFORE opening our own — the
+        # same "sweep before create" ordering `_sweep_dead_pid_cache_dirs`
+        # (backends/seatbelt.py, #5985) uses, for the same reason: our own
+        # destination doesn't exist yet at this point, so there's nothing
+        # of ours for the sweep to even consider.
+        _sweep_dead_pid_stall_dumps(path, logger=logger)
         snapshot = diagnostic_snapshot(path)
         if snapshot is None:
             logger.error("%s: could not open the tripwire's own stall-dump snapshot at %s", label, path)

--- a/tests/runtime/test_5985_stall_dump_sweep.py
+++ b/tests/runtime/test_5985_stall_dump_sweep.py
@@ -1,0 +1,150 @@
+"""Tier 2: dead-pid `stall_dump.<pid>.log` sweep (#5985's remaining scope).
+
+#5981/#5983/#6005 closed the `.sb` sandbox-profile leak the same way: a
+pid-scoped destination plus a liveness-gated sweep of dead siblings,
+never age-based, no config knob. lead-coder found #5997 reproduced the
+identical unbounded-leftover class for `stall_dump.<pid>.log` (a pid was
+put in this filename too, but nothing ever sweeps it) -- this file mirrors
+`tests/security/test_sandbox_seatbelt.py`'s own #5985 tests, same shape,
+different mechanism (`unlink` on a flat file here, vs. `rmtree` on a
+pid-subdirectory there).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from reyn.runtime import loop_tripwire
+from reyn.runtime.loop_tripwire import StallDumpArm, _sweep_dead_pid_stall_dumps
+
+
+@pytest.fixture(autouse=True)
+def _reset_dead_pid_sweep_flag():
+    """`_sweep_dead_pid_stall_dumps` runs at most ONCE per process — without
+    resetting it, whichever test in this file runs first consumes that
+    "once" for every test after it, silently no-opping the sweep in every
+    test that means to exercise it (same rationale as
+    `test_sandbox_seatbelt.py`'s identically-named fixture)."""
+    loop_tripwire._swept_dead_pid_stall_dumps = False
+    yield
+    loop_tripwire._swept_dead_pid_stall_dumps = False
+
+
+def _dead_pid() -> int:
+    """A real, guaranteed-not-alive pid — spawn a trivial subprocess and
+    let it exit, then use its own pid. Cheaper and more honest than
+    guessing a large integer that MIGHT collide with something real on a
+    busy machine."""
+    import subprocess
+    import sys
+
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def test_sweep_removes_a_dead_pids_stall_dump_file(tmp_path):
+    """Tier 2: a sibling `stall_dump.<pid>.log` whose owning process has
+    already exited IS removed — the same "who stops this if it repeats"
+    answer #5985 already gave the `.sb` cache."""
+    dead = tmp_path / f"stall_dump.{_dead_pid()}.log"
+    dead.write_text("stale stack dump", encoding="utf-8")
+    own_path = tmp_path / "stall_dump.999999999.log"  # never actually opened
+
+    _sweep_dead_pid_stall_dumps(str(own_path), logger=logging.getLogger(__name__))
+
+    assert not dead.exists()
+
+
+def test_sweep_does_not_remove_a_live_pids_stall_dump_file(tmp_path):
+    """Tier 2: strip-falsify's counterpart — a sibling `stall_dump.<pid>.log`
+    whose owning process is ALIVE (this test's own real parent process, a
+    genuinely distinct running pid) survives the sweep untouched.
+
+    NON-VACUITY (strip-falsified locally, in-file Edit -> run -> Edit
+    back): replacing the `pid_alive(pid)` check with an unconditional
+    False makes this assertion fail."""
+    import os
+
+    live_pid = os.getppid()
+    live = tmp_path / f"stall_dump.{live_pid}.log"
+    live.write_text("still needed", encoding="utf-8")
+    own_path = tmp_path / "stall_dump.999999999.log"
+
+    _sweep_dead_pid_stall_dumps(str(own_path), logger=logging.getLogger(__name__))
+
+    assert live.exists(), (
+        "a LIVE sibling's stall-dump file was removed — this is exactly the "
+        "failure #5981/#5985's own investigation ruled out a blanket sweep over"
+    )
+
+
+def test_sweep_ignores_non_matching_names(tmp_path):
+    """Tier 2: a stray file that doesn't match `stall_dump.<digits>.log`
+    (reyn.log itself, a different process's unrelated file, a typo) is
+    left alone rather than raising or being swept as if it were one of
+    this mechanism's own files."""
+    stray = tmp_path / "reyn.log"
+    stray.write_text("operational log", encoding="utf-8")
+    almost = tmp_path / "stall_dump.notapid.log"
+    almost.write_text("x", encoding="utf-8")
+    own_path = tmp_path / "stall_dump.999999999.log"
+
+    _sweep_dead_pid_stall_dumps(str(own_path), logger=logging.getLogger(__name__))  # must not raise
+
+    assert stray.exists()
+    assert almost.exists()
+
+
+def test_sweep_runs_at_most_once_per_process(tmp_path):
+    """Tier 2: the module-level guard — a second call in the same process
+    is a no-op even if a fresh dead-pid file appears in between."""
+    own_path = tmp_path / "stall_dump.999999999.log"
+    _sweep_dead_pid_stall_dumps(str(own_path), logger=logging.getLogger(__name__))  # consumes the "once"
+
+    dead = tmp_path / f"stall_dump.{_dead_pid()}.log"
+    dead.write_text("stale", encoding="utf-8")
+
+    _sweep_dead_pid_stall_dumps(str(own_path), logger=logging.getLogger(__name__))  # must be a no-op
+
+    assert dead.exists(), "the sweep ran a second time in the same process"
+
+
+def test_sweep_logs_the_removed_count(tmp_path, caplog):
+    """Tier 2: #5985 co-vet precedent (PR #6005) — the sweep's outcome must
+    be observable, not silent on every branch.
+
+    NON-VACUITY (strip-falsified locally, in-file Edit -> run -> Edit
+    back): removing the `logger.info(...)` call makes this assertion fail
+    — there would be nothing in the log to assert on."""
+    dead = tmp_path / f"stall_dump.{_dead_pid()}.log"
+    dead.write_text("stale", encoding="utf-8")
+    own_path = tmp_path / "stall_dump.999999999.log"
+
+    with caplog.at_level(logging.INFO, logger=__name__):
+        _sweep_dead_pid_stall_dumps(str(own_path), logger=logging.getLogger(__name__))
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("removed 1 dead-pid file" in m for m in messages), (
+        f"the sweep's own outcome (1 file removed) left no observable trace — "
+        f"records were: {messages}"
+    )
+
+
+def test_stall_dump_arm_open_triggers_the_sweep(tmp_path):
+    """Tier 2: integration — a real `StallDumpArm.open()` call (the actual
+    production chokepoint, both `app.py` and `server.py`) triggers the
+    sweep as a side effect, not just the unit-level direct call above."""
+    dead = tmp_path / f"stall_dump.{_dead_pid()}.log"
+    dead.write_text("stale", encoding="utf-8")
+
+    own_path = tmp_path / "stall_dump.888888888.log"
+    arm = StallDumpArm.open(
+        seconds=1.0, path=str(own_path), logger=logging.getLogger(__name__), label="test",
+    )
+    assert arm is not None
+
+    assert not dead.exists()
+
+    arm.close()

--- a/tests/runtime/test_5985_stall_dump_sweep.py
+++ b/tests/runtime/test_5985_stall_dump_sweep.py
@@ -9,6 +9,7 @@ put in this filename too, but nothing ever sweeps it) -- this file mirrors
 different mechanism (`unlink` on a flat file here, vs. `rmtree` on a
 pid-subdirectory there).
 """
+# EXEMPT: _dead_pid()'s subprocess.Popen([sys.executable, "-c", "pass"]) never touches reyn
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
**[docs-maintainer]** — Closes #5985.

## What

The final `.sb` cache PR (#6005/#6009) closed the normal-exit + crash/SIGKILL leftover paths for the sandbox-profile cache. lead-coder found #5997 reproduced the identical class for the stall stack-dump's own filename (`stall_dump.<pid>.log`, now pid-scoped since #5977② -- but nothing ever swept a dead process's own leftover).

`_sweep_dead_pid_stall_dumps` (new, `loop_tripwire.py`) reuses the exact mechanism #6005 established -- not a new one:
- Liveness (`reyn.data.index.build_lock.pid_alive`), never age -- no constant to be wrong about.
- No config knob.
- Runs at most once per process, right before this process opens its own destination -- `StallDumpArm.open`, the one production chokepoint both `app.py` and `server.py` already go through, so both callers get the sweep automatically with no per-caller wiring.
- Logs the outcome (removed/failed counts) unconditionally, including 0/0, matching #6005's own co-vet-driven observability requirement.

Only structural difference from the `.sb` mechanism: `unlink` on a flat file here vs. `rmtree` on a pid-subdirectory there -- `stall_dump.<pid>.log` was never a directory, so there's nothing to scope into a subdirectory for.

## Verification

All three directions strip-falsified independently (the liveness check, the removal call, the log call -- each in-file Edit -> run -> Edit back): the corresponding test goes RED, confirming none of the three witnesses are vacuous.

## Test plan
- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5985_stall_dump_sweep.py` -- 6/6 OK
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/` path-conditional gates -- all green
- [x] `pytest tests/runtime/test_5985_stall_dump_sweep.py tests/runtime/test_5977_stall_dump_suppression.py tests/runtime/test_5898_loop_tripwire.py tests/runtime/test_5998_disarm_before_reset.py tests/web/test_5898_web_loop_tripwire.py tests/interfaces/test_loop_probe_3539.py tests/interfaces/test_3671_stall_trace_startup_wiring.py` -- 63 passed
- [x] (skipped -- Visual, standing waiver 2026-08-08)

security 配下ではありませんが `PR #6005/#6009` と同型の mechanism なので、念のため architect の目通しをお願いできればと思います。merge は lead-coder にお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
