### PR TITLE
docs(part of #5974): change what a record MEANS and every bound that counted it keeps passing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,10 +169,10 @@ A rule nobody is told to read is not a rule. Every entry below names the act
 that triggers it; "when in doubt" is not a trigger, because the failures these
 prevent are the ones that remove the doubt.
 
-- **Before filing an issue** — `docs/deep-dives/contributing/issue-management.md`. An issue gets its axis label(s) when it is **filed**, not later; no axis label means "not yet judged", so an unlabelled backlog carries no order to dispatch by.
-- **Before reading a green as evidence, or listing what to cover/exempt** — `docs/deep-dives/contributing/verification-hazards.md`
+- **Before filing an issue** — `docs/deep-dives/contributing/issue-management.md`. An issue gets its axis label(s) at **filing**, not later; no axis label means "not yet judged", so an unlabelled backlog has no dispatch order.
+- **Before reading a green as evidence, listing what to cover/exempt, or redefining a record** — `docs/deep-dives/contributing/verification-hazards.md`
 - **Before writing a blocking point** — `docs/deep-dives/contributing/test-review-six-questions.md`
-- **When a Tier-1 rule above seems wrong or costly** — `docs/deep-dives/contributing/tier1-rationale.md`; **PR workflow's** own rationale: `docs/deep-dives/contributing/pr-workflow.md`
+- **When a Tier-1 rule seems wrong or costly** — `docs/deep-dives/contributing/tier1-rationale.md`; **PR workflow's** own rationale: `docs/deep-dives/contributing/pr-workflow.md`
 - **When you touch session/agent state on disk** — `docs/concepts/runtime/workspace.md`; **`.reyn/` layout** (recovery-core vs persist/audit/cache, the write-gate): `docs/reference/runtime/reyn-dir-layout.md`
 - **When you emit, read, or replay an audit-event** — `docs/concepts/runtime/events.md`
 - **When you add or change a permission decision** — `docs/concepts/runtime/permission-model.md`

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -2091,6 +2091,106 @@ answer — but write down *why*, next to the list, so the next person does not
 re-derive the question. A list with a stated reason is a decision; a list
 without one is an accident that outlives its author.
 
+## 29. Change what a record MEANS and every bound that counted it keeps passing, guarding nothing
+
+**The act that fires this: you are about to change what a record's contents
+mean** — a body moved out of a line and replaced by a reference, a value
+replaced by an id, a synchronous field replaced by a promise. The new shape
+is usually better. The bounds that were counting the old shape do not
+notice, and they do not fail: they keep running, keep passing, and keep
+reporting a number that no longer stands for the resource they exist to
+limit.
+
+This is not §28's failure. There the population went stale — the list
+stopped naming everything it should. Here the population is complete and
+every member is counted correctly. What moved is the **unit**: the quantity
+being measured stopped being the quantity that hurts.
+
+### The instance: one migration, three bounds, none of them touched
+
+`#5896` moved tool-result bodies out of `history.jsonl` and left a
+`content_ref` behind. Disk went from 663 MB to 8.8 MB — the migration did
+exactly what it promised. Three separate bounds were counting the old line:
+
+| bound | what it counts | what it was there to limit | after the change |
+|---|---|---|---|
+| `history_resident.max_bytes` = 256 MiB | `len(json.dumps(asdict(msg)))` | how much history stays in memory | a ref row serialises to ~400 B, so the cap stopped evicting |
+| `read_history_after(max_bytes=)` = 8 MiB | bytes of the JSONL **lines** read | how much a compaction pass materialises | 8 MiB of refs admits 597 MB of bodies |
+| `process_footprint.cap_bytes` | — | the process's own memory ceiling | shipped as `None` with `enforce=False` |
+
+None of the three raised. None went red. Two of them were still printing
+a byte number in a config the operator could read, and that number was
+true about the thing being counted and false about the thing being
+guarded.
+
+The result, measured on a live machine: startup 91 MB, attach 285 MB, and
+then **one `hello` message took the process to 16 GB** — 600,321,181
+characters of request payload, uploaded over 85.6 seconds before the
+provider refused it with a 413. The recovery path then read the same
+600 MB again.
+
+### Why the guard's own docstring did not help
+
+`read_history_after`'s cap was not an accident. Its docstring says, in the
+words of the two reviewers who put it there, **"Bounded materialization, not
+bounded examination"** — it was written by people thinking about exactly
+this failure, and it names the right property. It still stopped guarding,
+because the sentence describes an intent and the code counts a proxy. When
+the proxy's relationship to the resource changed, the sentence stayed true
+as a statement of purpose and became false as a description of behaviour.
+
+**A bound's docstring cannot tell you whether it still binds.** Only the
+relationship between what it counts and what it protects can, and that
+relationship lives outside the bound.
+
+### The question, asked at change time and not at design time
+
+The usual advice — "make sure your limit measures the right thing" — fires
+when the limit is written, which is the one moment it is certainly correct.
+The failure lands later, in a change that never touches the limit at all.
+So the question belongs to the **change**:
+
+> **Can you name every bound that counts this record?**
+
+That population is derivable, which is the point (§28): the record type has
+a reader set, and `git grep` produces it. What is not derivable is the
+intent behind each bound, so the enumeration is where a human has to look —
+but the enumeration itself should never be a list someone maintains.
+
+### Two things that make the answer cheap
+
+**Measure the resource, not a stand-in, when you can.** The fix that landed
+counts a resident row's own bytes **plus** the body its reference can pull
+(`session.py`'s eviction weight), so the cap once again bounds the thing
+that grows. Where the real quantity is expensive to obtain, store it when
+you write the record rather than deriving it at read time.
+
+**Give the two quantities different types.** `ResidentBytes` and
+`BodyBytes` are now distinct `NewType`s over `int`. Before that they were
+both `int`, and passing one where the other belonged was invisible; a
+reviewer had to notice. The type does not make the bound correct — it makes
+the specific confusion that broke it unconstructible.
+
+### A fourth kind, which is not a unit drift at all
+
+`process_footprint.cap_bytes` was `None` with `enforce=False`. Nothing
+about its unit was wrong; the mechanism existed and was not in effect. It
+is worth keeping in the same table only to make the distinction visible:
+**"the mechanism exists" and "the mechanism is in effect" are different
+observations, and a config key answers the first one.** A memory ceiling
+had been asked for, built, and shipped off — and the question "did we build
+that?" returned yes for a year of reading.
+
+### The cost, stated
+
+Deriving a bound's real quantity is not free. Counting a body's bytes may
+mean a `stat` per row, or a field written at persist time that then has to
+stay correct. The alternative on offer is not "a cheaper correct bound" —
+it is a bound that is cheap because it counts something else, and whose
+failure mode is silence. Where you take the cheap one, write down what it
+counts and what it is standing in for, next to the number, so the next
+representation change has something to grep for.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[architect]** — `verification-hazards.md` §29。#5974 の起票どおり、**#5973 が着地して 5 件目のデータ点（正しい bound の形）が出たので書きました。**

## 何を書いたか

**発火する行為**: 「**記録の中身が何を意味するかを変えようとしている**」— 本体を行から出して参照に、値を id に、同期の field を promise に。

**#5896 の実例**: 行の意味を「本体」から「参照」に変えた。**その行を数えていた bound が 3 つ在り、1 つも触られず、1 つも赤くならず、3 つとも守る対象を失った。**

| bound | 数えていたもの | 守るはずだったもの |
|---|---|---|
| `history_resident.max_bytes` 256 MiB | ref 行の serialise 長（~400 B） | 常駐する履歴の量 |
| `read_history_after(max_bytes=)` 8 MiB | jsonl の**行**バイト | 1 パスが材料化する量（参照 8 MiB ＝ 本体 597 MB） |
| `process_footprint.cap_bytes` | — | process 自身の上限（`None` / `enforce=False` で出荷） |

**実測**: 起動 91 MB → attach 285 MB → **`hello` 1 通で 16 GB**、`input_chars=600,321,181` を **85.6 秒**かけて送信し 413。

## §28 と分けた理由

**§28 は母集団が腐る**（一覧が全部を名指さなくなる）。**本節は母集団が完全で、単位が動く。**

∴ **発火する行為が違います** — §28 は**一覧を書く時**、本節は**記録の意味を変える時**。**処方も違います。**

## この節が持てた 2 つの材料

- ⭐ **guard の docstring が「Bounded materialization, not bounded examination」と *正しい性質を名指していた*** のに守れなくなった、という実例。**docstring は「まだ縛れているか」に答えられない**という節の核心が、実物で示せます。
- ⭐ **着地した修理の形**（eviction の重みに body bytes を加算／材料化予算／chunk ごとの token 数え／`ResidentBytes` と `BodyBytes` を別型に）。**診断だけでなく修理を見せられます。**

## ⚠️ 4 番目は単位のずれ *ではない* と明記

`cap_bytes=None`/`enforce=False` は**単位は正しく、機構が効いていない**。同じ表に置いたのは**区別を見せるため**で、**「機構が在る」と「機構が効いている」は別の観測**、そして **config key は前者にしか答えない**と書きました。

## CLAUDE.md

⚠️ **既存 pointer の trigger が、本節の発火 act を覆っていませんでした** ∴ **同じ行に `or redefining a record` を追加**（新しい行は足していません）。

**語数は 2657 → 2655。** 同じ list の 2 entry から 4 語回収（`when it is filed, not later` → `at filing, not later`／`carries no order to dispatch by` → `has no dispatch order`／`Tier-1 rule above seems` → `Tier-1 rule seems`）。**`--write-baseline` は使っていません。**

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml`
- [x] `python scripts/check_doc_anchors.py`
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] `python scripts/claude_md_word_count_ratchet.py`（4 本を `&&` 連結、exit 0）
- [x] 節番号 **1..29 連番**、**`## See also` の *前***（#5971 の再発防止）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow
