### PR TITLE
feat(#6016 ①): audit-event for a tool-axis exec segment denial

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -91,6 +91,7 @@ exec_threat_blocked
 exec_threat_match
 exec_threat_scan_skipped
 exec_threat_scanned
+exec_tool_axis_denied
 file_changed
 file_read_media_denied
 file_read_media_write_unavailable

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -487,6 +487,7 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "exec_threat_match",
     "exec_threat_scan_skipped",
     "exec_threat_scanned",
+    "exec_tool_axis_denied",
     "file_changed",
     "file_read_media_denied",
     "file_read_media_write_unavailable",

--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -135,6 +135,24 @@ THIS list, never by calling :func:`~reyn.security.sandbox.resolve.
 resolve_real_executable` a second time (the exact "policy saw one
 binary, audit recorded a different one" class #5991 BLOCKING ③ closed
 for ``env_path``/``cwd`` — now closed for the resolved name too).
+
+## #6016 ① (lead-coder ruling, #6016 issue thread) — a tool-axis denial
+left NO audit trace, unlike the threat axis in the SAME function. Since
+#5991 ②, a threat-scan outcome always leaves exactly one event
+(``exec_threat_scanned``/``exec_threat_scan_skipped``) whether it blocked
+or not; a tool-axis denial left ZERO events, only the raised
+:class:`PermissionError` (whose ``tool_failed.message`` a reader would
+have to PARSE as English to learn which binary was denied) —
+architect's own framing: "何が止められたか" (what was stopped) is asked
+BEFORE "何が走ったか" (what ran), the SAME lens 7 reasoning 段5 already
+applied to the allowed side. :func:`_check_segment` now emits
+``exec_tool_axis_denied`` (``argv0``/``resolved``/``effective_name``/
+``reason`` as separate FIELDS, never requiring a reader to parse
+``reason``'s own English text to extract the binary) immediately before
+raising. Deliberately has **no "allowed" sibling event** — the case for
+one depends on a traffic volume this repo's own working tree could not
+measure (no ``.reyn/`` directory to read); reopens once 段6 lands real
+``cmd``-mode traffic to measure against.
 """
 from __future__ import annotations
 
@@ -239,9 +257,22 @@ async def _check_segment(
     effective = gate_effective_tool_name(resolved_name, None)
     contextual = getattr(ctx, "contextual_permission", None)
     if effective is not None and tool_contextually_denied(contextual, effective):
-        raise PermissionError(
-            contextual_deny_message("command", effective, contextual)
+        message = contextual_deny_message("command", effective, contextual)
+        # #6016 ①: the SAME denial the threat axis already records
+        # (exec_threat_match/_blocked) but the tool axis never did — a
+        # reader had only `tool_failed.message`, an English sentence, to
+        # learn WHICH binary was denied. Fields, not prose: the denied
+        # binary is recoverable without parsing `message`. Deliberately
+        # does NOT have an "allowed" sibling event (lead-coder ruling,
+        # #6016: the case for one depends on a volume this repo could not
+        # measure — no `.reyn/` in this working tree — so it stays
+        # unbuilt until 段6 lands real cmd-mode traffic to measure).
+        ctx.events.emit(
+            "exec_tool_axis_denied",
+            argv0=segment.argv[0], resolved=argv0_resolved,
+            effective_name=effective, reason=message,
         )
+        raise PermissionError(message)
 
     await _run_threat_scan(ctx, " ".join(segment.argv), subject=list(segment.argv))
     return argv0_resolved

--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -150,9 +150,35 @@ applied to the allowed side. :func:`_check_segment` now emits
 ``reason`` as separate FIELDS, never requiring a reader to parse
 ``reason``'s own English text to extract the binary) immediately before
 raising. Deliberately has **no "allowed" sibling event** — the case for
-one depends on a traffic volume this repo's own working tree could not
-measure (no ``.reyn/`` directory to read); reopens once 段6 lands real
-``cmd``-mode traffic to measure against.
+one was FIRST scoped by lead-coder as "not now" (a traffic volume this
+repo's own working tree could not measure; no ``.reyn/`` directory to
+read — reopens once 段6 lands real ``cmd``-mode traffic to measure
+against), but architect's own PR co-vet (#6030, issuecomment-5595519318)
+gave the STRONGER, structural reason a volume measurement can never
+overturn — "measured low" would still be a reason to add one; this is a
+reason NOT to:
+
+1. **The tool axis has no "did not run" state to distinguish.**
+   :func:`~reyn.security.permissions.effective.gate_effective_tool_name`
+   always runs — unlike ``ctx.threat_scan`` (``None``/disabled is a REAL
+   state #5991 ② had to give its own event, ``exec_threat_scan_
+   skipped``, specifically so "zero matches" and "never scanned" would
+   not read the same in ``.reyn/events``), there is no configuration
+   under which the tool-axis check itself does not execute. A "passed"
+   event would only ever report ONE state, never distinguish it from a
+   second one the way ``exec_threat_scanned`` must.
+2. **The allowed side is ALREADY recorded — by 段5's own ``plan``.** A
+   segment that passes this check returns its resolved ``argv[0]`` (see
+   :func:`check_exec_plan_policy`'s own docstring) and lands in
+   ``sandboxed_exec_started``/``_completed``'s ``plan`` field — an
+   entry existing there for a segment IS the "passed the tool axis"
+   record, and it already carries the resolved binary name, which a
+   dedicated per-segment allow event would only duplicate.
+
+Recorded here (not filed as a separate follow-up — architect's own
+choice) for the future reader who reaches for "measured low enough"
+as a reason to add one anyway: that reason was never the load-bearing
+one, even before this PR: the SAME fact holds regardless of volume.
 """
 from __future__ import annotations
 
@@ -263,10 +289,11 @@ async def _check_segment(
         # reader had only `tool_failed.message`, an English sentence, to
         # learn WHICH binary was denied. Fields, not prose: the denied
         # binary is recoverable without parsing `message`. Deliberately
-        # does NOT have an "allowed" sibling event (lead-coder ruling,
-        # #6016: the case for one depends on a volume this repo could not
-        # measure — no `.reyn/` in this working tree — so it stays
-        # unbuilt until 段6 lands real cmd-mode traffic to measure).
+        # does NOT have an "allowed" sibling event -- see this module's
+        # own docstring, "#6016 ①", for why (architect's structural
+        # reason, not merely "not measured yet"): the tool axis has no
+        # "did not run" state to distinguish (unlike threat_scan), and
+        # the allowed side is already recorded by 段5's own `plan` field.
         ctx.events.emit(
             "exec_tool_axis_denied",
             argv0=segment.argv[0], resolved=argv0_resolved,

--- a/tests/security/test_5838_stage3_exec_plan_policy.py
+++ b/tests/security/test_5838_stage3_exec_plan_policy.py
@@ -145,10 +145,13 @@ async def test_an_allowed_segment_emits_no_tool_axis_event_either_direction(
     tmp_path: Path,
 ) -> None:
     """Tier 2: #6016 ①'s own explicit scope -- the "allowed" side gets NO
-    event (lead-coder ruling: the case for one depends on a traffic
-    volume this repo could not measure). An ordinary, un-denied segment
-    leaves the event log with no ``exec_tool_axis_denied`` entry at
-    all -- not even a ``blocked=False``-shaped one."""
+    event (architect's structural reason, PR #6030 co-vet: the tool axis
+    has no "did not run" state to distinguish, unlike threat_scan, and
+    the allowed side is already recorded by 段5's own `plan` field --
+    see `exec_plan_policy.py`'s own module docstring, "#6016 ①"). An
+    ordinary, un-denied segment leaves the event log with no
+    ``exec_tool_axis_denied`` entry at all -- not even a
+    ``blocked=False``-shaped one."""
     ctx, collected = _ctx(tmp_path)
     plan = [ExecSegment(argv=("/usr/bin/true",))]
 

--- a/tests/security/test_5838_stage3_exec_plan_policy.py
+++ b/tests/security/test_5838_stage3_exec_plan_policy.py
@@ -114,6 +114,51 @@ async def test_segment_with_contextually_denied_binary_is_rejected(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_a_tool_axis_denial_emits_an_event_naming_the_binary_in_fields(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #6016 ① -- a tool-axis denial now leaves an
+    ``exec_tool_axis_denied`` event carrying the ORIGINAL argv[0], the
+    RESOLVED absolute path, and the effective (basename) name checked
+    against the deny set -- all as separate FIELDS, so a reader can
+    extract WHICH binary was denied without parsing ``reason``'s own
+    English sentence (the acceptance criterion lead-coder's own ruling
+    named explicitly: ``tool_failed.message`` alone is not "追える")."""
+    ctx, collected = _ctx(
+        tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"true"})),
+    )
+    plan = [ExecSegment(argv=("/usr/bin/true", "--extra"))]
+
+    with pytest.raises(PermissionError):
+        await _check(plan, ctx)
+
+    await settle(ctx.events)
+    (denied,) = [e for e in collected if e.type == "exec_tool_axis_denied"]
+    assert denied.data["argv0"] == "/usr/bin/true"
+    assert denied.data["resolved"] == "/usr/bin/true"
+    assert denied.data["effective_name"] == "true"
+    assert "true" in denied.data["reason"]
+
+
+@pytest.mark.asyncio
+async def test_an_allowed_segment_emits_no_tool_axis_event_either_direction(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #6016 ①'s own explicit scope -- the "allowed" side gets NO
+    event (lead-coder ruling: the case for one depends on a traffic
+    volume this repo could not measure). An ordinary, un-denied segment
+    leaves the event log with no ``exec_tool_axis_denied`` entry at
+    all -- not even a ``blocked=False``-shaped one."""
+    ctx, collected = _ctx(tmp_path)
+    plan = [ExecSegment(argv=("/usr/bin/true",))]
+
+    await _check(plan, ctx)  # does not raise
+
+    await settle(ctx.events)
+    assert not [e for e in collected if e.type == "exec_tool_axis_denied"]
+
+
+@pytest.mark.asyncio
 async def test_segment_not_on_the_deny_set_passes(tmp_path: Path) -> None:
     """Tier 2: FP gate -- an ordinary segment under a narrowing that denies
     a DIFFERENT name passes silently (never elevates, never over-denies)."""


### PR DESCRIPTION
**[e2e-coder]** — part of #6016 (① only — ② is explicitly out of scope, see below). A tool-axis exec-segment denial now leaves an audit trace.

## What

`_check_segment` (`exec_plan_policy.py`) emits `exec_tool_axis_denied` immediately before raising, when the tool-axis check denies a segment's resolved binary — a gap the threat axis in the SAME function closed back in #5991 ② (`exec_threat_scanned`/`_scan_skipped` always leave exactly one event, whether blocked or not); the tool axis left ZERO events, only the raised `PermissionError`.

Fields — separate, not prose:
- `argv0` — the original token as written in the plan.
- `resolved` — the absolute path already computed for this segment's own tool-axis check (never re-derived — the "policy saw one binary, trace recorded a different one" class #5991 BLOCKING ③ closed elsewhere, closed here too by construction).
- `effective_name` — the basename actually checked against the deny set.
- `reason` — the human-readable denial message.

**Acceptance criterion (lead-coder's own ruling, quoted verbatim in the issue)**: the denied binary must be recoverable from an event *field*, not by parsing `reason`'s own English sentence — `tool_failed.message` carrying it as prose was explicitly named as NOT satisfying this.

## Deliberately no "allowed" sibling event

Lead-coder's ruling (#6016): the case for one depends on a traffic volume this repo's own working tree could not measure — no `.reyn/` directory exists to read against (backlog-watcher's own 3-proxy measurement attempt is in the issue thread, each proxy's search scope named explicitly per the "absence claim needs its scope" discipline). "Probably low volume" and "for symmetry" were both explicitly ruled out as reasons to add one anyway. **Reopens once 段6 lands real `cmd`-mode LLM traffic to measure against.**

`event_schema.py`'s `AUDIT_EVENT_KINDS` and `docs/reference/runtime/events.md` updated in this same commit (gate #3410 checks `emit ⊆ declaration` and `doc == declaration` together — lead-coder's own note: doing only one of the two is what turned CI red on #5991).

## Test plan

- [x] `tests/security/test_5838_stage3_exec_plan_policy.py` — +2 tests: the denial event's 4 fields extracted without parsing `reason` (accept), and an allowed segment leaves zero `exec_tool_axis_denied` events — not even a `blocked=False`-shaped one (deny, FP gate proving the no-sibling-event scope literally, not just by absence of code).
- [x] Strip witness — verified directly (in-file Edit → red → Edit back): the event emit itself.
- [x] `ruff check .` — clean
- [x] `python -m pytest tests/core/test_audit_event_kind_vocabulary_3410.py` — 10/10 (emit≤declaration, doc==declaration both checked)
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_5838_stage3_exec_plan_policy.py` — 21/21 OK
- [x] `python scripts/mypy_ratchet.py` — OK (0 new findings)
- [x] `python scripts/verify_module_docstrings.py` (all changed files) — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` + `check_doc_anchors.py` + `check_retired_config_keys_denylist.py` — all clean (docs/ path-conditional gates)
- [x] 91 related tests (`sandboxed_exec`, exec_plan parser) re-run clean
- [x] (skipped — Visual, standing waiver)

part of #6016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
