### PR TITLE
fix(#6021): loop tripwire is opt-in (never fires by default) -- owner ruling

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -104,7 +104,7 @@ from .gutter import (
     ReynRightGutter,
 )
 from .intervention_panel import InterventionPanel
-from .loop_probe import LoopTripwire
+from .loop_probe import LoopTripwire, tripwire_threshold_ms_from_env
 from .presenter import (
     _COMPACTION_PROGRESS_KEY,
     _RESULT_KIND_KEY,
@@ -1534,8 +1534,11 @@ class TextualChatApp(App):
         #: path that ends a recording before it would fire disarms it first,
         #: see :meth:`_voice_cancel_timeout_timer`).
         self._voice_timeout_timer: "Timer | None" = None
-        #: Watches how late the event loop runs (#3539). Always on; see
-        #: ``loop_probe`` for why it is not opt-in. Reset via
+        #: Watches how late the event loop runs (#3539). #6021 (owner
+        #: ruling): opt-in via REYN_TRIPWIRE_MS, never fires by default
+        #: — see ``loop_probe``/``loop_tripwire``'s own module docstring
+        #: for the full story (a self-calibrating alternative was
+        #: designed and rejected by the owner directly). Reset via
         #: :meth:`reset_loop_tripwire`, not a constructor parameter —
         #: #4855 follow-up (lead-coder's own retraction, round 3): a
         #: test needing a CLEAN tripwire is reacting to contamination
@@ -1546,7 +1549,14 @@ class TextualChatApp(App):
         #: mount-time stall just the same, making a constructor seam
         #: unreachable dead code for the actual failure mode it would
         #: exist to fix.
-        self._loop_tripwire = LoopTripwire()
+        # #6021: threshold read fresh from REYN_TRIPWIRE_MS at construction
+        # — off (never fires) unless an operator who knows THIS machine's
+        # own healthy ceiling sets it. See tripwire_threshold_ms_from_env's
+        # own docstring for why (a self-calibrating threshold was designed
+        # and rejected — 2 new unmeasured constants of its own).
+        self._loop_tripwire = LoopTripwire(
+            threshold_ms=tripwire_threshold_ms_from_env(logger=logger),
+        )
         #: #5907 ①: the single-in-flight FIFO every wire-touching unit
         #: (a slash command's run unit, a submit round-trip) goes through,
         #: and its one worker — see :meth:`_enqueue_wire`.
@@ -2376,12 +2386,21 @@ class TextualChatApp(App):
     async def _watch_loop_responsiveness(self) -> None:
         """Report ONCE if the event loop stops running on time (#3539).
 
-        Always on. The symptom this watches for arrives unannounced, so an
-        opt-in probe would only ever be enabled after the occurrence someone
-        wanted to measure — #3638 closed that way. The cost is one float
-        comparison per tick against a measured baseline where a 10 ms task
-        never exceeded 12 ms over 463 chunks, so a healthy stream never trips
-        it.
+        #6021 (owner ruling, real-machine hit — supersedes the "always on"
+        paragraph this replaces): opt-in via ``REYN_TRIPWIRE_MS``, never
+        fires by default. Originally always-on for the reason below (the
+        symptom this watches for arrives unannounced, so an opt-in probe
+        would only ever be enabled after the occurrence someone wanted to
+        measure — #3638 closed that way), but the fixed threshold that
+        shipped with that decision (250ms, "well above a measured 10ms
+        task's own 12ms ceiling") was one machine's own number, applied
+        everywhere — the owner's own real machine (Windows/git-bash)
+        routinely exceeded it on healthy runs. A self-calibrating
+        threshold was designed and REJECTED by the owner directly (2 new
+        unmeasured constants of its own); the owner's own resolution is
+        this opt-in instead — see ``loop_tripwire``'s own module
+        docstring for the full account. The cost, when armed, is
+        unchanged: one float comparison per tick.
 
         The notice is decision-enabling rather than a bare complaint: it says
         how long, and how to record the detail next time.
@@ -2408,12 +2427,16 @@ class TextualChatApp(App):
         one process-wide ``faulthandler`` timer (re-armed every tick,
         ``repeat=False`` — see that module's own updated docstring for why
         this shape, not the turn-arm's ``repeat=True``): if a tick fails to
-        land within :data:`_TRIPWIRE_MS`, the PENDING timer fires on its own
+        land within the tripwire's own :attr:`~reyn.runtime.loop_tripwire.
+        LoopTripwire.threshold_ms`, the PENDING timer fires on its own
         OS thread — independent of this asyncio loop, so it fires even when
         the loop itself is the thing blocked — and dumps the main thread's
         stack to ``reyn.log`` mid-stall, not after. This is armed
-        UNCONDITIONALLY (no ``REYN_STALL_TRACE`` opt-in), matching the
-        tripwire's own "arrives unannounced" reasoning above; see
+        whenever the TRIPWIRE itself is (``REYN_TRIPWIRE_MS`` — #6021,
+        owner ruling, superseding the "unconditionally... arrives
+        unannounced" claim this paragraph used to make: NOT
+        ``REYN_STALL_TRACE``, a different opt-in entirely, still
+        unrelated to this one); see
         ``stall_trace.py``'s own docstring for what this costs the OTHER
         (turn-scoped) caller of the same global timer once this worker has
         started.
@@ -2502,6 +2525,7 @@ class TextualChatApp(App):
         updated docstring.
         """
         import asyncio  # noqa: PLC0415
+        import math  # noqa: PLC0415
         import time  # noqa: PLC0415
         from collections import deque  # noqa: PLC0415
 
@@ -2511,7 +2535,6 @@ class TextualChatApp(App):
 
         from .loop_probe import (  # noqa: PLC0415
             _TICK_SECONDS,
-            _TRIPWIRE_MS,
             StallDumpArm,
             stall_banner,
             stall_dump_path,
@@ -2524,17 +2547,33 @@ class TextualChatApp(App):
         # dead-man's switch and LoopTripwire.observe()'s own comparison, so
         # "did the loop stall" and "should a stack have been dumped for it"
         # can never disagree about WHERE the line is.
-        _STACK_DUMP_SECONDS = _TRIPWIRE_MS / 1000
-        # #5877/#5873/#5977 ②, ONE implementation since #5898: this
-        # worker's OWN fd, opened once against its own single dedicated
-        # dump file (never reyn.log — see stall_dump_path's own
-        # docstring) and held for its whole lifetime. `None` (no
-        # FileHandler installed, so no directory to derive a path from)
-        # means this dead-man's switch never arms at all for this
-        # worker's lifetime.
-        _stack_dump = StallDumpArm.open(
-            seconds=_STACK_DUMP_SECONDS, path=stall_dump_path(_find_file_handler_path()),
-            logger=logger, label="textual chat",
+        #
+        # #6021 (owner ruling, correcting lead-coder's own earlier "①
+        # threshold / ② dump-on-fire are separable" framing): reads
+        # ``self._loop_tripwire.threshold_ms`` — the SAME instance
+        # ``on_mount``/``reset_loop_tripwire`` already constructed from
+        # ``REYN_TRIPWIRE_MS`` — rather than a SECOND, independent env
+        # read of its own. Two mechanisms sharing one VALUE (not one
+        # SOURCE) is exactly the trap this issue itself was: whoever next
+        # changes one of the two would silently desync from the other.
+        _stack_dump_threshold_ms = self._loop_tripwire.threshold_ms
+        # #6021: "the default doesn't fire" means, per the owner's own
+        # words, the FILE never appears at all — not an empty one. #4986's
+        # own comment ("the log file is opened (empty) the moment the
+        # watchdog is armed") makes "armed" and "file exists" the SAME
+        # fact — so an UNARMED watchdog must mean `StallDumpArm.open`
+        # itself is never called, not called-then-inert. This reuses the
+        # SAME "no genuinely stable destination, no attempt" branch
+        # `path=None` already takes (#5977 ②) — no new branch shape, only
+        # a second reason to take the existing one.
+        _stack_dump = (
+            StallDumpArm.open(
+                seconds=_stack_dump_threshold_ms / 1000,
+                path=stall_dump_path(_find_file_handler_path()),
+                logger=logger, label="textual chat",
+            )
+            if math.isfinite(_stack_dump_threshold_ms)
+            else None
         )
 
         # #4761 ② (lead-coder review): a stall that never recovers — #4761's
@@ -2602,7 +2641,7 @@ class TextualChatApp(App):
                     # fire" — the SAME comparison LoopTripwire.observe
                     # makes internally, never a readback of faulthandler's
                     # (nonexistent) fired state.
-                    stack_dumped = lateness_ms > _TRIPWIRE_MS
+                    stack_dumped = lateness_ms > self._loop_tripwire.threshold_ms
                     if stack_dumped:
                         # #5992 (self-caught correction, lead-coder review
                         # of PR #5988): an EARLIER version called
@@ -3839,7 +3878,10 @@ class TextualChatApp(App):
         app.py) also touches every caller — a compile-time-visible
         breakage, not a silent no-op one file away.
         """
-        self._loop_tripwire = LoopTripwire()
+        # #6021: same env-var-derived threshold as the constructor site.
+        self._loop_tripwire = LoopTripwire(
+            threshold_ms=tripwire_threshold_ms_from_env(logger=logger),
+        )
 
     @property
     def pump_ticks(self) -> int:

--- a/src/reyn/interfaces/inline/textual_chat/loop_probe.py
+++ b/src/reyn/interfaces/inline/textual_chat/loop_probe.py
@@ -15,6 +15,7 @@ from reyn.runtime.loop_tripwire import (
     _DUMP_ENV,
     _RECORD_INTERVAL_S,
     _TICK_SECONDS,
+    _TRIPWIRE_ENV,
     _TRIPWIRE_MS,
     LoopTripwire,
     StallDumpArm,
@@ -24,6 +25,7 @@ from reyn.runtime.loop_tripwire import (
     stall_dump_path,
     stall_log_line,
     stall_recovered_log_line,
+    tripwire_threshold_ms_from_env,
     watch_event_loop,
     write_record,
 )
@@ -32,6 +34,7 @@ __all__ = [
     "_DUMP_ENV",
     "_RECORD_INTERVAL_S",
     "_TICK_SECONDS",
+    "_TRIPWIRE_ENV",
     "_TRIPWIRE_MS",
     "LoopTripwire",
     "StallDumpArm",
@@ -41,6 +44,7 @@ __all__ = [
     "stall_dump_path",
     "stall_log_line",
     "stall_recovered_log_line",
+    "tripwire_threshold_ms_from_env",
     "watch_event_loop",
     "write_record",
 ]

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -173,38 +173,62 @@ async def _lifespan(app: FastAPI):
     install_asyncio_exception_handler(asyncio.get_running_loop())
 
     # ── Event-loop tripwire (#5898, #5894 ②) ───────────────────────────────
-    # Always on, shipped config: `reyn:web`'s loop blocked for 7 minutes on
-    # O(history bytes) CPU work and NOTHING in this process recorded it —
-    # `stall_trace.py` is a REYN_STALL_TRACE opt-in and the tripwire lived
-    # in textual_chat — so the stall was visible only as its clients'
-    # symptoms. Same watcher the CUI runs (reyn.runtime.loop_tripwire):
-    # one WARNING per stall episode + one at recovery on reyn's own log,
-    # and — when a log FileHandler is installed — the main thread's stack
-    # dumped INTO that log mid-stall by the per-tick faulthandler
-    # dead-man's switch, so "what was it doing" is answered by the
-    # process itself, not reconstructed from `sample` afterwards.
+    # #6021 (owner ruling): opt-in via REYN_TRIPWIRE_MS, never fires by
+    # default — see reyn.runtime.loop_tripwire's own module docstring for
+    # the full story (a self-calibrating threshold was designed and
+    # rejected). Originally always-on, shipped config: `reyn:web`'s loop
+    # blocked for 7 minutes on O(history bytes) CPU work and NOTHING in
+    # this process recorded it — `stall_trace.py` is a REYN_STALL_TRACE
+    # opt-in and the tripwire lived in textual_chat — so the stall was
+    # visible only as its clients' symptoms. Same watcher the CUI runs
+    # (reyn.runtime.loop_tripwire): one WARNING per stall episode + one
+    # at recovery on reyn's own log when armed, and — when a log
+    # FileHandler is ALSO installed — the main thread's stack dumped
+    # INTO that log mid-stall by the per-tick faulthandler dead-man's
+    # switch, so "what was it doing" is answered by the process itself,
+    # not reconstructed from `sample` afterwards.
+    import math  # noqa: PLC0415
+
     from reyn.runtime.loop_tripwire import (  # noqa: PLC0415
-        _TRIPWIRE_MS,
         LoopTripwire,
         StallDumpArm,
         stall_dump_path,
         stall_log_line,
         stall_recovered_log_line,
+        tripwire_threshold_ms_from_env,
         watch_event_loop,
     )
     from reyn.runtime.stall_trace import find_file_handler_path  # noqa: PLC0415
 
-    _tripwire = LoopTripwire()
+    # #6021: off (never fires) unless REYN_TRIPWIRE_MS names a value —
+    # matches the CUI's own construction (app.py's on_mount).
+    _tripwire = LoopTripwire(threshold_ms=tripwire_threshold_ms_from_env(logger=logger))
     app.state.loop_tripwire = _tripwire
     # #5977 ③: bound to a name (rather than passed inline) so the on_stall
     # lambda below can read its own .path — the same arm the dead-man's
     # switch itself uses, never a second, independently-derived path.
-    _stack_dump = StallDumpArm.open(
-        # #5977 ②: its own single, always-overwritten file beside
-        # reyn.log — never reyn.log itself (see stall_dump_path's
-        # own docstring for why).
-        seconds=_TRIPWIRE_MS / 1000, path=stall_dump_path(find_file_handler_path()),
-        logger=logger, label="reyn:web",
+    #
+    # #6021 (owner ruling): reads `_tripwire.threshold_ms` — the SAME
+    # instance just constructed above — rather than the module constant
+    # directly, so the arm timer's own duration and the tripwire's own
+    # stall comparison can never desync (see app.py's identical comment
+    # for the full story). When disabled (REYN_TRIPWIRE_MS unset),
+    # `StallDumpArm.open` itself is never called — "the default doesn't
+    # fire" means the file never appears at all, not an empty one
+    # (#4986's own "opened (empty) the moment the watchdog is armed" —
+    # unarmed means unopened).
+    _stack_dump_threshold_ms = _tripwire.threshold_ms
+    _stack_dump = (
+        StallDumpArm.open(
+            # #5977 ②: its own single, always-overwritten file beside
+            # reyn.log — never reyn.log itself (see stall_dump_path's
+            # own docstring for why).
+            seconds=_stack_dump_threshold_ms / 1000,
+            path=stall_dump_path(find_file_handler_path()),
+            logger=logger, label="reyn:web",
+        )
+        if math.isfinite(_stack_dump_threshold_ms)
+        else None
     )
     app.state.loop_tripwire_task = asyncio.create_task(
         watch_event_loop(

--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -4,14 +4,28 @@
 Two layers, because they answer different questions and only one of them can be
 switched on in advance.
 
-**A tripwire that is always on.** The symptom this exists for — "the UI froze
-while a reply streamed" (#3539), "no HTTP request returned for 7 minutes"
-(#5898) — arrives unannounced, so an opt-in probe is only ever enabled *after*
-someone has already lost the occurrence they wanted to measure. #3638 closed
-exactly that way: by the time anyone could look, the symptom had stopped
-happening. The tripwire therefore runs unconditionally and costs a comparison
-against a float per tick; when the loop is late by more than
-:data:`_TRIPWIRE_MS` it says so ONCE, and says what to do next.
+**A tripwire that ran on by default, now opt-in (#6021, owner ruling —
+supersedes the paragraph below).** The symptom this exists for — "the UI
+froze while a reply streamed" (#3539), "no HTTP request returned for 7
+minutes" (#5898) — arrives unannounced, which argued for an unconditional
+default: an opt-in probe is only ever enabled *after* someone has already
+lost the occurrence they wanted to measure (#3638 closed exactly that
+way). But the THRESHOLD that decision shipped with (:data:`_TRIPWIRE_MS`)
+was one machine's own measurement, applied to every machine — the owner's
+real one (Windows/git-bash) routinely exceeded it on healthy runs, firing
+constantly and writing a full-thread-stack dump file every time (#6021).
+A self-calibrating threshold was designed and REJECTED by the owner
+directly: it would have introduced 2 new unmeasured constants of its own
+(a calibration window, a safety multiplier) — the SAME "a number nobody
+measured for THIS machine" shape one level down. The owner's own
+resolution: **no threshold by default — an operator who knows their own
+machine sets one.** :data:`_TRIPWIRE_MS` defaults to ``float("inf")``
+(never fires); :func:`tripwire_threshold_ms_from_env` reads
+:data:`_TRIPWIRE_ENV` for the opt-in value. When disabled,
+:class:`StallDumpArm` is never even opened — the dump FILE does not
+exist at all, matching the owner's own words ("規定は発火しない") read
+literally: what the owner calls "firing" is the file appearing, not an
+internal comparison.
 
 **Detail behind an env var.** Everything that costs more than a comparison —
 per-chunk wait/work split, per-delta handler timing — is written only when
@@ -56,12 +70,34 @@ from typing import Any, Callable
 from reyn.data.index.build_lock import pid_alive
 from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot, diagnostic_snapshot
 
-#: A loop tick later than this is worth telling someone about. Set well above
-#: the measured healthy ceiling (a 10 ms-period task never exceeded 12 ms over
-#: 463 chunks) so an ordinary stream never trips it — the tripwire's value is
-#: that it stays quiet, and a threshold that fires on healthy runs would be
-#: read as noise and ignored.
-_TRIPWIRE_MS = 250.0
+#: #6021 (owner ruling, real-machine hit): a loop tick later than this is
+#: worth telling someone about — OPT-IN, no threshold by default. The
+#: number this constant used to hold (250.0, "well above the measured
+#: healthy ceiling — a 10 ms-period task never exceeded 12 ms over 463
+#: chunks") was a measurement of ONE machine, applied unconditionally to
+#: every other one; the owner's own real machine (Windows/git-bash)
+#: routinely exceeds 250ms on an ordinary, healthy run, so the tripwire
+#: fired constantly there — the exact "read as noise and ignored" failure
+#: this module's own docstring already predicted for a threshold that
+#: fires on healthy runs. A self-calibrating threshold (observe this
+#: machine's own healthy ticks at startup, set the threshold from that)
+#: was designed and REJECTED by the owner directly — it would have
+#: introduced 2 new unmeasured constants of its own (a calibration window,
+#: a safety multiplier), reproducing the SAME "a number nobody measured
+#: for THIS machine" shape one level down. ``float("inf")`` — never fires
+#: — is the default; :func:`tripwire_threshold_ms_from_env` reads
+#: :data:`_TRIPWIRE_ENV` for an operator who has looked at THEIR OWN
+#: machine and knows what to set. No config surface with a numeric
+#: default exists to raise (CLAUDE.md: "a limit that can be set is a
+#: limit someone can raise") — there is no default to raise, only an
+#: explicit opt-in.
+_TRIPWIRE_MS = float("inf")
+
+#: #6021: names the ms threshold above :data:`_TRIPWIRE_MS`'s own default
+#: (never fires) — matches the existing env-var-opt-in idiom this module
+#: already has two instances of (:data:`_DUMP_ENV`/``REYN_PROF_DUMP``,
+#: and ``REYN_STALL_TRACE`` in ``stall_trace.py``), not a new style.
+_TRIPWIRE_ENV = "REYN_TRIPWIRE_MS"
 
 #: How often the tripwire wakes. Long enough to cost nothing, short enough that
 #: a stall a human would notice cannot hide between two ticks.
@@ -81,6 +117,48 @@ _TICK_SECONDS = 0.05
 _RECORD_INTERVAL_S = 2.0
 
 _DUMP_ENV = "REYN_PROF_DUMP"
+
+
+def tripwire_threshold_ms_from_env(*, logger: logging.Logger) -> float:
+    """The configured tripwire threshold in ms, or :data:`_TRIPWIRE_MS`
+    (``float("inf")`` — never fires) if the env var is unset, empty,
+    non-numeric, zero, or negative — every one of those means "off," the
+    default, matching :func:`~reyn.runtime.stall_trace.
+    stall_trace_seconds_from_env`'s own established shape for the SAME
+    reason (#6021): a caller need only construct :class:`LoopTripwire`
+    with this value, never branch on WHY it came out disabled.
+
+    ``logger`` is a required PARAMETER, not a module-level object — this
+    module has none (see :func:`_sweep_dead_pid_stall_dumps`'s own
+    identical shape): a runtime-generic module used by both the TUI and
+    ``reyn:web`` logs under whichever CALLER's own logger name, not a
+    third, hidden ``reyn.runtime.loop_tripwire`` namespace neither
+    consumer would think to look at.
+
+    Read at call time, not captured at import (the same reason
+    :func:`dump_path` reads :data:`_DUMP_ENV` per call) — a long-lived
+    process could in principle be told to start watching without a
+    restart, and every one of this function's 3 production call sites
+    already calls it fresh at its own ``LoopTripwire()`` construction
+    point, never once at import."""
+    raw = os.environ.get(_TRIPWIRE_ENV)
+    if not raw:
+        return _TRIPWIRE_MS
+    try:
+        threshold_ms = float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number; loop tripwire stays disabled",
+            _TRIPWIRE_ENV, raw,
+        )
+        return _TRIPWIRE_MS
+    if threshold_ms <= 0:
+        logger.warning(
+            "%s=%r is not positive; loop tripwire stays disabled",
+            _TRIPWIRE_ENV, raw,
+        )
+        return _TRIPWIRE_MS
+    return threshold_ms
 
 
 def stall_dump_path(reyn_log_path: "str | None") -> "str | None":

--- a/tests/interfaces/test_3671_stall_trace_startup_wiring.py
+++ b/tests/interfaces/test_3671_stall_trace_startup_wiring.py
@@ -167,6 +167,9 @@ async def test_stall_trace_disarmed_at_first_frame_via_on_mount(
     reyn.log-shaped destination exists (#5877 architect ruling) — without
     it this test's own SECOND-disarm premise would not hold at all."""
     monkeypatch.setenv("REYN_STALL_TRACE", "5")
+    # #6021: this test's own SECOND-disarm premise needs the tripwire's
+    # own worker to have armed something in the first place.
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
 
     calls: list[str] = []
     monkeypatch.setattr(stall_trace, "disarm", lambda: calls.append("disarm"))
@@ -204,9 +207,21 @@ async def test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists(
     borrowed stream object's fd number can be silently reused once that
     stream closes — see ``find_file_handler_path``'s own docstring for
     the reproduced mechanism). Deliberately with ``REYN_STALL_TRACE``
-    UNSET: this arm must fire regardless, the same "arrives unannounced,
-    so it cannot wait for a manual opt-in" reasoning ``loop_probe.py``'s
-    own module docstring already states for the tripwire itself. Wiring
+    UNSET: this arm must fire regardless — that opt-in gates a DIFFERENT
+    mechanism entirely (the turn-scoped watchdog, ``stall_trace.py``'s
+    own concern).
+
+    #6021 (owner ruling, supersedes this test's own earlier premise):
+    ``REYN_TRIPWIRE_MS`` IS set here, deliberately — this dead-man's
+    switch used to arm regardless of ANY env var ("arrives unannounced,
+    so it cannot wait for a manual opt-in," ``loop_probe.py``'s own
+    former module docstring), but the owner's own real-machine hit
+    (routine 250ms fires on a healthy machine) made THAT threshold
+    itself opt-in — the sibling test right below asserts the NEW
+    accept-side of that (no ``REYN_TRIPWIRE_MS`` → this arm never
+    happens, PERIOD, ``FileHandler`` or not). This test's own subject
+    (the fd/inode/repeat=False shape once armed) is unaffected — it
+    still needs a real arm to observe, so it explicitly opts in. Wiring
     only — no real delay, no threshold crossing (banned by testing
     policy's duration rules, this file's own module docstring).
 
@@ -214,6 +229,9 @@ async def test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists(
     path (``reyn.log``) — it is ``stall_dump_path()``'s derived single
     dedicated file, the SAME directory, a fixed different name."""
     monkeypatch.delenv("REYN_STALL_TRACE", raising=False)
+    # #6021: opt in explicitly — this test's own subject needs a real
+    # arm to observe (see the docstring's own #6021 paragraph above).
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
 
     calls: "list[tuple[float, object, bool | None]]" = []
     monkeypatch.setattr(
@@ -256,6 +274,45 @@ async def test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists(
         assert os.fstat(file_arg).st_ino == expected_path.stat().st_ino, (
             "the armed fd does not point at the derived, pid-scoped stall-dump snapshot path"
         )
+
+
+@pytest.mark.asyncio
+async def test_the_tripwire_never_arms_or_opens_a_file_without_REYN_TRIPWIRE_MS(
+    monkeypatch, installed_file_handler: Path,
+) -> None:
+    """Tier 2: #6021 (owner ruling) — the NEW accept-side, the mirror of
+    ``test_the_tripwire_arms_its_own_fd_when_a_file_handler_exists``
+    right above: with a REAL ``FileHandler`` installed (so the OLD
+    "#5877: no destination, no attempt" reason for staying disarmed does
+    NOT apply) but ``REYN_TRIPWIRE_MS`` left UNSET, the dead-man's switch
+    must still never arm — and, per the owner's own literal words ("規定
+    は発火しない" read together with the dump FILE being what "発火" means
+    to them), the destination FILE must not even come into existence.
+    Not "opened empty" — genuinely absent, matching #4986's own comment
+    that this class's own docstring quotes ("the log file is opened
+    (empty) the moment the watchdog is armed" — unarmed therefore means
+    unopened)."""
+    monkeypatch.delenv("REYN_STALL_TRACE", raising=False)
+    monkeypatch.delenv("REYN_TRIPWIRE_MS", raising=False)
+
+    calls: "list[object]" = []
+    monkeypatch.setattr(stall_trace, "arm", lambda *a, **kw: calls.append((a, kw)))
+    monkeypatch.setattr(stall_trace, "disarm", lambda: None)
+
+    app = TextualChatApp(transport=QueueTransport())
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+    assert calls == [], (
+        f"the tripwire armed with no REYN_TRIPWIRE_MS set: {calls!r} — the "
+        "default must stay off even with a real FileHandler installed"
+    )
+    expected_path = installed_file_handler.with_name(f"stall_dump.{os.getpid()}.log")
+    assert not expected_path.exists(), (
+        "the dump file must not exist at all when disabled -- not created "
+        "empty, genuinely absent (StallDumpArm.open must never be called)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_loop_probe_3539.py
+++ b/tests/interfaces/test_loop_probe_3539.py
@@ -31,6 +31,7 @@ from reyn.interfaces.inline.textual_chat.loop_probe import (
     stall_banner,
     stall_log_line,
     stall_recovered_log_line,
+    tripwire_threshold_ms_from_env,
     write_record,
 )
 from reyn.interfaces.transport.client_transport import ClientTransportStub
@@ -159,6 +160,45 @@ def test_detail_is_off_unless_a_path_is_named(monkeypatch) -> None:
     assert dump_path() is None
 
 
+def test_tripwire_threshold_is_disabled_unless_the_env_var_is_set(monkeypatch, caplog) -> None:
+    """Tier 2: #6021 (owner ruling) — no ``REYN_TRIPWIRE_MS``, no
+    threshold: the function returns the disabled sentinel
+    (``float("inf")``), matching :func:`~reyn.runtime.stall_trace.
+    stall_trace_seconds_from_env`'s own "unset means off" shape."""
+    import logging
+
+    monkeypatch.delenv("REYN_TRIPWIRE_MS", raising=False)
+    logger = logging.getLogger("test-6021")
+
+    assert tripwire_threshold_ms_from_env(logger=logger) == float("inf")
+
+
+def test_tripwire_threshold_reads_a_valid_env_var(monkeypatch) -> None:
+    """Tier 2: set to a real number, that number is the threshold — the
+    OTHER accept criterion (armed fires at ITS value)."""
+    import logging
+
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", "500")
+    logger = logging.getLogger("test-6021")
+
+    assert tripwire_threshold_ms_from_env(logger=logger) == 500.0
+
+
+@pytest.mark.parametrize("raw", ["not-a-number", "0", "-10", ""])
+def test_tripwire_threshold_falls_back_to_disabled_on_a_bad_value(
+    monkeypatch, raw: str,
+) -> None:
+    """Tier 2: non-numeric, zero, negative, or empty all mean "off," the
+    same as unset — never a crash, never a silently-adopted nonsense
+    threshold (e.g. a negative number would make EVERY tick a stall)."""
+    import logging
+
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", raw)
+    logger = logging.getLogger("test-6021")
+
+    assert tripwire_threshold_ms_from_env(logger=logger) == float("inf")
+
+
 def test_write_record_touches_nothing_when_off(monkeypatch, tmp_path: Path) -> None:
     """Tier 2: the default path creates no file anywhere.
 
@@ -230,15 +270,33 @@ def test_the_environment_axes_carry_host_load_and_process_footprint() -> None:
 
 
 def test_the_tripwire_stays_quiet_on_a_healthy_loop() -> None:
-    """Tier 2: a healthy stream never trips it.
+    """Tier 2: a healthy stream never trips an ARMED tripwire.
 
     The measured baseline is a 10 ms-period task never exceeding 12 ms over 463
     chunks. A tripwire that fired on those would be read as noise and ignored,
     which is the same as not having one.
     """
-    tripwire = LoopTripwire()
+    tripwire = LoopTripwire(threshold_ms=250.0)
 
     assert all(tripwire.observe(lateness) is None for lateness in (0.1, 5.0, 12.0, 40.0))
+    assert not tripwire.fired
+
+
+def test_the_default_tripwire_never_fires_at_all() -> None:
+    """Tier 2: #6021 (owner ruling) — the DEFAULT ``LoopTripwire()``, with
+    no ``threshold_ms`` given, never fires — not "on healthy loads," on
+    ANYTHING, including a magnitude that would have crossed the OLD
+    always-on default (250ms) many times over. This is the actual
+    property #6021 asks for: opt-in, not "a higher/safer default."
+
+    Strip-falsifier (verified by hand: ``_TRIPWIRE_MS`` reverted to
+    ``250.0``): this test goes red — ``observe(9000.0)`` returns a
+    magnitude, not ``None``."""
+    tripwire = LoopTripwire()
+
+    assert tripwire.observe(9000.0) is None, (
+        "the default tripwire must never fire, regardless of magnitude"
+    )
     assert not tripwire.fired
 
 
@@ -454,6 +512,10 @@ async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkey
 
     monkeypatch.delenv("REYN_PROF_DUMP", raising=False)
     transport = QueueTransport()
+    # #6021: threshold is opt-in now (default: never fires) — arm it
+    # so this test's own clock.jump can be detected, matching the
+    # old always-on default's own value.
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
     app = TextualChatApp(transport=transport)
     logger_name = "reyn.interfaces.inline.textual_chat.app"
     # #4844: a virtual clock, not a real time.sleep() — see _VirtualClock's
@@ -462,7 +524,7 @@ async def test_recovery_notice_is_visible_without_arming_the_dump(caplog, monkey
     # magnitude past any margin a test could afford to wait for).
     clock = _VirtualClock()
     monkeypatch.setattr(time, "perf_counter", clock)
-    stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+    stall_seconds = (250.0 + 150) / 1000  # #6021: matches the REYN_TRIPWIRE_MS armed above
     with caplog.at_level(logging.WARNING, logger=logger_name):
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
@@ -539,8 +601,12 @@ async def test_recovery_notice_survives_the_real_interactive_logging_floor(
         logging.basicConfig(
             filename=str(logfile), level=logging.WARNING, force=True,
         )
-        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        stall_seconds = (250.0 + 150) / 1000  # #6021: matches the REYN_TRIPWIRE_MS armed above
         transport = QueueTransport()
+        # #6021: threshold is opt-in now (default: never fires) — arm it
+        # so this test's own clock.jump can be detected, matching the
+        # old always-on default's own value.
+        monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
         app = TextualChatApp(transport=transport)
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
@@ -598,6 +664,10 @@ async def test_the_app_actually_shows_the_notice_when_the_loop_stalls(caplog, mo
     import logging
 
     transport = QueueTransport()
+    # #6021: threshold is opt-in now (default: never fires) — arm it
+    # so this test's own clock.jump can be detected, matching the
+    # old always-on default's own value.
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
     app = TextualChatApp(transport=transport)
     # #4844: virtual clock, no real sleep — see _VirtualClock's docstring.
     clock = _VirtualClock()
@@ -667,6 +737,10 @@ async def test_a_stall_costs_no_row_of_layout(caplog, monkeypatch) -> None:
     import logging
 
     transport = QueueTransport()
+    # #6021: threshold is opt-in now (default: never fires) — arm it
+    # so this test's own clock.jump can be detected, matching the
+    # old always-on default's own value.
+    monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
     app = TextualChatApp(transport=transport)
     logger_name = "reyn.interfaces.inline.textual_chat.app"
     # #4844: virtual clock, no real sleep — see _VirtualClock's docstring.
@@ -893,8 +967,12 @@ async def test_pump_heartbeat_reaches_the_default_visible_notices(
         logging.basicConfig(
             filename=str(logfile), level=logging.WARNING, force=True,
         )
-        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        stall_seconds = (250.0 + 150) / 1000  # #6021: matches the REYN_TRIPWIRE_MS armed above
         transport = QueueTransport()
+        # #6021: threshold is opt-in now (default: never fires) — arm it
+        # so this test's own clock.jump can be detected, matching the
+        # old always-on default's own value.
+        monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
         app = TextualChatApp(transport=transport)
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
@@ -1031,8 +1109,12 @@ async def test_keys_received_reaches_the_default_visible_stall_notice(
         logging.basicConfig(
             filename=str(logfile), level=logging.WARNING, force=True,
         )
-        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        stall_seconds = (250.0 + 150) / 1000  # #6021: matches the REYN_TRIPWIRE_MS armed above
         transport = QueueTransport()
+        # #6021: threshold is opt-in now (default: never fires) — arm it
+        # so this test's own clock.jump can be detected, matching the
+        # old always-on default's own value.
+        monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
         app = TextualChatApp(transport=transport)
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()
@@ -1222,8 +1304,12 @@ async def test_turn_active_reaches_the_default_visible_stall_notice(
         logging.basicConfig(
             filename=str(logfile), level=logging.WARNING, force=True,
         )
-        stall_seconds = (loop_probe._TRIPWIRE_MS + 150) / 1000
+        stall_seconds = (250.0 + 150) / 1000  # #6021: matches the REYN_TRIPWIRE_MS armed above
         transport = QueueTransport()
+        # #6021: threshold is opt-in now (default: never fires) — arm it
+        # so this test's own clock.jump can be detected, matching the
+        # old always-on default's own value.
+        monkeypatch.setenv("REYN_TRIPWIRE_MS", "250")
         app = TextualChatApp(transport=transport)
         async with app.run_test(size=(80, 24)) as pilot:
             await pilot.pause()


### PR DESCRIPTION
**[tui-coder]** — fixes #6021. owner-hit, priority.

## The ruling
Owner rejected the self-calibrating threshold I designed (it would have added 2 new unmeasured constants — a calibration window, a safety multiplier) and decided directly: **no threshold by default.** `REYN_TRIPWIRE_MS` names one explicitly, matching the existing env-var-opt-in idiom (`REYN_STALL_TRACE`, `REYN_PROF_DUMP`), no new style.

## A real coupling found mid-implementation (reported, confirmed, then fixed)
`_TRIPWIRE_MS` was ALSO the raw `faulthandler` dead-man's-switch arm timer's own duration (`app.py`/`server.py`'s `_STACK_DUMP_SECONDS`) — completely independent of `LoopTripwire`'s own state, re-armed every tick regardless of whether a stall was ever reported. Silencing only `LoopTripwire`'s own notices would have left the actual dump **file** (the owner's real complaint — "ダンプには250msでタイムアウトと先頭にある") written exactly as often as before. Fixed per the owner's own accept criterion, read literally ("規定は発火しない" — what they call "firing" is the file appearing): `StallDumpArm.open()` is now skipped entirely when the threshold is disabled — the file does not exist at all, not opened-then-empty. Both mechanisms now read the SAME already-constructed `LoopTripwire` instance's own `threshold_ms`, never two independent env reads that could desync (the exact trap the original coupling was).

## Docs updated
The module's own "always on" claims (`loop_tripwire.py`'s module docstring, `app.py` ×2, `server.py`) are DECIDING docs — updated to state the new ruling, with the "why it was always-on" preserved as history, not silently deleted (CLAUDE.md).

## Tests
9 existing tests across `test_loop_probe_3539.py`/`test_3671_stall_trace_startup_wiring.py` updated to explicitly opt in (`REYN_TRIPWIRE_MS`) where their own subject needs a real arm to observe — without this they'd hang forever waiting for a stall that can no longer fire by default. 2 new accept-side tests: armed (file exists, correct fd/inode) / unarmed (file genuinely absent, not empty). `test_the_tripwire_stays_quiet_on_a_healthy_loop` split so the DEFAULT-never-fires property (#6021's actual subject) isn't left as a vacuous side effect of an unrelated, now-trivially-true assertion.

Strip-verified (in-file Edit, both directions): reverting the `math.isfinite()` gate to an unconditional `StallDumpArm.open()` call turns the new accept-side test red (`arm()` called with `seconds=inf`).

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path gates — all green.
- [x] `suspected_time_dependence_ratchet.py` flags `tests/security/test_5986_drain_grace_narrowed_except.py` — confirmed pre-existing (already merged via #6017, zero diff against `origin/main` in this branch, untouched here).
- [x] Scoped pytest: `test_loop_probe_3539.py`, `test_3671_stall_trace_startup_wiring.py`, `test_5898_loop_tripwire.py`, `test_5898_web_loop_tripwire.py`, `test_5977_stall_dump_suppression.py`, `test_5956_screen_timeout_diagnostics.py`, `test_5998_disarm_before_reset.py` — 73 passed.
- [x] (skipped — Visual, standing waiver)

Pushing without waiting on CI per your instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
