### PR TITLE
part of #6014: stage B -- wire 3 CLAUDE.md-declared invariant gates into path-scoped per-PR workflows

### DIFF
--- a/.github/workflows/suspected-time-dependence-ratchet-gate.yml
+++ b/.github/workflows/suspected-time-dependence-ratchet-gate.yml
@@ -1,0 +1,46 @@
+name: suspected time dependence ratchet gate
+
+# #6014 stage B: suspected_time_dependence_ratchet.py (#4846) was already
+# LISTED in root CLAUDE.md's own `tests/` path-conditional gate line (run
+# it locally before opening a tests/-touching PR) but had no CI workflow of
+# its own -- so main's own doc told a human to run it, while nothing
+# mechanical enforced that they actually had. Its only tests/ coverage
+# exercises the detector against a synthetic tmp_path fixture, never the
+# real tree. See #6014's own issue body and comment thread for the census.
+#
+# `paths: tests/**` matches the CLAUDE.md line it's already conditioned on
+# exactly -- a change outside tests/ cannot add or remove a suspected
+# sleep/range/timeout site this script counts.
+#
+# No fetch-depth: 0 / --check-growth here -- this script only has
+# --write-baseline (see its own module docstring: "no exception-comment
+# escape hatch"), not a BASE_REF-diff mode; a plain run against the
+# committed baseline is the whole gate, same shallow-checkout shape as
+# bare-tests-import-reference-gate.yml.
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  suspected-time-dependence-ratchet:
+    name: suspected time dependence ratchet gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/suspected_time_dependence_ratchet.py is stdlib-only (argparse
+      # / ast / json). No pip install needed.
+      - name: Check no new suspected sleep/range/timeout site under tests/
+        run: |
+          python scripts/suspected_time_dependence_ratchet.py

--- a/.github/workflows/tui-reactive-ratchet-gate.yml
+++ b/.github/workflows/tui-reactive-ratchet-gate.yml
@@ -1,0 +1,48 @@
+name: tui reactive ratchet gate
+
+# #6014 stage B: check_tui_reactive_ratchet.py (#5131 gate B) was written as
+# a ratchet -- reactive_count never DECREASES, imperative_push_count never
+# INCREASES -- but was referenced from neither a per-PR workflow nor
+# main-invariant-sweep.yml's own enumeration; its only tests/ coverage
+# exercises the detector against a synthetic tmp_path fixture, never the
+# real tree. See #6014's own issue body and comment thread for the census.
+#
+# Same src/reyn/interfaces/CLAUDE.md scoping reasoning as
+# tui-widget-boundary-gate.yml -- this rule lives next to the TUI code it
+# binds (owner ruling), so `paths` keeps this gate from applying to every
+# PR regardless of whether it touches that directory.
+#
+# fetch-depth: 0 + --check-growth "origin/${{ github.base_ref }}" is the
+# same skeleton flat-tests-ratchet.yml/mypy already use for a
+# baseline-vs-merge-base diff (architect/#3726 precedent, cited in this
+# script's own module docstring) -- rejects a baseline edit that isn't
+# backed by a real measured change, not merely a baseline that changed.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/interfaces/**"
+
+permissions:
+  contents: read
+
+jobs:
+  tui-reactive-ratchet:
+    name: tui reactive ratchet gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_tui_reactive_ratchet.py is stdlib-only (argparse /
+      # ast / json / subprocess). No pip install needed.
+      - name: Check the reactive floor/imperative-push ceiling ratchet
+        run: |
+          python scripts/check_tui_reactive_ratchet.py --check-growth "origin/${{ github.base_ref }}"

--- a/.github/workflows/tui-widget-boundary-gate.yml
+++ b/.github/workflows/tui-widget-boundary-gate.yml
@@ -1,0 +1,46 @@
+name: tui widget boundary gate
+
+# #6014 stage B: check_tui_widget_boundary.py (#5131 gate A) was written as
+# a gate -- pins that a textual_chat/ WIDGET module never imports
+# reyn.interfaces.transport or reyn.runtime.registry -- but was referenced
+# from neither a per-PR workflow nor main-invariant-sweep.yml's own
+# enumeration; its only tests/ coverage exercises the detector against a
+# synthetic tmp_path fixture, never the real tree. See #6014's own issue
+# body and comment thread for the census.
+#
+# The rule itself lives in src/reyn/interfaces/CLAUDE.md, not root CLAUDE.md
+# -- an owner ruling that TUI-specific rules stay next to the code they
+# bind, read only by a session that opens those files (an unrelated session
+# shouldn't have to carry them). Wiring this into a repo-wide gate would
+# have applied it to every PR regardless of whether it touches
+# src/reyn/interfaces/ at all, in tension with that ruling -- `paths` below
+# keeps this scoped to the same directory the rule already lives next to,
+# the same shape #6012's silent-except-ratchet-gate.yml took for the same
+# reason.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/interfaces/**"
+
+permissions:
+  contents: read
+
+jobs:
+  tui-widget-boundary:
+    name: tui widget boundary gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_tui_widget_boundary.py is stdlib-only (ast / pathlib /
+      # sys). No pip install needed.
+      - name: Check no textual_chat/ widget module imports transport or registry
+        run: |
+          python scripts/check_tui_widget_boundary.py

--- a/scripts/suspected_time_dependence_ratchet_baseline.json
+++ b/scripts/suspected_time_dependence_ratchet_baseline.json
@@ -191,6 +191,7 @@
     "tests/runtime/test_slash_rewind_self_cancel_3362.py": 2,
     "tests/runtime/test_startup_timing_3671.py": 21,
     "tests/scripts/test_reyn_web_proc.py": 4,
+    "tests/security/test_5986_drain_grace_narrowed_except.py": 1,
     "tests/security/test_subprocess_cancel_1470.py": 1
   }
 }


### PR DESCRIPTION
**[tui-coder]** — part of #6014 (stage B — needs a `paths:`-filter judgment, per lead-coder's ruling).

Wires 3 already-CLAUDE.md-declared invariant gates into path-scoped per-PR workflows: `check_tui_widget_boundary.py` + `check_tui_reactive_ratchet.py` (both `src/reyn/interfaces/CLAUDE.md`, #5131) and `suspected_time_dependence_ratchet.py` (root `CLAUDE.md`'s `tests/` path-conditional line). Unlike stage C, all 3 were already named in a CLAUDE.md — only the CI wiring was missing; their existing `tests/` coverage exercises each detector against a synthetic `tmp_path` fixture, never the real tree.

Kept off `main-invariant-sweep.yml`'s whole-tree scan per lead-coder's own instruction: the two `tui_*` rules live in `src/reyn/interfaces/CLAUDE.md` specifically because of an owner ruling that TUI-specific rules stay next to the code they bind, read only by a session opening those files — a whole-tree gate would apply the rule to every PR regardless of path, in tension with that. `paths: src/reyn/interfaces/**` (same shape as #6012's `silent-except-ratchet-gate.yml`) keeps each gate scoped to that directory; `suspected_time_dependence_ratchet.py` gets `paths: tests/**`, matching the CLAUDE.md line it's already conditioned on. No CLAUDE.md edit needed.

## A real drift surfaced by wiring this for the first time
`suspected_time_dependence_ratchet.py`'s committed baseline had never been re-measured against `main` (nothing ran it there before). Doing so found 1 already-landed, pre-existing suspected floor site: `tests/security/test_5986_drain_grace_narrowed_except.py`'s `asyncio.sleep(0.01)` inside an unbounded `while not path.exists()` poll (landed by #6017) — a legitimate poll-interval sleep, not a duration the assert depends on, but syntactically indistinguishable to this script (disclosed limitation, its own docstring). `--write-baseline` re-measured the real tree and added exactly that one line — without it, this gate would start **red on `main`** from its very first run, on the next `tests/`-touching PR, for a site this PR did not introduce.

`check_tui_widget_boundary.py` / `check_tui_reactive_ratchet.py` both measure clean against the current tree — no baseline change for either.

## Test plan
- [x] `ruff check .` — green.
- [x] `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green (`tests/` touched: baseline JSON only).
- [x] `mypy_ratchet.py` — nothing to check (no `.py` changed).
- [x] All 3 newly-wired scripts re-run locally against this branch: `rc=0`.
- [x] (skipped — Visual, standing waiver; workflow files + one baseline JSON only)

merge: lead-coder. Pushing without waiting on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
