### PR TITLE
part of #6014: stage C -- wire 3 never-run invariant gates into main-invariant-sweep.yml

### DIFF
--- a/.github/workflows/main-invariant-sweep.yml
+++ b/.github/workflows/main-invariant-sweep.yml
@@ -179,3 +179,22 @@ jobs:
       - name: no-hardcoded-compaction-role-tuple
         if: ${{ !cancelled() }}
         run: python scripts/check_no_hardcoded_compaction_role_tuple.py
+
+      # #6014 stage C: these 3 were never in this file's enumeration and
+      # not referenced from any CLAUDE.md path-conditional line either —
+      # written, but never actually run against the real tree since the
+      # day each landed (their own `tests/` coverage only drives the
+      # detector against a synthetic `tmp_path` fixture, never the real
+      # tree). All 3 measured rc=0 against main before being added here
+      # (see #6014's own issue body and comment thread).
+      - name: approval-ledger-import-boundary
+        if: ${{ !cancelled() }}
+        run: python scripts/check_approval_ledger_import_boundary.py
+
+      - name: hooks-declared-reachable
+        if: ${{ !cancelled() }}
+        run: python scripts/check_hooks_declared_reachable.py
+
+      - name: remote-snapshot-placeholder-declared
+        if: ${{ !cancelled() }}
+        run: python scripts/check_remote_snapshot_placeholder_declared.py


### PR DESCRIPTION
**[tui-coder]** — part of #6014 (stage C — no judgment required, per lead-coder's ruling).

Adds `check_approval_ledger_import_boundary.py`, `check_hooks_declared_reachable.py`, and `check_remote_snapshot_placeholder_declared.py` to `main-invariant-sweep.yml`'s explicit enumeration.

lead-coder's own census: all 3 scripts enforce a real invariant (non-zero exit on a genuine violation, confirmed by backlog-watcher's read-only classification in #6014's own comment thread) but were referenced from neither any per-PR workflow nor any `CLAUDE.md` path-conditional line — their only existing `tests/` coverage exercises the detector against a synthetic `tmp_path` fixture, never the real tree, so none of the 3 had ever actually run against `main`.

All 3 measured `rc=0` against `main` (lead-coder, then re-verified here on `origin/main`) before landing — this PR does not redden `main`.

Stage B (the other 3 scripts from the same census — `check_tui_widget_boundary.py` / `check_tui_reactive_ratchet.py` / `suspected_time_dependence_ratchet.py`) needs a `paths:`-filter judgment call and is deliberately a separate PR, per lead-coder's explicit instruction not to mix the two (different amount of judgment required).

## Test plan
- [x] `ruff check .` — no python changed, passes.
- [x] `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `mypy_ratchet.py` — all green (no `tests/`/`src/` files touched).
- [x] The 3 newly-wired scripts re-run locally against this branch's tree: all `rc=0`.
- [x] (skipped — Visual, standing waiver; this PR touches only a workflow file)

merge: lead-coder. Pushing without waiting on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
