### PR TITLE
fix(#5986): noop_backend's post-kill drain narrows its except and stops flying blind; test_5956's flaky healthy-tripwire assert fixed

### DIFF
--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -291,15 +291,41 @@ class NoopBackend:
         )
 
         if cancel_task in done:
-            # cancel_inflight() fired: kill process group + return partial output.
+            # cancel_inflight() fired: kill process group, then try to read
+            # whatever output the drain captured before the kill (#5986:
+            # this is a BEST-EFFORT read, not a guarantee — see the
+            # except below for what happens when it doesn't land).
             await kill_process_tree(proc)
             cancel_task.cancel()
-            # Read whatever output was captured before the kill.
             try:
                 stdout_b, stderr_b, _trunc = await asyncio.wait_for(
-                    asyncio.shield(comm_future), timeout=3.0,
+                    asyncio.shield(comm_future), timeout=POST_KILL_DRAIN_GRACE_SECONDS,
                 )
-            except (asyncio.TimeoutError, Exception):
+            except (asyncio.TimeoutError, subprocess.TimeoutExpired) as exc:
+                # #5986 (lead-coder review): narrowed from a bare
+                # `Exception` (which silently swallowed EVERYTHING,
+                # including a genuine bug in `communicate_capped` itself
+                # — #5990's own "nobody reports this failure" shape) to
+                # the two outcomes this drain can actually raise:
+                # `asyncio.TimeoutError` from this `wait_for` itself (the
+                # post-kill grace period elapsed with the streams still
+                # open — a killed process whose child inherited the pipe,
+                # #3862's own shape) and `subprocess.TimeoutExpired`,
+                # which `communicate_capped`'s own docstring declares it
+                # raises on ITS internal timeout. Any OTHER exception is
+                # a real defect, not an expected drain outcome, and is
+                # left to propagate rather than silently discarded here.
+                # The empty result below is a REAL LOSS (the process
+                # produced output between the kill and this timeout that
+                # nobody will ever see) — logged once, at WARNING, so an
+                # operator investigating a cancelled run with unexpectedly
+                # empty output has a reason on record, not silence.
+                _logger.warning(
+                    "noop_backend: could not capture partial output after "
+                    "cancel — drain did not complete within %.1fs of the "
+                    "kill (%s: %s); returning empty stdout/stderr",
+                    POST_KILL_DRAIN_GRACE_SECONDS, type(exc).__name__, exc,
+                )
                 stdout_b, stderr_b, _trunc = b"", b"", False
             return SandboxResult(
                 returncode=-int(signal.SIGTERM),
@@ -314,9 +340,18 @@ class NoopBackend:
             await kill_process_tree(proc)
             try:
                 stdout_b, stderr_b, _trunc = await asyncio.wait_for(
-                    asyncio.shield(comm_future), timeout=3.0,
+                    asyncio.shield(comm_future), timeout=POST_KILL_DRAIN_GRACE_SECONDS,
                 )
-            except (asyncio.TimeoutError, Exception):
+            except (asyncio.TimeoutError, subprocess.TimeoutExpired) as exc:
+                # #5986: same narrowed exception set and the same real
+                # loss as the cancel branch above — see its own comment.
+                _logger.warning(
+                    "noop_backend: could not capture partial output after "
+                    "a policy timeout — drain did not complete within "
+                    "%.1fs of the kill (%s: %s); returning empty "
+                    "stdout/stderr",
+                    POST_KILL_DRAIN_GRACE_SECONDS, type(exc).__name__, exc,
+                )
                 stdout_b, stderr_b, _trunc = b"", b"", False
             return SandboxResult(
                 returncode=-1,

--- a/tests/interfaces/test_5956_screen_timeout_diagnostics.py
+++ b/tests/interfaces/test_5956_screen_timeout_diagnostics.py
@@ -45,15 +45,31 @@ async def test_collects_real_pump_ticks_and_loop_tripwire_state() -> None:
     app = TextualChatApp(transport=_empty_transport())
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
+        # #5986 (lead-coder, CI flake trace): this asserts the COLLECTOR
+        # reads REAL values off a real app's LoopTripwire, not that a real
+        # host managed to schedule this test's own ticks within threshold
+        # -- the two got conflated by reading the tripwire's state as
+        # accumulated since MOUNT, which genuinely CAN exceed the
+        # threshold on a loaded CI runner (owner-hit: PR #5979, run
+        # `34180575013`). ``reset_loop_tripwire()`` -- the SAME public
+        # seam ``test_loop_probe_3539.py``'s own tests already use for
+        # "a clean instance, deterministic regardless of what happened
+        # during mount" -- gives this read a freshly-constructed,
+        # never-yet-observed-a-tick tripwire: `fired` and
+        # `max_lateness_ms` are then trivially, structurally correct
+        # (there has been no tick since reset to observe ANY lateness on,
+        # real or not), not a bet on this run's own scheduling luck.
+        app.reset_loop_tripwire()
         diagnostics = collect_screen_timeout_diagnostics(app)
 
         assert isinstance(diagnostics["pump_ticks"], int)
         tripwire = diagnostics["loop_tripwire"]
-        assert tripwire["fired"] is False, "a healthy run must not report an active stall"
+        assert tripwire["fired"] is False, "a freshly-reset tripwire must not report an active stall"
         assert tripwire["max_lateness_ms"] < tripwire["threshold_ms"], (
-            "a healthy run's worst observed lateness must stay under its "
-            "own threshold -- both real values, read off the app's own "
-            "LoopTripwire, not pinned to an exact synthetic number"
+            "a freshly-reset tripwire's own zero-lateness starting state "
+            "must read back under its own threshold -- both real values, "
+            "read off the app's own LoopTripwire, not pinned to an exact "
+            "synthetic number"
         )
         # A fresh TextualChatApp already runs its own real internal worker
         # (e.g. `_pump_frames`) -- this asserts the SHAPE is right, not

--- a/tests/security/test_5986_drain_grace_narrowed_except.py
+++ b/tests/security/test_5986_drain_grace_narrowed_except.py
@@ -1,0 +1,169 @@
+"""Tier 2: #5986 (lead-coder review) — ``NoopBackend.run``'s post-kill drain
+read (both the cancel branch and the policy-timeout branch) had 3 defects
+in ``src/reyn/security/sandbox/noop_backend.py``:
+
+1. ``timeout=3.0`` — a bare literal with no stated rationale, byte-identical
+   to the already-named :data:`~reyn.security.sandbox.policy.
+   POST_KILL_DRAIN_GRACE_SECONDS`.
+2. ``except (asyncio.TimeoutError, Exception):`` — ``asyncio.TimeoutError``
+   IS an ``Exception`` subclass, so this caught EVERYTHING (the #5990-class
+   "nobody reports this failure" shape) and silently swapped the result for
+   empty output.
+3. The cancel branch's own comment ("kill process group + return partial
+   output") was FALSE for the except path specifically — it returns EMPTY
+   output there, not partial.
+
+Fixed: the except narrowed to ``(asyncio.TimeoutError, subprocess.
+TimeoutExpired)`` — the two outcomes ``communicate_capped``'s own docstring
+and this ``wait_for`` call can actually produce — with a ``_logger.warning``
+on the empty-output path (a real, operator-visible fact: partial output
+existed and was lost, not silence).
+
+Real ``NoopBackend`` + a real subprocess throughout (the established idiom
+from ``test_subprocess_cancel_1470.py``'s own cancel tests) — no mocks.
+Forcing the drain-grace ``asyncio.TimeoutError`` deterministically (not by
+RACING a small timeout against a real drain that usually finishes near-
+instantly once the killed process's own pipe closes — that raced and lost,
+observed by hand) needs the SAME real hang this module's own #3862
+reference describes: a DETACHED grandchild (``setsid``, its own process
+group) that inherits the pipe's write end and outlives the killed process
+tree, so ``communicate_capped``'s blocking read never sees EOF on its own
+— a real, unbounded hang this test's own ``asyncio.wait_for`` genuinely
+has to interrupt, not a race against how fast a normal drain happens to
+finish. ``POST_KILL_DRAIN_GRACE_SECONDS`` is monkeypatched only to keep
+this fast (the grandchild would otherwise make the DEFAULT 3s grace, not
+a chosen shorter one, the thing under test — the property doesn't change
+with the value, since the read never completes regardless)."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+
+import pytest
+
+from reyn.security.sandbox import noop_backend as noop_backend_module
+from reyn.security.sandbox.noop_backend import NoopBackend
+from reyn.security.sandbox.policy import SandboxPolicy
+
+_POLICY = SandboxPolicy(timeout_seconds=30)
+_LOGGER = "reyn.security.sandbox.noop_backend"
+
+
+async def _wait_for_file(path) -> None:
+    """Same unbounded-poll idiom as ``test_subprocess_cancel_1470.py``'s
+    own helper — no attempt cap, CI's own kill switch is the ceiling."""
+    while not path.exists():
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_a_drain_that_cannot_complete_in_time_warns_and_returns_empty(
+    tmp_path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the cancel branch's own except — real subprocess, real
+    cancel, a real drain that genuinely never sees EOF (a detached
+    grandchild survives the kill, per this module's own #3862 reference).
+    The empty-output result must be logged, not silent.
+
+    Strip-falsifier (verified by hand: the except reverted to
+    ``except (asyncio.TimeoutError, Exception):`` with no ``_logger.warning``
+    call inside it): this test goes red — no ``WARNING`` record, and the
+    #5990-class silent-except shape is back."""
+    monkeypatch.setattr(noop_backend_module, "POST_KILL_DRAIN_GRACE_SECONDS", 0.2)
+    caplog.set_level(logging.WARNING, logger=_LOGGER)
+
+    backend = NoopBackend()
+    event = asyncio.Event()
+    ready = tmp_path / "ready"
+    detached = tmp_path / "detached"
+    # `setsid`(1) isn't shipped on macOS, so detaching into a NEW process
+    # group (the property under test — killing the OUTER script's own
+    # process group must not touch this) goes through `os.setsid()`
+    # directly: the backgrounded python3 process calls it, touches its
+    # OWN ready marker (an observable condition to wait on — cancelling
+    # before this genuinely-async setsid()+exec has landed would leave
+    # the grandchild still in the ORIGINAL group, killed along with it,
+    # confirmed by hand), then `exec`s into `sleep 60` in place — one
+    # process, a NEW session/pgid, still holding the inherited stdout
+    # write end the ORIGINAL pipe reads from, so communicate_capped's
+    # blocking read never reaches EOF on its own.
+    # The grandchild writes ITS OWN pid into the ready marker — its
+    # detached fd keeps `communicate_capped`'s own background executor
+    # thread (a non-daemon thread, by this module's own docstring)
+    # blocked reading forever, so this test kills it explicitly in
+    # `finally` rather than leaving it (and pytest's own process exit)
+    # hanging on a real 60s sleep.
+    script = (
+        f"touch {ready}\n"
+        "(python3 -c \"import os; os.setsid(); "
+        f"open('{detached}', 'w').write(str(os.getpid())); "
+        "os.execvp('sleep', ['sleep', '60'])\" &)\n"
+        "sleep 60\n"
+    )
+
+    async def _fire_cancel() -> None:
+        await _wait_for_file(ready)
+        await _wait_for_file(detached)
+        event.set()
+
+    fire_task = asyncio.create_task(_fire_cancel())
+    try:
+        result = await backend.run(["/bin/sh", "-c", script], _POLICY, cancel_event=event)
+        await fire_task
+
+        assert result.cancelled is True
+        assert result.stdout == b"" and result.stderr == b"", (
+            "the detached grandchild keeps the pipe open past the drain grace "
+            "-- empty output is the correct, honest result here"
+        )
+        drain_warnings = [
+            r.getMessage() for r in caplog.records
+            if r.name == _LOGGER and r.levelname == "WARNING"
+            and "could not capture partial output" in r.getMessage()
+        ]
+        assert drain_warnings != [], (
+            f"#5986 REGRESSION: a drain that could not complete in time must be "
+            f"logged, not silently swapped for empty output — got "
+            f"{[(r.name, r.getMessage()) for r in caplog.records]!r}"
+        )
+    finally:
+        grandchild_pid = int(detached.read_text())
+        try:
+            os.kill(grandchild_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_a_normal_cancel_with_time_to_drain_needs_no_warning(tmp_path, caplog) -> None:
+    """Tier 2: regression guard — the ordinary case (real grace, real
+    drain completes) must stay exactly as quiet as before; the fix adds a
+    signal on the failure path, not noise on the routine one. Reuses
+    ``test_subprocess_cancel_1470.py``'s own established cancel-with-
+    partial-output shape."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER)
+    backend = NoopBackend()
+    event = asyncio.Event()
+    ready = tmp_path / "ready"
+    script = "echo partial_output\ntouch {ready}\nsleep 60\n".format(ready=ready)
+
+    async def _fire_cancel() -> None:
+        await _wait_for_file(ready)
+        event.set()
+
+    fire_task = asyncio.create_task(_fire_cancel())
+    result = await backend.run(["/bin/sh", "-c", script], _POLICY, cancel_event=event)
+    await fire_task
+
+    assert result.cancelled is True
+    drain_warnings = [
+        r.getMessage() for r in caplog.records
+        if r.name == _LOGGER and r.levelname == "WARNING"
+        and "could not capture partial output" in r.getMessage()
+    ]
+    assert drain_warnings == [], (
+        f"#5986 REGRESSION: a drain that completed normally must not warn — "
+        f"got {drain_warnings!r}"
+    )


### PR DESCRIPTION
**[tui-coder]** — fixes #5986.

## noop_backend.py — 3 defects in 5 lines, both branches (cancel + policy-timeout)
1. `timeout=3.0` → `timeout=POST_KILL_DRAIN_GRACE_SECONDS` (byte-identical value, now the named constant instead of a bare literal).
2. `except (asyncio.TimeoutError, Exception):` → narrowed to `(asyncio.TimeoutError, subprocess.TimeoutExpired)` — the two outcomes `communicate_capped`'s own docstring and this `wait_for` can actually produce. `TimeoutError` IS an `Exception`, so the old tuple caught everything, including a real bug in `communicate_capped` itself (the #5990-class "nobody reports this failure" shape). Anything else now propagates.
3. The cancel branch's own comment ("return partial output") was false for the except path — it returns EMPTY there. Fixed, and a `_logger.warning` added on that path: partial output existed and was lost, now a recorded fact, not silence.

### Test
Real `NoopBackend` + a real subprocess — a detached grandchild (`os.setsid()` + `execvp`, `setsid`(1) isn't on macOS) that survives the process-group kill, matching the module's own #3862 reference, so the drain genuinely never sees EOF. No mocks, and not a timing race — the drain never completes regardless of the grace value, so a small monkeypatched `POST_KILL_DRAIN_GRACE_SECONDS` just keeps the test fast, it isn't the thing making the assertion pass. Strip-verified in-file: reverting to the bare except with no log goes red; a regression-guard sibling confirms the ordinary (no-warning) case stays quiet.

## Test 2 — the CI flake from PR #5979 (run `34180575013`)
`test_5956_screen_timeout_diagnostics.py`'s healthy-tripwire assert read state accumulated since **mount**, which can genuinely exceed the threshold on a loaded CI runner — a real wall-clock dependency even though no `sleep`/`timeout` was ever written. Fixed with the SAME public seam `test_loop_probe_3539.py`'s own sibling tests already use for exactly this purpose: `app.reset_loop_tripwire()` right before reading diagnostics, so the assertion is against a freshly-constructed, never-yet-ticked tripwire — structurally correct regardless of real CI scheduling. No new mechanism.

`test_subprocess_cancel_1470.py`'s own separate ready-marker-ordering flake is a different mechanism (out of scope here, per your own instruction).

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `suspected_time_dependence_ratchet.py`, and the `tests/`-path gates — all green.
- [x] Scoped pytest: `test_5986_drain_grace_narrowed_except.py`, `test_5956_screen_timeout_diagnostics.py`, `test_subprocess_cancel_1470.py`, `test_loop_probe_3539.py` — 45 passed, 2 skipped (documented Darwin-only, never run in CI).
- [x] (skipped — Visual, standing waiver)

`security/sandbox/` deliberately left out of #6012's own `silent_except_ratchet.py` gate scope, per your instruction — not widened here.

## Scope disclosure (added post-TESTS-READ, architect's own broader census)
The same byte-identical `timeout=3.0` + bare-except-then-empty shape exists at 7 MORE sites: `container_backend.py:784,:799`, `_subprocess_io.py:391`, `landlock.py:627,:643`, `seatbelt.py:773,:789`. This PR fixes only the 2 in `noop_backend.py` — not because they were touched first, but because `seatbelt` is Darwin-only and `landlock` is Linux-only while every one of this repo's 44 `runs-on` entries is `ubuntu-latest`: a fix to either would ship with **no CI witness at all**, and this PR's own detached-grandchild witness only holds for `noop`. The real fix for the other 7 is collapsing all 9 into one shared post-kill-drain helper (backend-agnostic) — architect is filing that as a separate issue.

`noop_backend` enforces nothing (a no-op backend); the backend the owner actually runs is `seatbelt`. Landing this PR first does not mean the more consequential path is fixed — flagging that explicitly so a later reader doesn't read presence-of-a-fix-here as coverage there.

Pushing without waiting on CI per your instruction. co-vet: architect (security). merge: you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn

