### PR TITLE
fix(#5982): internal history readers fold an out-of-boundary ref, never crash

### DIFF
--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -2170,6 +2170,50 @@ class MediaStore:
             preview = f.read(max_bytes)
         return preview, True, total_bytes
 
+    def read_tool_result_preview_for_internal_reader(
+        self, path_str: str, *, max_bytes: int,
+    ) -> "tuple[str, bool, int]":
+        """#5982: the SAME read as :meth:`read_tool_result_preview`, for
+        an INTERNAL reader that must not be stopped by an uncaught
+        exception on a malformed/malicious ``path_str`` — a boundary
+        violation is folded into the SAME ``found=False`` an internal
+        reader already gets for a genuinely missing file (both answer
+        "no body available" identically to a caller with no separate
+        channel for "why").
+
+        ⚠️ **Not the same as silently swallowing the distinction.** A
+        boundary violation logs a WARNING distinct from the ordinary
+        not-found case before folding — ``path_str`` reaching this method
+        outside the valid boundary is itself a defect (something
+        constructed an invalid ref), and #5982's own condition is that
+        folding must never make that defect permanently invisible. This
+        is the LOG-only sibling of :func:`~reyn.runtime.services.
+        router_history_buffer.resolve_history_content`'s own fold (which
+        goes further — an audit-event plus a distinct ``LostReason``,
+        because that caller already has a structured "reason" channel a
+        raw preview read does not).
+
+        **External-boundary callers keep the raising form.**
+        :meth:`read_tool_result_preview` itself is UNCHANGED — an
+        external-input caller (none exist for the preview form today,
+        but the pattern must not silently invert) that needs to
+        distinguish "malicious path" from "legitimately missing" for its
+        own response (the same reason ``interfaces/web/routers/
+        resources.py`` keeps calling the raising :meth:`read_tool_result`
+        for the non-preview form) still has that raising primitive
+        available."""
+        try:
+            return self.read_tool_result_preview(path_str, max_bytes=max_bytes)
+        except PermissionError:
+            logger.warning(
+                "read_tool_result_preview_for_internal_reader: %r resolved "
+                "outside the storage boundary — folded to not-found for "
+                "this internal reader (this ref should never have reached "
+                "here; the caller is the thing to investigate, not this "
+                "read)", path_str,
+            )
+            return "", False, 0
+
     # ── Cross-host routing (#385 β core impl sub-task 1) ──────────────
 
     def _attach_cross_host_fields(

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -631,11 +631,29 @@ class LostReason(StrEnum):
     in that window also reads as ``EXTERNAL``. Stage ③ (spilled-first
     ordering with un-spilled eviction, owner-confirmation-pending — NOT
     part of this change) is where this stops being derivable at all and
-    needs its own record."""
+    needs its own record.
+
+    ``OUTSIDE_BOUNDARY`` (#5982): a DIFFERENT failure class from the three
+    above — those all mean "the file used to be there and now genuinely
+    is not" (normal, an expected design property: an offloaded body may
+    be GC'd). This one means the entry's own ``ref`` resolves to a path
+    ``MediaStore`` refuses to read at all (outside ``history_content_
+    root``/``tool_results_dir`` — ``read_tool_result``'s own boundary
+    check, ``PermissionError``) — an ABNORMAL state: something constructed
+    a ``ref`` that never should have existed. #5982's own explicit
+    condition: this reason must never be folded into ``EXTERNAL`` or any
+    other "file missing" reason — mixing "normal" (file legitimately gone)
+    with "abnormal" (a malformed/malicious ref reached an internal reader)
+    would let the normal case bury the abnormal one from any observer
+    reading ``LostReason`` alone (the same "two zeros" shape #5991 ② named
+    for a different field). Computed fresh at read time, never persisted —
+    same "compute, don't store" discipline #5438 already established for
+    ``GC``/``EXTERNAL``, not a new ledger."""
 
     GC = "gc"
     NEVER_PERSISTED = "never_persisted"
     EXTERNAL = "external"
+    OUTSIDE_BOUNDARY = "outside_boundary"
 
 # #5612 (owner ruling — "永続化というのは llm に見える履歴が元に戻らない
 # ということ、history.jsonl に追記するということ"): the reactive
@@ -963,15 +981,17 @@ class ChatMessage:
 
         Returns ``None`` (never raises) for every "unknown" case: the ref
         is absent, ``media_store`` is unset, the backing file is missing
-        (``found=False``), OR the ref names a path OUTSIDE
-        ``media_store``'s own boundary (``read_tool_result_preview``
-        raises ``PermissionError`` there, caught here — the same fold
-        this file's own :func:`_materialise_path_ref_content` already
-        applies to this exact exception). This runs on the hot append
-        path (:meth:`Session._evict_oldest_resident_entries`, called
-        from every :meth:`Session._append_history`) — an uncaught raise
-        for one out-of-boundary row would make every future append fail,
-        turning a degrade into a hard stop."""
+        (``found=False``), OR the ref names a path OUTSIDE ``media_
+        store``'s own boundary — folded to ``found=False`` by ``media_
+        store``'s own internal-reader entrypoint (#5982:
+        :meth:`~reyn.data.workspace.media_store.MediaStore.read_tool_
+        result_preview_for_internal_reader`, which LOGS the fold
+        distinctly rather than silently dropping the "why" the way a
+        bare ``try/except PermissionError`` here used to). This runs on
+        the hot append path (:meth:`Session._evict_oldest_resident_
+        entries`, called from every :meth:`Session._append_history`) —
+        an uncaught raise for one out-of-boundary row would make every
+        future append fail, turning a degrade into a hard stop."""
         if not self._body_bytes_cached:
             self._body_bytes_cache = self._derive_body_bytes(media_store)
             self._body_bytes_cached = True
@@ -995,16 +1015,20 @@ class ChatMessage:
         # Session._append_history runs on EVERY append). Uncaught, ONE
         # out-of-boundary ref would make every future append raise,
         # turning a degrade (this PR's own "unknown -> treated safely by
-        # ①②③") into a hard stop. Folded to the SAME "unknown" None every
-        # other branch here returns — the same fold this file's own
-        # _materialise_path_ref_content already applies to this exact
-        # exception, not a new convention.
-        try:
-            _head, found, total_bytes = media_store.read_tool_result_preview(
-                ref, max_bytes=0,
-            )
-        except PermissionError:
-            return None
+        # ①②③") into a hard stop.
+        #
+        # #5982: switched from a bare try/except around the raising form
+        # to MediaStore's own internal-reader entrypoint — the earlier
+        # local fold (still shown in this comment's own history) silently
+        # dropped the "why" the moment PermissionError was caught here;
+        # the new entrypoint still folds to the SAME "unknown" None every
+        # other branch here returns, but now LOGS the fold distinctly
+        # from an ordinary not-found (see that method's own docstring)
+        # instead of the defect (a ref outside the boundary reached an
+        # internal reader) going permanently unobserved.
+        _head, found, total_bytes = media_store.read_tool_result_preview_for_internal_reader(
+            ref, max_bytes=0,
+        )
         return BodyBytes(total_bytes) if found else None
 
     @property

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -82,7 +82,10 @@ def bounded_content_preview(media_store: Any, ref: str, *, max_bytes: int) -> st
     never two that could drift apart."""
     if media_store is None:
         return "(content unavailable — media store not configured)"
-    head, found, total_bytes = media_store.read_tool_result_preview(
+    # #5982: the internal-reader form -- a boundary-violating ref folds
+    # to found=False (logged, never a silent swallow) instead of an
+    # uncaught PermissionError stopping this wire-build.
+    head, found, total_bytes = media_store.read_tool_result_preview_for_internal_reader(
         ref, max_bytes=max_bytes,
     )
     if not found:
@@ -381,11 +384,57 @@ def resolve_history_content(
     def _file_exists(rel_path: str) -> bool:
         return (_Path(project_dir) / rel_path).is_file()
 
-    resolved = resolve(
-        HistoryContentEntry(spilled=spilled, content=content, ref=ref),
-        file_exists=_file_exists,
-        read_text=read_text,
-    )
+    def _lost(*, reason: "LostReason") -> str:
+        # #5982: the single place BOTH `resolve()`'s own "lost" branch
+        # (file genuinely missing) and the PermissionError catch below
+        # (a boundary violation) land -- so the placeholder text and the
+        # audit-event are written once, not duplicated per caller.
+        if events is not None and (seen_lost_refs is None or ref not in seen_lost_refs):
+            if seen_lost_refs is not None:
+                seen_lost_refs.add(ref)
+            import hashlib
+            ref_sha256 = "sha256:" + hashlib.sha256(ref.encode("utf-8")).hexdigest()
+            events.emit(
+                "offloaded_content_unavailable",
+                ref=ref, reason=str(reason), ref_sha256=ref_sha256,
+            )
+        if reason == LostReason.OUTSIDE_BOUNDARY:
+            # Deliberately DIFFERENT wording from the branch below -- the
+            # file may well still EXIST on disk (just outside the
+            # boundary this reader may access), so "no longer exists /
+            # deleted or garbage-collected" would be an ACTIVELY FALSE
+            # claim for this reason, not merely a vaguer one.
+            return (
+                f"[content lost: the offloaded body at {ref!r} could not be "
+                f"read — it resolves outside the storage boundary this "
+                f"reader is permitted to access (reason: {reason})]"
+            )
+        return (
+            f"[content lost: the offloaded body at {ref!r} no longer exists "
+            f"on disk — it may have been deleted or garbage-collected "
+            f"(reason: {reason})]"
+        )
+
+    try:
+        resolved = resolve(
+            HistoryContentEntry(spilled=spilled, content=content, ref=ref),
+            file_exists=_file_exists,
+            read_text=read_text,
+        )
+    except PermissionError:
+        # #5982: `read_text` (in production, `MediaStore.read_tool_
+        # result`) raises when `ref` resolves outside its own boundary --
+        # a MALFORMED or malicious ref, never a legitimately-missing file
+        # (resolve()'s own "lost" branch already covers "missing", via
+        # `file_exists() is False`, BEFORE `read_text` is ever called —
+        # reaching read_text at all means `file_exists` already said
+        # True). Folded to the SAME "lost" answer an internal reader
+        # already has for a missing file (never re-raised, so this stops
+        # being an uncaught-exception class), but with a DISTINCT reason
+        # — never attributed to GC/EXTERNAL, which would misleadingly
+        # claim the file used to legitimately exist and is now gone (see
+        # LostReason.OUTSIDE_BOUNDARY's own docstring).
+        return _lost(reason=LostReason.OUTSIDE_BOUNDARY)
     if resolved.kind == "inline":
         return resolved.value
     if resolved.kind == "lost":
@@ -396,20 +445,7 @@ def resolve_history_content(
             reason = LostReason.GC
         else:
             reason = LostReason.EXTERNAL
-        if events is not None and (seen_lost_refs is None or ref not in seen_lost_refs):
-            if seen_lost_refs is not None:
-                seen_lost_refs.add(ref)
-            import hashlib
-            ref_sha256 = "sha256:" + hashlib.sha256(ref.encode("utf-8")).hexdigest()
-            events.emit(
-                "offloaded_content_unavailable",
-                ref=ref, reason=str(reason), ref_sha256=ref_sha256,
-            )
-        return (
-            f"[content lost: the offloaded body at {ref!r} no longer exists "
-            f"on disk — it may have been deleted or garbage-collected "
-            f"(reason: {reason})]"
-        )
+        return _lost(reason=reason)
     return content
 
 

--- a/tests/runtime/test_5982_internal_boundary_fold.py
+++ b/tests/runtime/test_5982_internal_boundary_fold.py
@@ -1,0 +1,207 @@
+"""Tier 2: #5982 -- an internal (non-HTTP) reader of `MediaStore`'s
+tool-result content must not be stopped by an out-of-boundary `ref`
+(`PermissionError`), and the fold must not erase the distinction between
+"file genuinely missing" (normal) and "ref resolves outside the storage
+boundary" (abnormal -- something constructed an invalid ref).
+
+Real `MediaStore` throughout (no fakes) -- a REAL file written OUTSIDE
+both `history_content_root`/`tool_results_dir` so `read_tool_result`'s
+own boundary check genuinely raises `PermissionError`, the same as
+production would for a malformed/malicious ref. `resolve_history_content`
+is exercised directly (the same minimal, real-`read_text`-closure
+pattern `tests/runtime/test_5896_stage3_migrate_bodies.py` already
+established for this exact function), not through a full session --
+the session-level wiring (which refs reach here at all) is out of this
+file's scope.
+
+`resources.py` (the ONE external-boundary caller, which must keep
+raising) is untouched by this PR and out of this file's scope --
+`tests/interfaces/web` already covers its 400 response.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+from reyn.runtime.chat_message import CONTENT_REF_META_KEY, SPILLED_META_KEY, LostReason
+from reyn.runtime.services.router_history_buffer import resolve_history_content
+from tests._support.events import collect_events
+
+
+def _store(tmp_path: Path) -> MediaStore:
+    return MediaStore(
+        MediaStoreConfig(), project_root=tmp_path,
+        agent_name="boundary-agent", session_id="s1",
+    )
+
+
+def _outside_boundary_ref(tmp_path: Path, *, body: str = "real body text") -> str:
+    """A ref that is a REAL, readable file on disk, project-relative, but
+    NOT under either of `MediaStore`'s two valid roots (both live under
+    `.reyn/` per `media_store.py`'s own construction) -- `read_tool_
+    result` genuinely raises `PermissionError` for this path, the same
+    as it would for any malformed/malicious ref an internal reader was
+    handed."""
+    outside = tmp_path / "definitely-outside-the-boundary.txt"
+    outside.write_text(body, encoding="utf-8")
+    return "definitely-outside-the-boundary.txt"
+
+
+# ─── resolve_history_content (session.py:4733 / router_history_buffer.py's
+# own read_text closures both funnel through this one function) ──────────
+
+
+def test_a_boundary_violating_ref_folds_to_lost_with_a_distinct_reason(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept -- an un-spilled entry (empty content, a ref) whose
+    ref resolves OUTSIDE MediaStore's own boundary no longer raises
+    PermissionError uncaught: resolve_history_content catches it and
+    returns the SAME "lost" shape a missing file gets, but with
+    LostReason.OUTSIDE_BOUNDARY (never GC/EXTERNAL -- see that reason's
+    own docstring for why conflating them would bury the abnormal case),
+    and DISTINCT wording (never claims the file "no longer exists" --
+    it may well still be sitting right there, just outside the
+    boundary)."""
+    store = _store(tmp_path)
+    events = EventLog()
+    collected = collect_events(events)
+    ref = _outside_boundary_ref(tmp_path)
+
+    result = resolve_history_content(
+        "", {CONTENT_REF_META_KEY: ref, SPILLED_META_KEY: False},
+        lambda: tmp_path, events, set(),
+        read_text=lambda r: store.read_tool_result(r)[0],
+    )
+
+    assert f"(reason: {LostReason.OUTSIDE_BOUNDARY})" in result
+    assert "no longer exists" not in result
+    assert "deleted or garbage-collected" not in result
+
+    (unavailable,) = [e for e in collected if e.type == "offloaded_content_unavailable"]
+    assert unavailable.data["reason"] == str(LostReason.OUTSIDE_BOUNDARY)
+    assert unavailable.data["ref"] == ref
+
+
+def test_a_genuinely_missing_file_still_says_gc_not_outside_boundary(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: deny sibling -- an un-spilled entry whose ref names a file
+    that is simply ABSENT (never reaches read_text at all -- resolve()'s
+    own file_exists check returns False first) is UNAFFECTED by this fix:
+    still `gc`, still the ordinary "no longer exists" wording. Proves the
+    new fold is additive, not a behavior change for the case it does not
+    apply to."""
+    events = EventLog()
+    collected = collect_events(events)
+
+    def _read_text_never_called(_ref: str) -> str:
+        raise AssertionError(
+            "read_text must not be called when file_exists already said False"
+        )
+
+    result = resolve_history_content(
+        "", {CONTENT_REF_META_KEY: "genuinely-missing.txt", SPILLED_META_KEY: False},
+        lambda: tmp_path, events, set(),
+        read_text=_read_text_never_called,
+    )
+
+    # Un-spilled + missing derives `external` (`resolve_history_content`'s
+    # own existing branch: `elif spilled: GC else: EXTERNAL`) -- `gc` is
+    # the SPILLED sibling's reason, not this cell's; either way, neither
+    # is `outside_boundary`, which is this test's own point.
+    assert "(reason: external)" in result
+    assert str(LostReason.OUTSIDE_BOUNDARY) not in result
+    assert "no longer exists" in result
+
+    (unavailable,) = [e for e in collected if e.type == "offloaded_content_unavailable"]
+    assert unavailable.data["reason"] == "external"
+
+
+def test_a_present_in_boundary_file_reads_normally_unaffected(tmp_path: Path) -> None:
+    """Tier 2: FP gate -- an ordinary, in-boundary ref with a real backing
+    file reads its actual body through resolve_history_content exactly
+    as before this fix, no placeholder, no event."""
+    store = _store(tmp_path)
+    events = EventLog()
+    collected = collect_events(events)
+    ref_block = store.save_tool_result("the real body", tool="t", seq=1)
+
+    result = resolve_history_content(
+        "", {CONTENT_REF_META_KEY: ref_block["path"], SPILLED_META_KEY: False},
+        lambda: tmp_path, events, set(),
+        read_text=lambda r: store.read_tool_result(r)[0],
+    )
+
+    assert result == "the real body"
+    assert not [e for e in collected if e.type == "offloaded_content_unavailable"]
+
+
+# ─── read_tool_result_preview_for_internal_reader (router_history_buffer.py's
+# bounded_content_preview / chat_message.py's _derive_body_bytes) ─────────
+
+
+def test_preview_for_internal_reader_folds_a_boundary_violation_and_warns(
+    tmp_path: Path, caplog,
+) -> None:
+    """Tier 2: accept -- the internal-reader preview entrypoint returns
+    found=False (never raises) for a ref outside the boundary, AND logs
+    a WARNING distinct from an ordinary not-found (asserted in the
+    sibling FP test below) -- #5982's own condition that folding must
+    not make the defect (an invalid ref reaching an internal reader)
+    permanently unobservable."""
+    import logging
+
+    store = _store(tmp_path)
+    ref = _outside_boundary_ref(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="reyn.data.workspace.media_store"):
+        preview, found, total_bytes = store.read_tool_result_preview_for_internal_reader(
+            ref, max_bytes=100,
+        )
+
+    assert (preview, found, total_bytes) == ("", False, 0)
+    assert any(
+        "outside the storage boundary" in r.message for r in caplog.records
+    ), f"expected a boundary-violation WARNING, got: {[r.message for r in caplog.records]}"
+
+
+def test_preview_for_internal_reader_missing_file_returns_not_found_without_warning(
+    tmp_path: Path, caplog,
+) -> None:
+    """Tier 2: deny sibling -- a genuinely missing (but in-boundary) ref
+    also returns found=False, but WITHOUT the boundary-violation
+    WARNING -- proves the log is a DISTINCT record for the abnormal case,
+    not merely tacked onto every not-found."""
+    import logging
+
+    store = _store(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="reyn.data.workspace.media_store"):
+        # In-boundary (under tool_results_dir) but the file itself does
+        # not exist -- a genuine not-found, distinct from the boundary
+        # violation the sibling test above exercises.
+        preview, found, total_bytes = store.read_tool_result_preview_for_internal_reader(
+            ".reyn/tool-results/genuinely-missing.txt", max_bytes=100,
+        )
+
+    assert (preview, found, total_bytes) == ("", False, 0)
+    assert not caplog.records, (
+        f"an ordinary not-found must not warn — got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_preview_for_internal_reader_present_file_reads_normally(tmp_path: Path) -> None:
+    """Tier 2: FP gate -- an ordinary, in-boundary, present ref previews
+    exactly as :meth:`MediaStore.read_tool_result_preview` already does."""
+    store = _store(tmp_path)
+    ref_block = store.save_tool_result("hello world", tool="t", seq=1)
+
+    preview, found, total_bytes = store.read_tool_result_preview_for_internal_reader(
+        ref_block["path"], max_bytes=100,
+    )
+
+    assert found is True
+    assert preview == "hello world"
+    assert total_bytes == len("hello world")


### PR DESCRIPTION
**[e2e-coder]** — closes #5982. An internal (non-HTTP) reader of `MediaStore`'s tool-result content must not be stopped by an out-of-boundary `ref` (`PermissionError`), and folding must not erase the distinction between "file genuinely missing" (normal) and "ref resolves outside the storage boundary" (abnormal — something constructed an invalid ref).

## Census (re-derived, not re-trusted from the ticket body)

Grepped `\.read_tool_result(` / `\.read_tool_result_preview(` across `src/` at this branch's own HEAD: 5 hits outside `resources.py:203` (which already folds to HTTP 400) —

- `session.py:4733` / `router_history_buffer.py:1080` — the two `read_text` closures `resolve_history_content()`/`resolve()` invoke.
- `chat_message.py`'s `_derive_body_bytes` / `router_history_buffer.py`'s `bounded_content_preview` — direct `read_tool_result_preview` callers.

Matches lead-coder's own re-derived population in the issue thread.

## Two fold points, matching where each pair already funnels

1. **`resolve_history_content`** (`router_history_buffer.py`) wraps the WHOLE `resolve()` call — which is what invokes the injected `read_text` closure, i.e. **both** `session.py:4733` and `router_history_buffer.py:1080` funnel through this one wrapper — in `try`/`except PermissionError`, folding to the SAME "lost" answer a missing file already gets, but with a **new, distinct** `LostReason.OUTSIDE_BOUNDARY` (never `GC`/`EXTERNAL`, which would misleadingly claim the file used to exist and is now gone) and **distinct placeholder wording** (never claims "no longer exists" — the file may well still be sitting right there, just outside the boundary). Computed fresh, never persisted — same "compute, don't store" discipline #5438 already established for `GC`/`EXTERNAL` (#5438 explicitly ruled out a new ledger).
2. **New `MediaStore` method** `read_tool_result_preview_for_internal_reader` — the SAME read as `read_tool_result_preview`, folds its own `PermissionError` to `found=False`, but **logs a WARNING distinct from an ordinary not-found first** (the defect — an invalid ref reaching an internal reader — must not become permanently unobservable just because the caller no longer crashes). `chat_message.py` and `router_history_buffer.py`'s own preview callers switched to it.

`resources.py` (the external-input boundary, needs the raising form to answer 400 vs 404) and `mcp/server.py:711` (out of the original census — its own docstring already documents intentional `PermissionError` propagation to the MCP client) are **both untouched** — verified by `git diff`, not just by intent.

## Test plan

- [x] `tests/runtime/test_5982_internal_boundary_fold.py` — 6 tests, real `MediaStore` + a REAL file written outside both valid roots (so `read_tool_result` genuinely raises, not a simulated exception): `resolve_history_content` folds with the distinct reason/wording (accept) and leaves a genuinely-missing ref's `gc`/`external` handling untouched (deny, FP gate) and an in-boundary present file unaffected (FP gate); the new preview entrypoint folds+warns (accept), a missing-but-in-boundary ref folds **without** the warning (deny, proving the log is distinct, not tacked onto every not-found), and a present file previews normally (FP gate).
- [x] Strip witness, 3 independent points — verified directly (in-file Edit → red → Edit back): the `resolve_history_content` `try`/`except` itself, the `OUTSIDE_BOUNDARY` reason value (mixing it with `EXTERNAL` fails the distinct-wording assertion too), and the new `MediaStore` method's own `try`/`except`.
- [x] 49 tests total (this file + every existing test touching `resolve_history_content`/`LostReason`/`read_tool_result_preview`/`body_bytes`) green.
- [x] `ruff check .` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5982_internal_boundary_fold.py` — 6/6 OK
- [x] `python scripts/mypy_ratchet.py` — OK (0 new findings)
- [x] `python scripts/verify_module_docstrings.py` (all changed files) — OK
- [x] (skipped — Visual, standing waiver)

Closes #5982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
