### PR TITLE
fix(#6022): give ensure_mcp_tools_cached's background probe task an owner in this test file

### DIFF
--- a/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
+++ b/tests/runtime/test_5167_mcp_hook_auto_subscribe.py
@@ -151,6 +151,19 @@ async def test_declared_concrete_hook_is_subscribed_with_no_turn_and_no_tool_cal
         )
     finally:
         await session.aclose_mcp_connections()
+        # #6022: session construction unconditionally kicks off
+        # RouterHostAdapter.ensure_mcp_tools_cached's background tools-probe
+        # (start_mcp_probe, #4401 A-4) as a TRACKED task
+        # (session._background_tasks, disposition="await") — a SEPARATE
+        # object from whatever client `aclose_mcp_connections` drains above.
+        # Production drains it via `AgentRegistry.shutdown()` ->
+        # `aclose_background_tasks()`; this test constructs Session directly
+        # (bypassing the registry) so nothing calls that seam without this
+        # line, and the leaked task then survives to pytest-asyncio's own
+        # blanket `_cancel_all_tasks` sweep at scope teardown (60s+ measured
+        # in CI, #6022's own root-cause instrumentation) instead of ending
+        # here, in this test's own scope, on this test's own terms.
+        await session.aclose_background_tasks()
 
 
 @pytest.mark.asyncio
@@ -165,9 +178,14 @@ async def test_no_declared_hook_means_no_subscribe_attempt(tmp_path: Path):
         permission_resolver=resolver,
     )
 
-    await session._auto_subscribe_mcp_resource_hooks()
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
 
-    assert _subscribed_uris(session, "srv") == []
+        assert _subscribed_uris(session, "srv") == []
+    finally:
+        # #6022: see the sibling test above for why both calls are needed.
+        await session.aclose_mcp_connections()
+        await session.aclose_background_tasks()
 
 
 # ── ② silence closed: every non-concrete/failed case is named, never mute ──
@@ -185,17 +203,25 @@ async def test_unconfigured_server_emits_warning_and_audit_event(tmp_path: Path)
     session._hook_dispatcher.replace_registry(session._build_hook_registry())
     collected = collect_events(events)
 
-    await session._auto_subscribe_mcp_resource_hooks()
-    await settle(events)
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
+        await settle(events)
 
-    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
-    assert matching, (
-        "an unconfigured-server hook produced no mcp_hook_subscribe_not_applied "
-        "audit-event — the declaration's non-effect went silent"
-    )
-    assert matching[0].data.get("server") == "not-configured"
-    assert matching[0].data.get("uri") == _URI
-    assert "not configured" in str(matching[0].data.get("reason", ""))
+        matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+        assert matching, (
+            "an unconfigured-server hook produced no mcp_hook_subscribe_not_applied "
+            "audit-event — the declaration's non-effect went silent"
+        )
+        assert matching[0].data.get("server") == "not-configured"
+        assert matching[0].data.get("uri") == _URI
+        assert "not configured" in str(matching[0].data.get("reason", ""))
+    finally:
+        # #6022: see test_declared_concrete_hook_... above for why both
+        # calls are needed. No `mcp_servers` here, but session construction
+        # still kicks off ensure_mcp_tools_cached's tracked background task
+        # unconditionally, so it must still be drained.
+        await session.aclose_mcp_connections()
+        await session.aclose_background_tasks()
 
 
 @pytest.mark.asyncio
@@ -218,14 +244,20 @@ async def test_permission_denied_emits_warning_and_audit_event(tmp_path: Path):
     session._hook_dispatcher.replace_registry(session._build_hook_registry())
     collected = collect_events(events)
 
-    await session._auto_subscribe_mcp_resource_hooks()
-    await settle(events)
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
+        await settle(events)
 
-    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
-    assert matching, "a permission-denied auto-subscribe must not fail silently"
-    assert matching[0].data.get("server") == "srv"
-    assert "permission" in str(matching[0].data.get("reason", "")).lower()
-    assert _subscribed_uris(session, "srv") == []
+        matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+        assert matching, "a permission-denied auto-subscribe must not fail silently"
+        assert matching[0].data.get("server") == "srv"
+        assert "permission" in str(matching[0].data.get("reason", "")).lower()
+        assert _subscribed_uris(session, "srv") == []
+    finally:
+        # #6022: see test_declared_concrete_hook_... above for why both
+        # calls are needed.
+        await session.aclose_mcp_connections()
+        await session.aclose_background_tasks()
 
 
 @pytest.mark.asyncio
@@ -249,16 +281,22 @@ async def test_glob_uri_matcher_is_not_auto_subscribed_but_is_reported(tmp_path:
     session._hook_dispatcher.replace_registry(session._build_hook_registry())
     collected = collect_events(events)
 
-    await session._auto_subscribe_mcp_resource_hooks()
-    await settle(events)
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
+        await settle(events)
 
-    assert _subscribed_uris(session, "srv") == [], (
-        "a glob uri must never be auto-subscribed — it names a SET, not one "
-        "concrete resource"
-    )
-    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
-    assert matching, "a glob-uri hook's non-effect must still be reported"
-    assert "glob" in str(matching[0].data.get("reason", "")).lower()
+        assert _subscribed_uris(session, "srv") == [], (
+            "a glob uri must never be auto-subscribed — it names a SET, not one "
+            "concrete resource"
+        )
+        matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+        assert matching, "a glob-uri hook's non-effect must still be reported"
+        assert "glob" in str(matching[0].data.get("reason", "")).lower()
+    finally:
+        # #6022: see test_declared_concrete_hook_... above for why both
+        # calls are needed.
+        await session.aclose_mcp_connections()
+        await session.aclose_background_tasks()
 
 
 @pytest.mark.asyncio
@@ -282,13 +320,19 @@ async def test_matcher_missing_server_or_uri_is_reported_not_silently_skipped(
     session._hook_dispatcher.replace_registry(session._build_hook_registry())
     collected = collect_events(events)
 
-    await session._auto_subscribe_mcp_resource_hooks()
-    await settle(events)
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
+        await settle(events)
 
-    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
-    assert matching, "a matcher-less hook's non-effect must still be reported"
-    assert matching[0].data.get("server") is None
-    assert matching[0].data.get("uri") is None
+        matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+        assert matching, "a matcher-less hook's non-effect must still be reported"
+        assert matching[0].data.get("server") is None
+        assert matching[0].data.get("uri") is None
+    finally:
+        # #6022: see test_declared_concrete_hook_... above for why both
+        # calls are needed.
+        await session.aclose_mcp_connections()
+        await session.aclose_background_tasks()
 
 
 @pytest.mark.asyncio
@@ -317,19 +361,25 @@ async def test_ephemeral_session_never_subscribes_but_still_reports_why(
     session._hook_dispatcher.replace_registry(session._build_hook_registry())
     collected = collect_events(events)
 
-    await session._auto_subscribe_mcp_resource_hooks()
-    await settle(events)
+    try:
+        await session._auto_subscribe_mcp_resource_hooks()
+        await settle(events)
 
-    assert _subscribed_uris(session, "srv") == [], (
-        "an ephemeral session must never actually subscribe — no persistent "
-        "connection exists for a push to arrive on"
-    )
-    matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
-    assert matching, (
-        "an ephemeral session's declared hook produced no "
-        "mcp_hook_subscribe_not_applied audit-event — declared, never "
-        "honored, never explained is the exact #5167 bug shape"
-    )
-    assert matching[0].data.get("server") == "srv"
-    assert matching[0].data.get("uri") == _URI
-    assert "ephemeral" in str(matching[0].data.get("reason", "")).lower()
+        assert _subscribed_uris(session, "srv") == [], (
+            "an ephemeral session must never actually subscribe — no persistent "
+            "connection exists for a push to arrive on"
+        )
+        matching = [e for e in collected if e.type == "mcp_hook_subscribe_not_applied"]
+        assert matching, (
+            "an ephemeral session's declared hook produced no "
+            "mcp_hook_subscribe_not_applied audit-event — declared, never "
+            "honored, never explained is the exact #5167 bug shape"
+        )
+        assert matching[0].data.get("server") == "srv"
+        assert matching[0].data.get("uri") == _URI
+        assert "ephemeral" in str(matching[0].data.get("reason", "")).lower()
+    finally:
+        # #6022: see test_declared_concrete_hook_... above for why both
+        # calls are needed.
+        await session.aclose_mcp_connections()
+        await session.aclose_background_tasks()


### PR DESCRIPTION
**[docs-maintainer]** — part of #6022.

## What

#5994②'s measurement found `tests/runtime/test_5167_mcp_hook_auto_subscribe.py`
spending ~240s of CI wall-clock (4 tests × ~60s each) in teardown. Root-caused
via faulthandler stack dumps + `asyncio.all_tasks()` instrumentation (see
#5994's own issue comments for the full trail): **not a 60-second constant
anywhere** in reyn, the `mcp` SDK, or `anyio` (verified absent by grep across
all three) — it is stdlib `asyncio.runners.Runner.close()`'s unbounded
`_cancel_all_tasks` safety net, finally reaping a background task this test
file never gave an owner.

## Mechanism (verified, not guessed)

Session construction (`start_mcp_probe`, #4401 A-4) unconditionally kicks off
`RouterHostAdapter.ensure_mcp_tools_cached()` as a **tracked** task
(`session._background_tasks`, a `TrackedTaskSet`, `disposition="await"`)
whenever `mcp_servers` is non-empty — 6 of this file's 7 tests configure a
real stdio-backed server. Production drains this via `AgentRegistry.
shutdown()` → `Session.aclose_background_tasks()` (#4759's own single drain
seam). This test file constructs `Session` directly
(`tests/_support/agent_session.make_session`, bypassing the registry
entirely — same as ~280 other call sites repo-wide) so nothing calls that
seam. The task then survives to pytest-asyncio's own scope-exit
`_cancel_all_tasks`, whose forced-cancellation path is what actually costs
~60s (`client.py`'s `_own_lifecycle`/`_do_close` docstring already names this
exact shape a "genuine leak", `_leaked_close=True`).

**A/B verified which call is load-bearing** (not assumed): adding only
`aclose_mcp_connections()` to a previously-bare test left the 60s stall
unchanged (that drains `MCPConnectionService`'s own clients — a *different*
object from `_mcp_probe_task`). Adding `aclose_background_tasks()` alongside
it dropped teardown from 60.01s to 0.10s, measured directly.

## Fix

Production already has an owner for this class of task (`TrackedTaskSet` +
`aclose_background_tasks()`, wired from `AgentRegistry.shutdown()`) — this
is a **test-side** gap, not a production defect. Added
`await session.aclose_mcp_connections(); await session.aclose_background_
tasks()` in a `finally` to every test in this file that constructs a
`Session`, mirroring the ONE test that already called the first of the two
(`test_declared_concrete_hook_...` — and, consistent with this root cause,
that test was never in the CI slow-teardown list).

## Not in scope (disclosed, not silently fixed)

- A separate, pre-existing "Task was destroyed but it is pending" warning
  for `EventLog._dispatch_consumer` surfaces on several of these tests
  regardless of this fix — these tests construct their own `EventLog()`
  directly and never close it. Different object, different owner question;
  left for a separate issue if it's judged worth one.
- `python scripts/suspected_time_dependence_ratchet.py` currently fails
  locally on a clean `origin/main` (`tests/security/test_5986_drain_grace_
  narrowed_except.py`, 0→1) — verified via `git stash` before touching this
  file. Pre-existing, from merged PR #6017, unrelated to this diff.

## Acceptance (lead-coder's own, #6022)

- ① scope ends without waiting — verified: 245s+ → 5.43s for the whole file.
- ② the probe's purpose (tools-cache warm-up) is unaffected — the fix only
  adds a drain call AFTER each test's own assertions; nothing about the
  probe's own construction/behavior changed.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_5167_mcp_hook_auto_subscribe.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `python scripts/check_no_core_dep_importorskip.py`
- [x] `python scripts/suspected_time_dependence_ratchet.py` — pre-existing unrelated failure, see "Not in scope" above
- [x] `pytest tests/runtime/test_5167_mcp_hook_auto_subscribe.py` (scoped) — 7 passed in 5.43s (was 245s+)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
