### PR TITLE
fix(#5989 ③): RemoteQueueView's dispatch/cancel seq-gate rejections now observable

### DIFF
--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -29,10 +29,13 @@ the transport edge as defense in depth (idempotent for the terminal surface).
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 
 from reyn.core.present.guard import get_neutralizer
 from reyn.llm.pricing import CostBreakdown
+
+logger = logging.getLogger(__name__)
 
 
 def _cost_breakdown_wire(breakdown: "CostBreakdown | None") -> "dict | None":
@@ -387,8 +390,33 @@ class RemoteQueueView:
     def apply_turn_started(self, *, chain_id: "str | None", seq: int) -> bool:
         """Apply a dispatch delta (removes the queued item matching
         ``chain_id``, if any); returns False (no-op) if the seq gate rejects
-        it as already reflected."""
+        it as already reflected.
+
+        #5989 ③ (lead-coder review, self-correction on the earlier "the log
+        was empty so nothing failed" reading — this class had zero
+        ``logger`` calls of its own, ``user_submitted``'s own rejection is
+        covered by its CALLER, :meth:`~reyn.interfaces.inline.textual_chat.
+        app.TextualChatApp._handle_user_submitted_event`, but a
+        dispatch/cancel rejection had no observer anywhere): a rejection
+        here is EXPECTED (a genuine replay — this exact dispatch was
+        already applied, and its matching queued item is already gone) when
+        no item with this ``chain_id`` remains in :attr:`items` — logged at
+        ``DEBUG``. It is SUSPICIOUS (the item this delta would have
+        promoted/removed is still sitting here, un-promoted — exactly the
+        shape of a wrongly-rejected delta, not a correctly-rejected one)
+        when a matching item DOES remain — logged at ``WARNING``. No new
+        state: both branches only ever READ :attr:`items`, the same
+        collection the gate already owns."""
         if seq <= self._last_seq:
+            stuck = [item for item in self.items.values() if item.get("chain_id") == chain_id]
+            log = logger.warning if stuck else logger.debug
+            log(
+                "RemoteQueueView: seq-gate rejected turn_started (chain_id=%r, seq=%r, "
+                "baseline=%r) — %s",
+                chain_id, seq, self._last_seq,
+                "a matching queued item is STILL present (unpromoted)" if stuck
+                else "already reflected, no matching item remains",
+            )
             return False
         for msg_id, item in list(self.items.items()):
             if item.get("chain_id") == chain_id:
@@ -405,8 +433,24 @@ class RemoteQueueView:
         order-race protocol as ``apply_user_submitted``/``apply_turn_started``
         (design-pass pin D): exclusive with a ``turn_started`` for the same
         item (the server guarantees only one of the two ever fires,
-        issue #3300 owner addendum §6a), so no double-removal ambiguity."""
+        issue #3300 owner addendum §6a), so no double-removal ambiguity.
+
+        #5989 ③: same discriminator as :meth:`apply_turn_started` — EXPECTED
+        (``DEBUG``) when ``msg_id`` is already absent from :attr:`items`
+        (already removed, a genuine replay of a cancel already applied);
+        SUSPICIOUS (``WARNING``) when it is still present (the row this
+        cancel targets never left the queue — the operator who cancelled it
+        would see it sitting there regardless)."""
         if seq <= self._last_seq:
+            stuck = msg_id in self.items
+            log = logger.warning if stuck else logger.debug
+            log(
+                "RemoteQueueView: seq-gate rejected inbox_cancel (msg_id=%r, seq=%r, "
+                "baseline=%r) — %s",
+                msg_id, seq, self._last_seq,
+                "the targeted item is STILL present (uncancelled)" if stuck
+                else "already reflected, item already absent",
+            )
             return False
         self.items.pop(msg_id, None)
         self._last_seq = seq

--- a/tests/interfaces/test_5989_3_queue_view_rejection_observability.py
+++ b/tests/interfaces/test_5989_3_queue_view_rejection_observability.py
@@ -1,0 +1,143 @@
+"""Tier 1: #5989 ③ (lead-coder review, self-correction) — ``RemoteQueueView``
+(``src/reyn/interfaces/transport/agui/state.py``) had ZERO ``logger`` calls
+of its own. ``apply_user_submitted``'s own rejection is covered by its
+CALLER (``TextualChatApp._handle_user_submitted_event``, already always
+``logger.warning`` — a ratified, tested decision, see
+``test_5886_own_client_ref_rejection_warns.py``, deliberately NOT touched
+here) — but ``apply_turn_started`` and ``apply_inbox_cancel`` had no
+observer anywhere: a wrongly-rejected dispatch/cancel delta was exactly as
+silent as the #5989 owner-hit's original enqueue-side bug, just one layer
+over.
+
+Discriminator (lead-coder: "誤って拒否した／正しく拒否した を区別できる形
+に、ただし判別子は実装者判断"): a rejection is EXPECTED (a genuine replay —
+this exact delta was already applied, its target item is already gone from
+:attr:`RemoteQueueView.items`) — logged at ``DEBUG``, no operational-log
+noise for the routine case. It is SUSPICIOUS (the item this delta would
+have promoted/removed is STILL present, un-promoted/un-cancelled — the
+exact shape a wrongly-rejected delta leaves behind) — logged at
+``WARNING``. Both directions are required (lead-coder's own accept
+criteria): ① a wrong rejection reaches WARNING ② a correct rejection does
+NOT flood the operational log at WARNING.
+
+Real ``RemoteQueueView`` throughout, seeded via its own public
+``apply_snapshot`` (never a private ``_last_seq`` poke) — no mocks, this
+class has no collaborator to fake.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.interfaces.transport.agui.state import RemoteQueueView
+
+_LOGGER = "reyn.interfaces.transport.agui.state"
+
+
+def _levels(caplog: pytest.LogCaptureFixture) -> "list[str]":
+    return [r.levelname for r in caplog.records if r.name == _LOGGER]
+
+
+# ---------------------------------------------------------------------------
+# apply_turn_started
+# ---------------------------------------------------------------------------
+
+
+def test_turn_started_rejection_of_a_still_queued_item_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: a ``turn_started`` delta rejected by the seq-gate while its
+    own target item is STILL sitting in ``items``, unpromoted — the shape a
+    WRONG rejection leaves behind. Must warn.
+
+    Strip-falsifier (verified by hand: the ``stuck`` check replaced with a
+    constant ``False``, so this branch is unconditionally logged at
+    ``debug``): this test goes red — no ``WARNING`` record."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m1", "chain_id": "c1", "text": "hi"}],
+        turn_active=False, queue_seq=5,
+    )
+    caplog.set_level("DEBUG", logger=_LOGGER)
+
+    applied = view.apply_turn_started(chain_id="c1", seq=3)  # stale: 3 <= 5
+
+    assert applied is False
+    assert "m1" in view.items, "the item must still be there — this IS the property under test"
+    assert _levels(caplog) == ["WARNING"], (
+        f"#5989 REGRESSION: a turn_started rejection whose target item is "
+        f"still queued must warn — got {_levels(caplog)!r}"
+    )
+
+
+def test_turn_started_rejection_of_an_already_promoted_item_stays_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: the SAME losing seq race, but the target item is already
+    gone (a genuine, harmless replay of a dispatch already applied) — must
+    NOT warn, only debug-log, so an operational log isn't flooded by the
+    routine, correct case.
+
+    Strip-falsifier (verified by hand: ``stuck`` forced to ``True``
+    unconditionally): this test goes red — a spurious ``WARNING`` appears
+    for the routine, already-resolved case."""
+    view = RemoteQueueView()
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=5)
+    caplog.set_level("DEBUG", logger=_LOGGER)
+
+    applied = view.apply_turn_started(chain_id="c1", seq=3)  # stale: 3 <= 5
+
+    assert applied is False
+    assert _levels(caplog) == ["DEBUG"], (
+        f"#5989 REGRESSION: a routine, already-resolved rejection must stay "
+        f"traceable at DEBUG and never escalate to WARNING — got "
+        f"{_levels(caplog)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_inbox_cancel
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_cancel_rejection_of_a_still_queued_item_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: the SAME discriminator, through ``apply_inbox_cancel``: the
+    cancel's own target ``msg_id`` is STILL present — a wrongly-rejected
+    cancel would leave the operator's own cancel silently ignored. Must
+    warn."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m1", "chain_id": "c1", "text": "hi"}],
+        turn_active=False, queue_seq=5,
+    )
+    caplog.set_level("DEBUG", logger=_LOGGER)
+
+    applied = view.apply_inbox_cancel(msg_id="m1", seq=3)  # stale: 3 <= 5
+
+    assert applied is False
+    assert "m1" in view.items
+    assert _levels(caplog) == ["WARNING"], (
+        f"#5989 REGRESSION: an inbox_cancel rejection whose target item is "
+        f"still queued must warn — got {_levels(caplog)!r}"
+    )
+
+
+def test_inbox_cancel_rejection_of_an_already_removed_item_stays_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: the routine case: the cancel's target is already gone (a
+    genuine replay of a cancel already applied, or the item was already
+    dispatched — #3300 §6a's exclusivity) — must not warn."""
+    view = RemoteQueueView()
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=5)
+    caplog.set_level("DEBUG", logger=_LOGGER)
+
+    applied = view.apply_inbox_cancel(msg_id="m1", seq=3)  # stale: 3 <= 5
+
+    assert applied is False
+    assert _levels(caplog) == ["DEBUG"], (
+        f"#5989 REGRESSION: a routine, already-resolved cancel rejection "
+        f"must stay traceable at DEBUG and never escalate to WARNING — got "
+        f"{_levels(caplog)!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5989. `Closes` intentionally not used — ② (owner-path reproduction) remains open.

lead-coder's own self-correction: `state.py` (`RemoteQueueView`) had **zero `logger` calls of its own**. `apply_user_submitted`'s own rejection is already covered by its caller (`TextualChatApp._handle_user_submitted_event`, always `logger.warning` — a ratified, tested decision, see `test_5886_own_client_ref_rejection_warns.py`, **deliberately not touched here**) — but `apply_turn_started` and `apply_inbox_cancel` had no observer anywhere. Not caught by #5990's own gate (an `except`-block census; this is a policy `return False`, a different shape).

## Discriminator (own design)
A rejection is **EXPECTED** (a genuine replay — the delta's own target item is already gone from `RemoteQueueView.items`, the same collection the gate already owns, no new state) → `DEBUG`. It is **SUSPICIOUS** (the item this delta would have promoted/removed is STILL present, unpromoted or uncancelled — the exact shape a wrongly-rejected delta leaves behind) → `WARNING`.

## Test
4 tests, real `RemoteQueueView` (no mocks), 2 per gate method (warn case / quiet case). Strip-falsified all 4 directions by hand (in-file Edit then Edit back): forcing the discriminator to always-false silences the wrong-rejection case; forcing it to always-true turns every routine, already-resolved rejection into a warning (the crying-wolf shape you asked to avoid).

## Design choice: plain logging, not an audit-event
This is diagnostic/observability, not a domain fact the audit trail needs to reconstruct — `AUDIT_EVENT_KINDS`/`events.md` untouched.

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green (`suspected_time_dependence_ratchet.py` also green this time, no drift).
- [x] Scoped pytest: `test_5989_3_queue_view_rejection_observability.py`, `test_5886_own_client_ref_rejection_warns.py`, `test_3300_p3_cancel_by_id.py`, `test_3300_p2a_queue_state_publish.py`, `test_5179_remote_own_message_seq_gate_race.py` — 31 passed.
- [x] (skipped — Visual, standing waiver)

Pushing without waiting on CI per your instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
