### PR TITLE
fix(part of #5990): report 24 silent-except config parse-error sites

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -442,6 +442,11 @@ def _build_render_template_config(raw: object) -> "RenderTemplateConfig":
         if max_output_chars <= 0:
             max_output_chars = defaults.max_output_chars
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "render_template.max_output_chars=%r is invalid (not an int); using %r",
+            max_output_chars, defaults.max_output_chars,
+        )
         max_output_chars = defaults.max_output_chars
 
     wall_clock_seconds = raw.get("wall_clock_seconds", defaults.wall_clock_seconds)
@@ -450,6 +455,11 @@ def _build_render_template_config(raw: object) -> "RenderTemplateConfig":
         if wall_clock_seconds <= 0:
             wall_clock_seconds = defaults.wall_clock_seconds
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "render_template.wall_clock_seconds=%r is invalid (not a float); using %r",
+            wall_clock_seconds, defaults.wall_clock_seconds,
+        )
         wall_clock_seconds = defaults.wall_clock_seconds
 
     return RenderTemplateConfig(
@@ -518,6 +528,11 @@ def _build_read_cap_config(raw: object) -> "ReadCapConfig":
         if inline_bytes <= 0:
             inline_bytes = defaults.inline_bytes
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "read_cap.inline_bytes=%r is invalid (not an int); using %r",
+            inline_bytes, defaults.inline_bytes,
+        )
         inline_bytes = defaults.inline_bytes
     return ReadCapConfig(inline_bytes=inline_bytes)
 
@@ -592,6 +607,11 @@ def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
         if max_bytes <= 0:
             max_bytes = defaults.max_bytes
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "history_resident.max_bytes=%r is invalid (not an int); using %r",
+            max_bytes, defaults.max_bytes,
+        )
         max_bytes = defaults.max_bytes
     return HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes))
 
@@ -692,6 +712,11 @@ def _build_logs_config(raw: object) -> "LogsConfig":
         if max_bytes <= 0:
             max_bytes = defaults.max_bytes
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "logs.max_bytes=%r is invalid (not an int); using %r",
+            max_bytes, defaults.max_bytes,
+        )
         max_bytes = defaults.max_bytes
     backup_count = raw.get("backup_count", defaults.backup_count)
     try:
@@ -699,6 +724,11 @@ def _build_logs_config(raw: object) -> "LogsConfig":
         if backup_count < 0:
             backup_count = defaults.backup_count
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "logs.backup_count=%r is invalid (not an int); using %r",
+            backup_count, defaults.backup_count,
+        )
         backup_count = defaults.backup_count
     return LogsConfig(max_bytes=max_bytes, backup_count=backup_count)
 
@@ -729,6 +759,11 @@ def _build_process_memory_config(raw: object) -> "ProcessMemoryConfig":
             if candidate > 0:
                 max_bytes = candidate
         except (TypeError, ValueError):
+            import logging
+            logging.getLogger(__name__).warning(
+                "process_memory.max_bytes=%r is invalid (not an int); using %r",
+                raw["max_bytes"], None,
+            )
             max_bytes = None
     enforce = bool(raw.get("enforce", False))
     return ProcessMemoryConfig(max_bytes=max_bytes, enforce=enforce)
@@ -780,6 +815,11 @@ def _build_image_config(raw: object) -> "ImageConfig":
         if row_height_cells <= 0:
             row_height_cells = defaults.row_height_cells
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "image.row_height_cells=%r is invalid (not an int); using %r",
+            row_height_cells, defaults.row_height_cells,
+        )
         row_height_cells = defaults.row_height_cells
     return ImageConfig(row_height_cells=row_height_cells)
 
@@ -825,6 +865,11 @@ def _build_tui_config(raw: object) -> "TuiConfig":
         if not (0 <= warn_percent <= 100):
             warn_percent = defaults.context_usage_warn_percent
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "tui.context_usage_warn_percent=%r is invalid (not an int); using %r",
+            warn_percent, defaults.context_usage_warn_percent,
+        )
         warn_percent = defaults.context_usage_warn_percent
     return TuiConfig(context_usage_warn_percent=warn_percent)
 
@@ -1631,6 +1676,11 @@ def _build_cost_warn_config(raw: object) -> "CostWarnConfig":
     try:
         threshold = float(threshold)
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "cost_warn.model_threshold_per_1m_input_usd=%r is invalid (not a float); using %r",
+            threshold, defaults.model_threshold_per_1m_input_usd,
+        )
         threshold = defaults.model_threshold_per_1m_input_usd
     block_on_high_cost = raw.get("block_on_high_cost", defaults.block_on_high_cost)
     return CostWarnConfig(
@@ -1648,11 +1698,21 @@ def _build_cost_limit(raw: object) -> CostLimitConfig:
         try:
             hard = float(hard)
         except (TypeError, ValueError):
+            import logging
+            logging.getLogger(__name__).warning(
+                "cost.*.hard_limit=%r is invalid (not a float); using %r",
+                hard, None,
+            )
             hard = None
     warn_ratio = raw.get("warn_ratio", 0.8)
     try:
         warn_ratio = float(warn_ratio)
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "cost.*.warn_ratio=%r is invalid (not a float); using %r",
+            warn_ratio, 0.8,
+        )
         warn_ratio = 0.8
     # FP-0005 (#1877): ``ask_on_exceed`` was subsumed into the unified
     # ``safety.on_limit`` 3-mode policy (clean-break, no shim). Warn an
@@ -1704,6 +1764,11 @@ def _build_cost_config(raw: object) -> CostConfig:
     try:
         warn_ratio = float(warn_ratio)
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "cost.rate_limit_warn_ratio=%r is invalid (not a float); using %r",
+            warn_ratio, 0.8,
+        )
         warn_ratio = 0.8
     return CostConfig(
         per_agent_tokens=_build_cost_limit(raw.get("per_agent_tokens")),

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -1705,6 +1705,11 @@ def _build_fs_watch_config(raw: object) -> FsWatchConfig:
     try:
         debounce_seconds = float(debounce)
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "fs_watch.debounce_seconds=%r is invalid (not a float); using %r",
+            debounce, 0.2,
+        )
         debounce_seconds = 0.2
     return FsWatchConfig(paths=paths, debounce_seconds=debounce_seconds)
 
@@ -1729,6 +1734,11 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         if cleanup_val < 0:
             cleanup_val = defaults.cleanup_period_days
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "audit_events.cleanup_period_days=%r is invalid (not an int); using %r",
+            cleanup, defaults.cleanup_period_days,
+        )
         cleanup_val = defaults.cleanup_period_days
     disk_percent = raw.get("max_disk_usage_percent", defaults.max_disk_usage_percent)
     try:
@@ -1736,6 +1746,11 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         if disk_percent_val < 0:
             disk_percent_val = defaults.max_disk_usage_percent
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "audit_events.max_disk_usage_percent=%r is invalid (not a float); using %r",
+            disk_percent, defaults.max_disk_usage_percent,
+        )
         disk_percent_val = defaults.max_disk_usage_percent
     # #4496 PR-2: `network` is a declared future value, not yet backed by an
     # implementation (see AuditEventsConfig.backend's own docstring) — an
@@ -1758,6 +1773,11 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         if coalesce_fragments_val <= 0:
             coalesce_fragments_val = defaults.agent_delta_coalesce_fragments
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "audit_events.agent_delta_coalesce_fragments=%r is invalid (not an int); using %r",
+            coalesce_fragments, defaults.agent_delta_coalesce_fragments,
+        )
         coalesce_fragments_val = defaults.agent_delta_coalesce_fragments
     coalesce_interval_ms = raw.get(
         "agent_delta_coalesce_interval_ms", defaults.agent_delta_coalesce_interval_ms,
@@ -1767,6 +1787,11 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         if coalesce_interval_ms_val <= 0:
             coalesce_interval_ms_val = defaults.agent_delta_coalesce_interval_ms
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "audit_events.agent_delta_coalesce_interval_ms=%r is invalid (not an int); using %r",
+            coalesce_interval_ms, defaults.agent_delta_coalesce_interval_ms,
+        )
         coalesce_interval_ms_val = defaults.agent_delta_coalesce_interval_ms
     # #4975: same "malformed/non-positive falls back to the default"
     # discipline as every other numeric field above.
@@ -1778,6 +1803,11 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         if provider_body_max_chars_val <= 0:
             provider_body_max_chars_val = defaults.provider_body_max_chars
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "audit_events.provider_body_max_chars=%r is invalid (not an int); using %r",
+            provider_body_max_chars, defaults.provider_body_max_chars,
+        )
         provider_body_max_chars_val = defaults.provider_body_max_chars
     # #5891: same "malformed/non-positive falls back to the default"
     # discipline as every other numeric field above.
@@ -1789,6 +1819,11 @@ def _build_audit_events_config(raw: object) -> AuditEventsConfig:
         if tool_result_max_chars_val <= 0:
             tool_result_max_chars_val = defaults.tool_result_max_chars
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "audit_events.tool_result_max_chars=%r is invalid (not an int); using %r",
+            tool_result_max_chars, defaults.tool_result_max_chars,
+        )
         tool_result_max_chars_val = defaults.tool_result_max_chars
     return AuditEventsConfig(
         max_bytes=int(raw.get("max_bytes", defaults.max_bytes)),
@@ -1911,6 +1946,11 @@ def _build_artifacts_config(raw: object) -> ArtifactsConfig:
         if limit_val <= 0:
             limit_val = defaults.remote_fallback_limit
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "artifacts.remote_fallback_limit=%r is invalid (not an int); using %r",
+            limit, defaults.remote_fallback_limit,
+        )
         limit_val = defaults.remote_fallback_limit
     return ArtifactsConfig(remote_fallback_limit=limit_val)
 

--- a/src/reyn/config/media.py
+++ b/src/reyn/config/media.py
@@ -187,11 +187,17 @@ def _build_web_fetch_config(raw: object) -> WebFetchConfig:
     else:
         verify_ssl = bool(verify_ssl_raw)
     defaults = WebFetchConfig()
+    max_download_bytes_raw = raw.get("max_download_bytes", defaults.max_download_bytes)
     try:
-        max_download_bytes = int(raw.get("max_download_bytes", defaults.max_download_bytes))
+        max_download_bytes = int(max_download_bytes_raw)
         if max_download_bytes <= 0:
             max_download_bytes = defaults.max_download_bytes
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "web_fetch.max_download_bytes=%r is invalid (not an int); using %r",
+            max_download_bytes_raw, defaults.max_download_bytes,
+        )
         max_download_bytes = defaults.max_download_bytes
     # #1956: bool, but tolerate a truthy string (e.g. an interpolated ${VAR}).
     ap_raw = raw.get("allow_private_ips")
@@ -258,11 +264,17 @@ def _build_gateway_config(raw: object) -> GatewayConfig:
     defaults."""
     if not isinstance(raw, dict):
         return GatewayConfig()
+    ws_max_size_raw = raw.get("ws_max_size", DEFAULT_WS_MAX_SIZE)
     try:
-        ws_max_size = int(raw.get("ws_max_size", DEFAULT_WS_MAX_SIZE))
+        ws_max_size = int(ws_max_size_raw)
         if ws_max_size <= 0:
             ws_max_size = DEFAULT_WS_MAX_SIZE
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "gateway.ws_max_size=%r is invalid (not an int); using %r",
+            ws_max_size_raw, DEFAULT_WS_MAX_SIZE,
+        )
         ws_max_size = DEFAULT_WS_MAX_SIZE
     default_design_raw = raw.get("default_design")
     default_design = (
@@ -369,6 +381,11 @@ def _build_multimodal_config(raw: object) -> MultimodalConfig:
     try:
         max_bytes = int(max_bytes_raw) if max_bytes_raw is not None else 5_000_000
     except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "multimodal.max_bytes=%r is invalid (not an int); using %r",
+            max_bytes_raw, 5_000_000,
+        )
         max_bytes = 5_000_000
     if max_bytes < 0:
         max_bytes = 5_000_000

--- a/tests/config/test_5990_chat_config_silent_except.py
+++ b/tests/config/test_5990_chat_config_silent_except.py
@@ -1,0 +1,202 @@
+"""Tier 1: #5990 (part of) — 13 `src/reyn/config/chat.py` parse-error sites
+that used to swallow a malformed value with a bare
+``except (TypeError, ValueError): x = default`` report NOTHING an
+operator would ever see (the issue's own census class). Each site now
+calls ``logging.getLogger(__name__).warning(...)`` on the SAME except
+branch before falling back — each test below pins, per site, BOTH
+halves (#5990 dispatch's own requirement): (a) the malformed value
+produces a visible warning, and (b) the default is still what is
+returned — a test checking only one half would pass even if the OTHER
+broke (the warning silently removed, or the fallback logic silently
+changed).
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.config.chat import (
+    CostConfig,
+    CostLimitConfig,
+    CostWarnConfig,
+    HistoryResidentConfig,
+    ImageConfig,
+    LogsConfig,
+    ProcessMemoryConfig,
+    ReadCapConfig,
+    RenderTemplateConfig,
+    TuiConfig,
+    _build_cost_config,
+    _build_cost_limit,
+    _build_cost_warn_config,
+    _build_history_resident_config,
+    _build_image_config,
+    _build_logs_config,
+    _build_process_memory_config,
+    _build_read_cap_config,
+    _build_render_template_config,
+    _build_tui_config,
+)
+
+_LOGGER_NAME = "reyn.config.chat"
+
+
+def test_render_template_max_output_chars_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `render_template.max_output_chars` — invalid value warns
+    AND the default (256_000) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_render_template_config({"max_output_chars": "oops"})
+    assert cfg.max_output_chars == RenderTemplateConfig().max_output_chars
+    assert any(
+        "render_template.max_output_chars" in r.message for r in caplog.records
+    )
+
+
+def test_render_template_wall_clock_seconds_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `render_template.wall_clock_seconds` — invalid value warns
+    AND the default (5.0) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_render_template_config({"wall_clock_seconds": "oops"})
+    assert cfg.wall_clock_seconds == RenderTemplateConfig().wall_clock_seconds
+    assert any(
+        "render_template.wall_clock_seconds" in r.message for r in caplog.records
+    )
+
+
+def test_read_cap_inline_bytes_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `read_cap.inline_bytes` — invalid value warns AND the
+    default (10_240) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_read_cap_config({"inline_bytes": "oops"})
+    assert cfg.inline_bytes == ReadCapConfig().inline_bytes
+    assert any("read_cap.inline_bytes" in r.message for r in caplog.records)
+
+
+def test_history_resident_max_bytes_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `history_resident.max_bytes` — invalid value warns AND the
+    default (256 MiB) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_history_resident_config({"max_bytes": "oops"})
+    assert cfg.max_bytes == HistoryResidentConfig().max_bytes
+    assert any("history_resident.max_bytes" in r.message for r in caplog.records)
+
+
+def test_logs_max_bytes_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `logs.max_bytes` — invalid value warns AND the default
+    (16 MiB) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_logs_config({"max_bytes": "oops"})
+    assert cfg.max_bytes == LogsConfig().max_bytes
+    assert any("logs.max_bytes" in r.message for r in caplog.records)
+
+
+def test_logs_backup_count_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `logs.backup_count` — invalid value warns AND the default
+    (4) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_logs_config({"backup_count": "oops"})
+    assert cfg.backup_count == LogsConfig().backup_count
+    assert any("logs.backup_count" in r.message for r in caplog.records)
+
+
+def test_process_memory_max_bytes_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `process_memory.max_bytes` — invalid value warns AND falls
+    back to the field's real default (None = no cap), never a magic
+    number."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_process_memory_config({"max_bytes": "oops"})
+    assert cfg.max_bytes == ProcessMemoryConfig().max_bytes is None
+    assert any("process_memory.max_bytes" in r.message for r in caplog.records)
+
+
+def test_image_row_height_cells_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `image.row_height_cells` — invalid value warns AND the
+    default (20) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_image_config({"row_height_cells": "oops"})
+    assert cfg.row_height_cells == ImageConfig().row_height_cells
+    assert any("image.row_height_cells" in r.message for r in caplog.records)
+
+
+def test_tui_context_usage_warn_percent_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `tui.context_usage_warn_percent` — invalid value warns AND
+    the default (80) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_tui_config({"context_usage_warn_percent": "oops"})
+    assert cfg.context_usage_warn_percent == TuiConfig().context_usage_warn_percent
+    assert any(
+        "tui.context_usage_warn_percent" in r.message for r in caplog.records
+    )
+
+
+def test_cost_warn_threshold_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `cost_warn.model_threshold_per_1m_input_usd` — invalid
+    value warns AND the default ($5/1M) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_cost_warn_config(
+            {"model_threshold_per_1m_input_usd": "oops"}
+        )
+    assert (
+        cfg.model_threshold_per_1m_input_usd
+        == CostWarnConfig().model_threshold_per_1m_input_usd
+    )
+    assert any(
+        "cost_warn.model_threshold_per_1m_input_usd" in r.message
+        for r in caplog.records
+    )
+
+
+def test_cost_limit_hard_limit_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `cost.*.hard_limit` (any `_build_cost_limit` namespace,
+    e.g. `per_agent_tokens`/`daily_tokens`) — invalid value warns AND
+    falls back to the field's real default (None = unlimited)."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_cost_limit({"hard_limit": "oops"})
+    assert cfg.hard_limit == CostLimitConfig().hard_limit is None
+    assert any("cost.*.hard_limit" in r.message for r in caplog.records)
+
+
+def test_cost_limit_warn_ratio_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `cost.*.warn_ratio` — invalid value warns AND the default
+    (0.8) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_cost_limit({"warn_ratio": "oops"})
+    assert cfg.warn_ratio == 0.8
+    assert any("cost.*.warn_ratio" in r.message for r in caplog.records)
+
+
+def test_cost_rate_limit_warn_ratio_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `cost.rate_limit_warn_ratio` — invalid value warns AND the
+    default (0.8) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_cost_config({"rate_limit_warn_ratio": "oops"})
+    assert cfg.rate_limit_warn_ratio == CostConfig().rate_limit_warn_ratio == 0.8
+    assert any("cost.rate_limit_warn_ratio" in r.message for r in caplog.records)
+
+
+# ── negative controls: a well-formed value never warns ──────────────────────
+
+
+def test_well_formed_render_template_values_do_not_warn(caplog) -> None:
+    """Tier 1: negative control — a well-formed `render_template:` block
+    parses through with no warning at all (the warning is specific to
+    the malformed-value branch, not emitted unconditionally)."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_render_template_config(
+            {"max_output_chars": 10, "wall_clock_seconds": 1.0}
+        )
+    assert cfg.max_output_chars == 10
+    assert cfg.wall_clock_seconds == 1.0
+    assert caplog.records == []
+
+
+def test_well_formed_cost_config_values_do_not_warn(caplog) -> None:
+    """Tier 1: negative control — a well-formed `cost:` block (including
+    a nested `_build_cost_limit` namespace) parses through with no
+    warning at all."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_cost_config(
+            {"rate_limit_warn_ratio": 0.5, "per_agent_tokens": {"hard_limit": 10}}
+        )
+    assert cfg.rate_limit_warn_ratio == 0.5
+    assert cfg.per_agent_tokens.hard_limit == 10.0
+    assert caplog.records == []

--- a/tests/config/test_5990_chat_config_silent_except.py
+++ b/tests/config/test_5990_chat_config_silent_except.py
@@ -186,7 +186,7 @@ def test_well_formed_render_template_values_do_not_warn(caplog) -> None:
         )
     assert cfg.max_output_chars == 10
     assert cfg.wall_clock_seconds == 1.0
-    assert caplog.records == []
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []
 
 
 def test_well_formed_cost_config_values_do_not_warn(caplog) -> None:
@@ -199,4 +199,4 @@ def test_well_formed_cost_config_values_do_not_warn(caplog) -> None:
         )
     assert cfg.rate_limit_warn_ratio == 0.5
     assert cfg.per_agent_tokens.hard_limit == 10.0
-    assert caplog.records == []
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/config/test_5990_infra_config_silent_except.py
+++ b/tests/config/test_5990_infra_config_silent_except.py
@@ -137,4 +137,4 @@ def test_well_formed_fs_watch_and_audit_events_do_not_warn(caplog) -> None:
     assert fs_cfg.debounce_seconds == 0.5
     assert audit_cfg.cleanup_period_days == 3
     assert audit_cfg.max_disk_usage_percent == 5.0
-    assert caplog.records == []
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/config/test_5990_infra_config_silent_except.py
+++ b/tests/config/test_5990_infra_config_silent_except.py
@@ -1,0 +1,140 @@
+"""Tier 1: #5990 (part of) — 8 `src/reyn/config/infra.py` parse-error sites
+that used to swallow a malformed value with a bare
+``except (TypeError, ValueError): x = default`` report NOTHING an
+operator would ever see. Each site now calls
+``logging.getLogger(__name__).warning(...)`` on the SAME except branch
+before falling back — each test below pins, per site, BOTH halves: (a)
+the malformed value produces a visible warning, and (b) the default is
+still what is returned.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.config.infra import (
+    ArtifactsConfig,
+    AuditEventsConfig,
+    FsWatchConfig,
+    _build_artifacts_config,
+    _build_audit_events_config,
+    _build_fs_watch_config,
+)
+
+_LOGGER_NAME = "reyn.config.infra"
+
+
+def test_fs_watch_debounce_seconds_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `fs_watch.debounce_seconds` — invalid value warns AND the
+    default (0.2) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_fs_watch_config({"paths": ["/x"], "debounce_seconds": "oops"})
+    assert cfg.debounce_seconds == FsWatchConfig().debounce_seconds
+    assert any("fs_watch.debounce_seconds" in r.message for r in caplog.records)
+
+
+def test_audit_events_cleanup_period_days_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `audit_events.cleanup_period_days` — invalid value warns
+    AND the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_audit_events_config({"cleanup_period_days": "oops"})
+    assert cfg.cleanup_period_days == AuditEventsConfig().cleanup_period_days
+    assert any(
+        "audit_events.cleanup_period_days" in r.message for r in caplog.records
+    )
+
+
+def test_audit_events_max_disk_usage_percent_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `audit_events.max_disk_usage_percent` — invalid value
+    warns AND the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_audit_events_config({"max_disk_usage_percent": "oops"})
+    assert cfg.max_disk_usage_percent == AuditEventsConfig().max_disk_usage_percent
+    assert any(
+        "audit_events.max_disk_usage_percent" in r.message for r in caplog.records
+    )
+
+
+def test_audit_events_coalesce_fragments_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `audit_events.agent_delta_coalesce_fragments` — invalid
+    value warns AND the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_audit_events_config(
+            {"agent_delta_coalesce_fragments": "oops"}
+        )
+    assert (
+        cfg.agent_delta_coalesce_fragments
+        == AuditEventsConfig().agent_delta_coalesce_fragments
+    )
+    assert any(
+        "audit_events.agent_delta_coalesce_fragments" in r.message
+        for r in caplog.records
+    )
+
+
+def test_audit_events_coalesce_interval_ms_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `audit_events.agent_delta_coalesce_interval_ms` — invalid
+    value warns AND the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_audit_events_config(
+            {"agent_delta_coalesce_interval_ms": "oops"}
+        )
+    assert (
+        cfg.agent_delta_coalesce_interval_ms
+        == AuditEventsConfig().agent_delta_coalesce_interval_ms
+    )
+    assert any(
+        "audit_events.agent_delta_coalesce_interval_ms" in r.message
+        for r in caplog.records
+    )
+
+
+def test_audit_events_provider_body_max_chars_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `audit_events.provider_body_max_chars` — invalid value
+    warns AND the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_audit_events_config({"provider_body_max_chars": "oops"})
+    assert (
+        cfg.provider_body_max_chars == AuditEventsConfig().provider_body_max_chars
+    )
+    assert any(
+        "audit_events.provider_body_max_chars" in r.message for r in caplog.records
+    )
+
+
+def test_audit_events_tool_result_max_chars_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `audit_events.tool_result_max_chars` — invalid value warns
+    AND the default (4000) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_audit_events_config({"tool_result_max_chars": "oops"})
+    assert cfg.tool_result_max_chars == AuditEventsConfig().tool_result_max_chars
+    assert any(
+        "audit_events.tool_result_max_chars" in r.message for r in caplog.records
+    )
+
+
+def test_artifacts_remote_fallback_limit_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `artifacts.remote_fallback_limit` — invalid value warns
+    AND the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_artifacts_config({"remote_fallback_limit": "oops"})
+    assert cfg.remote_fallback_limit == ArtifactsConfig().remote_fallback_limit
+    assert any(
+        "artifacts.remote_fallback_limit" in r.message for r in caplog.records
+    )
+
+
+# ── negative controls: well-formed values never warn ─────────────────────────
+
+
+def test_well_formed_fs_watch_and_audit_events_do_not_warn(caplog) -> None:
+    """Tier 1: negative control — well-formed `fs_watch:`/`audit_events:`
+    blocks parse through with no warning at all."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        fs_cfg = _build_fs_watch_config({"paths": ["/x"], "debounce_seconds": 0.5})
+        audit_cfg = _build_audit_events_config(
+            {"cleanup_period_days": 3, "max_disk_usage_percent": 5.0}
+        )
+    assert fs_cfg.debounce_seconds == 0.5
+    assert audit_cfg.cleanup_period_days == 3
+    assert audit_cfg.max_disk_usage_percent == 5.0
+    assert caplog.records == []

--- a/tests/config/test_5990_media_config_silent_except.py
+++ b/tests/config/test_5990_media_config_silent_except.py
@@ -66,4 +66,4 @@ def test_well_formed_media_values_do_not_warn(caplog) -> None:
     assert web_cfg.max_download_bytes == 123
     assert gw_cfg.ws_max_size == 456
     assert mm_cfg.max_bytes == 789
-    assert caplog.records == []
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/config/test_5990_media_config_silent_except.py
+++ b/tests/config/test_5990_media_config_silent_except.py
@@ -1,0 +1,69 @@
+"""Tier 1: #5990 (part of) — 3 `src/reyn/config/media.py` parse-error sites
+that used to swallow a malformed value with a bare
+``except (TypeError, ValueError): x = default`` report NOTHING an
+operator would ever see. Each site now calls
+``logging.getLogger(__name__).warning(...)`` on the SAME except branch
+before falling back — each test below pins, per site, BOTH halves: (a)
+the malformed value produces a visible warning, and (b) the default is
+still what is returned.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.config.media import (
+    DEFAULT_WS_MAX_SIZE,
+    GatewayConfig,
+    MultimodalConfig,
+    WebFetchConfig,
+    _build_gateway_config,
+    _build_multimodal_config,
+    _build_web_fetch_config,
+)
+
+_LOGGER_NAME = "reyn.config.media"
+
+
+def test_web_fetch_max_download_bytes_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `web_fetch.max_download_bytes` — invalid value warns AND
+    the default is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_web_fetch_config({"max_download_bytes": "oops"})
+    assert cfg.max_download_bytes == WebFetchConfig().max_download_bytes
+    assert any(
+        "web_fetch.max_download_bytes" in r.message for r in caplog.records
+    )
+
+
+def test_gateway_ws_max_size_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `gateway.ws_max_size` — invalid value warns AND the
+    default (`DEFAULT_WS_MAX_SIZE`) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_gateway_config({"ws_max_size": "oops"})
+    assert cfg.ws_max_size == DEFAULT_WS_MAX_SIZE == GatewayConfig().ws_max_size
+    assert any("gateway.ws_max_size" in r.message for r in caplog.records)
+
+
+def test_multimodal_max_bytes_warns_and_falls_back(caplog) -> None:
+    """Tier 1: `multimodal.max_bytes` — invalid value warns AND the
+    default (5_000_000) is still what ships."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        cfg = _build_multimodal_config({"max_bytes": "oops"})
+    assert cfg.max_bytes == MultimodalConfig().max_bytes
+    assert any("multimodal.max_bytes" in r.message for r in caplog.records)
+
+
+# ── negative controls: well-formed values never warn ─────────────────────────
+
+
+def test_well_formed_media_values_do_not_warn(caplog) -> None:
+    """Tier 1: negative control — well-formed `web_fetch:`/`gateway:`/
+    `multimodal:` blocks parse through with no warning at all."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        web_cfg = _build_web_fetch_config({"max_download_bytes": 123})
+        gw_cfg = _build_gateway_config({"ws_max_size": 456})
+        mm_cfg = _build_multimodal_config({"max_bytes": 789})
+    assert web_cfg.max_download_bytes == 123
+    assert gw_cfg.ws_max_size == 456
+    assert mm_cfg.max_bytes == 789
+    assert caplog.records == []


### PR DESCRIPTION
**[backlog-watcher]** — part of #5990. Fixes exactly the 24 sites from lead-coder's AST census (`origin/main` @ `99d68ccfd`): `src/reyn/config/chat.py` (13), `src/reyn/config/infra.py` (8), `src/reyn/config/media.py` (3).

## What changed

Each site was an `except (TypeError, ValueError): x = default` that silently swallowed a malformed raw config value and fell back to a default, with no visible report reaching the operator. Each now calls:

```python
import logging
logging.getLogger(__name__).warning(
    "<config.key>=%r is invalid (<reason>); using %r",
    <raw_value_expr>, <default_expr>,
)
```

on the SAME except branch, before falling back — the exact convention `chat.py`'s own `_build_render_mode` (#3273) already uses for its unknown-value case. Default behaviour is unchanged: an invalid value still starts up fine with the same default; the only change is that the fallback is no longer silent.

Sites fixed (dotted config key used in the warning message):
- `render_template.max_output_chars` / `.wall_clock_seconds`
- `read_cap.inline_bytes`
- `history_resident.max_bytes`
- `logs.max_bytes` / `.backup_count`
- `process_memory.max_bytes`
- `image.row_height_cells`
- `tui.context_usage_warn_percent`
- `cost_warn.model_threshold_per_1m_input_usd`
- `cost.*.hard_limit` / `.warn_ratio` (the shared `_build_cost_limit` namespace — `per_agent_tokens`/`daily_tokens`/etc. all route through it, mirroring the existing `cost.*.ask_on_exceed` deprecation-warning convention already in that function)
- `cost.rate_limit_warn_ratio`
- `fs_watch.debounce_seconds`
- `audit_events.cleanup_period_days` / `.max_disk_usage_percent` / `.agent_delta_coalesce_fragments` / `.agent_delta_coalesce_interval_ms` / `.provider_body_max_chars` / `.tool_result_max_chars`
- `artifacts.remote_fallback_limit`
- `web_fetch.max_download_bytes`
- `gateway.ws_max_size`
- `multimodal.max_bytes`

## Tests

`tests/config/test_5990_{chat,infra,media}_config_silent_except.py` — one test per site (24 sites) plus 3 negative controls. Each site's test checks BOTH halves per dispatch's rule 3:
- (a) feeding an invalid value triggers the warning (via `caplog`, matched against the logger name + the dotted config key in the message), AND
- (b) the field still holds the real default afterward.

The negative-control tests (one per module) prove a well-formed value never warns, so the warning is specific to the malformed branch, not unconditional.

No mocks — real builder functions, real dataclass defaults, `caplog` for the log assertion.

## Gates run locally

- [x] `ruff check .` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict <3 new test files>` — 28/28 OK
- [x] `python scripts/verify_module_docstrings.py <3 changed src files>` — OK
- [x] `python scripts/mypy_ratchet.py` — OK (changed-files, baselined)
- [x] `python scripts/flat_tests_ratchet.py` — OK
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (re-run right before push)
- [x] `tests/` path-conditional gates: `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py` — all OK
- [x] `pytest` scoped to the 3 new test files + the existing config/core tests touching the same builders (92 passed)
- [ ] (skipped — Visual; standing waiver, no UI surface touched)

## Test plan

- [x] Every fixed site's malformed-value branch now logs a `WARNING` with the dotted config key, the raw value, and the default
- [x] Every fixed site still returns the SAME default value it did before (no default-behaviour change)
- [x] Negative control: a well-formed value for each module produces zero warnings
- [x] All pre-PR gates above green locally

Part of #5990 — NOT closing it (34 other violation sites + a gate-design decision remain for a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5