### PR TITLE
fix: scope #5536's caplog ERROR/WARNING windows to their own subject logger

### DIFF
--- a/tests/hooks/test_5536_consent_gate_failure_visible.py
+++ b/tests/hooks/test_5536_consent_gate_failure_visible.py
@@ -88,7 +88,15 @@ async def test_consent_gate_raise_logs_the_fail_closed_fallback(caplog):
     with caplog.at_level(logging.WARNING):
         await disp.dispatch("turn_end", {})
 
-    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    # scoped to THIS test's own subject logger (dispatcher.py's
+    # `_log = logging.getLogger(__name__)`) — see test_5536_run_shell_hook_
+    # fatal_scope.py's sibling fix for why an unscoped caplog.records count
+    # is fragile under `-n auto` (a background subject left by an earlier,
+    # unrelated test can land in this same window).
+    warnings = [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == "reyn.hooks.dispatcher"
+    ]
     (only,) = warnings  # exactly one warning — unpack-must-flip
     assert "fail-closed" in only.message
     assert "fail-open" not in only.message.lower() or "never fail-open" in only.message
@@ -115,7 +123,9 @@ async def test_a_non_raising_gate_logs_nothing(caplog):
     with caplog.at_level(logging.WARNING):
         await disp.dispatch("turn_end", {})
 
-    assert caplog.records == []
+    # scoped to this file's own subject logger — see the sibling
+    # test above and test_5536_run_shell_hook_fatal_scope.py for why.
+    assert [r for r in caplog.records if r.name == "reyn.hooks.dispatcher"] == []
     (call,) = run_shell.calls
     _args, kwargs = call
     assert kwargs["consent_bus"] == "a-real-live-bus-object"

--- a/tests/hooks/test_5536_run_shell_hook_fatal_scope.py
+++ b/tests/hooks/test_5536_run_shell_hook_fatal_scope.py
@@ -130,6 +130,20 @@ async def test_an_ordinary_exception_is_still_caught_and_logged(
         )
 
     assert result is None
-    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    # scoped to THIS test's own subject logger (shell_runner.py's
+    # `_log = logging.getLogger(__name__)`) — NOT every ERROR record in
+    # caplog's window. caplog.at_level(logging.ERROR) above captures the
+    # ROOT logger process-wide; under `-n auto` a background subject left
+    # by an EARLIER, unrelated test (measured: litellm's cached aiohttp
+    # ClientSession, GC'd mid-run, logs "Unclosed client session" via the
+    # stdlib `asyncio` logger) can land in this exact window on the same
+    # xdist worker. This test's own claim is "reyn's own bug is never
+    # swallowed by an outer catch" — it has no business counting a
+    # different subsystem's own log. Filtering by logger name is the
+    # narrowing (never widen the assertion to tolerate >1 record).
+    error_records = [
+        r for r in caplog.records
+        if r.levelno >= logging.ERROR and r.name == "reyn.hooks.shell_runner"
+    ]
     (only,) = error_records  # exactly one ERROR log — unpack-must-flip
     assert "true" in only.getMessage() or "OSError" in only.getMessage()


### PR DESCRIPTION
**[e2e-coder]** — P0 investigation into #6031's `test_5536_run_shell_hook_fatal_scope.py` unpack failure (a docs-only PR, so the diff couldn't have caused it). Root-caused via primary evidence, not the docs diff.

## What broke

`main`'s own `test.yml` re-run against the same head (`d97140717`) was **clean on 3.11** — the failure only showed on #6031's own PR-triggered run. `caplog.at_level(logging.ERROR)` captures the **root logger process-wide**, not just this test's own subject. Pulled attempt 1's raw log (`gh api .../jobs/<id>/logs`):

```
ERROR    asyncio:base_events.py:1785 Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc2ec4f8910>
ERROR    reyn.hooks.shell_runner:shell_runner.py:993 shell-hook 'true': unexpected error: subprocess machinery failed
```

The extra record is an `aiohttp.ClientSession` GC finalizer warning via the **`asyncio`** logger — zero relation to `reyn.hooks.shell_runner`. Under `-n auto`, this test's xdist worker had earlier run an unrelated litellm-touching test whose cached async client got GC'd mid-run, landing in this test's caplog window.

Swept the last 60 `main` `test.yml` runs (~44h): this is the **first-ever** occurrence of this specific failure, not a pre-existing flake.

## Fix (fix-forward, never widen the tolerance)

Per lead-coder's explicit constraint: never loosen "exactly one ERROR record" to "one or two" — that would let a genuine reyn bug hide behind someone else's noise. Narrowed the **observation window** instead, to each test's own subject logger (`r.name == "reyn.hooks.shell_runner"` / `"reyn.hooks.dispatcher"`).

Audited `tests/` for the same unscoped-caplog-count shape (level-only filter + exact unpack/equality, no logger/message narrowing): found exactly one sibling file with the identical fragility, `test_5536_consent_gate_failure_visible.py` (2 assertions) — fixed alongside.

Strip-falsified both directions, in-file (Edit → run → Edit back, no `git stash`/`checkout`/`restore`):
- Filtering to a nonexistent logger name → RED with 0 records (not a vacuous pass).
- Removing the logger filter → a foreign-logger record satisfies an assertion that should require the test's own subsystem.

## Not in scope (disclosed, reported separately)

The `aiohttp.ClientSession` leak itself is a **real, separate resource-leak defect**: `tests/conftest.py`'s `_isolate_litellm_process_globals` (#5918) calls `litellm.in_memory_llm_clients_cache.flush_cache()` before every test, which clears dict references **without closing** the underlying cached async client — orphaning any real litellm-touching test's session into GC, non-deterministically, in some later unrelated test's own execution window. Reported to lead-coder for triage; not fixed here (production-adjacent, touches a global autouse fixture's asyncio-loop semantics — needs its own design decision).

## Test plan

- [x] `pytest tests/hooks/test_5536_run_shell_hook_fatal_scope.py tests/hooks/test_5536_consent_gate_failure_visible.py -q` — 4 passed
- [x] Strip-falsify both directions, both files — in-file Edit only
- [x] `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green
- [x] (skipped — Visual, standing waiver)

No issue filed for this fix per lead-coder's own standing instruction (owner: don't fragment tooling/discipline questions into tickets) — direct fix-forward as directed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S