### PR TITLE
fix(#6034): close cached litellm async clients before flush_cache()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ the tree I am measuring" is not something a test may assume.
 """
 from __future__ import annotations
 
+import asyncio
 import copy
 import faulthandler
 import importlib.util
@@ -465,6 +466,47 @@ _LITELLM_ISOLATED_ATTRS = (
 )
 
 
+def _close_cached_litellm_clients_before_flush(litellm) -> None:
+    """#6034: close every client `litellm.in_memory_llm_clients_cache`
+    is currently holding, before `_isolate_litellm_process_globals`
+    below drops the cache's own references to them.
+
+    Uses litellm's own official close routine — the SAME one
+    `reyn.llm.llm._close_litellm_async_clients` calls in production
+    (`litellm.llms.custom_httpx.async_client_cleanup.
+    close_litellm_async_clients`) — never a hand-rolled dispatch on the
+    cached object's own shape. That routine's 3-branch dispatch is
+    known to miss a bare `AsyncOpenAI`-shaped client (#4365, a
+    confirmed UPSTREAM gap, owner ruling: reyn does not grow a branch
+    of its own to cover litellm's own cache-key shapes — see #4365's
+    own "does reyn's code grow when the third party's case count
+    grows?" test) — this call closes everything litellm's own routine
+    already knows how to close, and best-effort no-ops on the rest,
+    same as production.
+
+    A throwaway `asyncio.run()`: this sync fixture runs OUTSIDE any
+    test-owned event loop (pytest-asyncio only starts one once the
+    test's own coroutine begins, and this fixture requests no
+    dependency on it) — guarded by `RuntimeError` anyway rather than
+    assumed, since a cleanup helper must never be the reason a test
+    fails.
+    """
+    close_all = getattr(
+        getattr(litellm.llms.custom_httpx, "async_client_cleanup", None),
+        "close_litellm_async_clients",
+        None,
+    )
+    if close_all is None:
+        return
+    try:
+        asyncio.run(close_all())
+    except RuntimeError:
+        # A loop is already running here after all (unexpected under the
+        # reasoning above) — best-effort only, never break the test over
+        # cleanup that failed to even get a loop to run on.
+        pass
+
+
 @pytest.fixture(autouse=True)
 def _isolate_litellm_process_globals() -> Iterator[None]:
     """Isolate litellm's process-global mutable state around every test
@@ -515,8 +557,23 @@ def _isolate_litellm_process_globals() -> Iterator[None]:
     # side of this fixture that resets going IN, because "no test has
     # cached anything yet" is what a clean run looks like, not a value to
     # snapshot-and-restore.
+    #
+    # #6034: `cache.flush_cache()` alone only clears the dict's KEYS —
+    # it never closes the cached clients' own underlying async HTTP
+    # session. A prior test's real litellm call left a still-open
+    # `aiohttp.ClientSession`/httpx client behind; dropping the only
+    # reference to it here orphans that session into garbage collection
+    # at some LATER, unrelated point (measured: `asyncio`'s own
+    # "Unclosed client session" finalizer warning landing in a
+    # completely different test's `caplog` window under `-n auto`, #6033).
+    # Close everything BEFORE flushing, via litellm's own official
+    # cleanup routine (the same one `llm.py::_close_litellm_async_clients`
+    # calls in production) — never reach into a cached client and close
+    # it by hand; that would make reyn own litellm's own client-shape
+    # dispatch, the thing #4365 explicitly ruled against.
     cache = getattr(litellm, "in_memory_llm_clients_cache", None)
     if cache is not None:
+        _close_cached_litellm_clients_before_flush(litellm)
         cache.flush_cache()
 
     # AFTER: every attribute in _LITELLM_ISOLATED_ATTRS restored to its

--- a/tests/dev/test_6034_close_cached_litellm_clients_before_flush.py
+++ b/tests/dev/test_6034_close_cached_litellm_clients_before_flush.py
@@ -1,0 +1,127 @@
+"""Tier 2: #6034 — ``tests/conftest.py``'s ``_isolate_litellm_process_
+globals`` autouse fixture (#5918) closes every cached litellm async
+client BEFORE dropping the cache's own references, instead of only
+dropping them.
+
+Root cause (measured, primary evidence — PR #6033's own investigation of
+a #6031 CI red): ``cache.flush_cache()`` alone clears the cache dict's
+KEYS but never calls ``.close()``/``.aclose()`` on the client objects
+those keys pointed at. A prior test's real litellm call left a still-open
+``aiohttp.ClientSession`` cached; the NEXT test's fixture-before-phase
+dropped the only reference to it, orphaning the session into garbage
+collection at some LATER, unrelated point — surfaced as ``asyncio``'s
+own "Unclosed client session" finalizer warning landing in a completely
+different test's ``caplog`` window under ``-n auto`` (#6033).
+
+Not the same root as #4365 (litellm's own OFFICIAL close routine misses
+a bare ``AsyncOpenAI``-shaped cached client — a confirmed upstream gap,
+owner ruling: reyn does not grow a branch of its own to cover it). This
+fix calls that SAME official routine, not a hand-rolled one — a real
+``BaseLLMAIOHTTPHandler``-wrapped session (the shape that routine's own
+branch ① DOES correctly close) is exactly what #6033's own primary
+evidence showed leaking, so this is the right shape to witness.
+
+Real, isolated inner pytest sessions throughout (``pytester``'s own
+subprocess seam, the same technique ``test_isolate_litellm_process_
+globals_5918.py`` already uses for the sibling fixture behavior) — never
+a mock of litellm or of pytest's own fixture machinery: the actual
+``tests/conftest.py`` fixture, the actual ``litellm`` module, a real
+``aiohttp.ClientSession`` wrapped in litellm's own real
+``BaseLLMAIOHTTPHandler``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+#: Same shape as test_isolate_litellm_process_globals_5918.py's own
+#: `_INNER_CONFTEST`.
+_INNER_CONFTEST = """
+import sys
+sys.path.insert(0, {repo_root!r})
+sys.path.insert(0, {src_root!r})
+from tests.conftest import _isolate_litellm_process_globals  # noqa: F401
+"""
+
+#: test_a caches a REAL, OPEN aiohttp.ClientSession wrapped in litellm's
+#: own BaseLLMAIOHTTPHandler (the exact shape close_litellm_async_clients'
+#: branch ① closes) and leaves it open -- never calling .close() itself,
+#: simulating the real shape (a test that drove a real litellm HTTP call
+#: and never explicitly drained it). test_b runs NEXT in the SAME inner
+#: session, so the fixture's own before-phase (between test_a and test_b)
+#: is the only thing that could have closed it.
+_INNER_TEST_CLOSE_BEFORE_FLUSH = """
+import asyncio
+import aiohttp
+import litellm
+from litellm.llms.custom_httpx.aiohttp_handler import BaseLLMAIOHTTPHandler
+
+_HANDLER_BOX = []
+
+def test_a_caches_an_open_aiohttp_backed_client_and_never_closes_it():
+    async def _make_open_session():
+        return aiohttp.ClientSession()
+
+    session = asyncio.run(_make_open_session())
+    assert not session.closed  # sanity: genuinely open going in
+    # NOT passed via the constructor's own `client_session=` kwarg -- that
+    # marks `_owns_session=False` (the constructor's own convention for
+    # "caller still owns this, close() must not touch it"), which would
+    # make close() correctly skip it and defeat this witness for the
+    # wrong reason. Assigning after construction (still `_owns_session`
+    # defaulting True from the no-arg constructor) matches how litellm's
+    # OWN real call sites populate a handler it does own.
+    handler = BaseLLMAIOHTTPHandler()
+    handler.client_session = session
+    litellm.in_memory_llm_clients_cache.set_cache("6034-poison-key", handler)
+    _HANDLER_BOX.append(handler)
+    # deliberately no close() here -- #6034's own real-world shape.
+
+def test_b_the_cached_client_was_closed_before_the_cache_was_flushed():
+    assert _HANDLER_BOX, "setup: test_a must run first, in this same process"
+    handler = _HANDLER_BOX[0]
+    assert handler.client_session.closed, (
+        "the isolation fixture dropped test_a's cached client WITHOUT "
+        "closing its underlying aiohttp.ClientSession first -- this is "
+        "#6034 itself: a still-open session orphaned into GC at some "
+        "later, unrelated point"
+    )
+    # #5918's own witness must still hold too -- the cache is still
+    # flushed (not merely closed-and-left-cached).
+    assert litellm.in_memory_llm_clients_cache.get_cache("6034-poison-key") is None, (
+        "closing before flush must not skip the flush itself -- #5918's "
+        "own isolation (a stale cached client reused by an unrelated "
+        "later test) would regress"
+    )
+"""
+
+
+def test_cached_client_is_closed_before_the_next_tests_cache_flush(
+    pytester: pytest.Pytester,
+) -> None:
+    """Tier 2: #6034 acceptance ① — a cached, still-open litellm async
+    client is closed by the fixture's before-phase, before the cache is
+    flushed for the next test. Combined with #5918's own flush witness
+    in the same inner session (①+② together, ordering-guaranteed via
+    pytester's own subprocess — never `-n auto`, the exact parallelism
+    this fixture exists to make irrelevant).
+
+    Strip: comment out the
+    `_close_cached_litellm_clients_before_flush(litellm)` call in
+    `tests/conftest.py`, leaving only `cache.flush_cache()` — `test_b`
+    goes red (`handler.client_session.closed` is `False`, performed
+    during review).
+    """
+    import reyn
+
+    repo_root = Path(reyn.__file__).resolve().parents[2]
+    src_root = str(repo_root / "src")
+
+    pytester.makeconftest(_INNER_CONFTEST.format(repo_root=str(repo_root), src_root=src_root))
+    pytester.makepyfile(test_inner=_INNER_TEST_CLOSE_BEFORE_FLUSH)
+
+    result = pytester.runpytest_subprocess("test_inner.py")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
**[e2e-coder]** — Root cause identified in #6033's own investigation, fix for the leak itself as requested.

Closes #6034

## What was wrong

`tests/conftest.py`'s `_isolate_litellm_process_globals` (#5918) calls `cache.flush_cache()` before every test. `flush_cache()` only clears the cache dict's **keys** — it never calls `.close()`/`.aclose()` on the client objects those keys pointed at:

```python
def flush_cache(self):
    self.cache_dict.clear()
    self.ttl_dict.clear()
    self.expiration_heap.clear()
```

A prior test's real litellm call left a still-open `aiohttp.ClientSession` cached; the next test's fixture-before-phase dropped the only reference to it, orphaning the session into garbage collection at some **later, unrelated** point — surfaced as `asyncio`'s own `"Unclosed client session"` finalizer warning landing in a completely different test's `caplog` window under `-n auto` (the exact symptom #6033 fixed the *observation window* for, without touching this root cause).

## Fix

Close every cached client via litellm's own **official** cleanup routine — `litellm.llms.custom_httpx.async_client_cleanup.close_litellm_async_clients`, the same one `llm.py`'s own `_close_litellm_async_clients` calls in production — before `flush_cache()` drops the references. Never a hand-rolled dispatch on the cached object's own shape; that would make reyn own litellm's own client-type coverage.

## Relationship to #4365 — judged: **different root, not the same defect**

- **#4365**: litellm's own official close routine, called *correctly*, has an internal 3-branch dispatch bug that misses a bare `AsyncOpenAI`-shaped cached client (a confirmed upstream gap, owner ruling: reyn does not grow a branch to cover it).
- **#6034**: reyn's own test fixture never called **any** close routine at all before dropping references.

Confirmed by reading litellm's actual `close_litellm_async_clients()` source directly (still byte-identical 3-branch dispatch, still misses `AsyncOpenAI`) and #4365's own issue thread. This fix calls litellm's official routine, which correctly closes the `BaseLLMAIOHTTPHandler`-wrapped aiohttp session shape #6033's own primary evidence showed leaking — but will **not** close an `AsyncOpenAI`-shaped cached client. #4365 remains a separate, open issue, unaffected by this PR.

## Witness (real objects, no mocks)

- `tests/dev/test_6034_close_cached_litellm_clients_before_flush.py` (new): a real `aiohttp.ClientSession` wrapped in litellm's own real `BaseLLMAIOHTTPHandler`, cached and left open by `test_a`; `test_b` (next test, same `pytester` subprocess session) asserts the fixture's before-phase closed it — before the cache was flushed.
- `tests/dev/test_isolate_litellm_process_globals_5918.py` (unchanged, re-run): #5918's own cache-clearing/attr-restore witnesses still pass — closing before flush does not skip the flush itself.

Strip-falsified in-file (Edit → run → Edit back, no `git stash`/`checkout`/`restore`): removing the close call goes RED (`client_session.closed` is `False`), confirming the witness is load-bearing.

## Test plan

- [x] `pytest tests/dev/test_6034_close_cached_litellm_clients_before_flush.py tests/dev/test_isolate_litellm_process_globals_5918.py -q` — 3 passed
- [x] `pytest tests/llm/test_litellm_lazy_load.py tests/llm/test_llm_run_async_shutdown_litellm_clients_2787.py -q` — 13 passed (adjacent litellm-boundary tests unaffected)
- [x] Strip-falsify, in-file Edit only
- [x] `ruff check`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py` — all green
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
