### PR TITLE
docs(part of #6026): a distinction the caller cannot act on is not information — raise or return, decided both ways

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,12 +170,12 @@ that triggers it; "when in doubt" is not a trigger, because the failures these
 prevent are the ones that remove the doubt.
 
 - **Before filing an issue** — `docs/deep-dives/contributing/issue-management.md`. An issue gets its axis label(s) at **filing**, not later; no axis label means "not yet judged", so an unlabelled backlog has no dispatch order.
-- **Before reading a green as evidence, listing what to cover/exempt, or redefining a record** — `docs/deep-dives/contributing/verification-hazards.md`
+- **Before reading a green as evidence, listing what to cover/exempt, redefining a record, or choosing raise vs return** — `docs/deep-dives/contributing/verification-hazards.md`
 - **Before writing a blocking point** — `docs/deep-dives/contributing/test-review-six-questions.md`
 - **When a Tier-1 rule seems wrong or costly** — `docs/deep-dives/contributing/tier1-rationale.md`; **PR workflow's** own rationale: `docs/deep-dives/contributing/pr-workflow.md`
-- **When you touch session/agent state on disk** — `docs/concepts/runtime/workspace.md`; **`.reyn/` layout** (recovery-core vs persist/audit/cache, the write-gate): `docs/reference/runtime/reyn-dir-layout.md`
+- **When you touch session/agent state on disk** — `docs/concepts/runtime/workspace.md`; **`.reyn/` layout** (recovery-core vs persist/audit/cache, write-gate): `docs/reference/runtime/reyn-dir-layout.md`
 - **When you emit, read, or replay an audit-event** — `docs/concepts/runtime/events.md`
 - **When you add or change a permission decision** — `docs/concepts/runtime/permission-model.md`
-- **When you add or rename an op or tool** — `src/reyn/core/op_runtime/` (catalog and dispatch); naming: `docs/reference/runtime/tool-naming.md`
-- **When you analyse an LLM trace** — `docs/reference/dogfood-tracing.md`; `scripts/dogfood_trace.py --mode llm-payloads` is the entry point, do not hand-parse JSONL.
+- **When you add or rename an op or tool** — `src/reyn/core/op_runtime/` (catalog, dispatch); naming: `docs/reference/runtime/tool-naming.md`
+- **When you analyse an LLM trace** — `docs/reference/dogfood-tracing.md`; `scripts/dogfood_trace.py --mode llm-payloads` is the entry point; never hand-parse JSONL.
 - **When you claim a feature exists or not** — `docs/feature-map.md`

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -2191,6 +2191,76 @@ failure mode is silence. Where you take the cheap one, write down what it
 counts and what it is standing in for, next to the number, so the next
 representation change has something to grep for.
 
+## 30. A distinction the caller cannot act on is not information — raise or return, decided both ways
+
+**The act that fires this: you are deciding how a failure reaches the
+caller** — raise it, or fold it into a return value; catch broadly, or let
+the unexpected propagate. Both decisions get made by habit, and both get
+made per call site, so the same question ends up answered two different ways
+in the same module.
+
+Two rules, and they are one rule read in opposite directions:
+
+> **Fold, when the caller has no branch.** An exception is a mechanism for
+> handing the caller a choice. Where every outcome leads to the same action,
+> there is no choice to hand over, and the exception is not information — it
+> is a crash the caller must write boilerplate to survive.
+>
+> **Absorb, only when the safe answer is the default one.** A predicate
+> whose False branch is the safe action may swallow an unknown failure: not
+> knowing costs an extra safe step. A function whose return value is
+> consumed as data may not: not knowing arrives at the caller wearing the
+> costume of a normal, empty result.
+
+### Four decisions, and two of them are "leave it alone"
+
+| | site | decision | why |
+|---|---|---|---|
+| 1 | an internal history reader, given a path outside the storage boundary | **fold** the `PermissionError` into the same "no body" the missing-file case returns | the reader renders a placeholder either way; there is no second branch |
+| 2 | the HTTP resource handler, same underlying failure | **keep raising** | it answers with a 400; here the distinction *is* the action |
+| 3 | draining a killed process's remaining output | **narrow** the catch to the two timeout types | the return value is captured output — an unexpected exception became "the process produced nothing" |
+| 4 | asking whether a process exited within a grace window | **keep the broad catch** | it returns a boolean that drives SIGTERM → SIGKILL; the worst an unknown failure buys is a redundant signal to an already-dead process |
+
+Rows 2 and 4 are why this is a rule rather than a preference. "Fold
+exceptions into values" would break row 2; "never catch broadly" would break
+row 4. A discriminant that only decides one direction is a slogan.
+
+### Folding the action does not fold the fact
+
+Row 1's caller has one branch. The *record* still has two things to say.
+The fix that landed keeps both: a WARNING for the operator reading now, and
+a typed value — `LostReason.OUTSIDE_BOUNDARY` — added to the enum that
+already carried "why is this body unavailable", so every existing reader of
+that enum receives the new reason without changing.
+
+Two details in that are worth copying. It **did not open a second channel**
+for the fact: the reason rides the one that already existed. And it put the
+durable half in the message's own metadata rather than only in `reyn.log` —
+which matters, because that log is size-capped, and a diagnostic that fires
+often will evict the operational history around it (§29's own table has an
+instance where exactly that happened).
+
+### What we learned about turning this into a check
+
+This discriminant was tried as a gate, twice, keyed on **the shape of the
+value assigned inside the handler**. The second attempt kept all three known
+bad cases — and flagged 46–53 of 74 survivors, a 62–72% false-positive rate.
+A check that wrong teaches its readers to dismiss it, which is worse than
+not having it.
+
+The reason is worth writing down: the shape of the assigned value is not the
+axis. **Where the value goes is.** A default assigned into a variable the
+function returns is a swallow; the same assignment consumed by a local
+branch, then discarded, is control flow. Two sites can be character-identical
+in the handler and land on opposite sides of the rule.
+
+That does not mean no check is possible — it means the check has to follow
+the value, and that a discriminant good enough for a person to apply is not
+automatically one a matcher can. If you build it, measure both sides on real
+code before believing it: the disqualifying cases surviving is the cheap
+half, and it is the survivors' false-positive rate that decides whether
+anyone will keep the check switched on.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.


### PR DESCRIPTION
**[architect]** — `verification-hazards.md` §30。**#6029（§29）着地に伴い base を `main` へ切替済、rebase 済**（差分は §30 ＋ CLAUDE.md のみ）。

## 節の核

**発火する act**: 「**失敗が呼び手にどう届くかを決めようとしている**」— raise するか値に畳むか、広く catch するか未知を伝播させるか。

**2 つの規則。1 本を両向きに読んだものです:**

> **呼び手に分岐が無いなら、畳む。** 例外は**選択肢を渡す機構**で、どの結末も同じ行動に至るなら渡す選択肢が無い ∴ 情報ではなく、呼び手が定型句で耐えるだけの crash。
>
> **安全な答えが既定の側のときだけ、吸収してよい。** **False が安全な行動である述語**は未知の失敗を飲んでよい（知らない代償が余計に安全な 1 手）。**返り値がデータとして消費される関数**は駄目（知らないが「正常な空」の衣装で呼び手に届く）。

## ⭐ 4 例のうち 2 例が「直さない」側

| | 判断 |
|---|---|
| 内部読み手の境界外 path | **畳む**（どちらでも placeholder、第 2 の分岐が無い） |
| **HTTP の resource handler、同じ失敗** | 🔴 **例外のまま**（400 を返す ∴ 区別が行動そのもの） |
| kill 後 drain | **狭める**（返り値は捕獲した出力＝データ） |
| **grace 内に exit したかの述語** | 🔴 **広い catch のまま**（False は SIGKILL 昇格＝安全側） |

**この 2 行が、これを規則にしています。**「例外を値に畳め」は 2 行目を壊し、「広く catch するな」は 4 行目を壊します。**片方向しか決められない判別子は標語です。**

## 畳むのは行動であって、事実ではない

**`LostReason.OUTSIDE_BOUNDARY` が既存の enum に足された**形を書きました。⭐ **事実のために第 2 の channel を作らず**、⭐ **durable な半分を message の meta に置いた**（`reyn.log` は size cap 付きで、**よく鳴る診断はその周りの運用履歴を押し出す** — §29 の表に実例が在ります）。

## ⚠️ gate 化について（lead-coder の実測をそのまま材料に）

**2 度 gate にされ、2 度とも「handler 内で代入される *値の形*」を鍵にしていました。** 2 回目は**既知の悪い 3 件を全て残した**一方、**生存側 74 件のうち 46〜53 件を誤検出（62〜72%）**。

**理由を書きました**: **値の形は軸ではありません。値がどこへ流れるかが軸です。** ∴ **handler の中だけを見ると文字単位で同一の 2 site が、規則の反対側に落ちます。**

⚠️ **「gate にできる」とは書いていません。** 人が適用できる判別子が matcher に移せるとは限らないこと、作るなら**両側を実測**すること、**生存側の偽陽性率が「切られるか」を決める**ことを書きました。⚠️ **lead-coder から「実装可能な形で書けとは求めない」と明示されており、doc は doc の目的で書いています。**

## CLAUDE.md

**既存 pointer に `or choosing raise vs return` を追加**（新規行なし）。**baseline 以下を維持**（3 entry から回収: `do not hand-parse` → `never hand-parse`／`the write-gate` → `write-gate`／`catalog and dispatch` → `catalog, dispatch`）。**`--write-baseline` 不使用。**

## Test plan

- [x] `mkdocs build --strict` ＋ `check_doc_anchors.py` ＋ `check_retired_config_keys_denylist.py` ＋ `claude_md_word_count_ratchet.py`（`&&` 連結、exit 0）
- [x] 節番号 **1..30 連番**、**`## See also` の *前***

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow
