### PR TITLE
feat(#6014 follow-up): every scripts/*.py declares its own CI role -- gate/report/manual, machine-checked

### DIFF
--- a/.github/workflows/ci-role-declared-gate.yml
+++ b/.github/workflows/ci-role-declared-gate.yml
@@ -1,0 +1,51 @@
+name: ci-role declared gate
+
+# #6014 follow-up: every top-level scripts/*.py file must declare its own
+# `CI: gate|report|manual` role (see scripts/check_ci_role_declared.py's
+# own module docstring for the full design and what each value obligates).
+# Not a baseline/ratchet -- see that script's own "Deliberately NOT a
+# ratchet" section for why a grandfathered-undeclared population would be
+# the exact silence #6014 exists to close.
+#
+# `paths: scripts/**` catches a new/edited script missing its own
+# declaration, or a script's role no longer matching its actual wiring.
+# `paths: .github/workflows/**` catches a workflow file edit that removes
+# a `gate`/`report` script's wiring without touching the script itself (a
+# rename, a step deleted from an unrelated cleanup). `paths: tests/
+# conftest.py` catches the THIRD wiring mechanism check_ci_role_declared.py
+# recognises (see its own `_wiring_haystack` docstring): removing the
+# `verify_env_identity.py` autouse-fixture reference there would silently
+# un-wire that script without touching either of the other two trees.
+# Between the three, every PR that could change any side of "declared vs.
+# actually wired" triggers this -- no composition gap to close via
+# main-invariant-sweep.yml the way #4257's diff-scoped gates needed one
+# (this check re-scans the WHOLE population every run, not a diff).
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/**"
+      - "tests/conftest.py"
+
+permissions:
+  contents: read
+
+jobs:
+  ci-role-declared:
+    name: ci-role declared gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_ci_role_declared.py is stdlib-only (ast / re /
+      # pathlib / sys). No pip install needed.
+      - name: Check every scripts/*.py declares and satisfies its CI role
+        run: |
+          python scripts/check_ci_role_declared.py

--- a/scripts/axis_label_gate.py
+++ b/scripts/axis_label_gate.py
@@ -72,6 +72,8 @@ constraint, reused here: an issue is a discussion vessel, not something
 this gate is allowed to stop. `needs-axis` only ever makes an existing gap
 VISIBLE (the same reason `blocked:external` works — "見えるから" — being
 seen is the entire mechanism), never closes or blocks the issue itself.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_approval_ledger_import_boundary.py
+++ b/scripts/check_approval_ledger_import_boundary.py
@@ -63,6 +63,8 @@ PASS, and the gate goes quietly blind rather than failing loud. Deriving
 the path from the REAL module's own ``__file__`` means a rename raises
 ``ImportError`` here instead — the gate breaks LOUDLY at the moment the
 thing it protects moves, rather than silently protecting nothing.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_bare_tests_import_reference.py
+++ b/scripts/check_bare_tests_import_reference.py
@@ -51,6 +51,8 @@ structural comparison against the real, current flat population, so a
 future flat file added tomorrow is covered automatically, the same way
 ``check_file_depth_reference.py``'s ``_support``/``fixtures`` detection
 needs no hardcoded directory names either.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_blocking_has_reread_note.py
+++ b/scripts/check_blocking_has_reread_note.py
@@ -85,6 +85,8 @@ stdlib-only (argparse / json / subprocess — the marker regexes and SHA
 logic are IMPORTED, not reimplemented), mirroring
 `check_pr_closing_intent.py`/`check_tests_read_names_its_tree.py` so CI
 runs it dep-free.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_cancel_swallow.py
+++ b/scripts/check_cancel_swallow.py
@@ -74,6 +74,8 @@ that same gate's own "not every hand-rolled shape is traceable" caveat.
 This gate only scans ``src/`` (production code) — the failure mode is a
 production defect (a real shutdown silently appearing to complete), not
 a test-authoring one.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_ci_role_declared.py
+++ b/scripts/check_ci_role_declared.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""#6014 follow-up gate — every top-level ``scripts/*.py`` file must
+declare its own CI role, and the declared role's own obligation must
+actually hold.
+
+## Why this exists
+
+#6014's own census found 6 gate scripts that were REFERENCED from a
+CLAUDE.md (or looked like a gate by name) but had never once run against
+the real tree — some were wired into neither a per-PR workflow nor
+``main-invariant-sweep.yml``'s explicit enumeration; nothing mechanical
+would ever have caught that absence. A human census (lead-coder's) missed
+2 of them on the first pass by grepping only the ROOT ``CLAUDE.md`` (there
+are 7), and separately conflated "referenced by name" with "will actually
+run" for a THIRD script (``check_claude_md_doc_overlap.py``) that reports
+but never fails. The same night surfaced a fourth state (#5265,
+``detect_5265_missing_required_context.py``): a script referenced from
+neither a workflow nor a CLAUDE.md, kept alive only by one person's
+recurring habit of running it by hand — invisible to any grep, and more
+dangerous than an outright absence because its results *look* like
+enforcement (memory pin: an invariant held up by someone's routine looks
+enforced and is not).
+
+## The declaration
+
+A single line, matched anywhere inside the module's own docstring (not
+necessarily the first line — unlike ``test_tier_audit.py``'s Tier
+convention, this repo's own scripts already use their first docstring
+line for an ``#NNNN — <one-line description>`` convention this gate does
+not want to displace)::
+
+    CI: gate
+    CI: report -- <who reads it, non-empty>
+    CI: manual -- <who runs it and by what act, non-empty>
+
+Design ruling (issue #6014, lead-coder): the three values are NOT the
+same check wearing three names -- each carries a DIFFERENT obligation,
+because collapsing ``report`` into ``gate`` would have this gate itself
+lie about what "declared" means (a ``report`` script is exactly the
+"wired, green, enforces nothing" state #6014 exists to make visible, not
+paper over):
+
+  - ``gate``    -- a real violation must turn CI red. Checked: the
+    script's own filename appears in some ``.github/workflows/*.yml``.
+  - ``report``  -- wired into CI, but deliberately never fails the run
+    (an audit/census tool). Checked: same wiring presence check as
+    ``gate``, PLUS a non-empty reason naming who reads the output. A
+    ``report`` that cannot name a reader is not a report -- it is nobody
+    watching, wearing a report's clothes.
+  - ``manual``  -- never runs unattended; a human invokes it. Checked:
+    a non-empty reason naming who runs it and by what act (a PR review
+    step, a periodic personal sweep, a one-off investigation). A
+    ``manual`` that cannot name a runner and an act is state 4 (#5265) --
+    "someone's habit" wearing ``manual``'s clothes instead of gate's.
+
+What this gate can verify mechanically stops at "the reason text is
+non-empty" -- it cannot read whether the reason genuinely names a person
+and an act, only a human reviewing the PR that adds or edits a
+declaration can. The value of requiring the line at all is exactly that a
+script whose maintainer cannot HONESTLY write a one-line reason is
+disclosing something by that failure, not by this gate's own logic.
+
+## Deliberately excluded from the population
+
+- Any ``scripts/_*.py`` (an existing informal convention already in use
+  -- ``_markers.py``, ``_file_depth_predicate.py``, ``_reyn_web_proc.py``
+  -- for a helper imported by other scripts/tests, never invoked as its
+  own CLI entry point).
+- Anything under a ``scripts/`` SUBDIRECTORY (``litellm_proxy_patch/``,
+  ``spike_lib/``, ``_sitecustomize_fake_embed/``) -- every CLAUDE.md
+  reference to a script names a flat ``scripts/<name>.py`` path (verified
+  by grep across all 7 ``CLAUDE.md`` files during #6014's design), never
+  a nested one; widening the population to nested files would pull in
+  library modules (``spike_lib/__init__.py`` has no CLI role to declare
+  at all) with no CLAUDE.md-derived reason to.
+
+## Deliberately NOT a ratchet
+
+#6014's own ruling: a baseline that grandfathers "not yet declared" is
+the exact silence this gate exists to close -- a script landing today
+with no ``CI:`` line is the SAME state as the 92 pre-existing scripts
+this PR migrates, and a ratchet would let today's version of that
+population go on being invisible to a NEW run for the same reason
+#6014's original 6 were. Every run checks every script in the population;
+there is no baseline file to fall behind.
+
+CI: gate
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _ROOT / "scripts"
+_WORKFLOWS_DIR = _ROOT / ".github" / "workflows"
+
+_CI_LINE_RE = re.compile(
+    r"^CI:\s*(gate|report|manual)(?:\s*--\s*(.*))?\s*$",
+    re.MULTILINE,
+)
+
+_VALID_ROLES = frozenset({"gate", "report", "manual"})
+
+
+def _population() -> "list[Path]":
+    """Every top-level ``scripts/*.py`` file, excluding underscore-prefixed
+    helpers. Non-recursive -- see module docstring for why nested files
+    (``litellm_proxy_patch/``, ``spike_lib/``) are out of scope."""
+    return sorted(
+        p for p in _SCRIPTS_DIR.glob("*.py")
+        if not p.name.startswith("_")
+    )
+
+
+def _docstring(path: Path) -> "str | None":
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError:
+        return None
+    return ast.get_docstring(tree)
+
+
+def _declared_role(docstring: "str | None") -> "tuple[str, str] | None | list[str]":
+    """Returns ``(role, reason)`` for exactly one match, ``None`` for no
+    match, or a list of ALL matched raw lines when more than one ``CI:``
+    line is present (ambiguous -- the caller reports this as its own
+    violation kind rather than silently taking the first or last)."""
+    if docstring is None:
+        return None
+    matches = list(_CI_LINE_RE.finditer(docstring))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        return [m.group(0).strip() for m in matches]
+    role = matches[0].group(1)
+    reason = (matches[0].group(2) or "").strip()
+    return role, reason
+
+
+def _wiring_haystack(scripts: "list[Path]", scripts_dir: Path, workflows_dir: Path) -> str:
+    """"Wired" is not always a direct ``.github/workflows/*.yml`` mention —
+    3 real scripts in this repo's own population are reached one layer
+    removed: ``verify_env_identity.py`` is invoked from ``tests/**/
+    conftest.py`` autouse fixtures (a real, structural pytest-collection
+    invocation, not a workflow step), and ``wheel_parity_probe.py`` /
+    ``wheel_plugin_install_probe.py`` are spawned by ``wheel_reachability_
+    smoke.py`` (itself directly workflow-wired), never named in any
+    workflow file themselves.
+
+    Two real invocation mechanisms, not a hand-typed name list: workflow
+    files ∪ conftest.py files form the base haystack; any script whose OWN
+    name appears there is ITSELF added to the haystack (one level of
+    transitive closure) — this is how a sibling-script dispatch chain like
+    wheel_reachability_smoke.py -> wheel_parity_probe.py resolves without
+    naming either script here. Deliberately NOT extended to every
+    script's source (only ones already confirmed directly wired) — that
+    would let an unrelated script's passing docstring mention of another
+    script's filename count as "wired", the exact false-accept shape this
+    whole gate exists to close."""
+    workflow_text = "\n".join(
+        p.read_text() for p in sorted(workflows_dir.glob("*.yml"))
+    )
+    conftest_text = "\n".join(
+        p.read_text()
+        for p in sorted(scripts_dir.parent.glob("tests/**/conftest.py"))
+    )
+    haystack = workflow_text + "\n" + conftest_text
+    directly_wired = [s for s in scripts if s.name in haystack]
+    return haystack + "\n" + "\n".join(s.read_text() for s in directly_wired)
+
+
+def find_violations(scripts_dir: Path, workflows_dir: Path) -> "list[str]":
+    scripts = sorted(
+        p for p in scripts_dir.glob("*.py") if not p.name.startswith("_")
+    )
+    haystack = _wiring_haystack(scripts, scripts_dir, workflows_dir)
+    violations: "list[str]" = []
+    for path in scripts:
+        rel = path.relative_to(scripts_dir.parent)
+        docstring = _docstring(path)
+        declared = _declared_role(docstring)
+        if declared is None:
+            violations.append(
+                f"{rel}: no `CI: gate|report|manual` line in its own module "
+                f"docstring"
+            )
+            continue
+        if isinstance(declared, list):
+            violations.append(
+                f"{rel}: {len(declared)} `CI:` lines found, ambiguous — "
+                f"exactly one required: {declared!r}"
+            )
+            continue
+        role, reason = declared
+        wired = path.name in haystack
+        if role == "gate":
+            if not wired:
+                violations.append(
+                    f"{rel}: declares `CI: gate` but its own filename does "
+                    f"not appear in any .github/workflows/*.yml — never "
+                    f"actually wired"
+                )
+        elif role == "report":
+            if not wired:
+                violations.append(
+                    f"{rel}: declares `CI: report` but its own filename "
+                    f"does not appear in any .github/workflows/*.yml"
+                )
+            if not reason:
+                violations.append(
+                    f"{rel}: declares `CI: report` with no reason naming "
+                    f"who reads it — `CI: report -- <reader>` required"
+                )
+        elif role == "manual":
+            if not reason:
+                violations.append(
+                    f"{rel}: declares `CI: manual` with no reason naming "
+                    f"who runs it and by what act — `CI: manual -- "
+                    f"<runner, act>` required"
+                )
+        else:  # pragma: no cover — regex already restricts to _VALID_ROLES
+            assert role in _VALID_ROLES
+    return violations
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv
+    scripts = _population()
+    # Vacuity guard (#4846-class): a scan that found zero scripts is a
+    # scanner failure -- a moved scripts/ dir, a broken glob -- not a
+    # clean population. See suspected_time_dependence_ratchet.py's own
+    # identical guard for the same reasoning.
+    if not scripts:
+        print(
+            "check_ci_role_declared FAILED: found 0 scripts under "
+            f"{_SCRIPTS_DIR} — this is a scanner failure, not a clean "
+            "population.",
+            file=sys.stderr,
+        )
+        return 1
+
+    violations = find_violations(_SCRIPTS_DIR, _WORKFLOWS_DIR)
+    if violations:
+        print(
+            f"check_ci_role_declared FAILED: {len(violations)} of "
+            f"{len(scripts)} script(s) in scripts/ fail their own "
+            "declared (or missing) CI role:\n",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        print(
+            "\nSee this script's own module docstring for the `CI: "
+            "gate|report|manual` grammar and what each value obligates.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check_ci_role_declared OK: {len(scripts)} script(s) in scripts/, "
+        "all declare a CI role and satisfy its obligation."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ci_role_declared.py
+++ b/scripts/check_ci_role_declared.py
@@ -140,6 +140,55 @@ def _declared_role(docstring: "str | None") -> "tuple[str, str] | None | list[st
     return role, reason
 
 
+def _stripped_source(path: Path) -> str:
+    """AST-reconstructed source with every module/class/function-level
+    DOCSTRING removed, and comments naturally absent (``ast`` never
+    retains them) -- what remains is CODE: real string-literal arguments
+    (a ``Path(...) / "other_script.py"`` construction), not commentary.
+
+    Exists because of a real bug (lead-coder review, #6032): this
+    script's OWN module docstring names ``check_claude_md_doc_overlap.py``
+    as a worked example of the ``report`` role. Once this script is
+    itself directly workflow-wired, its RAW source text (docstring
+    included) used to enter ``_wiring_haystack``'s transitive-closure
+    step, so that PROSE mention alone made ``check_claude_md_doc_overlap.
+    py`` read as "wired" -- the exact false-accept this module's own
+    design claims to prevent, produced by the sentence that made that
+    claim. A mention is not a call; only code is."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = node.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                body.pop(0)
+    return ast.unparse(tree)
+
+
+_YAML_COMMENT_RE = re.compile(r"#.*$", re.MULTILINE)
+
+
+def _stripped_yaml(text: str) -> str:
+    """Strip ``#``-to-end-of-line comments from a workflow file's text —
+    the same false-accept shape as ``_stripped_source`` above, one layer
+    up: a workflow's own RATIONALE comment naming a script in passing
+    (this gate's own ``ci-role-declared-gate.yml`` names ``verify_env_
+    identity.py`` in exactly such a comment, explaining why ``tests/
+    conftest.py`` is in its own ``paths:`` list) must not count as
+    "wired" on its own. No ``run:`` line in this repo's workflows has
+    been found to contain a literal ``#`` inside a quoted string
+    (checked by hand, #6032) -- if one ever does, this naive strip would
+    truncate that line rather than mis-detect a script, a safe failure
+    direction (under-matching a real wiring line reads as a FALSE
+    violation, which a human notices and fixes, not a silent false
+    accept)."""
+    return _YAML_COMMENT_RE.sub("", text)
+
+
 def _wiring_haystack(scripts: "list[Path]", scripts_dir: Path, workflows_dir: Path) -> str:
     """"Wired" is not always a direct ``.github/workflows/*.yml`` mention —
     3 real scripts in this repo's own population are reached one layer
@@ -151,25 +200,40 @@ def _wiring_haystack(scripts: "list[Path]", scripts_dir: Path, workflows_dir: Pa
     workflow file themselves.
 
     Two real invocation mechanisms, not a hand-typed name list: workflow
-    files ∪ conftest.py files form the base haystack; any script whose OWN
-    name appears there is ITSELF added to the haystack (one level of
-    transitive closure) — this is how a sibling-script dispatch chain like
-    wheel_reachability_smoke.py -> wheel_parity_probe.py resolves without
-    naming either script here. Deliberately NOT extended to every
-    script's source (only ones already confirmed directly wired) — that
-    would let an unrelated script's passing docstring mention of another
-    script's filename count as "wired", the exact false-accept shape this
-    whole gate exists to close."""
+    files ∪ conftest.py files form the base haystack (comments stripped
+    from both -- see ``_stripped_yaml``/``_stripped_source``); any script
+    whose own name appears there is ITSELF added to the haystack, its own
+    comments/docstrings ALSO stripped (one level of transitive closure)
+    — this is how a sibling-script dispatch chain like
+    ``wheel_reachability_smoke.py -> wheel_parity_probe.py`` resolves
+    without naming either script here. Deliberately NOT extended to
+    every script's source (only ones already confirmed directly wired)
+    -- that would let an unrelated script's passing mention of another
+    script's filename count as "wired", the exact false-accept shape
+    this whole gate exists to close.
+
+    Residual disclosed, not solved: a real STRING LITERAL that merely
+    QUOTES another script's filename in an f-string/error message (not a
+    docstring, not a comment, but also not a real invocation -- e.g.
+    ``print(f"see {other_script} for detail")``) still reads as "wired"
+    here. Measured against the current 92-script population (#6032):
+    zero such sites found by hand-reviewing every ``gate``/``report``
+    verdict's own wiring path (see the PR body's own per-script table).
+    Not closed structurally because doing so would need parsing WHICH
+    AST context a string constant sits in (a subprocess/Path argument
+    vs. an arbitrary string) -- a real distinction, deferred until a
+    site is found, per this module's own "don't build unmeasured
+    machinery" bar."""
     workflow_text = "\n".join(
-        p.read_text() for p in sorted(workflows_dir.glob("*.yml"))
+        _stripped_yaml(p.read_text()) for p in sorted(workflows_dir.glob("*.yml"))
     )
     conftest_text = "\n".join(
-        p.read_text()
+        _stripped_source(p)
         for p in sorted(scripts_dir.parent.glob("tests/**/conftest.py"))
     )
     haystack = workflow_text + "\n" + conftest_text
     directly_wired = [s for s in scripts if s.name in haystack]
-    return haystack + "\n" + "\n".join(s.read_text() for s in directly_wired)
+    return haystack + "\n" + "\n".join(_stripped_source(s) for s in directly_wired)
 
 
 def find_violations(scripts_dir: Path, workflows_dir: Path) -> "list[str]":

--- a/scripts/check_claude_md_doc_overlap.py
+++ b/scripts/check_claude_md_doc_overlap.py
@@ -37,7 +37,7 @@ it reports every span >=15 words and leaves severity judgment to the
 reader, per #4858's own explicit warning that "always require both" is
 the wrong rule for this population.
 
-CI: report -- read by lead-coder when re-measuring CLAUDE.md overlap after an edit
+CI: manual -- run by hand by lead-coder when re-measuring CLAUDE.md overlap after an edit; not wired into any workflow
 """
 from __future__ import annotations
 

--- a/scripts/check_claude_md_doc_overlap.py
+++ b/scripts/check_claude_md_doc_overlap.py
@@ -36,6 +36,8 @@ to tell a legitimate short quote from an accidental one by shape alone);
 it reports every span >=15 words and leaves severity judgment to the
 reader, per #4858's own explicit warning that "always require both" is
 the wrong rule for this population.
+
+CI: report -- read by lead-coder when re-measuring CLAUDE.md overlap after an edit
 """
 from __future__ import annotations
 

--- a/scripts/check_collect_events_settle.py
+++ b/scripts/check_collect_events_settle.py
@@ -177,6 +177,8 @@ function, than the read.
 This gate's own starting population is zero (all 31 found instances were
 fixed in the same PR that added this gate) — any hit here is a new
 regression, not inherited debt.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_doc_anchors.py
+++ b/scripts/check_doc_anchors.py
@@ -74,6 +74,8 @@ runs immediately; the anchor check below it needs `mkdocs build --strict -f
 its output in `site/` at the repo root — wired as an additional step in the
 same CI job right after that build, in `.github/workflows/test.yml`, so no
 second build and no new dependency).
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -131,6 +131,8 @@ fallback, `_print_findings_and_exit_code` (still returns 1 on a
 finding — useful for a human running `--pr N` by hand; only the CI
 workflow ignores it now), and every existing test. None of that was
 what broke.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_fastmcp_import_boundary.py
+++ b/scripts/check_fastmcp_import_boundary.py
@@ -43,6 +43,8 @@ Same reasoning as ``check_bare_tests_import_reference.py``/
 ``check_file_depth_reference.py``: whether a file imports ``fastmcp``
 directly is fully determined by its CURRENT content, no move or diff
 needed. A pure population scan against a real, verified-zero baseline.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_file_depth_reference.py
+++ b/scripts/check_file_depth_reference.py
@@ -157,6 +157,8 @@ restricting to module-level glob roots specifically targets "eager
 fixture discovery at import time" (this gate's real broken instance)
 while structurally excluding the runtime-directory false-positive risk
 the review flagged. See :func:`_missing_module_level_glob_roots`.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_hooks_declared_reachable.py
+++ b/scripts/check_hooks_declared_reachable.py
@@ -78,6 +78,8 @@ is set-theoretic: declared ⊆ reachable-without-LLM. Landing #5190 with
 today's 9 declarable kinds and today's 9 registered citations makes the
 diff empty NOW — every future kind added to the schema must arrive with
 its own citation in the SAME PR, or this gate fails.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_load_yaml_vocabulary.py
+++ b/scripts/check_load_yaml_vocabulary.py
@@ -59,7 +59,10 @@ than folded into :func:`find_violations` above so the two axes stay
 independently testable — a fixture exercising only the `vocabulary=`
 axis (the tests below) does not also have to supply a real
 `token_map=` to stay a valid accept-case, and vice versa. `main()`
-below reports both."""
+below reports both.
+
+CI: gate
+"""
 from __future__ import annotations
 
 import ast

--- a/scripts/check_no_core_dep_importorskip.py
+++ b/scripts/check_no_core_dep_importorskip.py
@@ -61,6 +61,8 @@ something outside ``[project].dependencies`` entirely — an extra, a dev
 tool, a test-only package) is silently fine, by construction: it is
 never even checked against the manifest-completeness failure mode, which
 only walks ``pyproject.toml``'s own core list.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_no_hardcoded_compaction_role_tuple.py
+++ b/scripts/check_no_hardcoded_compaction_role_tuple.py
@@ -39,6 +39,8 @@ Same reasoning as ``check_fastmcp_import_boundary.py``: whether a file
 hand-types the tuple is fully determined by its CURRENT content, no move
 or diff needed. A pure population scan against a real, verified-zero
 baseline (this gate's own starting population, post-#5699, is zero).
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_open_blocking_checkboxes.py
+++ b/scripts/check_open_blocking_checkboxes.py
@@ -140,6 +140,8 @@ normalization. Same unit condition B already uses (one line).
 stdlib-only (argparse / json / re / subprocess), mirroring
 `check_pr_closing_intent.py`/`check_tests_read_names_its_tree.py` so CI
 runs it dep-free.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -306,6 +306,8 @@ The parsing logic (``find_closing_declarations`` / ``find_nonclosing_declaration
 / ``check_contradictions``) is pure — no network, no subprocess — so it is
 fully unit-testable. ``fetch_pr_data`` is a thin ``gh`` wrapper kept
 separate so the pure logic can be exercised without hitting GitHub.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -115,7 +115,10 @@ value's placeholder-ness declared" — so :func:`find_unwired_key_
 violations` does not consult ①②③ at all; see its own docstring for the
 full reasoning and #5771's own issue thread for why this axis is
 deliberately reported wide (every unbacked key), not filtered down to
-an allowlisted few."""
+an allowlisted few.
+
+CI: gate
+"""
 from __future__ import annotations
 
 import ast

--- a/scripts/check_retired_config_keys_denylist.py
+++ b/scripts/check_retired_config_keys_denylist.py
@@ -150,6 +150,8 @@ two exclusion classes above) returns ZERO hits. Requiring a baseline would
 mean committing an empty one — simpler to just fail on any hit, which also
 means a new violation surfaces immediately instead of needing
 `--write-baseline` run first to notice it slipped through.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_subprocess_reyn_pin.py
+++ b/scripts/check_subprocess_reyn_pin.py
@@ -89,6 +89,8 @@ appearing — nothing needs editing in the baseline for a fix to "count".
 
 Keyed on the FILE, not (file, line) — an unrelated edit elsewhere in the
 file must never itself flip the gate red.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_task_funnel_bypass.py
+++ b/scripts/check_task_funnel_bypass.py
@@ -166,6 +166,8 @@ needed), forcing whoever introduced it to add a declared entry and
 classify it BEFORE the PR is green. That one required action is what
 makes ``"false_positive"`` entries countable: they are not a "same as
 before" default that requires nobody to write anything down.
+
+CI: report -- read by lead-coder from the workflow's ::warning:: annotation -- own main() is gate-shaped but task-funnel-bypass-gate.yml deliberately runs it warn-only
 """
 from __future__ import annotations
 

--- a/scripts/check_tests_dir_names.py
+++ b/scripts/check_tests_dir_names.py
@@ -69,6 +69,8 @@ predate this gate entirely). A NEW top-level ``tests/<name>/`` directory
 ``--write-baseline`` and ``--check-growth`` mirror ``flat_tests_ratchet.py``
 exactly, including the same hand-edit-the-baseline loophole and the same
 guard against it.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_tests_path_literal_reference.py
+++ b/scripts/check_tests_path_literal_reference.py
@@ -96,6 +96,8 @@ generated-output directory; `git ls-files` needs none).
 
 Run directly against the real repo tree; see ``check_tests_path_literal_reference_baseline.json``
 and the paired test file's ``test_the_real_repo_tree_measurement_matches_the_baseline``.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_tests_read_names_its_tree.py
+++ b/scripts/check_tests_read_names_its_tree.py
@@ -107,6 +107,8 @@ already warns about.
 
 stdlib-only (argparse / json / re / subprocess), mirroring
 ``scripts/check_pr_closing_intent.py`` so CI runs it dep-free.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_tui_reactive_ratchet.py
+++ b/scripts/check_tui_reactive_ratchet.py
@@ -43,6 +43,8 @@ NOT a duplication detector, NOT a proof of sufficiency — a floor and a
 ceiling that stop this specific regression from being silent, nothing
 more. See ``src/reyn/interfaces/CLAUDE.md``'s own #5131 section for the
 4 rules this gate is a PARTIAL, structural witness for.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/check_tui_widget_boundary.py
+++ b/scripts/check_tui_widget_boundary.py
@@ -16,6 +16,8 @@ silently erode as new widget files land.
 IS the seam between the wire and the widget tree) — excluded by name, not
 grandfathered by a baseline: this is a fixed architectural role, not a
 population of legacy violations to shrink over time.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/claude_md_word_count_ratchet.py
+++ b/scripts/claude_md_word_count_ratchet.py
@@ -40,6 +40,8 @@ explicit that adding rules is fine. What is forbidden is doing so for free:
 file, which is the concrete form of "write down that you are raising every
 session's per-turn cost" (lead-coder's own framing, #4872 dispatch) -- an
 action, not merely a comment nobody has to make.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/cleanup_agent_worktrees.py
+++ b/scripts/cleanup_agent_worktrees.py
@@ -15,6 +15,8 @@ Usage:
     python scripts/cleanup_agent_worktrees.py --include-alive --dry-run  # dangerous
     python scripts/cleanup_agent_worktrees.py --include-dirty --dry-run  # dangerous
     python scripts/cleanup_agent_worktrees.py --json        # machine-readable
+
+CI: manual -- run by whoever is clearing stale agent worktrees, via its own CLI flags
 """
 from __future__ import annotations
 

--- a/scripts/compaction_outcome_dist.py
+++ b/scripts/compaction_outcome_dist.py
@@ -25,6 +25,8 @@ Usage:
 
 Emits a JSON summary to stdout (redirect to a file for the #1128 record, then
 cat+copy it — never hand-type the numbers).
+
+CI: manual -- run by hand for one-off compaction-outcome research
 """
 from __future__ import annotations
 

--- a/scripts/crop_art.py
+++ b/scripts/crop_art.py
@@ -13,6 +13,8 @@ Examples
 
 # Pass extra chafa options (after --):
   python scripts/crop_art.py horse.png -c 10 -H 6 -- --colors 256 --symbols block+sextant
+
+CI: manual -- run by hand as a chafa image-crop convenience wrapper
 """
 import argparse
 import subprocess

--- a/scripts/detect_4986_teardown_hang.py
+++ b/scripts/detect_4986_teardown_hang.py
@@ -50,6 +50,8 @@ the thin, separately-swappable network layer.
 Usage:
     python scripts/detect_4986_teardown_hang.py --run-id <id>
     python scripts/detect_4986_teardown_hang.py --log-file <path>
+
+CI: report -- read by lead-coder from the auto-posted PR comment -- workflow deliberately captures its exit code under set +e and never fails the job
 """
 from __future__ import annotations
 

--- a/scripts/detect_5265_missing_required_context.py
+++ b/scripts/detect_5265_missing_required_context.py
@@ -104,6 +104,8 @@ from OUTSIDE Actions (a peer session's own sweep, or reyn-broker's
 Usage:
     python scripts/detect_5265_missing_required_context.py --pr 5912
     python scripts/detect_5265_missing_required_context.py --head-sha <sha>
+
+CI: manual -- run by backlog-watcher's own periodic patrol, invoked from outside GitHub Actions per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/detect_5265_startup_failure_blocked_prs.py
+++ b/scripts/detect_5265_startup_failure_blocked_prs.py
@@ -52,6 +52,8 @@ Usage:
     python scripts/detect_5265_startup_failure_blocked_prs.py --pr 5262
     python scripts/detect_5265_startup_failure_blocked_prs.py --head-sha <sha>
     python scripts/detect_5265_startup_failure_blocked_prs.py --fixture runs.json
+
+CI: manual -- run by backlog-watcher's own periodic patrol, invoked from outside GitHub Actions per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/detect_5419_behind_files.py
+++ b/scripts/detect_5419_behind_files.py
@@ -86,6 +86,8 @@ wrappers below are the separately-swappable network/subprocess layer.
 Usage:
     python scripts/detect_5419_behind_files.py --base origin/main --head HEAD
     python scripts/detect_5419_behind_files.py --pr 123
+
+CI: report -- read by lead-coder from the workflow's ::warning:: annotation -- own docstring says report, not block
 """
 from __future__ import annotations
 

--- a/scripts/detect_5478_deleted_files.py
+++ b/scripts/detect_5478_deleted_files.py
@@ -51,6 +51,8 @@ together would blur which one actually fired.
 Usage:
     python scripts/detect_5478_deleted_files.py --pr 123
     python scripts/detect_5478_deleted_files.py --base origin/main --head HEAD
+
+CI: report -- read by lead-coder from the PR comment this posts -- own docstring says report, never block
 """
 from __future__ import annotations
 

--- a/scripts/detect_attractor.py
+++ b/scripts/detect_attractor.py
@@ -10,6 +10,8 @@ Usage:
     python scripts/detect_attractor.py --trace <jsonl_path> --output-format json
     python scripts/detect_attractor.py --trace <jsonl_path> --summary-only
     python scripts/detect_attractor.py --trace <jsonl_path> --filter-caller router
+
+CI: manual -- run by hand during a dogfooding trace review
 """
 from __future__ import annotations
 

--- a/scripts/df2187_harness.py
+++ b/scripts/df2187_harness.py
@@ -12,6 +12,8 @@ A/B by codebase on the import path:
 Self-validate FIRST (lead mandate): confirm the harness drives the ownership chain
 (execute-wake → child_settled → completion-join → lead DONE) on the #2187 arm before
 taking the A/B differential — so a harness bug can't confound the efficacy result.
+
+CI: manual -- run by hand as a #2187 dogfood A/B session driver
 """
 from __future__ import annotations
 

--- a/scripts/diag_tiktoken_cache.py
+++ b/scripts/diag_tiktoken_cache.py
@@ -41,6 +41,8 @@ ALGORITHM it now delegates to is exercised for real by
 consumer this script shares it with); if the underlying CACHE MECHANISM
 itself needs a test, that belongs on ``reyn/__init__.py``'s own
 TIKTOKEN_CACHE_DIR default, not here.
+
+CI: manual -- run by an operator diagnosing a tiktoken cache issue, per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_1822_content_threat_verify.py
+++ b/scripts/dogfood_1822_content_threat_verify.py
@@ -21,6 +21,8 @@ runs); legit argv is checked via the same scan logic the handler uses (no exec).
 
 Config = production default: ThreatScanConfig() (enabled, fence_enabled,
 block_severity="block", fail_open).
+
+CI: manual -- run by hand for a #1822 live threat-scan coverage pass
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_aggregate.py
+++ b/scripts/dogfood_aggregate.py
@@ -23,6 +23,8 @@ Usage::
 Tier 2 testing seam: ``load_worker_results``, ``compute_totals``,
 ``build_aggregate``, and ``render_comparison_table`` are independent
 pure functions consumed by ``test_dogfood_aggregate.py``.
+
+CI: manual -- run by hand to aggregate per-worker dogfood JSON output
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_b23_driver.py
+++ b/scripts/dogfood_b23_driver.py
@@ -21,6 +21,8 @@ After the chat finishes, the driver inspects:
 
 It emits a 4-outcome verdict (verified / inconclusive / refuted / blocked)
 following the prelude's prediction rubric.
+
+CI: manual -- run by hand as a dogfood scenario driver against a live reyn chat --cui
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_b24_driver.py
+++ b/scripts/dogfood_b24_driver.py
@@ -25,6 +25,8 @@ After the chat finishes, the driver inspects:
 
 It emits a 4-outcome verdict (verified / inconclusive / refuted / blocked)
 following the prelude's prediction rubric.
+
+CI: manual -- run by hand as a dogfood scenario driver against a live reyn chat --cui
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_batch_config.py
+++ b/scripts/dogfood_batch_config.py
@@ -36,6 +36,8 @@ Config shape (YAML)::
         aggregate_path: docs/deep-dives/journal/dogfood/2026-05-19-batch-42-b40-v2-cumulative/aggregate.json
 
     journal_dir: docs/deep-dives/journal/dogfood/2026-05-21-batch-44-...
+
+CI: manual -- imported as a shared config/loader library by the dogfood_*_driver scripts, never run directly
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_batch_dispatch.py
+++ b/scripts/dogfood_batch_dispatch.py
@@ -25,6 +25,8 @@ Per-batch past-batch verdict citation: the prompts include the
 worker's prior verdicts pulled from the most recent ``past_batches``
 entry (= the one listed FIRST in the config). This eliminates the
 manual paste step that previously took ~10-15 min per batch dispatch.
+
+CI: manual -- run by hand to generate per-worker dogfood dispatch prompts/worktrees
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_fp_retest.py
+++ b/scripts/dogfood_fp_retest.py
@@ -26,6 +26,8 @@ Usage:
       [--tiers weak strong]
 
 Idempotent resume: completed runs are skipped via runs.jsonl in --out dir.
+
+CI: manual -- run by hand as a multi-tier false-positive retest driver against a live reyn web
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_g4_spike.py
+++ b/scripts/dogfood_g4_spike.py
@@ -17,6 +17,8 @@ Usage:
       --phase primary \\
       [--smoke-test] \\
       [--out spike_results/fp_0011/]
+
+CI: manual -- run by hand as a G4 spike A/B driver against a live reyn web
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_long_session.py
+++ b/scripts/dogfood_long_session.py
@@ -30,6 +30,8 @@ Note on --n-shot:
     server). If they don't exist you'll get a JSON-RPC "Unknown agent" error —
     in that case use the default agent (n-shot=1) or pre-create the agents with
     `reyn agent new`.
+
+CI: manual -- run by hand as a long-session dogfood driver
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_rag_helper.py
+++ b/scripts/dogfood_rag_helper.py
@@ -9,6 +9,8 @@ Usage in scenario driver:
     sys.path.insert(0, "<reyn_root>/scripts")
     from dogfood_rag_helper import register_fake_embedding_provider, seed_test_files
     register_fake_embedding_provider()
+
+CI: manual -- imported as a shared setup library by other dogfood drivers, never run directly
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_s1_driver.py
+++ b/scripts/dogfood_s1_driver.py
@@ -9,6 +9,8 @@ observing:
 
 Clears history.jsonl between runs to ensure N=3 independence
 (fix for B16-S1-1 pattern).
+
+CI: manual -- run by hand as a dogfood scenario driver
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_s5_b18_driver.py
+++ b/scripts/dogfood_s5_b18_driver.py
@@ -14,6 +14,8 @@ Verdict criteria (per run):
   hallucination (B17-S5-1)
 - inconclusive: subprocess error / driver bug / can't determine
 - blocked: structural blocker
+
+CI: manual -- run by hand as a batch-18 dogfood scenario driver
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_s6_b18_driver.py
+++ b/scripts/dogfood_s6_b18_driver.py
@@ -15,6 +15,8 @@ Verdict criteria:
   refuted      — recall not invoked, OR sources has only one source.
   inconclusive — driver/subprocess error.
   blocked      — structural blocker (e.g. tool absent from catalog).
+
+CI: manual -- run by hand as a batch-18 dogfood scenario driver
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_s6_b20_driver.py
+++ b/scripts/dogfood_s6_b20_driver.py
@@ -25,6 +25,8 @@ Verdict criteria (= 原則 12 verdict false-attribution discipline):
   attractor, not multi-source related)
 - inconclusive: driver / subprocess error
 - blocked: structural pre-check fail (= recall not in catalog)
+
+CI: manual -- run by hand as a batch-20 dogfood scenario driver
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_sp_render.py
+++ b/scripts/dogfood_sp_render.py
@@ -31,6 +31,8 @@ Usage:
 
     # Legacy fixture byte-identity check (future Phase 5 prep):
     python scripts/dogfood_sp_render.py --legacy-check
+
+CI: manual -- run by hand as a dogfooding render/dev utility
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -15,6 +15,8 @@ Usage:
     # Multiple trace files (merged chronologically):
     python scripts/dogfood_trace.py --mode llm-payloads --trace a.jsonl --trace b.jsonl
     python scripts/dogfood_trace.py --mode llm-payloads --trace a.jsonl,b.jsonl
+
+CI: manual -- run by hand as the LLM-trace analysis entry point, per CLAUDE.md's own 'when you analyse a trace' line
 """
 from __future__ import annotations
 

--- a/scripts/dogfood_variant_replay.py
+++ b/scripts/dogfood_variant_replay.py
@@ -46,6 +46,8 @@ expression evaluates against three locals: ``content`` (str|None),
 Tier 2 testing seam: ``classify_response`` is imported by the test
 suite to verify classifier ordering + fallback behaviour without
 running real subprocesses.
+
+CI: manual -- run by hand for an ablation comparison replay
 """
 from __future__ import annotations
 

--- a/scripts/embedding_bench.py
+++ b/scripts/embedding_bench.py
@@ -39,6 +39,8 @@ no router state attached (= static-categories only). Dynamic categories
 as their static-category placeholders only; this is intentional — bench
 queries target the universal-catalog surface a fresh-context LLM would
 see, not the per-session catalog superset.
+
+CI: manual -- run by hand as an embedding benchmark -- gate-shaped exit codes exist but it is not wired into any workflow
 """
 from __future__ import annotations
 

--- a/scripts/flat_tests_disposition_check.py
+++ b/scripts/flat_tests_disposition_check.py
@@ -93,6 +93,8 @@ either way (it's frozen), so a file with a recorded `moved` entry whose PR
 hasn't merged yet is accounted for (has a disposition entry), not
 unprocessed — correct: the outstanding work is "land the PR," not "decide
 what to do with this file."
+
+CI: manual -- run by hand as a #3879 disposition bookkeeping tool, not listed in any workflow or CLAUDE.md pre-PR check
 """
 from __future__ import annotations
 

--- a/scripts/flat_tests_ratchet.py
+++ b/scripts/flat_tests_ratchet.py
@@ -38,6 +38,8 @@ its own CI-rejected condition (``--check-growth``, diffed against a base
 ref). mypy's ratchet does not need this because a hand-edited baseline entry
 there is indistinguishable from a real, still-measured finding; a hand-edited
 entry here can exist with NO corresponding file on disk at all.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/function_shape_metrics.py
+++ b/scripts/function_shape_metrics.py
@@ -34,6 +34,8 @@ Usage:
 
 Reads only the file given. No git, no network: to measure a merge-base, check
 it out (or ``git show <sha>:<path> > /tmp/x.py``) and run this on that copy.
+
+CI: manual -- run by hand to print structural function-shape metrics for a PR body, not a pass/fail check
 """
 from __future__ import annotations
 

--- a/scripts/gen_docs_redirects.py
+++ b/scripts/gen_docs_redirects.py
@@ -17,6 +17,8 @@ Usage:
 
 Covers EVERY ``*.html`` under the site (completeness — no page left without a
 legacy redirect).
+
+CI: report -- read by whoever reviews pages.yml's own build output -- a generator, not a checker
 """
 from __future__ import annotations
 

--- a/scripts/hn_research.py
+++ b/scripts/hn_research.py
@@ -45,6 +45,8 @@ Cache behavior:
     a cached file is used if it exists and contains valid JSON; a corrupt or
     missing file triggers a live fetch. Cache files are never expired
     automatically — delete the directory to force a full re-fetch.
+
+CI: manual -- run by hand for HN research, not CI-wired
 """
 from __future__ import annotations
 

--- a/scripts/llm_replay.py
+++ b/scripts/llm_replay.py
@@ -19,6 +19,8 @@ Usage:
     python scripts/llm_replay.py <request_id> --trace <jsonl_path> \\
         --patch 'tools[0].function.parameters.properties.name.enum=["a","b"]' \\
         --diff --n 10
+
+CI: manual -- run by hand for an interactive/one-off LLM-call replay and patch session
 """
 from __future__ import annotations
 

--- a/scripts/mcp_conformance.py
+++ b/scripts/mcp_conformance.py
@@ -33,6 +33,8 @@ which is the whole point of the matrix per the #3698 acceptance criterion):
 Run: python scripts/mcp_conformance.py
 Writes: docs/reference/runtime/mcp-conformance.json (machine, diffed by ②)
         docs/reference/runtime/mcp-conformance.md   (human, generated FROM the json)
+
+CI: manual -- run by hand for an MCP conformance investigation, writes report files for a human to read
 """
 from __future__ import annotations
 

--- a/scripts/mcp_probe.py
+++ b/scripts/mcp_probe.py
@@ -14,6 +14,8 @@ Usage::
 
 All flags optional; sensible defaults derive from the script's own
 location (= the repo's project root) and the `reyn` on PATH.
+
+CI: manual -- run by hand for a quick dev-only MCP-stdio probe, per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -23,6 +23,8 @@ issue #318 / #319 workaround note: when calling this script against a
 freshly-installed server, edit reyn.local.yaml to (a) add `type: stdio`
 and (b) rename the auto-generated `server-foo` key to a stable short
 name. See issues for repro details.
+
+CI: manual -- run by hand to confirm a fresh MCP server install/connectivity, per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/mcp_stdio_repro.py
+++ b/scripts/mcp_stdio_repro.py
@@ -6,6 +6,8 @@ blind to, (2) split platform-independent vs Windows-only, and (3) empirically an
 cacheable-vs-per-call (does a cached client survive a 2nd call + close without the task-boundary
 crash?). Owner crash keywords: BaseExceptionGroup / cancel scope crossed task boundary /
 BrokenResourceError / ConnectionReset.
+
+CI: manual -- run by hand as a scratch investigation tool, per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/measure_router_host_adapter_consumers.py
+++ b/scripts/measure_router_host_adapter_consumers.py
@@ -49,6 +49,8 @@ attributes, so a newly landed bundle updates it with no edit here.
 stdlib-only (``ast``/``pathlib``), no ``reyn`` import: both registries and the
 signature are AST-derived from the file on disk, so a hand-maintained list can
 never drift from what is measured.
+
+CI: manual -- its module is imported by a test to derive a predicate; the CLI entry point itself is never wired to gate anything
 """
 from __future__ import annotations
 

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -29,6 +29,8 @@ methods):
     on every other line; everything left over is code.
 
 Purely reads structure; makes no behavioural claim about the code.
+
+CI: manual -- run by hand to produce a PR-body report; own docstring says it makes no behavioural claim about the code
 """
 import argparse
 import ast

--- a/scripts/mypy_ratchet.py
+++ b/scripts/mypy_ratchet.py
@@ -153,6 +153,8 @@ ruling defers it to "after 1-3, measured": the three changes above may
 already remove enough of the cost that a daemon's own complexity (a
 long-lived process per repo, its own staleness/restart questions) is not
 worth taking on without first seeing whether it is still needed.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/pytest_skip_census.py
+++ b/scripts/pytest_skip_census.py
@@ -58,6 +58,8 @@ things pytest's own `-r` summary already prints for free:
   contributes 0 to the skipped tally, not 1), so a collection-error count
   needs its OWN, separate line on the same summary or that population
   stays invisible even after this script ships.
+
+CI: report -- read by whoever reviews test.yml's own step output -- own docstring says its exit code is always 0
 """
 from __future__ import annotations
 

--- a/scripts/rekey_fixtures.py
+++ b/scripts/rekey_fixtures.py
@@ -37,6 +37,8 @@ the affirmative. Two mechanisms close it, and the FIRST is the one that matters:
    the first is success.** The patcher reports its call count; a scan that never
    invoked ``_replay`` (bad pattern, collection error, a fixture wired some other
    way) is reported as an error with a non-zero exit, never as "up to date".
+
+CI: manual -- run by hand to rekey test fixtures, not CI-wired
 """
 from __future__ import annotations
 

--- a/scripts/s7_driver.py
+++ b/scripts/s7_driver.py
@@ -16,6 +16,8 @@ Observations:
   2. Run N=3 chat turns via subprocess (reyn chat --cui s7_dogfood).
   3. Read events log to confirm recall tool was NOT called.
   4. Verify LLM reply references seeded memory content.
+
+CI: manual -- run by hand as a one-off dogfood driver
 """
 from __future__ import annotations
 

--- a/scripts/s8_b18_driver.py
+++ b/scripts/s8_b18_driver.py
@@ -15,6 +15,8 @@ Notes on permission gating in A2A web context:
     BEFORE the server's resolver is constructed (lazy init).  If the resolver was
     already constructed earlier, we mutate it via a debug HTTP call (if available),
     otherwise we observe the deny path and report.
+
+CI: manual -- run by hand as a batch-18 dogfood driver against a local A2A server
 """
 from __future__ import annotations
 

--- a/scripts/s9_b18_driver.py
+++ b/scripts/s9_b18_driver.py
@@ -10,6 +10,8 @@ For each run:
   4. Invoke `reyn run index_docs '<json_input>'` with cost_warn_threshold:5 in input
   5. Parse trace dump for LLM decision
   6. Inspect workspace for chunks.jsonl / SQLite db / sources.yaml side effects
+
+CI: manual -- run by hand as a cost-preflight-gate dogfood driver
 """
 from __future__ import annotations
 

--- a/scripts/sandbox_argv_rewrite_probe_3869.py
+++ b/scripts/sandbox_argv_rewrite_probe_3869.py
@@ -25,6 +25,8 @@ Landlock+seccomp-restricted child CAN rewrite both its argv and its
 PR_SET_NAME) was recorded on #3869, and the CI step was then removed —
 this file is kept as a standalone script for a future rerun (e.g. after a
 sandbox-layer change) rather than deleted, but is not itself a gate.
+
+CI: manual -- kept for a future one-shot rerun per its own docstring; the CI step that used it was already removed
 """
 from __future__ import annotations
 

--- a/scripts/sandbox_landlock_deny_gate.py
+++ b/scripts/sandbox_landlock_deny_gate.py
@@ -56,6 +56,8 @@ own machine. Note the direction of the gap: the runner sits ABOVE the installed
 base, not below it, so this job is *least* likely to see the ABI-gated defects.
 Do not read a green run of this script as "the sandbox is validated on Linux".
 Read it as: "on this one ABI, on this one kernel, all three denies fired today."
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/sandbox_load_method_witness_3229.py
+++ b/scripts/sandbox_load_method_witness_3229.py
@@ -66,6 +66,8 @@ wrap_command-then-observe-the-filesystem oracle every existing probe uses)
 purely as CI-conformance evidence, exactly the ``axis_contract`` /
 ``test_sandbox_axis_contract_2983.py`` precedent CLAUDE.md names for
 "richer per-axis contract, CI-only".
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/sandbox_seccomp_x86_64_live_smoke.py
+++ b/scripts/sandbox_seccomp_x86_64_live_smoke.py
@@ -37,6 +37,8 @@ shipped with, not all of them:
 Do not read a green run of this script as "the sandbox is validated". Read it as
 "the syscall-name-resolution gap #2975 flagged as predicted-not-measured is now
 measured on x86_64" — see the PR body for the fuller table (#2983).
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/silent_except_ratchet.py
+++ b/scripts/silent_except_ratchet.py
@@ -102,6 +102,8 @@ evidence this has ever actually happened is on record (the same
 "population measured as zero, so not built" reasoning architect gave for
 #6009's directory-sweep candidate) — flagged here as a disclosed gap,
 not engineered around.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/spike_judge.py
+++ b/scripts/spike_judge.py
@@ -3,6 +3,8 @@
 Public API (imported by the driver, track B):
     judge_narration(*, final_output, narration, judge_focus) -> dict
     heuristic_grade(*, final_output, narration) -> dict
+
+CI: manual -- imported as a library by a G4 spike driver; its __main__ block is a smoke-test demo only
 """
 
 from __future__ import annotations

--- a/scripts/spike_preflight.py
+++ b/scripts/spike_preflight.py
@@ -14,6 +14,8 @@ Checks:
 
 Exit 0 = all checks PASS or WARN.  Exit 1 = any check FAIL (hard error).
 The script is idempotent — repeated runs are safe.
+
+CI: manual -- run by hand once before a spike begins, per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/suggest_test_dir.py
+++ b/scripts/suggest_test_dir.py
@@ -21,6 +21,8 @@ by pure alphabetical tie-break — forcing CI to require a specific directory
 would make an ordinary refactor's import-line diff fail the gate for a reason
 unrelated to the refactor itself. See ``check_no_new_flat_tests.py`` for the
 one thing Stage 0 DOES enforce (no new file lands directly in ``tests/``).
+
+CI: manual -- run by hand or invoked interactively -- own docstring says deliberately advisory, not enforced
 """
 from __future__ import annotations
 

--- a/scripts/suspected_time_dependence_ratchet.py
+++ b/scripts/suspected_time_dependence_ratchet.py
@@ -104,6 +104,8 @@ read as a healthy, fully-baselined zero, indistinguishable from "347
 suspects, all now fixed." `main()` asserts the scanned-file count is
 nonzero BEFORE ever comparing against the baseline, and fails loud,
 separately from the ratchet's own pass/fail, if it is not.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/swe_bench_runner.py
+++ b/scripts/swe_bench_runner.py
@@ -32,6 +32,8 @@ exits 0 so the harness batch keeps going::
     {"instance_id": "...", "model_name_or_path": "reyn", "error": "..."}
 
 All progress / diagnostic messages go to stderr only.
+
+CI: manual -- run by hand as an SWE-bench harness driver; own docstring says it exits 0 so the batch keeps going regardless of outcome
 """
 from __future__ import annotations
 

--- a/scripts/test_tier_audit.py
+++ b/scripts/test_tier_audit.py
@@ -18,6 +18,8 @@ Usage:
     python scripts/test_tier_audit.py --strict tests/
     python scripts/test_tier_audit.py --check format-pinning tests/
     python scripts/test_tier_audit.py --json tests/ | jq .
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/tier4_candidate_signals.py
+++ b/scripts/tier4_candidate_signals.py
@@ -47,6 +47,8 @@ never as "the population is mostly Tier 1/2".
 5. `narrow_tier2` — the docstring declares "Tier 2" but the test body calls
    into exactly ONE distinct `reyn.*`-sourced name — a broad Tier claim
    resting on a single, narrow call site.
+
+CI: manual -- run by hand for a Tier-4-candidate signal report -- own docstring says not a CI gate
 """
 from __future__ import annotations
 

--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -32,6 +32,8 @@ dependency (#3723) — it reads `pip`'s own recorded provenance
 ``reyn`` actually came from. ``CHECKS`` below is the enumeration; each entry
 carries the remedy for its own finding, so the gate that fires is the thing that
 explains itself.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/verify_module_docstrings.py
+++ b/scripts/verify_module_docstrings.py
@@ -20,6 +20,8 @@ on creative phrasings — those stay covered by review.
 
 stdlib-only (ast / re / argparse / pathlib), mirroring
 scripts/test_tier_audit.py, so CI runs it dep-free.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/verify_package_move.py
+++ b/scripts/verify_package_move.py
@@ -33,6 +33,8 @@ Ref-classes checked:
 
 stdlib-only (ast / re / argparse / pathlib) so CI can run it without deps,
 mirroring scripts/test_tier_audit.py.
+
+CI: manual -- run by hand as the C-series post-refactor straggler check, per its own docstring
 """
 from __future__ import annotations
 

--- a/scripts/wheel_parity_probe.py
+++ b/scripts/wheel_parity_probe.py
@@ -23,6 +23,8 @@ false-passes nothing.
 
 Exits 0 iff every check passes; exits 1 (with a ``[PASS]``/``[FAIL]`` line per
 check) on any assertion failure — reporting every failure, not stopping early.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/wheel_plugin_install_probe.py
+++ b/scripts/wheel_plugin_install_probe.py
@@ -48,6 +48,8 @@ responsibility onto genuinely works.
 
 Exits 0 iff every check passes; exits 1 with a ``[PASS]``/``[FAIL]`` line per
 check.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/scripts/wheel_reachability_smoke.py
+++ b/scripts/wheel_reachability_smoke.py
@@ -61,6 +61,8 @@ Exits 0 iff every check passes; exits non-zero (with a PASS/FAIL line per
 check) on the first structural failure or any assertion failure. Cleans up
 the temp wheel directory and venv in a ``finally`` block, on success or
 failure alike.
+
+CI: gate
 """
 from __future__ import annotations
 

--- a/tests/scripts/test_6014_ci_role_declared.py
+++ b/tests/scripts/test_6014_ci_role_declared.py
@@ -31,6 +31,21 @@ def _write_workflow(workflows_dir: Path, name: str, content: str) -> None:
     (workflows_dir / name).write_text(content, encoding="utf-8")
 
 
+def _write_script_with_code(
+    scripts_dir: Path, name: str, docstring_body: str, code_body: str,
+) -> None:
+    """Like ``_write_script``, but with real CODE after the docstring —
+    ``_write_script`` alone can only ever produce a bare docstring, which
+    ``_stripped_source`` now strips entirely (see #6032's own false-accept
+    fix): a test that needs a filename mentioned in actual CODE (a real
+    subprocess-target constant, not prose) must write code, not another
+    docstring line dressed up as one."""
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / name).write_text(
+        f'"""{docstring_body}"""\n{code_body}\n', encoding="utf-8",
+    )
+
+
 def test_a_script_with_no_ci_line_is_a_violation(tmp_path: Path) -> None:
     """Tier 2: the core state #6014 exists to close — a script that never
     said anything about its own CI role at all (the pre-migration state of
@@ -166,19 +181,51 @@ def test_a_script_spawned_by_a_directly_wired_sibling_script_counts_as_wired(
     """Tier 2: the real edge case #6014's own census found —
     ``wheel_parity_probe.py``/``wheel_plugin_install_probe.py`` are never
     named in any workflow file themselves; they are spawned by
-    ``wheel_reachability_smoke.py``, which IS directly workflow-wired.
-    One level of transitive closure (see ``_wiring_haystack``'s own
-    docstring) must resolve this without naming either script here."""
+    ``wheel_reachability_smoke.py``, which IS directly workflow-wired,
+    via a real CODE reference (``_PROBE_SCRIPT = ... / "wheel_parity_
+    probe.py"``), not a docstring mention. One level of transitive
+    closure (see ``_wiring_haystack``'s own docstring) must resolve this
+    without naming either script here."""
     scripts_dir = tmp_path / "scripts"
     workflows_dir = tmp_path / "workflows"
     _write_script(scripts_dir, "spawned_probe.py", "CI: gate\n")
-    _write_script(
-        scripts_dir, "parent_smoke.py",
-        "CI: gate\n\nSubprocess target: scripts/spawned_probe.py\n",
+    _write_script_with_code(
+        scripts_dir, "parent_smoke.py", "CI: gate\n",
+        'SPAWNED = "scripts/spawned_probe.py"\n',
     )
     _write_workflow(workflows_dir, "some.yml", "run: python scripts/parent_smoke.py\n")
 
     assert find_violations(scripts_dir, workflows_dir) == []
+
+
+def test_a_directly_wired_scripts_own_docstring_mention_is_not_wiring(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the exact false-accept lead-coder's review of #6032 caught
+    live — ``check_ci_role_declared.py`` (this gate's own script) is
+    itself directly workflow-wired, and its own module docstring names
+    ``check_claude_md_doc_overlap.py`` as a worked example. Before the
+    fix, that PROSE mention alone (raw source text entering the
+    transitive-closure haystack) made the mentioned script read as
+    "wired" — the exact false-accept this gate exists to close, produced
+    by the sentence that explained it. A docstring is not code."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "unwired_report.py", "CI: report -- someone\n")
+    _write_script_with_code(
+        scripts_dir, "wired_gate.py",
+        "A gate that mentions scripts/unwired_report.py as a worked example "
+        "in its own rationale, not as a real invocation.\n\nCI: gate\n",
+        "pass\n",
+    )
+    _write_workflow(workflows_dir, "some.yml", "run: python scripts/wired_gate.py\n")
+
+    violations = find_violations(scripts_dir, workflows_dir)
+
+    assert any("unwired_report.py" in v for v in violations), (
+        "a script named only in another directly-wired script's own "
+        "DOCSTRING must still be reported as not actually wired"
+    )
 
 
 def test_a_script_reached_only_via_an_unwired_siblings_docstring_is_still_a_violation(

--- a/tests/scripts/test_6014_ci_role_declared.py
+++ b/tests/scripts/test_6014_ci_role_declared.py
@@ -1,0 +1,267 @@
+"""Tier 2: #6014 follow-up gate — scripts/check_ci_role_declared.py.
+
+Every top-level ``scripts/*.py`` must declare its own ``CI: gate|report|
+manual`` role, and the declared role's own obligation (wired into a
+workflow, and/or a non-empty reason naming a reader/runner) must actually
+hold. See that script's own module docstring for the full design and the
+issue #6014 ruling behind the three-value split (``report`` is not folded
+into ``gate`` — each carries a different obligation).
+
+Real files on a real ``tmp_path`` (mirrors ``test_5131_tui_widget_
+boundary.py``'s own no-mocks placement/rationale) — no mocks. Drives both
+``find_violations`` directly (the detector) and ``main()`` (the CLI
+wiring), per that same file's own precedent that a green detector result
+is not evidence the CLI path ever reaches it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.check_ci_role_declared as check_ci_role_declared
+from scripts.check_ci_role_declared import find_violations, main
+
+
+def _write_script(scripts_dir: Path, name: str, docstring_body: str) -> None:
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / name).write_text(f'"""{docstring_body}"""\n', encoding="utf-8")
+
+
+def _write_workflow(workflows_dir: Path, name: str, content: str) -> None:
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    (workflows_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_a_script_with_no_ci_line_is_a_violation(tmp_path: Path) -> None:
+    """Tier 2: the core state #6014 exists to close — a script that never
+    said anything about its own CI role at all (the pre-migration state of
+    all 92 real scripts, and the exact shape #5265's orphan script was
+    in)."""
+    scripts_dir = tmp_path / "scripts"
+    _write_script(scripts_dir, "some_check.py", "Just a description, no CI line.")
+
+    violations = find_violations(scripts_dir, tmp_path / "workflows")
+
+    assert violations != []
+    assert any("no `CI: gate|report|manual` line" in v for v in violations)
+
+
+def test_two_ci_lines_are_ambiguous_not_silently_resolved(tmp_path: Path) -> None:
+    """Tier 2: falsification contrast — a script cannot declare two roles;
+    this must be its own violation kind, not "first one wins" or "last
+    one wins" silently."""
+    scripts_dir = tmp_path / "scripts"
+    _write_script(
+        scripts_dir, "confused.py",
+        "CI: gate\nCI: manual -- someone, sometimes\n",
+    )
+
+    violations = find_violations(scripts_dir, tmp_path / "workflows")
+
+    assert violations != []
+    assert any("ambiguous" in v for v in violations)
+
+
+def test_declared_gate_wired_into_a_workflow_is_clean(tmp_path: Path) -> None:
+    """Tier 2: the satisfied case for `gate` — its own filename appears in
+    some workflow file's text."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "wired_gate.py", "CI: gate\n")
+    _write_workflow(workflows_dir, "some.yml", "run: python scripts/wired_gate.py\n")
+
+    assert find_violations(scripts_dir, workflows_dir) == []
+
+
+def test_declared_gate_not_wired_is_a_violation(tmp_path: Path) -> None:
+    """Tier 2: the exact failure #6014's own census found by hand three
+    times over — a script that SAYS it is a gate but appears in no
+    workflow at all."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "orphan_gate.py", "CI: gate\n")
+    _write_workflow(workflows_dir, "unrelated.yml", "run: python scripts/other.py\n")
+
+    violations = find_violations(scripts_dir, workflows_dir)
+
+    assert violations != []
+    assert any("never actually wired" in v for v in violations)
+
+
+def test_declared_report_wired_with_a_reader_is_clean(tmp_path: Path) -> None:
+    """Tier 2: `report`'s satisfied case — wired AND names a reader."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(
+        scripts_dir, "audit_tool.py",
+        "CI: report -- read by lead-coder during periodic sweeps\n",
+    )
+    _write_workflow(workflows_dir, "some.yml", "run: python scripts/audit_tool.py\n")
+
+    assert find_violations(scripts_dir, workflows_dir) == []
+
+
+def test_declared_report_with_no_reader_is_a_violation_even_if_wired(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the exact false-accept #6014's design flagged — collapsing
+    `report` into `gate`'s single check (wired-only) would let a `report`
+    with nobody actually reading it pass silently. This is issue #6014's
+    ruling #1's own discriminator: `report` needs a SEPARATE obligation,
+    not just `gate`'s check reused."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "unread_report.py", "CI: report\n")
+    _write_workflow(workflows_dir, "some.yml", "run: python scripts/unread_report.py\n")
+
+    violations = find_violations(scripts_dir, workflows_dir)
+
+    assert violations != []
+    assert any("no reason naming who reads it" in v for v in violations)
+
+
+def test_declared_report_not_wired_is_a_violation(tmp_path: Path) -> None:
+    """Tier 2: `report` still needs the wiring half of its obligation —
+    a reason alone does not excuse an absent workflow reference."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "orphan_report.py", "CI: report -- someone\n")
+    _write_workflow(workflows_dir, "unrelated.yml", "run: python scripts/other.py\n")
+
+    violations = find_violations(scripts_dir, workflows_dir)
+
+    assert violations != []
+    assert any("does not appear in any" in v for v in violations)
+
+
+def test_declared_manual_with_a_runner_and_act_is_clean(tmp_path: Path) -> None:
+    """Tier 2: `manual`'s satisfied case — no wiring required at all, only
+    a non-empty reason naming who runs it and by what act."""
+    scripts_dir = tmp_path / "scripts"
+    _write_script(
+        scripts_dir, "human_tool.py",
+        "CI: manual -- run by backlog-watcher during an ad hoc triage sweep\n",
+    )
+
+    assert find_violations(scripts_dir, tmp_path / "workflows") == []
+
+
+def test_declared_manual_with_no_reason_is_state_4(tmp_path: Path) -> None:
+    """Tier 2: the exact #5265-shaped trap #6014's design names explicitly
+    — a `manual` declaration with nobody named as the runner is "someone's
+    habit" wearing `manual`'s clothes, not a real declaration. This is the
+    discriminator's own falsifiability: writing `CI: manual` alone must
+    NOT silently pass."""
+    scripts_dir = tmp_path / "scripts"
+    _write_script(scripts_dir, "habit_only.py", "CI: manual\n")
+
+    violations = find_violations(scripts_dir, tmp_path / "workflows")
+
+    assert violations != []
+    assert any("no reason naming who runs it" in v for v in violations)
+
+
+def test_a_script_spawned_by_a_directly_wired_sibling_script_counts_as_wired(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the real edge case #6014's own census found —
+    ``wheel_parity_probe.py``/``wheel_plugin_install_probe.py`` are never
+    named in any workflow file themselves; they are spawned by
+    ``wheel_reachability_smoke.py``, which IS directly workflow-wired.
+    One level of transitive closure (see ``_wiring_haystack``'s own
+    docstring) must resolve this without naming either script here."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "spawned_probe.py", "CI: gate\n")
+    _write_script(
+        scripts_dir, "parent_smoke.py",
+        "CI: gate\n\nSubprocess target: scripts/spawned_probe.py\n",
+    )
+    _write_workflow(workflows_dir, "some.yml", "run: python scripts/parent_smoke.py\n")
+
+    assert find_violations(scripts_dir, workflows_dir) == []
+
+
+def test_a_script_reached_only_via_an_unwired_siblings_docstring_is_still_a_violation(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: falsification contrast — the transitive closure is ONE
+    level, gated on the sibling ITSELF being directly wired; a mention
+    inside a script that is NOT directly wired must not launder an
+    unrelated script into "wired" for free."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "spawned_probe.py", "CI: gate\n")
+    _write_script(
+        scripts_dir, "unwired_sibling.py",
+        "CI: manual -- run by hand\n\nSee also scripts/spawned_probe.py.\n",
+    )
+    _write_workflow(workflows_dir, "unrelated.yml", "run: python scripts/other.py\n")
+
+    violations = find_violations(scripts_dir, workflows_dir)
+
+    assert violations != []
+    assert any("spawned_probe.py" in v for v in violations)
+
+
+def test_underscore_prefixed_files_are_excluded_from_the_population(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a helper module (the existing `_markers.py`-shaped
+    convention) carries no CI role to declare at all — it must not even
+    enter the population, so a bare undeclared `_helper.py` is not a
+    violation."""
+    scripts_dir = tmp_path / "scripts"
+    _write_script(scripts_dir, "_helper.py", "No CI line, and none needed.")
+
+    assert find_violations(scripts_dir, tmp_path / "workflows") == []
+
+
+def test_main_exits_nonzero_when_the_real_scripts_dir_has_a_violation(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the blocking gap ``test_5131_tui_widget_boundary.py``'s own
+    precedent names directly — a green ``find_violations`` result proves
+    nothing about whether ``main()``'s own CLI path reaches it. Monkeypatch
+    the MODULE-LEVEL ``_SCRIPTS_DIR``/``_WORKFLOWS_DIR`` (fresh name
+    lookups inside ``main()``, not bound defaults) and drive ``main()``
+    itself."""
+    scripts_dir = tmp_path / "scripts"
+    _write_script(scripts_dir, "undeclared.py", "No CI line here either.")
+    monkeypatch.setattr(check_ci_role_declared, "_SCRIPTS_DIR", scripts_dir)
+    monkeypatch.setattr(
+        check_ci_role_declared, "_WORKFLOWS_DIR", tmp_path / "workflows",
+    )
+
+    assert main() == 1
+
+
+def test_main_exits_zero_on_a_fully_compliant_fixture_population(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: falsification contrast for the test above — a fixture
+    population with every script satisfying its own declared role still
+    passes through ``main()``'s full CLI path to exit 0."""
+    scripts_dir = tmp_path / "scripts"
+    workflows_dir = tmp_path / "workflows"
+    _write_script(scripts_dir, "clean_gate.py", "CI: gate\n")
+    _write_workflow(workflows_dir, "some.yml", "run: python scripts/clean_gate.py\n")
+    monkeypatch.setattr(check_ci_role_declared, "_SCRIPTS_DIR", scripts_dir)
+    monkeypatch.setattr(check_ci_role_declared, "_WORKFLOWS_DIR", workflows_dir)
+
+    assert main() == 0
+
+
+def test_main_refuses_to_read_an_empty_population_as_clean(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: vacuity guard (#4846-class) — a scan that finds ZERO
+    scripts is a scanner failure (a moved directory, a broken glob), not a
+    clean population; must not read as green."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    monkeypatch.setattr(check_ci_role_declared, "_SCRIPTS_DIR", scripts_dir)
+    monkeypatch.setattr(
+        check_ci_role_declared, "_WORKFLOWS_DIR", tmp_path / "workflows",
+    )
+
+    assert main() == 1


### PR DESCRIPTION
**[tui-coder]** — closes #6014 (the follow-up-gate design ruling; the original census's B/C dispositions already landed via #6027/#6028).

Every top-level `scripts/*.py` (92 files) now declares its own CI role — `CI: gate`, `CI: report -- <reader>`, or `CI: manual -- <runner, act>` — as a line inside its own module docstring, and `scripts/check_ci_role_declared.py` (new, itself `CI: gate`) mechanically checks the declared role's own obligation holds. No hand-typed classification table anywhere — population and role both come from each script's own structural self-declaration, matched the same way `test_tier_audit.py` already matches a Tier line.

## Design (posted to #6014 first, ruled on, then implemented)

lead-coder's 3 corrections from the design ruling:
1. **`report` is a separate check from `gate`**, not folded in — `gate` needs wiring; `report` needs wiring **and** a non-empty reason naming a reader; `manual` needs a non-empty reason naming a runner and an act. Collapsing `report` into `gate`'s single "wired?" check would have this new gate itself lie about what "declared" means, since `report` **is** the "wired, green, enforces nothing" state #6014 exists to expose.
2. **Bulk migration, one PR, no ratchet** — a grandfathered-undeclared baseline would be the exact silence #6014 closes. Mechanical classification (read each `main()`'s real return-1 condition, check actual wiring) delegated to a subagent census per owner's standing "mechanical investigation → subagent" directive; all 92 verdicts landed, 0 `UNCLEAR`.
3. **Industry-precedent pass** (owner's standing instruction) — pre-commit `stages:`, ESLint `meta.type`, Bazel `tags=["manual"]` (this repo's own `manual` value already lines up with it), BuildKite `soft_fail: true` all put the declaration in the **orchestrator**, not the artifact — that shape structurally cannot detect a script wired nowhere at all, which is exactly what #5265's own state needs caught, so the declaration lives in each script's own docstring instead. Noted as issue comment.

## A real edge case the census found

3 scripts (`verify_env_identity.py`, `wheel_parity_probe.py`, `wheel_plugin_install_probe.py`) are genuine gates never named in any workflow file directly — reached one layer removed, via a `tests/conftest.py` autouse fixture or a sibling script's own subprocess spawn (`wheel_reachability_smoke.py`, itself directly wired). `_wiring_haystack()` resolves both via two real invocation mechanisms (conftest.py text + one level of transitive closure through scripts already confirmed directly wired) — not a hardcoded exemption list naming these 3 files.

## Wiring

`.github/workflows/ci-role-declared-gate.yml`, `paths: scripts/**, .github/workflows/**, tests/conftest.py` — covers all 3 wiring mechanisms the checker itself recognises, so no PR that could change either side of "declared vs. actually wired" escapes it. Kept off `main-invariant-sweep.yml`'s whole-tree scan, matching #6014 stage B's own scoping precedent (#6012's shape) — no composition gap to close since this re-scans the whole population every run, not a diff.

## Tests

`tests/scripts/test_6014_ci_role_declared.py`, 15 cases: each of the 3 roles' satisfied/violated obligation, the ambiguous-multiple-declarations case, the underscore-helper exclusion, both transitive-wiring directions (positive + the false-accept contrast where an unwired sibling must NOT launder wiring), the CLI-wiring gap (`main()` itself, not just `find_violations`), and the vacuity guard. Strip-falsified by hand (both directions): disabling the gate-wiring check and the report-reason check each independently turn their own dedicated test red; restored.

## Test plan
- [x] `ruff check .` — green.
- [x] `scripts/check_ci_role_declared.py` against the real tree — `93 script(s), all declare a CI role and satisfy its obligation`.
- [x] `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py` — all green.
- [x] Scoped pytest: `tests/scripts/test_6014_ci_role_declared.py` — 15 passed.
- [x] (skipped — Visual, standing waiver)

review: lead-coder. Pushing without waiting on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
