### PR TITLE
fix(part of #5989 symptom 3): buffer pre-handler-install log records instead of losing them

### DIFF
--- a/src/reyn/interfaces/cli/__init__.py
+++ b/src/reyn/interfaces/cli/__init__.py
@@ -29,6 +29,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
+    # #5989 symptom 3: buffer WARNING+ records (and warnings.warn calls)
+    # from the very first statement of this function — the interactive
+    # CUI's own log-file redirect (chat._setup_interactive_logging) does
+    # not install until partway through startup, and a record emitted
+    # before that has no handler to reach; see early_log_buffer.py's own
+    # module docstring for the full design. Must run before anything else
+    # in this function that could log, including tracemalloc arming below.
+    from reyn.runtime.early_log_buffer import install as _install_early_log_buffer  # noqa: PLC0415
+
+    _install_early_log_buffer()
     # #5959 stage ③: arm tracemalloc (opt-in, REYN_MEMORY_TRACE) FIRST,
     # before anything else in this function runs — tracemalloc only
     # attributes allocations that happen AFTER it starts, so arming it any

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -334,7 +334,19 @@ def _setup_interactive_logging(project_root: Path) -> None:
     warnings), at worst an alarming full traceback from a caught error. Sending
     logs to a file keeps the UI clean while preserving them for debugging. Called
     once, before load_project_context (which may emit WARNING records), so the
-    file handler is in place before the first log call.
+    file handler is in place before the first log call THIS FUNCTION'S OWN
+    caller can control.
+
+    #5989 symptom 3: this is not the true start of the process, though —
+    anything logged between interpreter startup and this call (argument
+    parsing, process registration, the import tree) has no handler to
+    reach yet. ``reyn.interfaces.cli.main`` installs a bounded, capacity-
+    limited buffer (:mod:`reyn.runtime.early_log_buffer`) as its own very
+    first statement specifically to catch that earlier window; this
+    function replays whatever it collected into the real handler below,
+    right after installing it — see that module's own docstring for the
+    full design and why a plain "buffer forever" primitive was not
+    enough on its own.
 
     Deliberately does NOT import litellm (perf: ``import litellm`` costs
     ~1.5s and this runs on the startup path, before the input box renders).
@@ -387,7 +399,16 @@ def _setup_interactive_logging(project_root: Path) -> None:
     from logging.handlers import RotatingFileHandler
 
     from reyn.config.chat import LogsConfig
-    from reyn.runtime import stall_trace
+    from reyn.runtime import early_log_buffer, stall_trace
+
+    # #5989 symptom 3: grab the early buffer BEFORE force=True below wipes
+    # it off the root logger — the module-level singleton survives being
+    # detached (it is a plain Python object reference, not tied to being
+    # attached), so this still works even though `force=True` removes it
+    # from `root.handlers`. `None` when this process never went through
+    # `reyn.interfaces.cli.main` (e.g. a test calling this function
+    # directly) — nothing to replay in that case.
+    early_buffer = early_log_buffer.get_installed()
 
     defaults = LogsConfig()
     log_dir = project_root / ".reyn" / "logs"
@@ -404,9 +425,19 @@ def _setup_interactive_logging(project_root: Path) -> None:
     logging.basicConfig(
         level=logging.WARNING,
         handlers=[handler],
-        force=True,  # safe: the interactive path has no prior logging setup
+        # #5989: NOT "no prior logging setup" any more — early_log_buffer.
+        # install() (called at the very top of cli.main()) already
+        # attached a bounded buffer + a stderr mirror to the root logger.
+        # force=True is still correct: it replaces BOTH with this real
+        # file handler, which is exactly what the interactive CUI wants
+        # going forward (no more stderr echo of WARNING+ records once the
+        # live region owns the terminal) — the buffer's own PAST records
+        # are recovered separately below, not lost by this wipe.
+        force=True,
     )
     logging.captureWarnings(True)
+    if early_buffer is not None:
+        early_buffer.replay_into(handler)
     # #5873 follow-up (architect, #5877 re-co-vet): declare the path
     # directly rather than making stall_trace.find_file_handler_path()
     # re-derive it by scanning root-logger handlers for one whose path

--- a/src/reyn/runtime/early_log_buffer.py
+++ b/src/reyn/runtime/early_log_buffer.py
@@ -37,18 +37,55 @@ which never install ANY file handler by design; or a crash before that
 call) would otherwise buffer records without bound for its entire life —
 six-questions #5 ("what does this accumulate, who bounds it") answered
 "nothing, forever" is not an answer. :class:`_BoundedEarlyBuffer` below
-replaces the plain list with a ``collections.deque(maxlen=capacity)`` —
-oldest record silently dropped once full, a real, stated ceiling
-independent of whether a target ever attaches.
+overrides ``emit()`` to stop accepting new records once ``capacity`` is
+reached, instead of growing forever.
+
+Not a ``MemoryHandler`` SUBCLASS, in the end, despite it being the
+precedent that led here: the semantics that matter for this use
+(refuse-past-capacity, count what was refused, no ``target``/``flush()``
+concept at all) replace enough of ``MemoryHandler``'s own state
+(``buffer``, ``target``) that inheriting from it would leave its
+UNoverridden methods (``close()``'s own ``flushOnClose`` path calls
+``self.flush()``, which reads attributes this class no longer sets)
+silently broken rather than merely unused. Subclassing plain
+``logging.Handler`` instead keeps every method on this class doing
+exactly what its own code says, at the cost of re-declaring `acquire`/
+`release` usage explicitly (inherited from ``logging.Handler`` itself,
+unchanged).
+
+## Which end drops on overflow — and why (lead-coder review of this PR's
+first version, caught live)
+
+The first version used a ``collections.deque(maxlen=capacity)``, which
+drops the OLDEST record once full — plausible-looking (it is the shape
+most "ring buffer" examples default to), but backwards for what THIS
+buffer exists to save: the motivating case is the record emitted closest
+to process start (the very first warning after interpreter init), and a
+buffer that drops FROM THE FRONT on overflow discards exactly that record
+the moment ``capacity`` is exceeded — recreating the original bug's own
+shape (the earliest record lost) via the fix meant to prevent it.
+
+Fixed: :meth:`_BoundedEarlyBuffer.emit` stops ACCEPTING new records once
+``capacity`` is reached — the buffer keeps the OLDEST ``capacity`` records
+(the ones closest to process start, the actually-motivating case) and
+counts how many later ones it had to refuse, rather than silently
+discarding either end. That count is not lost either: :meth:`replay_into`
+appends one synthetic ``WARNING`` record stating exactly how many were
+dropped, so a ``reyn.log`` reader can tell "0 records lost" from "N
+records lost" instead of the two reading identically (lead-coder review:
+the durable, cross-session-readable surface is ``reyn.log`` itself —
+#5977's own measured incident — not the stderr mirror, which is only
+this ONE process's own terminal).
 
 ## What happens on each of the two paths
 
 - **A target attaches** (the interactive CUI installs its real handler):
-  every buffered record (up to ``capacity``, oldest-dropped beyond that)
-  replays into it once, in order, then the buffer is cleared and never
-  buffers again — see :meth:`_BoundedEarlyBuffer.replay_into`.
+  every buffered record (the earliest ``capacity`` of them) replays into
+  it once, in order, followed by the dropped-count record if any were
+  refused, then the buffer is cleared and never buffers again — see
+  :meth:`_BoundedEarlyBuffer.replay_into`.
 - **No target ever attaches** (``--cui``/non-TTY, or an early crash): the
-  bounded buffer just sits capped, doing nothing further, for the rest of
+  buffer just sits at its cap, refusing further records, for the rest of
   the process's life — bounded memory, no behavioural change to anything
   else. The mirrored ``StreamHandler(sys.stderr)`` installed alongside it
   (see :func:`install`) keeps stderr visibility IDENTICAL to what
@@ -70,56 +107,106 @@ one — the same format change #4362 already accepted for the
 post-handler-install window, now starting earlier. Calling it twice
 (here, and again inside ``_setup_interactive_logging``) is idempotent —
 ``logging.captureWarnings`` only (re)installs the same monkeypatch.
+
+## Capacity
+
+``_DEFAULT_CAPACITY = 200`` is an ESTIMATE, not a measurement (owner's
+standing directive asks for the structural reasoning when a real count
+isn't taken, not a fabricated one): the window this buffer covers runs
+from interpreter start through ``reyn.interfaces.cli.main``'s own
+argument parsing and :func:`~reyn.runtime.process_registry.
+register_process` call, before ``_setup_interactive_logging`` — a
+handful of statements and one import tree, not a loop that could emit
+records proportional to input size. 200 is generous headroom over what
+that shape could structurally produce, not a tight fit. If it is wrong
+in either direction, the failure mode is no longer silent either way: a
+capacity too LOW still keeps the earliest records (the motivating case)
+and reports exactly how many later ones it refused (this section's own
+fix above); a capacity too HIGH costs a few hundred extra ``LogRecord``
+objects for a few milliseconds of process life — never observed, never
+measured, not worth measuring.
 """
 from __future__ import annotations
 
 import logging
 import sys
-from collections import deque
-from logging.handlers import MemoryHandler
 
-#: Matches the field name/shape #5873 already established for the real
-#: RotatingFileHandler's own bound ("a limit that can be set is a limit
-#: someone can raise" does not apply here — this is a fixed, small ceiling
-#: on a startup-only window, not an operator-configurable log destination).
+#: See this module's own "Capacity" section for why this is an estimate,
+#: not a measurement, and why being wrong in either direction stays safe.
 _DEFAULT_CAPACITY = 200
 
 
-class _BoundedEarlyBuffer(MemoryHandler):
-    """A :class:`~logging.handlers.MemoryHandler` with NO auto-flush and a
-    hard-bounded buffer — see this module's own docstring for why the
-    stock class's "unbounded without a target" gap matters here.
-    ``target`` is always ``None`` at construction; the only way records
-    leave the buffer is :meth:`replay_into`, called explicitly once a
-    real handler exists."""
+class _BoundedEarlyBuffer(logging.Handler):
+    """Buffers up to ``capacity`` records — the EARLIEST ones, the actual
+    motivating case (see module docstring's own "which end drops"
+    section) — refusing (not silently overwriting) anything past that,
+    while counting how many were refused. The only way records leave the
+    buffer is :meth:`replay_into`, called explicitly once a real handler
+    exists; there is no target to flush into before that, so nothing
+    auto-flushes."""
 
     def __init__(self, capacity: int) -> None:
-        super().__init__(capacity=capacity, flushLevel=logging.CRITICAL + 1, target=None)
-        # Replaces BufferingHandler's own plain `list` with a bounded
-        # deque -- appending past `capacity` silently drops the OLDEST
-        # entry instead of growing forever (see module docstring).
-        # ignore[assignment] below: BufferingHandler types `self.buffer`
-        # as `list`; a `deque` stays a Sequence everywhere the base
-        # class's own code (close()'s flush()) reads it.
-        self.buffer: "deque[logging.LogRecord]" = deque(maxlen=capacity)  # type: ignore[assignment]
+        super().__init__()
+        self._capacity = capacity
+        self._records: "list[logging.LogRecord]" = []
+        self._dropped = 0
 
-    def shouldFlush(self, record: logging.LogRecord) -> bool:
-        """Never auto-flush -- ``target`` is always ``None`` here, so the
-        base class's own ``flush()`` would no-op anyway (module
-        docstring); :meth:`replay_into` is the only exit."""
-        del record
-        return False
+    @property
+    def kept_messages(self) -> "tuple[str, ...]":
+        """The currently-buffered records' own formatted messages, in
+        order — a public, read-only surface so a caller (a test
+        included) does not need to reach into ``_records`` directly."""
+        self.acquire()
+        try:
+            return tuple(r.getMessage() for r in self._records)
+        finally:
+            self.release()
+
+    @property
+    def dropped_count(self) -> int:
+        """How many records this instance has refused past ``capacity``
+        since the last :meth:`replay_into` (or since construction, if
+        none happened yet)."""
+        self.acquire()
+        try:
+            return self._dropped
+        finally:
+            self.release()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.acquire()
+        try:
+            if len(self._records) < self._capacity:
+                self._records.append(record)
+            else:
+                self._dropped += 1
+        finally:
+            self.release()
 
     def replay_into(self, target: logging.Handler) -> None:
         """Hand every currently-buffered record to *target*, in order,
-        then clear the buffer. Idempotent — calling this again with an
-        already-empty buffer is a no-op, so a caller does not need to
-        track whether it already replayed once."""
+        then — if any records were refused past ``capacity`` — one
+        synthetic ``WARNING`` stating exactly how many, so a ``reyn.log``
+        reader can tell "0 lost" from "N lost" rather than the two
+        looking identical. Clears the buffer and its drop counter
+        afterward. Idempotent — calling this again with an already-empty
+        buffer and zero drops is a no-op."""
         self.acquire()
         try:
-            for record in self.buffer:
+            for record in self._records:
                 target.handle(record)
-            self.buffer.clear()
+            if self._dropped:
+                dropped_logger = logging.getLogger(__name__)
+                dropped_record = dropped_logger.makeRecord(
+                    dropped_logger.name, logging.WARNING, __file__, 0,
+                    "%d early log record(s) were dropped before the "
+                    "interactive CUI's own log file existed (buffer "
+                    "capacity=%d exceeded)",
+                    (self._dropped, self._capacity), None,
+                )
+                target.handle(dropped_record)
+            self._records.clear()
+            self._dropped = 0
         finally:
             self.release()
 

--- a/src/reyn/runtime/early_log_buffer.py
+++ b/src/reyn/runtime/early_log_buffer.py
@@ -1,0 +1,166 @@
+"""#5989 symptom 3 (owner-hit — TUI unresponsive; ``reyn.log`` stayed at 0
+lines for the whole session): the interactive CUI's own log redirect
+(``chat._setup_interactive_logging``) installs a ``RotatingFileHandler``
+partway through startup — anything logged BEFORE that call (interpreter
+init, ``argparse``, :func:`~reyn.runtime.process_registry.register_process`,
+the import tree) has no handler to reach yet. Python's own fallback for
+"a record with no handler anywhere in the hierarchy" is ``logging.
+lastResort`` — a bare ``StreamHandler(sys.stderr)`` at ``WARNING`` — so a
+pre-redirect record goes straight to stderr and is gone: once the real file
+handler installs later, there is no mechanism that goes back and writes it
+into ``reyn.log``.
+
+lead-coder's own explicit scoping (issue #5989 comment thread): this closes
+the HOLE ("a record emitted here is unrecoverable"), not symptom 3 itself
+— the reported "0 lines for 5 minutes of live usage" is a different order
+of magnitude than this narrow startup window and still needs an owner
+real-machine trace to explain.
+
+## Industry precedent (checked before designing, per owner's standing
+directive)
+
+``logging.handlers.MemoryHandler`` is the stdlib's own "buffer records,
+flush to a target once one exists" primitive — the exact shape this needs
+(buffer everything from process start, replay it into the real
+``RotatingFileHandler`` the moment :func:`~reyn.interfaces.cli.commands.
+chat._setup_interactive_logging` installs it). Reused, not reinvented,
+with one deliberate deviation:
+
+``MemoryHandler.flush()``'s own docstring states "the record buffer is
+only cleared if a target has been set" — verified by reading ``cpython``'s
+own source (3.13): with no target, ``BufferingHandler.emit()`` still
+unconditionally does ``self.buffer.append(record)`` (a plain ``list``)
+forever — ``shouldFlush()``/``flush()`` firing at ``capacity`` does
+NOTHING to trim it without a target already attached. A process that never
+reaches ``_setup_interactive_logging`` at all (``--cui``/non-TTY runs,
+which never install ANY file handler by design; or a crash before that
+call) would otherwise buffer records without bound for its entire life —
+six-questions #5 ("what does this accumulate, who bounds it") answered
+"nothing, forever" is not an answer. :class:`_BoundedEarlyBuffer` below
+replaces the plain list with a ``collections.deque(maxlen=capacity)`` —
+oldest record silently dropped once full, a real, stated ceiling
+independent of whether a target ever attaches.
+
+## What happens on each of the two paths
+
+- **A target attaches** (the interactive CUI installs its real handler):
+  every buffered record (up to ``capacity``, oldest-dropped beyond that)
+  replays into it once, in order, then the buffer is cleared and never
+  buffers again — see :meth:`_BoundedEarlyBuffer.replay_into`.
+- **No target ever attaches** (``--cui``/non-TTY, or an early crash): the
+  bounded buffer just sits capped, doing nothing further, for the rest of
+  the process's life — bounded memory, no behavioural change to anything
+  else. The mirrored ``StreamHandler(sys.stderr)`` installed alongside it
+  (see :func:`install`) keeps stderr visibility IDENTICAL to what
+  ``logging.lastResort`` already provided before this change (same level,
+  same destination) — this module only makes that fallback explicit
+  early enough to also feed the buffer; it does not add or remove a
+  second copy of anything a non-interactive run already showed.
+
+``logging.captureWarnings(True)`` is armed in the SAME early window (not
+only later, inside ``_setup_interactive_logging`` as before) — a bare
+``warnings.warn(...)`` before the real handler installs is the same
+unrecoverable-loss shape as a logging call, and #4362 already established
+that raw ``warnings.warn`` must not corrupt the interactive UI either.
+Disclosed cost, not hidden: this changes ``warnings.warn``'s own OUTPUT
+FORMAT (via ``py.warnings``'s logger + this module's `Formatter`, not
+``warnings.showwarning``'s own ``path:line: Category: message`` shape) for
+every ``reyn`` invocation from process start, not only the interactive
+one — the same format change #4362 already accepted for the
+post-handler-install window, now starting earlier. Calling it twice
+(here, and again inside ``_setup_interactive_logging``) is idempotent —
+``logging.captureWarnings`` only (re)installs the same monkeypatch.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from collections import deque
+from logging.handlers import MemoryHandler
+
+#: Matches the field name/shape #5873 already established for the real
+#: RotatingFileHandler's own bound ("a limit that can be set is a limit
+#: someone can raise" does not apply here — this is a fixed, small ceiling
+#: on a startup-only window, not an operator-configurable log destination).
+_DEFAULT_CAPACITY = 200
+
+
+class _BoundedEarlyBuffer(MemoryHandler):
+    """A :class:`~logging.handlers.MemoryHandler` with NO auto-flush and a
+    hard-bounded buffer — see this module's own docstring for why the
+    stock class's "unbounded without a target" gap matters here.
+    ``target`` is always ``None`` at construction; the only way records
+    leave the buffer is :meth:`replay_into`, called explicitly once a
+    real handler exists."""
+
+    def __init__(self, capacity: int) -> None:
+        super().__init__(capacity=capacity, flushLevel=logging.CRITICAL + 1, target=None)
+        # Replaces BufferingHandler's own plain `list` with a bounded
+        # deque -- appending past `capacity` silently drops the OLDEST
+        # entry instead of growing forever (see module docstring).
+        # ignore[assignment] below: BufferingHandler types `self.buffer`
+        # as `list`; a `deque` stays a Sequence everywhere the base
+        # class's own code (close()'s flush()) reads it.
+        self.buffer: "deque[logging.LogRecord]" = deque(maxlen=capacity)  # type: ignore[assignment]
+
+    def shouldFlush(self, record: logging.LogRecord) -> bool:
+        """Never auto-flush -- ``target`` is always ``None`` here, so the
+        base class's own ``flush()`` would no-op anyway (module
+        docstring); :meth:`replay_into` is the only exit."""
+        del record
+        return False
+
+    def replay_into(self, target: logging.Handler) -> None:
+        """Hand every currently-buffered record to *target*, in order,
+        then clear the buffer. Idempotent — calling this again with an
+        already-empty buffer is a no-op, so a caller does not need to
+        track whether it already replayed once."""
+        self.acquire()
+        try:
+            for record in self.buffer:
+                target.handle(record)
+            self.buffer.clear()
+        finally:
+            self.release()
+
+
+_installed: "_BoundedEarlyBuffer | None" = None
+
+
+def install(capacity: int = _DEFAULT_CAPACITY) -> _BoundedEarlyBuffer:
+    """Install the bounded early buffer (plus a stderr mirror matching
+    ``logging.lastResort``'s own level/destination) on the root logger, as
+    early in process startup as this can be called. Idempotent — a second
+    call returns the SAME instance already installed, never double-installs.
+
+    Call this as the very first statement of ``reyn``'s own CLI entry
+    point (:func:`reyn.interfaces.cli.main`) — before anything else that
+    could log, including argument parsing and process registration."""
+    global _installed
+    if _installed is not None:
+        return _installed
+    root = logging.getLogger()
+    mirror = logging.StreamHandler(sys.stderr)
+    mirror.setLevel(logging.WARNING)
+    root.addHandler(mirror)
+    buffer = _BoundedEarlyBuffer(capacity)
+    buffer.setLevel(logging.WARNING)
+    root.addHandler(buffer)
+    logging.captureWarnings(True)
+    _installed = buffer
+    return buffer
+
+
+def get_installed() -> "_BoundedEarlyBuffer | None":
+    """The buffer :func:`install` armed, or ``None`` if this process never
+    called it (e.g. a test constructing ``chat._setup_interactive_logging``
+    directly, never having gone through the real CLI entry point)."""
+    return _installed
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clears the module-level singleton so a test can call
+    :func:`install` again as if starting fresh. Never called from
+    production code."""
+    global _installed
+    _installed = None

--- a/src/reyn/runtime/early_log_buffer.py
+++ b/src/reyn/runtime/early_log_buffer.py
@@ -84,15 +84,39 @@ this ONE process's own terminal).
   it once, in order, followed by the dropped-count record if any were
   refused, then the buffer is cleared and never buffers again — see
   :meth:`_BoundedEarlyBuffer.replay_into`.
-- **No target ever attaches** (``--cui``/non-TTY, or an early crash): the
-  buffer just sits at its cap, refusing further records, for the rest of
-  the process's life — bounded memory, no behavioural change to anything
-  else. The mirrored ``StreamHandler(sys.stderr)`` installed alongside it
-  (see :func:`install`) keeps stderr visibility IDENTICAL to what
-  ``logging.lastResort`` already provided before this change (same level,
-  same destination) — this module only makes that fallback explicit
-  early enough to also feed the buffer; it does not add or remove a
-  second copy of anything a non-interactive run already showed.
+- **No target ever attaches** (``--cui``/non-TTY, which never installs
+  ANY file handler by design; or an early crash before
+  ``_setup_interactive_logging`` runs): an :mod:`atexit` hook (armed by
+  :func:`install`) dumps whatever is still buffered straight to stderr,
+  ONCE, at process exit — see :func:`_flush_to_stderr_at_exit`.
+
+## A real regression, caught by owner review, and its fix (#6043)
+
+The first version of this module installed a SECOND stderr handler
+(``mirror``) unconditionally alongside the buffer, reasoning it "matches
+``logging.lastResort``'s own level/destination, so it doesn't change
+current visibility." That reasoning does not hold, and it broke the
+interactive CUI on a real machine (owner report, #6043 — "reyn.log に
+残せば良いのにわざわざ stderr 使ってるの？", a raw ``logging`` line
+appearing between the sent-queue and the input box):
+
+- ``logging.lastResort`` only fires when a logger's effective handler
+  chain is EMPTY — the moment ANY handler attaches to root (the buffer
+  itself, with no mirror at all), ``lastResort`` already stops firing on
+  its own. The mirror did not "keep the same destination active"; it
+  added a SECOND, unconditional one that fires on every single record,
+  not only when nothing else would have caught it.
+- The buffer's own purpose was "replay into ``reyn.log`` later" — once
+  that replay lands, writing the SAME records to stderr too is not
+  preserving prior behaviour, it is duplicating output, live, for the
+  entire time the interactive TUI owns the terminal (every WARNING+
+  record from then on, not just the pre-handler window this module
+  exists to cover).
+
+Fixed: no mirror handler at all. The ONLY path records ever reach stderr
+through THIS module is the exit-time fallback above, and only when
+:meth:`_BoundedEarlyBuffer.replay_into` never ran at all — the interactive
+path (where ``replay_into`` DOES run) never sees it.
 
 ``logging.captureWarnings(True)`` is armed in the SAME early window (not
 only later, inside ``_setup_interactive_logging`` as before) — a bare
@@ -128,6 +152,7 @@ measured, not worth measuring.
 """
 from __future__ import annotations
 
+import atexit
 import logging
 import sys
 
@@ -150,6 +175,11 @@ class _BoundedEarlyBuffer(logging.Handler):
         self._capacity = capacity
         self._records: "list[logging.LogRecord]" = []
         self._dropped = 0
+        #: True once :meth:`replay_into` has run at least once — the
+        #: exit-time fallback (:func:`_flush_to_stderr_at_exit`) checks
+        #: this to stay a no-op on the interactive path, where a real
+        #: replay already happened.
+        self.replayed = False
 
     @property
     def kept_messages(self) -> "tuple[str, ...]":
@@ -207,6 +237,7 @@ class _BoundedEarlyBuffer(logging.Handler):
                 target.handle(dropped_record)
             self._records.clear()
             self._dropped = 0
+            self.replayed = True
         finally:
             self.release()
 
@@ -214,11 +245,29 @@ class _BoundedEarlyBuffer(logging.Handler):
 _installed: "_BoundedEarlyBuffer | None" = None
 
 
+def _flush_to_stderr_at_exit(buffer: _BoundedEarlyBuffer) -> None:
+    """#6043: the ``atexit`` fallback for the ONE real path where
+    :meth:`_BoundedEarlyBuffer.replay_into` never runs — ``--cui``/
+    non-TTY invocations (which never call ``chat._setup_interactive_
+    logging`` at all, by design) and an early crash before that call.
+    A no-op if ``replay_into`` already ran (the interactive path) —
+    checked first, so this never duplicates output there."""
+    if buffer.replayed:
+        return
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    buffer.replay_into(stderr_handler)
+
+
 def install(capacity: int = _DEFAULT_CAPACITY) -> _BoundedEarlyBuffer:
-    """Install the bounded early buffer (plus a stderr mirror matching
-    ``logging.lastResort``'s own level/destination) on the root logger, as
-    early in process startup as this can be called. Idempotent — a second
-    call returns the SAME instance already installed, never double-installs.
+    """Install the bounded early buffer on the root logger, as early in
+    process startup as this can be called. Idempotent — a second call
+    returns the SAME instance already installed, never double-installs.
+
+    #6043: NO stderr mirror handler — see this module's own "A real
+    regression" section for why one existed here before and why it was
+    wrong. The only path buffered records reach stderr through this
+    module is :func:`_flush_to_stderr_at_exit`, armed below, which only
+    acts if :meth:`_BoundedEarlyBuffer.replay_into` never ran.
 
     Call this as the very first statement of ``reyn``'s own CLI entry
     point (:func:`reyn.interfaces.cli.main`) — before anything else that
@@ -227,14 +276,12 @@ def install(capacity: int = _DEFAULT_CAPACITY) -> _BoundedEarlyBuffer:
     if _installed is not None:
         return _installed
     root = logging.getLogger()
-    mirror = logging.StreamHandler(sys.stderr)
-    mirror.setLevel(logging.WARNING)
-    root.addHandler(mirror)
     buffer = _BoundedEarlyBuffer(capacity)
     buffer.setLevel(logging.WARNING)
     root.addHandler(buffer)
     logging.captureWarnings(True)
     _installed = buffer
+    atexit.register(_flush_to_stderr_at_exit, buffer)
     return buffer
 
 
@@ -246,8 +293,19 @@ def get_installed() -> "_BoundedEarlyBuffer | None":
 
 
 def _reset_for_tests() -> None:
-    """Test-only: clears the module-level singleton so a test can call
-    :func:`install` again as if starting fresh. Never called from
-    production code."""
+    """Test-only: clears the module-level singleton AND unregisters the
+    ``atexit`` fallback :func:`install` armed, so a test can call
+    :func:`install` again as if starting fresh. Without the ``atexit.
+    unregister`` call, every test that calls :func:`install` would leave
+    its own fallback registered — accumulating for the rest of the
+    pytest process's life, each one referencing a stale buffer instance,
+    all firing (harmlessly, but pointlessly) at the real pytest process's
+    own exit. ``atexit.unregister`` matches by the callable itself
+    (:func:`_flush_to_stderr_at_exit`), not by the *buffer* argument it
+    was registered with, so this removes every pending registration this
+    module has ever made in THIS process, not only the most recent one —
+    correct here since a test-only reset should leave none behind at
+    all. Never called from production code."""
     global _installed
+    atexit.unregister(_flush_to_stderr_at_exit)
     _installed = None

--- a/tests/interfaces/test_inline_interactive_logging.py
+++ b/tests/interfaces/test_inline_interactive_logging.py
@@ -253,3 +253,68 @@ def test_existing_file_handler_readers_still_find_the_rotating_handler(
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
+
+
+# ── #5989 symptom 3: a pre-handler-install record is not lost ──────────────
+
+
+def test_a_warning_before_setup_replays_into_the_real_file_once_installed(
+    tmp_path,
+) -> None:
+    """Tier 2: #5989 symptom 3 — a WARNING emitted BEFORE
+    `_setup_interactive_logging` runs (the true early-startup window,
+    everything from interpreter init through `reyn.interfaces.cli.main`'s
+    own argument parsing/process registration) must still land in
+    reyn.log once the real handler installs, via the early buffer
+    `cli.main()` arms as its own first statement.
+
+    Strip-falsifier (verified by hand: the `early_buffer.replay_into(
+    handler)` call removed from `_setup_interactive_logging`): this test
+    goes red — the early marker never appears in the file, only records
+    logged AFTER setup do."""
+    from reyn.runtime import early_log_buffer
+
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        early_log_buffer.install()
+        logging.getLogger("reyn.canary").warning("pre-setup-marker-71dc")
+
+        _setup_interactive_logging(tmp_path)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+
+        for h in root.handlers:
+            h.flush()
+
+        assert "pre-setup-marker-71dc" in log_file.read_text(), (
+            "#5989 REGRESSION: a WARNING logged before "
+            "_setup_interactive_logging ran did not replay into the real "
+            "file handler once it installed"
+        )
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        early_log_buffer._reset_for_tests()
+
+
+def test_setup_interactive_logging_works_with_no_early_buffer_installed(
+    tmp_path,
+) -> None:
+    """Tier 2: falsification contrast — a process that never went through
+    `reyn.interfaces.cli.main` (this function called directly, matching
+    how every OTHER test in this file already drives it) must not error
+    just because `early_log_buffer.get_installed()` returns `None`."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+        logging.getLogger("reyn.canary").warning("no-early-buffer-marker")
+        for h in root.handlers:
+            h.flush()
+        assert "no-early-buffer-marker" in log_file.read_text()
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)

--- a/tests/runtime/test_5989_early_log_buffer.py
+++ b/tests/runtime/test_5989_early_log_buffer.py
@@ -116,12 +116,19 @@ def test_replay_clears_the_buffer_so_a_second_replay_is_a_no_op() -> None:
         _restore_logging_state(saved)
 
 
-def test_the_buffer_never_grows_past_its_own_capacity() -> None:
+def test_the_buffer_never_grows_past_its_own_capacity_and_keeps_the_earliest(
+) -> None:
     """Tier 2: six-questions #5 — MORE records than `capacity` are emitted
-    with NO target ever attached; the buffer must stay capped (oldest
-    dropped), not grow without bound (the real gap in stdlib's own
-    `MemoryHandler` without a target — module docstring, verified by
-    reading cpython's source)."""
+    with NO target ever attached; the buffer must stay capped, not grow
+    without bound (the real gap in stdlib's own `MemoryHandler` without a
+    target — module docstring, verified by reading cpython's source).
+
+    Which end survives matters, not just "some 3 survive" (module
+    docstring's own "which end drops" section, lead-coder review): this
+    buffer exists to save the EARLIEST record (the one closest to
+    process start, the actual motivating case) — dropping from the
+    front on overflow would recreate that exact loss. Pinned here: the
+    3 SURVIVORS are markers 0/1/2 (the earliest), not 7/8/9."""
     saved = _save_logging_state()
     try:
         buffer = early_log_buffer.install(capacity=3)
@@ -131,16 +138,89 @@ def test_the_buffer_never_grows_past_its_own_capacity() -> None:
 
         # The exact-contents check below also pins the count (exactly 3
         # survivors) -- six-questions #5's own answer, "capped at
-        # capacity, oldest dropped," is what this asserts, not a bare
-        # size.
-        kept = [r.getMessage() for r in buffer.buffer]
-        assert kept == ["marker-7", "marker-8", "marker-9"], (
-            f"#5989 REGRESSION: buffer must stay capped at capacity=3, "
-            f"oldest dropped — expected exactly the 3 most recent "
-            f"markers, got {kept!r}"
+        # capacity, EARLIEST kept, rest counted as dropped," is what
+        # this asserts, not a bare size.
+        kept = buffer.kept_messages
+        assert kept == ("marker-0", "marker-1", "marker-2"), (
+            f"#5989 REGRESSION: buffer must keep the EARLIEST capacity=3 "
+            f"records (the motivating case — see module docstring's "
+            f"'which end drops' section), not the most recent — "
+            f"got {kept!r}"
+        )
+        assert buffer.dropped_count == 7, (
+            f"#5989 REGRESSION: the 7 refused records (10 emitted - "
+            f"capacity 3) must be COUNTED, not silently discarded with "
+            f"no trace — got {buffer.dropped_count}"
         )
     finally:
         _restore_logging_state(saved)
+
+
+def test_replay_reports_how_many_early_records_were_dropped() -> None:
+    """Tier 2: lead-coder review — a dropped count that never reaches
+    `reyn.log` leaves a reader unable to tell "0 lost" from "N lost"
+    (the durable, cross-session surface — #5977's own measured
+    incident — not the stderr mirror, which only this ONE process's own
+    terminal sees). `replay_into` must emit ONE synthetic record stating
+    the exact count, after the real buffered records.
+
+    Strip-falsifier (verified by hand: the `if self._dropped:` branch in
+    `replay_into` removed): this test goes red — no record mentioning
+    the drop count reaches the target at all."""
+    saved = _save_logging_state()
+    captured: "list[str]" = []
+
+    class _RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    try:
+        buffer = early_log_buffer.install(capacity=2)
+        logger = logging.getLogger("reyn.canary")
+        for i in range(5):
+            logger.warning("marker-%d", i)
+
+        buffer.replay_into(_RecordingHandler())
+    finally:
+        _restore_logging_state(saved)
+
+    # Exact-contents equality (not a bare len()) pins BOTH the count and
+    # the order: the 2 kept records, then exactly one drop-count record
+    # naming the real count (3 refused: 5 emitted - capacity 2) -- a
+    # missing, duplicated, or miscounted drop record all fail this.
+    assert captured == [
+        "marker-0", "marker-1",
+        "3 early log record(s) were dropped before the interactive CUI's "
+        "own log file existed (buffer capacity=2 exceeded)",
+    ], (
+        f"#5989 REGRESSION: expected the 2 kept records plus exactly 1 "
+        f"drop-count record naming the real count — got {captured!r}"
+    )
+
+
+def test_replay_with_nothing_dropped_reports_nothing_extra() -> None:
+    """Tier 2: falsification contrast for the test above — when NOTHING
+    was dropped, `replay_into` must not emit a spurious drop-count
+    record (a reader must be able to trust its ABSENCE as "0 lost", not
+    have to parse "0 record(s) dropped" every time)."""
+    saved = _save_logging_state()
+    captured: "list[str]" = []
+
+    class _RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    try:
+        buffer = early_log_buffer.install(capacity=10)
+        logging.getLogger("reyn.canary").warning("only-marker")
+        buffer.replay_into(_RecordingHandler())
+    finally:
+        _restore_logging_state(saved)
+
+    assert captured == ["only-marker"], (
+        f"#5989 REGRESSION: replay_into must not emit a drop-count "
+        f"record when nothing was dropped — got {captured!r}"
+    )
 
 
 def test_a_bare_warnings_warn_before_a_target_attaches_also_replays(

--- a/tests/runtime/test_5989_early_log_buffer.py
+++ b/tests/runtime/test_5989_early_log_buffer.py
@@ -1,0 +1,211 @@
+"""Tier 2: #5989 symptom 3 — reyn.runtime.early_log_buffer.
+
+A WARNING+ record (or a bare ``warnings.warn``) emitted BEFORE the
+interactive CUI's own ``RotatingFileHandler`` installs must not be
+unrecoverably lost — it should replay into the real handler once one
+exists, and the buffer holding it in the meantime must be bounded even
+if no target ever attaches. See that module's own docstring for the
+full design (including the ``MemoryHandler``-without-a-target gap this
+was built to avoid).
+
+Real ``logging`` module throughout (no mocks) — global logging state
+(root handlers/level, ``logging.captureWarnings``'s own guard, and this
+module's own installed-singleton) is saved+restored per test, the same
+pattern ``test_inline_interactive_logging.py`` already established.
+"""
+from __future__ import annotations
+
+import logging
+import warnings
+
+from reyn.runtime import early_log_buffer
+
+
+def _save_logging_state():
+    root = logging.getLogger()
+    return root.handlers[:], root.level
+
+
+def _restore_logging_state(saved) -> None:
+    handlers, level = saved
+    root = logging.getLogger()
+    logging.captureWarnings(False)
+    root.handlers[:] = handlers
+    root.setLevel(level)
+    # early_log_buffer's own test-support seam (module docstring: "never
+    # called from production code") -- not a private-attribute poke, this
+    # module deliberately provides it so a test can start the next case
+    # as if install() had never run.
+    early_log_buffer._reset_for_tests()
+
+
+def test_install_is_idempotent() -> None:
+    """Tier 2: a second `install()` call returns the SAME instance, not a
+    fresh one — the whole point is ONE buffer per process, installed once
+    at the true start."""
+    saved = _save_logging_state()
+    try:
+        first = early_log_buffer.install()
+        second = early_log_buffer.install()
+        assert first is second, (
+            "#5989 REGRESSION: install() must not double-install a second "
+            "buffer instance on a repeated call"
+        )
+    finally:
+        _restore_logging_state(saved)
+
+
+def test_a_warning_emitted_before_a_target_attaches_replays_into_it() -> None:
+    """Tier 2: the core accept criterion — a record emitted in the "before
+    any real handler exists" window is NOT lost, once a target attaches.
+
+    Strip-falsifier (verified by hand: `install()` reverted to installing
+    nothing / a no-op): this test goes red — the target handler's own
+    captured records stays empty, since nothing buffered the early
+    record for later replay."""
+    saved = _save_logging_state()
+    captured: "list[str]" = []
+
+    class _RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    try:
+        buffer = early_log_buffer.install()
+        logging.getLogger("reyn.canary").warning("early-marker-4a11")
+
+        target = _RecordingHandler()
+        buffer.replay_into(target)
+
+        assert captured == ["early-marker-4a11"], (
+            f"#5989 REGRESSION: a WARNING emitted before a target attached "
+            f"did not replay into it — got {captured!r}"
+        )
+    finally:
+        _restore_logging_state(saved)
+
+
+def test_replay_clears_the_buffer_so_a_second_replay_is_a_no_op() -> None:
+    """Tier 2: `replay_into` is idempotent — a record already replayed once
+    must not replay AGAIN into a second target (double-delivery)."""
+    saved = _save_logging_state()
+    first_capture: "list[str]" = []
+    second_capture: "list[str]" = []
+
+    class _RecordingHandler(logging.Handler):
+        def __init__(self, sink: "list[str]") -> None:
+            super().__init__()
+            self._sink = sink
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self._sink.append(record.getMessage())
+
+    try:
+        buffer = early_log_buffer.install()
+        logging.getLogger("reyn.canary").warning("replay-once-marker")
+
+        buffer.replay_into(_RecordingHandler(first_capture))
+        buffer.replay_into(_RecordingHandler(second_capture))
+
+        assert first_capture == ["replay-once-marker"]
+        assert second_capture == [], (
+            f"#5989 REGRESSION: a second replay_into() delivered the same "
+            f"record again — got {second_capture!r}"
+        )
+    finally:
+        _restore_logging_state(saved)
+
+
+def test_the_buffer_never_grows_past_its_own_capacity() -> None:
+    """Tier 2: six-questions #5 — MORE records than `capacity` are emitted
+    with NO target ever attached; the buffer must stay capped (oldest
+    dropped), not grow without bound (the real gap in stdlib's own
+    `MemoryHandler` without a target — module docstring, verified by
+    reading cpython's source)."""
+    saved = _save_logging_state()
+    try:
+        buffer = early_log_buffer.install(capacity=3)
+        logger = logging.getLogger("reyn.canary")
+        for i in range(10):
+            logger.warning("marker-%d", i)
+
+        # The exact-contents check below also pins the count (exactly 3
+        # survivors) -- six-questions #5's own answer, "capped at
+        # capacity, oldest dropped," is what this asserts, not a bare
+        # size.
+        kept = [r.getMessage() for r in buffer.buffer]
+        assert kept == ["marker-7", "marker-8", "marker-9"], (
+            f"#5989 REGRESSION: buffer must stay capped at capacity=3, "
+            f"oldest dropped — expected exactly the 3 most recent "
+            f"markers, got {kept!r}"
+        )
+    finally:
+        _restore_logging_state(saved)
+
+
+def test_a_bare_warnings_warn_before_a_target_attaches_also_replays(
+) -> None:
+    """Tier 2: accept criterion ③ — `captureWarnings(True)` is armed in
+    THIS early window too (not only later inside `_setup_interactive_
+    logging`), so a bare `warnings.warn` before any real handler exists
+    is captured into the SAME buffer as a logging call, and replays the
+    same way.
+
+    Strip-falsifier (verified by hand: `install()`'s own
+    `logging.captureWarnings(True)` call removed): this test goes red —
+    the bare warning never reaches the logging system at all, so nothing
+    is in the buffer to replay."""
+    saved = _save_logging_state()
+    captured: "list[str]" = []
+
+    class _RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    try:
+        buffer = early_log_buffer.install()
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            warnings.warn(
+                "early-bare-warning-marker", category=ResourceWarning, stacklevel=1,
+            )
+
+        target = _RecordingHandler()
+        buffer.replay_into(target)
+
+        assert any("early-bare-warning-marker" in m for m in captured), (
+            f"#5989 REGRESSION: a bare warnings.warn() before a target "
+            f"attached did not reach the early buffer — got {captured!r}"
+        )
+    finally:
+        _restore_logging_state(saved)
+
+
+def test_with_no_target_ever_attached_stderr_visibility_is_unchanged() -> None:
+    """Tier 2: the "handler never attaches" path (--cui / non-TTY, or an
+    early crash) — the stderr mirror `install()` also attaches must keep
+    showing WARNING+ records, matching what `logging.lastResort` already
+    did before this module existed. Regression guard for the
+    non-interactive path, not just "the buffer doesn't grow.\""""
+    import io
+    import sys
+
+    saved = _save_logging_state()
+    fake_stderr = io.StringIO()
+    real_stderr = sys.stderr
+    try:
+        sys.stderr = fake_stderr
+        early_log_buffer.install()
+        logging.getLogger("reyn.canary").warning("stderr-mirror-marker")
+        for h in logging.getLogger().handlers:
+            h.flush()
+
+        assert "stderr-mirror-marker" in fake_stderr.getvalue(), (
+            "#5989 REGRESSION: with no target ever attached, a WARNING "
+            "must still reach stderr (the same visibility "
+            "logging.lastResort already provided) — got "
+            f"{fake_stderr.getvalue()!r}"
+        )
+    finally:
+        sys.stderr = real_stderr
+        _restore_logging_state(saved)

--- a/tests/runtime/test_5989_early_log_buffer.py
+++ b/tests/runtime/test_5989_early_log_buffer.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import logging
 import warnings
 
+import pytest
+
 from reyn.runtime import early_log_buffer
 
 
@@ -261,12 +263,17 @@ def test_a_bare_warnings_warn_before_a_target_attaches_also_replays(
         _restore_logging_state(saved)
 
 
-def test_with_no_target_ever_attached_stderr_visibility_is_unchanged() -> None:
-    """Tier 2: the "handler never attaches" path (--cui / non-TTY, or an
-    early crash) — the stderr mirror `install()` also attaches must keep
-    showing WARNING+ records, matching what `logging.lastResort` already
-    did before this module existed. Regression guard for the
-    non-interactive path, not just "the buffer doesn't grow.\""""
+def test_with_no_target_ever_attached_the_exit_fallback_reaches_stderr() -> None:
+    """Tier 2: #6043 — the "handler never attaches" path (--cui / non-TTY,
+    or an early crash) must not lose buffered records forever; the
+    `atexit` fallback (`_flush_to_stderr_at_exit`, called here directly
+    rather than by actually exiting the process — the real trigger is
+    `atexit`, this drives the SAME function) delivers them to stderr.
+
+    NOT live visibility (module docstring's own "A real regression"
+    section — that was #6043's own bug): this is deferred to the
+    fallback running, matching production's own `atexit`-triggered
+    timing, not `install()` time."""
     import io
     import sys
 
@@ -275,17 +282,67 @@ def test_with_no_target_ever_attached_stderr_visibility_is_unchanged() -> None:
     real_stderr = sys.stderr
     try:
         sys.stderr = fake_stderr
-        early_log_buffer.install()
-        logging.getLogger("reyn.canary").warning("stderr-mirror-marker")
-        for h in logging.getLogger().handlers:
-            h.flush()
+        buffer = early_log_buffer.install()
+        logging.getLogger("reyn.canary").warning("stderr-fallback-marker")
 
-        assert "stderr-mirror-marker" in fake_stderr.getvalue(), (
-            "#5989 REGRESSION: with no target ever attached, a WARNING "
-            "must still reach stderr (the same visibility "
-            "logging.lastResort already provided) — got "
+        assert "stderr-fallback-marker" not in fake_stderr.getvalue(), (
+            "test setup sanity: a WARNING must NOT reach stderr live "
+            "(the #6043 bug this module no longer has) -- only at the "
+            "exit-fallback below"
+        )
+
+        early_log_buffer._flush_to_stderr_at_exit(buffer)
+
+        assert "stderr-fallback-marker" in fake_stderr.getvalue(), (
+            "#5989 REGRESSION: with no target ever attached, the exit-time "
+            "fallback must still deliver a WARNING to stderr — got "
             f"{fake_stderr.getvalue()!r}"
         )
     finally:
         sys.stderr = real_stderr
+        _restore_logging_state(saved)
+
+
+def test_the_exit_fallback_never_constructs_a_handler_once_already_replayed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #6043 — `_flush_to_stderr_at_exit`'s own `if buffer.
+    replayed: return` guard, witnessed directly (NOT via stderr content —
+    disclosed, not hidden: `replay_into` is independently idempotent on
+    an already-empty buffer, so a version of this test asserting merely
+    "stderr stays empty" would pass even with the guard deleted, since
+    the empty buffer alone already produces no output either way — that
+    shape was caught writing this test and is NOT what is asserted
+    below). Witnessed instead: whether `_flush_to_stderr_at_exit` even
+    CONSTRUCTS a `logging.StreamHandler` at all — spied via monkeypatch
+    (the real class still runs; only the call is recorded, same "wrap
+    the real thing" shape this file's other tests already use).
+
+    Strip-falsifier (verified by hand: the `if buffer.replayed: return`
+    guard removed): this test goes red — a `StreamHandler` gets
+    constructed even though nothing was buffered to replay."""
+    saved = _save_logging_state()
+    constructed: "list[object]" = []
+    real_stream_handler = logging.StreamHandler
+
+    def spy_stream_handler(*args, **kwargs):  # type: ignore[no-untyped-def]
+        handler = real_stream_handler(*args, **kwargs)
+        constructed.append(handler)
+        return handler
+
+    try:
+        buffer = early_log_buffer.install()
+        logging.getLogger("reyn.canary").warning("already-replayed-marker")
+        buffer.replay_into(logging.NullHandler())
+        assert buffer.replayed is True
+
+        monkeypatch.setattr(logging, "StreamHandler", spy_stream_handler)
+        early_log_buffer._flush_to_stderr_at_exit(buffer)
+
+        assert constructed == [], (
+            f"#6043 REGRESSION: _flush_to_stderr_at_exit constructed a "
+            f"StreamHandler even though replay_into() already ran — "
+            f"got {constructed!r}"
+        )
+    finally:
         _restore_logging_state(saved)


### PR DESCRIPTION
**[tui-coder]** — part of #5989 (symptom 3, lead-coder's ruling: https://github.com/tya5/reyn/issues/5989#issuecomment-5610338474). Not `Closes` — symptoms 1/2 and the reported 5-minutes-0-lines magnitude both remain open, pending an owner real-machine trace.

## The hole this closes (not symptom 3 itself)

`chat._setup_interactive_logging()` installs a `RotatingFileHandler` partway through startup — anything logged before that call (interpreter init, argparse, `process_registry.register_process()`, the import tree) has no handler to reach and falls to `logging.lastResort` (raw stderr), gone forever once the real handler installs. My own earlier investigation stated explicitly this narrow window doesn't by itself explain "0 lines for 5 minutes"; lead-coder's ruling: fix the hole anyway, keep it scoped.

## Industry precedent (checked first, per owner's standing directive)

`logging.handlers.MemoryHandler` is the stdlib's own buffer-until-a-target primitive — reused, with one deviation found by reading cpython's own source: `MemoryHandler.flush()` only clears its buffer once a target is set, and `BufferingHandler.emit()` keeps appending to a plain `list` unconditionally otherwise — unbounded growth for any process that never reaches `_setup_interactive_logging` at all (`--cui`/non-TTY, or an early crash). `_BoundedEarlyBuffer` (new, `src/reyn/runtime/early_log_buffer.py`) subclasses `MemoryHandler` with a `deque(maxlen=capacity)` replacing that list — oldest record dropped once full, a real stated ceiling regardless of whether a target ever attaches.

## Wiring

`reyn.interfaces.cli.main()` installs the buffer (+ a stderr mirror matching `logging.lastResort`'s own level/destination, so non-interactive visibility is unchanged) as its own first statement. `_setup_interactive_logging()` grabs the module-level singleton (survives `basicConfig(force=True)` detaching it from root) and replays its contents into the real handler right after installing it. `logging.captureWarnings(True)` is armed in the same early window too — disclosed cost: this changes `warnings.warn`'s own output format for every `reyn` invocation from process start, not only the interactive path (same format change #4362 already accepted for the post-install window).

## Tests

6 new unit tests (`early_log_buffer`'s own: replay, idempotent replay, bounded growth, bare-`warnings.warn` capture, the no-target-ever-attaches stderr-visibility regression guard) + 2 new integration tests (`test_inline_interactive_logging.py`: a pre-setup WARNING replays into the real file; the function still works with no early buffer installed, matching every other existing test in that file). Strip-falsified by hand: disabling `replay_into()`'s call site turns the integration test red; a `len(x)==N` assertion in the bounded-growth test was replaced with content-equality per `test_tier_audit.py`'s own format-pinning check.

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `silent_except_ratchet.py` — all green.
- [x] Scoped pytest: `test_5989_early_log_buffer.py` (6), `test_inline_interactive_logging.py` (9), `test_litellm_lazy_load.py` + `test_config_warning_chrome_4194.py` (23, neighborhood) — 38 passed.
- [x] (skipped — Visual, standing waiver)

review: lead-coder. Pushing without waiting on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
