### PR TITLE
fix(part of #6000 ②): DiagnosticSnapshot.reset() never releases its own fd number

### DIFF
--- a/src/reyn/runtime/diagnostic_snapshot.py
+++ b/src/reyn/runtime/diagnostic_snapshot.py
@@ -40,11 +40,40 @@ class DiagnosticSnapshot:
     ever written. :meth:`reset` must be called only AFTER the caller has
     observed that the PREVIOUS write landed, never preemptively on every
     re-arm.
+
+    #6000 ②/architect: :attr:`fd` and :attr:`usable` are TWO SEPARATE
+    facts, not one overloaded ``None``. The original design used
+    ``fd is None`` to mean both "never opened / already closed" AND
+    "reset() just failed, don't write here" — the moment ``reset()``
+    stopped ever releasing the fd number (the whole point of ②), those
+    two facts diverged: a failed ``reset()`` leaves a real, still-open
+    fd (the number is never released, on purpose) that is nonetheless
+    NOT SAFE to arm against again (stale content, or an orphaned inode)
+    — ``fd is None`` can no longer answer "may I arm/write." This repo
+    has already recorded "``None`` standing for two facts fails open" as
+    a recurring shape (architect, reviewing this PR) — this is its 3rd
+    instance. :attr:`usable` answers the arming question; :attr:`fd`
+    answers "what number, if any, do I have."
     """
+
+    #: Narrower than the built-in ``open(path, "a")``'s own default
+    #: (``0o666``) — a stall/diagnostic dump can contain a path or argv
+    #: (#6000, architect review), so this deliberately NARROWS rather
+    #: than merely matching the historical default. ``os.open``'s own
+    #: default (``0o777``, masked by umask) would be wider still.
+    _MODE = 0o600
 
     def __init__(self, path: str, fd: int) -> None:
         self._path = path
+        #: Never ``None`` while this instance is otherwise alive — see
+        #: the class docstring. Only :meth:`close` releases it, in the
+        #: one case where releasing the number really is the right
+        #: outcome (an intentional, final teardown).
         self._fd: "int | None" = fd
+        #: False after a `reset()` failure (or after `close()`) — "may
+        #: this snapshot be armed or written to." See the class
+        #: docstring for why this is a SEPARATE fact from `fd`.
+        self._usable = True
 
     @classmethod
     def open(cls, path: str) -> "DiagnosticSnapshot | None":
@@ -57,18 +86,30 @@ class DiagnosticSnapshot:
             parent = os.path.dirname(path)
             if parent:
                 os.makedirs(parent, exist_ok=True)
-            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, cls._MODE)
         except OSError:
             return None
         return cls(path, fd)
 
     @property
     def fd(self) -> "int | None":
-        """The live fd to write into, or ``None`` if opening/reopening
-        last failed (:meth:`reset` sets this on a failed reopen; the
-        instance stays unusable rather than silently resurrecting with a
-        stale value)."""
+        """The fd number this instance holds, or ``None`` if the initial
+        :meth:`open` never succeeded (no instance exists in that case,
+        so this is really "never constructed"), or :meth:`close` already
+        ran. #6000 ②: NOT ``None`` after a failed :meth:`reset` — that
+        fd is still open and still this number, just not
+        :attr:`usable`. A caller deciding whether to ARM must check
+        :attr:`usable`, never ``fd is None`` — see the class docstring."""
         return self._fd
+
+    @property
+    def usable(self) -> bool:
+        """Whether this snapshot may still be armed or written to right
+        now. ``False`` after a `reset()` failure (see that method's own
+        docstring) or after `close()`. Composed with ``fd is not None``
+        so a not-yet-opened or already-closed instance also reads as
+        unusable without a second check."""
+        return self._usable and self._fd is not None
 
     @property
     def path(self) -> str:
@@ -79,8 +120,8 @@ class DiagnosticSnapshot:
         :attr:`path` (inode identity) — ``False`` if something external
         deleted or moved it out from under this instance (a cleanup tool
         touching the file, an operator ``rm``ing it, …) since this fd was
-        last opened. ``False`` on ``fd is None`` too, matching every
-        other "nothing usable" case here.
+        last opened. ``False`` when :attr:`usable` is already ``False``
+        too, matching every other "nothing usable" case here.
 
         Not a rotation check — this module drives no rotation of its own
         (see the module docstring) — but the SAME question a rotation
@@ -90,8 +131,9 @@ class DiagnosticSnapshot:
         now-orphaned fd writes dumps nobody can ever read again — never
         with an error, since the write itself still succeeds — the exact
         silent-loss shape lead-coder flagged reviewing #5988."""
-        if self._fd is None:
+        if not self.usable:
             return False
+        assert self._fd is not None  # `usable` already confirmed this
         try:
             return os.stat(self._path).st_ino == os.fstat(self._fd).st_ino
         except OSError:
@@ -100,27 +142,49 @@ class DiagnosticSnapshot:
     def reset(self) -> None:
         """Truncate for the NEXT write — see the class docstring's
         truncate-timing trap for why this must be called only after a
-        PREVIOUS write is known to have landed, never preemptively. Sets
-        :attr:`fd` to ``None`` on a failure — every further write attempt
-        against this instance then no-ops, matching :meth:`open`'s own
-        "cannot open → never arms" posture.
+        PREVIOUS write is known to have landed, never preemptively.
 
         #6000 ②/architect (superseding #5998's own "the caller must
         disarm first" contract, kept below as HISTORY): the fd NUMBER
-        this method exposes is now never released back to the OS across
-        a `reset`, in EITHER of its two cases —
+        this method exposes is now NEVER released back to the OS across
+        a `reset` — UNCONDITIONALLY, including on failure, not only on
+        the two success paths. (lead-coder + architect review of this
+        PR's own first version caught two real gaps here: the common-case
+        `except` branch called `os.close(self._fd)` on a truncate
+        failure — releasing the number — and the external-change branch's
+        own `except` branch set `self._fd = None` on a reopen failure
+        with NO close at all — a genuine LEAK, the fd stays open but this
+        instance forgets it. "Rare" was not an answer to either: ② exists
+        to replace "usually nobody forgets" with "cannot happen," and a
+        failure path is exactly the code a discipline-based guarantee
+        quietly stops covering.)
 
-          - the common case (:meth:`points_at_current_file` still true —
-            nothing external touched *path*): truncated IN PLACE via
-            ``os.ftruncate`` + ``os.lseek``, never closed at all.
-          - the external-change case (something deleted/replaced *path*
-            since this fd was opened): a NEW fd is opened at *path*, then
-            :func:`os.dup2` onto :attr:`fd`'s OWN number — ``dup2`` is
-            POSIX-atomic, so that number is NEVER momentarily unused, the
-            decisive difference from "close old, then open new" (which
-            has exactly the momentary gap a stale, still-armed timer can
-            land in). :attr:`fd`'s own Python-side int is unchanged
-            either way.
+        Fixed shape — ALL THREE real outcomes leave :attr:`fd` exactly
+        as it was, an open, unreleased fd:
+
+          - common case, success (:meth:`points_at_current_file` still
+            true): truncated IN PLACE via ``os.ftruncate`` + ``os.lseek``,
+            never closed at all.
+          - external-change case, success (something deleted/replaced
+            *path* since this fd was opened): a NEW fd is opened at
+            *path*, then :func:`os.dup2` onto :attr:`fd`'s OWN number —
+            ``dup2`` is POSIX-atomic, so that number is NEVER momentarily
+            unused, the decisive difference from "close old, then open
+            new" (which has exactly the momentary gap a stale,
+            still-armed timer can land in).
+          - EITHER case, ``OSError`` (``ftruncate``/``lseek``/``open``/
+            ``dup2`` failed): :attr:`fd` is untouched, but :attr:`usable`
+            becomes ``False`` — this instance will no longer be armed or
+            written to (the caller must check :attr:`usable`, not
+            ``fd is None``), which is what actually prevents the
+            #5977-class regression a silent "keep writing, un-truncated"
+            fallback would reintroduce (content growing unbounded because
+            nothing ever stops the writes). Six-questions #5 ("what does
+            this accumulate, who bounds it"): NOTHING accumulates — one
+            fd, held for the rest of this instance's life, exactly as the
+            success path already holds one; the only thing that changes
+            on failure is whether writes are still attempted, not how
+            many fds exist.
 
         #5998 history (now moot, not deleted): before this fix, this
         method DID close :attr:`fd` with no notion of whether a
@@ -137,31 +201,32 @@ class DiagnosticSnapshot:
         disarm at all. This class still does not import or know about
         ``stall_trace``/``faulthandler`` — the fix does not depend on
         that either."""
-        if self._fd is None:
+        if not self.usable:
             return
+        assert self._fd is not None  # `usable` already confirmed this
         if self.points_at_current_file():
             try:
                 os.ftruncate(self._fd, 0)
                 os.lseek(self._fd, 0, os.SEEK_SET)
             except OSError:
-                try:
-                    os.close(self._fd)
-                except OSError:
-                    pass
-                self._fd = None
+                self._usable = False  # fd stays open+held; just not armed again
             return
         try:
-            new_fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+            new_fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, self._MODE)
         except OSError:
-            self._fd = None
+            self._usable = False  # old fd stays open+held, still orphaned
             return
         try:
             os.dup2(new_fd, self._fd)
+        except OSError:
+            self._usable = False  # dup2 failed atomically -- self._fd untouched
         finally:
             os.close(new_fd)
 
     def close(self) -> None:
-        """Idempotent."""
+        """Idempotent. The one place this class intentionally releases
+        the fd number — a final, explicit teardown, not the reuse-window
+        hazard :meth:`reset` was fixed to avoid."""
         if self._fd is None:
             return
         try:
@@ -169,6 +234,7 @@ class DiagnosticSnapshot:
         except OSError:
             pass
         self._fd = None
+        self._usable = False
 
 
 def diagnostic_snapshot(path: str) -> "DiagnosticSnapshot | None":

--- a/src/reyn/runtime/diagnostic_snapshot.py
+++ b/src/reyn/runtime/diagnostic_snapshot.py
@@ -98,40 +98,67 @@ class DiagnosticSnapshot:
             return False
 
     def reset(self) -> None:
-        """Truncate and reopen for the NEXT write — see the class
-        docstring's truncate-timing trap for why this must be called only
-        after a PREVIOUS write is known to have landed, never
-        preemptively. Sets :attr:`fd` to ``None`` on a failed reopen
-        (parent directory removed mid-run, permissions changed, …) —
-        every further write attempt against this instance then no-ops,
-        matching :meth:`open`'s own "cannot open → never arms" posture.
+        """Truncate for the NEXT write — see the class docstring's
+        truncate-timing trap for why this must be called only after a
+        PREVIOUS write is known to have landed, never preemptively. Sets
+        :attr:`fd` to ``None`` on a failure — every further write attempt
+        against this instance then no-ops, matching :meth:`open`'s own
+        "cannot open → never arms" posture.
 
-        #5998: this method closes :attr:`fd` with no notion of whether a
-        TIMER-DRIVEN writer (``faulthandler.dump_traceback_later`` is
-        this module's own first such caller, via
-        :class:`~reyn.runtime.loop_tripwire.StallDumpArm`) is currently
-        armed against that exact fd NUMBER — deliberately: this class
-        stays reusable by any future snapshot writer, including ones with
-        no such consumer at all, so it does not import or know about
-        ``stall_trace``/``faulthandler``. A caller that DOES have such a
-        consumer must quiesce (disarm) it before calling :meth:`reset`,
-        the same way it must before calling :meth:`close` — see
-        :class:`~reyn.runtime.loop_tripwire.StallDumpArm`'s own
-        ``_disarm_before_reset`` for why: closing a still-armed fd frees
-        its number back to the OS, which can hand that SAME number to an
-        unrelated file/socket/pipe opened moments later, and the pending
-        timer then writes into THAT — silently, no exception, no
-        indication anything went wrong at either end."""
+        #6000 ②/architect (superseding #5998's own "the caller must
+        disarm first" contract, kept below as HISTORY): the fd NUMBER
+        this method exposes is now never released back to the OS across
+        a `reset`, in EITHER of its two cases —
+
+          - the common case (:meth:`points_at_current_file` still true —
+            nothing external touched *path*): truncated IN PLACE via
+            ``os.ftruncate`` + ``os.lseek``, never closed at all.
+          - the external-change case (something deleted/replaced *path*
+            since this fd was opened): a NEW fd is opened at *path*, then
+            :func:`os.dup2` onto :attr:`fd`'s OWN number — ``dup2`` is
+            POSIX-atomic, so that number is NEVER momentarily unused, the
+            decisive difference from "close old, then open new" (which
+            has exactly the momentary gap a stale, still-armed timer can
+            land in). :attr:`fd`'s own Python-side int is unchanged
+            either way.
+
+        #5998 history (now moot, not deleted): before this fix, this
+        method DID close :attr:`fd` with no notion of whether a
+        TIMER-DRIVEN writer (``faulthandler.dump_traceback_later``, via
+        :class:`~reyn.runtime.loop_tripwire.StallDumpArm`) was currently
+        armed against that exact fd number — a caller with such a
+        consumer had to disarm it first, or a freed number could be
+        handed to an unrelated file/socket/pipe moments later, with the
+        pending timer then writing into THAT. #5998's own `_disarm_
+        before_reset` callers are UNCHANGED (disarming before a call that
+        no longer needs it is harmless, not deleted for that reason) —
+        but the property "the fd number is stable" now holds
+        STRUCTURALLY, independent of whether a caller remembers to
+        disarm at all. This class still does not import or know about
+        ``stall_trace``/``faulthandler`` — the fix does not depend on
+        that either."""
         if self._fd is None:
             return
+        if self.points_at_current_file():
+            try:
+                os.ftruncate(self._fd, 0)
+                os.lseek(self._fd, 0, os.SEEK_SET)
+            except OSError:
+                try:
+                    os.close(self._fd)
+                except OSError:
+                    pass
+                self._fd = None
+            return
         try:
-            os.close(self._fd)
-        except OSError:
-            pass
-        try:
-            self._fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+            new_fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
         except OSError:
             self._fd = None
+            return
+        try:
+            os.dup2(new_fd, self._fd)
+        finally:
+            os.close(new_fd)
 
     def close(self) -> None:
         """Idempotent."""

--- a/src/reyn/runtime/diagnostic_snapshot.py
+++ b/src/reyn/runtime/diagnostic_snapshot.py
@@ -214,7 +214,7 @@ class DiagnosticSnapshot:
         try:
             new_fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, self._MODE)
         except OSError:
-            self._usable = False  # old fd stays open+held, still orphaned
+            self._usable = False  # old fd stays open and held, unchanged
             return
         try:
             os.dup2(new_fd, self._fd)

--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -887,8 +887,14 @@ class StallDumpArm:
     @property
     def armed(self) -> bool:
         """Whether this arm currently holds a usable fd (False after a
-        failed reopen — the switch stays disarmed until :meth:`close`)."""
-        return self._snapshot.fd is not None
+        failed reopen — the switch stays disarmed until :meth:`close`).
+
+        #6000 ②: reads ``DiagnosticSnapshot.usable``, not ``fd is None``
+        — after this class's own fix, a failed reset leaves the fd
+        NUMBER intact (never released) but marks the snapshot unusable;
+        ``fd is None`` would now read ``armed=True`` on a snapshot that
+        must NOT be written to again."""
+        return self._snapshot.usable
 
     @property
     def fd(self) -> "int | None":
@@ -936,14 +942,19 @@ class StallDumpArm:
         below disarms FIRST — see :meth:`_disarm_before_reset`'s own
         docstring for why a plain ``self._snapshot.reset()`` here would
         be the exact same fd-reuse hazard #5877 found and :meth:`close`
-        already guards against."""
+        already guards against.
+
+        #6000 ②: both checks below read ``DiagnosticSnapshot.usable``,
+        not ``fd is None`` — a failed reopen now leaves a real, held fd
+        number (never released) that must still not be armed again; see
+        that class's own docstring for why the two facts diverged."""
         from reyn.runtime.stall_trace import arm as _arm
 
-        if self._snapshot.fd is None:
+        if not self._snapshot.usable:
             return False
         if not self._snapshot.points_at_current_file():
             self._disarm_before_reset()
-            if self._snapshot.fd is None:
+            if not self._snapshot.usable:
                 self._logger.error(
                     "%s: could not reopen the tripwire's own stall-dump snapshot after "
                     "it was removed or moved out from under it", self._label,

--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -981,7 +981,20 @@ class StallDumpArm:
         TUI startup bracket disarms before an interactive turn can begin,
         and the tripwire is the PERMANENT occupant of the timer from
         first frame onward) — this call inherits that same precondition,
-        it does not introduce a new one."""
+        it does not introduce a new one.
+
+        #6000 ②/architect (superseding this method's own original "this
+        call is what makes reset() safe" reasoning): ``DiagnosticSnapshot.
+        reset()`` itself now never releases its own fd NUMBER back to the
+        OS (``os.ftruncate``/``os.lseek`` in place, or ``os.dup2`` onto
+        the SAME number on an external-change reopen) — the fd-reuse
+        hazard this call originally guarded against is closed
+        STRUCTURALLY now, independent of whether any caller disarms
+        first. This call itself is UNCHANGED and still runs at every
+        site above — disarming before a call that no longer needs it is
+        harmless, and the disarm still has its own independent purpose
+        (a stale timer must not fire into a truncated-and-about-to-be-
+        rewritten file's PRIOR content either)."""
         from reyn.runtime.stall_trace import disarm as _disarm
 
         _disarm()

--- a/tests/runtime/test_6000_fd_number_never_released.py
+++ b/tests/runtime/test_6000_fd_number_never_released.py
@@ -489,7 +489,23 @@ def test_stall_dump_arm_refuses_to_rearm_after_a_failed_reset(
     unboundedly, on every single `rearm()` call from then on -- the
     exact "reyn.log fills with a repeated line" class #5977 closed.
     Witnessed here on THAT axis instead: disarm-call count and log
-    record count across MULTIPLE `rearm()` calls, not the return value."""
+    record count across MULTIPLE `rearm()` calls, not the return value.
+
+    lead-coder review: `caplog.records` collects every record that
+    reached the ROOT logger in this worker process, not just this
+    arm's own `"t6000"` logger -- `caplog.set_level(..., logger=...)`
+    only raises that ONE logger's threshold, it does not filter what
+    `.records` accumulates. Filtered to `r.name == "t6000"` below (the
+    exact shape #6033 fixed the same day elsewhere in this repo, after
+    an unrelated background `asyncio` warning on the same pytest-xdist
+    worker falsely reddened an unfiltered `caplog.records == []`
+    assertion on PR #6031).
+
+    `stall_trace.disarm` is spied (real call still runs, only the call
+    is recorded), not faked -- CLAUDE.md's no-fake-a-collaborator rule
+    still applies here: this module exposes no public seam for "how
+    many times was disarm called," so wrapping the real function is
+    the way to observe that fact without inventing one."""
     path = tmp_path / "stall_dump.log"
     arm = StallDumpArm.open(seconds=60.0, path=str(path), logger=logging.getLogger("t6000"), label="t6000")
     assert arm is not None
@@ -539,9 +555,10 @@ def test_stall_dump_arm_refuses_to_rearm_after_a_failed_reset(
             f"prevent) — got {len(disarm_calls)} disarm call(s) across 3 "
             f"rearm() calls"
         )
-        assert caplog.records == [], (
+        own_records = [r for r in caplog.records if r.name == "t6000"]
+        assert own_records == [], (
             f"#6000 REGRESSION: rearm() on an already-unusable snapshot "
-            f"logged {len(caplog.records)} record(s) across 3 calls -- "
+            f"logged {len(own_records)} record(s) across 3 calls -- "
             f"the same repeated-ERROR-line shape #5977 closed, reintroduced "
             f"here if the first `usable` guard is skipped"
         )

--- a/tests/runtime/test_6000_fd_number_never_released.py
+++ b/tests/runtime/test_6000_fd_number_never_released.py
@@ -50,12 +50,14 @@ file's own ``_spy_on_disarm_and_reset`` already uses for
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 import pytest
 
 from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot
+from reyn.runtime.loop_tripwire import StallDumpArm
 
 
 def test_reset_on_an_untouched_file_never_changes_the_fd_number(tmp_path: Path) -> None:
@@ -242,3 +244,264 @@ def test_the_external_change_case_never_calls_os_close_on_its_own_fd(
         f"called os.close({own_fd}) — the fd number was momentarily "
         f"released back to the OS instead of dup2'd onto in place"
     )
+
+
+# ---------------------------------------------------------------------------
+# lead-coder review of this PR's first version: the two SUCCESS paths above
+# are not "either of its two cases" -- an OSError inside either one is a
+# real THIRD case, and the first version's own except branches closed the
+# fd (common case) or silently leaked it (external-change case) on
+# failure, both routes this method's own docstring claimed did not exist.
+# ---------------------------------------------------------------------------
+
+
+def _is_open(fd: int) -> bool:
+    try:
+        os.fstat(fd)
+        return True
+    except OSError:
+        return False
+
+
+def test_a_failed_truncate_never_closes_or_nulls_the_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the common-case failure path — an `os.ftruncate` OSError
+    must leave `fd` untouched: same number, still genuinely OPEN (not a
+    stale int left over from a closed fd), never `None`.
+
+    Strip-falsifier (verified by hand: the `except OSError` branch
+    reverted to `os.close(self._fd); self._fd = None`): this test goes
+    red — `snapshot.fd` becomes `None`."""
+    snapshot = DiagnosticSnapshot.open(str(tmp_path / "snap.log"))
+    assert snapshot is not None
+    before = snapshot.fd
+
+    def failing_ftruncate(fd: int, length: int) -> None:
+        raise OSError("simulated ftruncate failure")
+
+    monkeypatch.setattr(os, "ftruncate", failing_ftruncate)
+    snapshot.reset()
+
+    assert snapshot.fd == before, (
+        f"#6000 REGRESSION: a failed truncate changed fd ({before} -> "
+        f"{snapshot.fd}) instead of leaving it untouched"
+    )
+    assert snapshot.fd is not None and _is_open(snapshot.fd), (
+        "#6000 REGRESSION: a failed truncate left fd as a closed/stale "
+        "number, not a genuinely open one"
+    )
+
+
+def test_a_failed_external_reopen_never_closes_or_nulls_the_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the external-change failure path — an `os.open` OSError
+    (reopening the NEW file at *path*) must leave the OLD fd untouched:
+    same number, still open, never `None`, never silently dropped.
+
+    Strip-falsifier (verified by hand: the `except OSError` branch
+    reverted to `self._fd = None` with no `os.close` at all — a genuine
+    LEAK, not merely a stale value): this test goes red — `snapshot.fd`
+    becomes `None` (the leak itself is invisible to THIS assertion, which
+    is exactly why the number/None check matters here, not fstat)."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+    before = snapshot.fd
+
+    path.unlink()
+    path.write_text("", encoding="utf-8")
+
+    def failing_open(*args: object, **kwargs: object) -> int:
+        raise OSError("simulated reopen failure")
+
+    monkeypatch.setattr(os, "open", failing_open)
+    snapshot.reset()
+
+    assert snapshot.fd == before, (
+        f"#6000 REGRESSION: a failed external reopen changed fd "
+        f"({before} -> {snapshot.fd}) instead of leaving the OLD one "
+        f"untouched"
+    )
+    assert snapshot.fd is not None and _is_open(snapshot.fd), (
+        "#6000 REGRESSION: a failed external reopen left fd as a closed/"
+        "stale number, not a genuinely open one"
+    )
+
+
+def test_a_failed_dup2_never_closes_or_nulls_the_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the external-change branch's own `dup2` failure — POSIX
+    guarantees `dup2` either succeeds atomically or leaves `oldfd`
+    unmodified on failure; this must not additionally close or null it
+    out on the Python side.
+
+    Strip-falsifier (verified by hand: the `dup2` call left un-caught,
+    letting the raised `OSError` propagate out of `reset()`): this test
+    goes red — the call raises instead of returning."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+    before = snapshot.fd
+
+    path.unlink()
+    path.write_text("", encoding="utf-8")
+
+    real_dup2 = os.dup2
+
+    def failing_dup2(fd: int, fd2: int) -> int:
+        # Scoped to THIS snapshot's own fd only -- pytest's own fd-capture
+        # teardown machinery also calls the real os.dup2, and a blanket
+        # patch would break it (observed by hand: an unscoped patch here
+        # crashes pytest's own "Captured stdout teardown" step).
+        if fd2 == before:
+            raise OSError("simulated dup2 failure")
+        return real_dup2(fd, fd2)
+
+    monkeypatch.setattr(os, "dup2", failing_dup2)
+    snapshot.reset()
+
+    assert snapshot.fd == before, (
+        f"#6000 REGRESSION: a failed dup2 changed fd ({before} -> "
+        f"{snapshot.fd}) instead of leaving it untouched"
+    )
+    assert snapshot.fd is not None and _is_open(snapshot.fd), (
+        "#6000 REGRESSION: a failed dup2 left fd as a closed/stale "
+        "number, not a genuinely open one"
+    )
+
+
+def test_open_creates_the_file_with_mode_0o600(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: architect review — `0o600`, deliberately NARROWER than
+    the historical `open(path, "a")`'s own default (`0o666`), not merely
+    matched to it: a stall/diagnostic dump can contain a path or argv,
+    which is worth keeping unreadable by other local users. (`os.open`'s
+    own default, `0o777` masked by umask, would be wider still.)"""
+    real_open = os.open
+    modes: "list[int]" = []
+
+    def spy_open(path: str, flags: int, mode: int = 0o777, *a: object, **kw: object) -> int:
+        modes.append(mode)
+        return real_open(path, flags, mode, *a, **kw)
+
+    monkeypatch.setattr(os, "open", spy_open)
+    snapshot = DiagnosticSnapshot.open(str(tmp_path / "snap.log"))
+    assert snapshot is not None
+
+    assert modes == [0o600], (
+        f"#6000 REGRESSION: DiagnosticSnapshot.open() did not pass an "
+        f"explicit mode=0o600 to os.open — got {modes!r}"
+    )
+
+
+def test_external_reopen_creates_the_file_with_mode_0o600(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the same mode fix, for `reset()`'s own external-change
+    reopen call site — a second `os.open` call this class makes, easy to
+    miss fixing only the first one."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+
+    path.unlink()
+    path.write_text("", encoding="utf-8")
+
+    real_open = os.open
+    modes: "list[int]" = []
+
+    def spy_open(p: str, flags: int, mode: int = 0o777, *a: object, **kw: object) -> int:
+        modes.append(mode)
+        return real_open(p, flags, mode, *a, **kw)
+
+    monkeypatch.setattr(os, "open", spy_open)
+    snapshot.reset()
+
+    assert modes == [0o600], (
+        f"#6000 REGRESSION: reset()'s external-change reopen did not "
+        f"pass an explicit mode=0o600 to os.open — got {modes!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# lead-coder + architect ruling: `_fd = None` was conflating "don't have a
+# number" with "not safe to use" -- once reset() stopped ever releasing the
+# number, those two facts diverged. `usable` is the new, separate answer to
+# "may this snapshot be armed/written to." Witnessed here at the
+# StallDumpArm level (the real caller), not just DiagnosticSnapshot's own.
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_becomes_unusable_but_keeps_its_fd_after_a_failed_reset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the two facts, witnessed together on the SAME failure — a
+    failed reset leaves `fd` unchanged (the number is held, not
+    released) AND `usable` false (do not write here again)."""
+    snapshot = DiagnosticSnapshot.open(str(tmp_path / "snap.log"))
+    assert snapshot is not None
+    before = snapshot.fd
+    assert snapshot.usable is True
+
+    def failing_ftruncate(fd: int, length: int) -> None:
+        raise OSError("simulated ftruncate failure")
+
+    monkeypatch.setattr(os, "ftruncate", failing_ftruncate)
+    snapshot.reset()
+
+    assert snapshot.fd == before, (
+        "#6000 REGRESSION: a failed reset must not change the fd number"
+    )
+    assert snapshot.usable is False, (
+        "#6000 REGRESSION: a failed reset must mark the snapshot unusable "
+        "-- fd staying open is not the same as safe to write to again"
+    )
+
+
+def test_stall_dump_arm_refuses_to_rearm_after_a_failed_reset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the real caller — `StallDumpArm.rearm()` must decline (not
+    silently arm against a stale, un-truncated fd) once its own snapshot
+    has gone unusable, and `armed` must reflect that too. This is the
+    property that actually prevents the #5977-class regression a silent
+    "keep writing, un-truncated" fallback would have reintroduced: no
+    arm means no more writes at all, not merely un-truncated ones.
+
+    Strip-falsifier (verified by hand: `armed`/`rearm`'s own checks
+    reverted to `fd is None`): this test goes red — `armed` reads `True`
+    and `rearm()` returns `True` even though the snapshot is unusable,
+    because the fd NUMBER itself was never released by the #6000 ② fix
+    (`fd is None` is never true here)."""
+    path = tmp_path / "stall_dump.log"
+    arm = StallDumpArm.open(seconds=60.0, path=str(path), logger=logging.getLogger("t6000"), label="t6000")
+    assert arm is not None
+    try:
+        assert arm.rearm() is True
+        assert arm.armed is True
+
+        def failing_ftruncate(fd: int, length: int) -> None:
+            raise OSError("simulated ftruncate failure")
+
+        monkeypatch.setattr(os, "ftruncate", failing_ftruncate)
+        # mark_fired() is the real call site that reaches reset() on the
+        # common (untouched-file) path -- same shape test_5998's own
+        # test_mark_fired_disarms_before_resetting_the_snapshot uses.
+        arm.mark_fired()
+
+        assert arm.armed is False, (
+            "#6000 REGRESSION: armed must go False once the snapshot's "
+            "own reset failed -- fd staying open (never released) must "
+            "not read as still armed"
+        )
+        assert arm.rearm() is False, (
+            "#6000 REGRESSION: rearm() must refuse to arm against an "
+            "unusable snapshot -- writing un-truncated content is the "
+            "#5977 regression this refusal exists to prevent"
+        )
+    finally:
+        arm.close()

--- a/tests/runtime/test_6000_fd_number_never_released.py
+++ b/tests/runtime/test_6000_fd_number_never_released.py
@@ -1,0 +1,244 @@
+"""Tier 2: #6000 ②/architect ruling — ``DiagnosticSnapshot.reset()`` never
+releases its own fd NUMBER back to the OS, in either of its two cases.
+
+Root shape (architect, #6000): ``faulthandler.dump_traceback_later`` (and
+any other timer-driven writer) commits to the fd NUMBER at arm time, not a
+live object — a file has an owner with a lifetime, a bare fd number does
+not, so the two do not naturally agree on when it is safe to let that
+number go back to the OS. #5998 closed the observed hazard by DISCIPLINE
+(every call site that could close the fd disarms first) — this closes it
+STRUCTURALLY instead: the number is never released at all, so there is
+nothing a 4th call site could forget.
+
+Two cases, each witnessed TWICE, for a reason found by hand while writing
+this file (disclosed, not hidden): asserting the fd NUMBER
+(``DiagnosticSnapshot.fd``) is unchanged before/after ``reset()`` is
+architect's own explicitly-requested witness, and it IS a real, true
+property of the fix — but measured by hand (this repo's real
+``os.open``/``os.close`` on this machine), a quiet single-threaded test
+process reliably hands the SAME fd number back to a close-then-reopen of
+the SAME path anyway (the kernel's free-list returns the lowest available
+number, and nothing else is allocating fds in that window) — so on its
+own, the fd-number assertion does NOT distinguish the fix from the OLD
+close-then-reopen shape it replaces; it would stay GREEN even reverted
+(verified by hand: reverting either branch to the old close-then-reopen
+shape left the number-only assertion passing). A second, DETERMINISTIC
+witness closes that gap: intercepting ``os.close`` and asserting it is
+NEVER called with the snapshot's own fd number during ``reset()`` — the
+FIXED implementation never calls ``os.close`` on that number at all (the
+common case skips it entirely; the external-change case's ``os.dup2``
+closes the old number as one atomic OS-level operation, never as a
+separate ``os.close()`` Python call), so this call-interception witness
+is what actually falsifies a reversion to the old shape.
+
+1. The common case — nothing external touched the path — truncated in
+   place via ``os.ftruncate``/``os.lseek``, no close at all.
+2. The external-change case — something deleted/replaced the path since
+   this fd was opened — reopened via ``os.dup2`` onto the SAME number
+   (POSIX-atomic: architect's own disclosed limitation is that ``dup2``'s
+   atomicity is a POSIX guarantee, not something reyn has measured
+   itself in this repo).
+
+Real files, real fds throughout (no mocks of ``DiagnosticSnapshot`` or
+domain collaborators) — the same no-mocks posture
+``test_5998_disarm_before_reset.py`` already established for this module.
+``os.close`` itself is intercepted (not faked — the real close still
+runs; only the CALL is recorded) purely to observe which fd numbers it
+is invoked with, the same "wrap the real thing, only record" shape that
+file's own ``_spy_on_disarm_and_reset`` already uses for
+``DiagnosticSnapshot.reset``/``stall_trace.disarm``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot
+
+
+def test_reset_on_an_untouched_file_never_changes_the_fd_number(tmp_path: Path) -> None:
+    """Tier 2: the common case — `reset()` truncates in place; the fd
+    NUMBER `DiagnosticSnapshot.fd` exposes is bit-for-bit identical
+    before and after, across MULTIPLE resets in a row.
+
+    NOT independently falsifiable (disclosed, module docstring): a quiet
+    single-threaded test process hands the SAME number back even from
+    the OLD close-then-reopen shape (verified by hand), so this test
+    alone would stay green reverted. Kept anyway as a real, true
+    property of the fix — paired with
+    `test_the_common_case_never_calls_os_close_on_its_own_fd`, which IS
+    the falsifiable witness for this same case."""
+    snapshot = DiagnosticSnapshot.open(str(tmp_path / "snap.log"))
+    assert snapshot is not None
+    before = snapshot.fd
+
+    for _ in range(3):
+        snapshot.reset()
+        assert snapshot.fd == before, (
+            f"#6000 REGRESSION: reset() on an untouched file changed the fd "
+            f"number ({before} -> {snapshot.fd}) — the number was released "
+            f"back to the OS at some point during reset()"
+        )
+
+
+def test_reset_actually_truncates_the_file_content(tmp_path: Path) -> None:
+    """Tier 2: falsification contrast for the test above — the in-place
+    `ftruncate`+`lseek` path must still perform a REAL truncate, not just
+    happen to keep the same fd number while leaving stale content behind
+    (the property `reset()` exists for in the first place)."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+    assert snapshot.fd is not None
+    os.write(snapshot.fd, b"stale dump content")
+    assert path.read_bytes() == b"stale dump content"
+
+    snapshot.reset()
+
+    assert path.read_bytes() == b"", (
+        "#6000 REGRESSION: reset() must still truncate the file's real "
+        "content, not merely preserve the fd number"
+    )
+
+
+def test_reset_after_external_delete_keeps_the_same_fd_number(tmp_path: Path) -> None:
+    """Tier 2: the external-change case — the path was deleted and
+    recreated (a NEW inode) by something outside this instance's control
+    since the fd was opened; `reset()` must still hand back the SAME fd
+    NUMBER (`os.dup2` onto it), never a freshly `os.open`-ed one.
+
+    NOT independently falsifiable (disclosed, module docstring): the
+    same "quiet process reuses the lowest freed number anyway" effect
+    applies here too (verified by hand). Kept as a real, true property
+    of the fix — paired with
+    `test_the_external_change_case_never_calls_os_close_on_its_own_fd`,
+    which IS the falsifiable witness for this same case."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+    before = snapshot.fd
+    pre_ino = path.stat().st_ino
+
+    path.unlink()
+    path.write_text("", encoding="utf-8")
+    assert path.stat().st_ino != pre_ino, "test setup sanity: a NEW inode at the same path"
+    assert not snapshot.points_at_current_file(), (
+        "test setup sanity: the snapshot's own fd must now point at the "
+        "UNLINKED (deleted) inode, not the new one at the same path"
+    )
+
+    snapshot.reset()
+
+    assert snapshot.fd == before, (
+        f"#6000 REGRESSION: reset() after an external delete/recreate "
+        f"changed the fd number ({before} -> {snapshot.fd}) — dup2 onto "
+        f"the old number did not happen, or the old number was released "
+        f"first"
+    )
+    assert snapshot.points_at_current_file(), (
+        "reset() must leave the fd pointing at the file CURRENTLY at "
+        "path, not the deleted one it was originally opened against"
+    )
+
+
+def test_reset_after_external_delete_writes_land_in_the_new_file(tmp_path: Path) -> None:
+    """Tier 2: functional-correctness contrast for the test above — same
+    fd NUMBER is necessary but not sufficient; a write after reset() must
+    actually reach the NEW file on disk, not silently vanish into the
+    orphaned (deleted) one dup2 replaced."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+    assert snapshot.fd is not None
+
+    path.unlink()
+    path.write_text("", encoding="utf-8")
+    snapshot.reset()
+
+    assert snapshot.fd is not None
+    os.write(snapshot.fd, b"a fresh dump")
+
+    assert path.read_bytes() == b"a fresh dump", (
+        "#6000 REGRESSION: a write after reset()'s dup2-based reopen did "
+        "not land in the file currently at path"
+    )
+
+
+def _spy_on_os_close(monkeypatch: pytest.MonkeyPatch) -> "list[int]":
+    """Wrap the real, public ``os.close`` — the real close still runs;
+    only the fd NUMBER it was called with is recorded. Same "wrap the
+    real thing, only record" shape as
+    ``test_5998_disarm_before_reset.py``'s own ``_spy_on_disarm_and_reset``."""
+    calls: "list[int]" = []
+    real_close = os.close
+
+    def spy_close(fd: int) -> None:
+        calls.append(fd)
+        real_close(fd)
+
+    monkeypatch.setattr(os, "close", spy_close)
+    return calls
+
+
+def test_the_common_case_never_calls_os_close_on_its_own_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the DETERMINISTIC witness the fd-number tests above cannot
+    be on their own (module docstring) — the fd-number assertion stays
+    green even reverted to the old close-then-reopen shape (a quiet test
+    process hands the same freed number straight back); this does not.
+    The fixed implementation never calls `os.close` with the snapshot's
+    own fd number in the common case at all — `os.ftruncate`/`os.lseek`
+    truncate in place.
+
+    Strip-falsifier (verified by hand: the common-case branch reverted
+    to `os.close(self._fd); self._fd = os.open(...)`): this test goes
+    red — `own_fd in calls` becomes `True`."""
+    snapshot = DiagnosticSnapshot.open(str(tmp_path / "snap.log"))
+    assert snapshot is not None
+    own_fd = snapshot.fd
+    calls = _spy_on_os_close(monkeypatch)
+
+    snapshot.reset()
+
+    assert own_fd not in calls, (
+        f"#6000 REGRESSION: reset() on an untouched file called os.close("
+        f"{own_fd}) — the fd number was momentarily released back to the "
+        f"OS, exactly the window dup2's atomicity exists to close"
+    )
+
+
+def test_the_external_change_case_never_calls_os_close_on_its_own_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the same deterministic witness for the external-change
+    branch — `os.dup2(new_fd, old_fd)` closes `old_fd` as ONE atomic
+    OS-level operation, never as a separate Python-level `os.close()`
+    call, so this stays clean for the fixed implementation and catches a
+    reversion to close-then-reopen the same way the test above does.
+
+    Strip-falsifier (verified by hand: the `os.dup2` branch reverted to
+    `os.close(self._fd); self._fd = os.open(...)`): this test goes red —
+    `own_fd in calls` becomes `True`."""
+    path = tmp_path / "snap.log"
+    snapshot = DiagnosticSnapshot.open(str(path))
+    assert snapshot is not None
+    own_fd = snapshot.fd
+
+    path.unlink()
+    path.write_text("", encoding="utf-8")
+    assert not snapshot.points_at_current_file(), (
+        "test setup sanity: the snapshot's own fd must point at the "
+        "unlinked (deleted) inode before reset()"
+    )
+
+    calls = _spy_on_os_close(monkeypatch)
+    snapshot.reset()
+
+    assert own_fd not in calls, (
+        f"#6000 REGRESSION: reset() after an external delete/recreate "
+        f"called os.close({own_fd}) — the fd number was momentarily "
+        f"released back to the OS instead of dup2'd onto in place"
+    )

--- a/tests/runtime/test_6000_fd_number_never_released.py
+++ b/tests/runtime/test_6000_fd_number_never_released.py
@@ -463,7 +463,7 @@ def test_snapshot_becomes_unusable_but_keeps_its_fd_after_a_failed_reset(
 
 
 def test_stall_dump_arm_refuses_to_rearm_after_a_failed_reset(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Tier 2: the real caller — `StallDumpArm.rearm()` must decline (not
     silently arm against a stale, un-truncated fd) once its own snapshot
@@ -472,11 +472,24 @@ def test_stall_dump_arm_refuses_to_rearm_after_a_failed_reset(
     "keep writing, un-truncated" fallback would have reintroduced: no
     arm means no more writes at all, not merely un-truncated ones.
 
-    Strip-falsifier (verified by hand: `armed`/`rearm`'s own checks
-    reverted to `fd is None`): this test goes red — `armed` reads `True`
-    and `rearm()` returns `True` even though the snapshot is unusable,
-    because the fd NUMBER itself was never released by the #6000 ② fix
-    (`fd is None` is never true here)."""
+    `armed` witnessed by RETURN VALUE (strip-falsifier, verified by hand:
+    `armed`'s own check reverted to `fd is None`): goes red directly --
+    `armed` reads `True` even though the snapshot is unusable.
+
+    `rearm`'s own FIRST guard (`if not usable: return False`) is
+    NOT witnessed by its return value -- lead-coder review of this PR's
+    first version: with that guard alone removed, `points_at_current_
+    file()` (unaffected -- it checks `usable` internally too) still
+    returns `False`, so `rearm` still enters its reopen branch, still
+    hits its OWN second `usable` check there, and still returns `False`
+    in the end -- the SAME observable return value either way. What
+    actually differs is called EVERY TICK on an already-unusable
+    snapshot without the first guard: `_disarm_before_reset()` runs (a
+    real disarm of the process-wide timer) and an ERROR is logged, both
+    unboundedly, on every single `rearm()` call from then on -- the
+    exact "reyn.log fills with a repeated line" class #5977 closed.
+    Witnessed here on THAT axis instead: disarm-call count and log
+    record count across MULTIPLE `rearm()` calls, not the return value."""
     path = tmp_path / "stall_dump.log"
     arm = StallDumpArm.open(seconds=60.0, path=str(path), logger=logging.getLogger("t6000"), label="t6000")
     assert arm is not None
@@ -498,10 +511,39 @@ def test_stall_dump_arm_refuses_to_rearm_after_a_failed_reset(
             "own reset failed -- fd staying open (never released) must "
             "not read as still armed"
         )
-        assert arm.rearm() is False, (
-            "#6000 REGRESSION: rearm() must refuse to arm against an "
-            "unusable snapshot -- writing un-truncated content is the "
-            "#5977 regression this refusal exists to prevent"
+
+        from reyn.runtime import stall_trace
+
+        disarm_calls: "list[None]" = []
+        real_disarm = stall_trace.disarm
+
+        def spy_disarm() -> None:
+            disarm_calls.append(None)
+            real_disarm()
+
+        monkeypatch.setattr(stall_trace, "disarm", spy_disarm)
+        caplog.set_level(logging.ERROR, logger="t6000")
+
+        for _ in range(3):
+            assert arm.rearm() is False, (
+                "#6000 REGRESSION: rearm() must refuse to arm against an "
+                "unusable snapshot -- writing un-truncated content is the "
+                "#5977 regression this refusal exists to prevent"
+            )
+
+        assert disarm_calls == [], (
+            f"#6000 REGRESSION: rearm()'s first `usable` guard must short-"
+            f"circuit BEFORE any disarm -- an already-unusable snapshot "
+            f"must not re-disarm the process-wide timer on every tick "
+            f"(the #5977-class log/disarm-flood this guard exists to "
+            f"prevent) — got {len(disarm_calls)} disarm call(s) across 3 "
+            f"rearm() calls"
+        )
+        assert caplog.records == [], (
+            f"#6000 REGRESSION: rearm() on an already-unusable snapshot "
+            f"logged {len(caplog.records)} record(s) across 3 calls -- "
+            f"the same repeated-ERROR-line shape #5977 closed, reintroduced "
+            f"here if the first `usable` guard is skipped"
         )
     finally:
         arm.close()


### PR DESCRIPTION
**[tui-coder]** — part of #6000 (②, architect's design ruling: https://github.com/tya5/reyn/issues/6000#issuecomment-5596236247, lead-coder's receipt: https://github.com/tya5/reyn/issues/6000#issuecomment-5601321581). Not `Closes` — whether this surface is the real SegFault cause is owner's own 2026-09-10 observation, not decided here.

`DiagnosticSnapshot.reset()` now never releases its own fd number back to the OS, in either of its two cases:
- common case (file untouched): `os.ftruncate` + `os.lseek`, no close.
- external-change case (path deleted/replaced): `os.dup2(new_fd, old_fd)` — POSIX-atomic, `old_fd` never momentarily unused.

①'s state (already closed, by discipline — every `StallDumpArm` close-adjacent call site disarms first) is unchanged; ② makes it structural instead — a caller that forgets to disarm no longer matters, because the fd number this method exposes is never freed at all. `_disarm_before_reset`'s own docstring updated: the mechanism it described (disarm is what makes this safe) no longer holds exclusively.

## A finding from writing the test (disclosed, not hidden)

Architect's own disclosed limit: `dup2`'s atomicity is a POSIX guarantee, not measured in this repo — required witnessing the raw fd **number**, not inferred behavior. Doing so found: a bare fd-number-before/after assertion does **not** reliably distinguish the fix from the OLD close-then-reopen shape — a quiet single-threaded test process hands the SAME freed number straight back from closing and reopening the same path (kernel's lowest-available-fd allocator, nothing else racing for it), verified by hand via strip-falsify (both branches, reverted to close-then-open, left the number-only assertion green). Kept the number assertions (real, true properties) but added the actual falsifiable witness: intercepting `os.close` and asserting it's never called with the snapshot's own fd number during `reset()` — `os.dup2` closes the old number as one atomic OS-level call, never a separate Python-level `os.close()`.

## Tests

`tests/runtime/test_6000_fd_number_never_released.py`, 6 cases — both branches × {number-stability, close-interception}, plus content-correctness and post-dup2-write-correctness contrasts. All 6 strip-falsified by hand (in-file Edit → run → Edit back, no `git checkout`/`stash`/`restore`); the close-interception pair is the one that actually goes red on a reversion.

Neighborhood: `test_5998_disarm_before_reset.py`, `test_5977_stall_dump_suppression.py` re-run, both still green (①'s discipline-based closure is untouched).

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py` — all green.
- [x] Scoped pytest: `test_6000_fd_number_never_released.py` (6), `test_5998_disarm_before_reset.py`, `test_5977_stall_dump_suppression.py` — 18 passed.
- [x] (skipped — Visual, standing waiver)

review: lead-coder. Pushing without waiting on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
