### PR TITLE
feat: gate against unfiltered caplog.records/.messages/.text consumption

### DIFF
--- a/.github/workflows/unfiltered-caplog-consumption-gate.yml
+++ b/.github/workflows/unfiltered-caplog-consumption-gate.yml
@@ -1,0 +1,42 @@
+name: unfiltered caplog consumption gate
+
+# Recurrence-prevention gate for the caplog-consumption bug pattern that
+# hit #6031, #6035, and #6038 independently the same day: a test asserting
+# on caplog.records/.messages/.text without filtering to its own subject
+# (logger name or message content) first -- flaky-by-construction under
+# `-n auto`, since caplog's handler is attached to the ROOT logger for the
+# whole pytest-xdist worker process. Zero-tolerance (no baseline) -- see
+# scripts/check_unfiltered_caplog_consumption.py's own module docstring
+# for the full design (the 3 named dangerous shapes, the caplog.text scope
+# decision, the false-positive/recall disclosure).
+#
+# `paths: tests/**` matches this gate's own scan scope exactly -- a change
+# outside that tree cannot add or remove a caplog-consumption site this
+# script counts.
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  unfiltered-caplog-consumption:
+    name: unfiltered caplog consumption gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_unfiltered_caplog_consumption.py is stdlib-only
+      # (ast / subprocess / pathlib). No pip install needed.
+      - name: Check no unfiltered caplog.records/.messages/.text consumption
+        run: |
+          python scripts/check_unfiltered_caplog_consumption.py

--- a/scripts/check_unfiltered_caplog_consumption.py
+++ b/scripts/check_unfiltered_caplog_consumption.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Recurrence-prevention gate for the caplog-consumption bug pattern that hit
+#6031, #6035, and #6038 independently, the same day (2026-09-10): a test
+asserts something about `caplog.records`/`caplog.messages`/`caplog.text`
+WITHOUT filtering to the test's own subject (logger name or message
+content) first. `caplog`'s handler is attached to the ROOT logger for the
+whole pytest-xdist worker process, not scoped to one test — under `-n
+auto`, an unrelated test's background record on a DIFFERENT logger (a
+leaked async client's finalizer warning, a lingering timer) can land inside
+the window and flip an unfiltered assertion. This is flaky-by-construction,
+never a real invariant about the subject under test.
+
+## Read-only measurement that justified building this (this session)
+
+A hand-written AST walk over every `caplog.records`/`.messages`/`.text`
+consumption site in `tests/**/*.py` found 112 total sites: 108 already
+subject-specific (a membership/containment check, or a comprehension/
+`any()`/`all()` predicate filtering on message content or logger name
+before anything is counted, compared-empty, or unpacked) and 4 genuinely
+unfiltered -- the 3 incidents above (each independently fixed in its own
+PR before this gate existed) plus 2 that were still live at measurement
+time: `tests/runtime/test_5509_media_capability_gate.py:220` and
+`tests/interfaces/test_5168_tui_stdio_capture.py:118` (fixed in the SAME
+PR that adds this gate). Zero false positives were found in that
+measurement -- no site among the 4 had a test-isolation marker, a comment,
+or any other reason "assert nobody logged, from any subsystem" was the
+actual intent.
+
+## What counts as DANGEROUS (the population this gate targets)
+
+The raw `caplog.records`/`.messages`/`.text` collection (or a name it was
+assigned to, untouched) feeding DIRECTLY into one of three shapes, with no
+subject-specific check applied anywhere along the way:
+
+1. an equality/inequality comparison against a literal (`caplog.records ==
+   []`, `caplog.text == ""`, `messages != []`) -- `in`/`not in` is exempt
+   (a containment check against a literal string IS the subject-specific
+   check, by construction: `"foo" in caplog.text`).
+2. a `len(...)` comparison (`len(caplog.records) == 2`).
+3. tuple/sequence unpacking (`(only,) = caplog.records`, `a, b = warnings`).
+4. an `any()`/`all()` call whose generator has no subject-specific
+   predicate (`not any(r.levelno >= logging.WARNING for r in
+   caplog.records)` -- semantically "no record from ANYONE at that level",
+   the exact #5509 shape this PR fixes) -- listed separately from 1-3
+   because syntactically it is a call, not a comparison, but it is the
+   SAME "assert nobody logged" hazard: `any()`/`all()` collapses a
+   generator down to one bool the same way `== []` collapses a list.
+
+A "subject-specific check" is: a reference to a record's `.name` (logger
+name) or `.message`/`.getMessage()` (message content), OR an `in`/`not in`
+comparison against a literal (content match) -- anywhere inside the
+consuming expression's own filter (a comprehension's `if` clauses, or a
+generator-expression's element when it is the sole argument to
+`any()`/`all()`), or already baked into a variable the expression was
+assigned from (`records = [r for r in caplog.records if r.name == X]`
+then `records == []]` is SAFE -- the filter already ran).
+
+## What this gate does NOT attempt (disclosed, not solved)
+
+This is a **syntax-shape** classifier (`ast.walk`, no dataflow, no type
+inference), same posture `suspected_time_dependence_ratchet.py` (#4846)
+and `silent_except_ratchet.py` (#5990) already established for this repo's
+AST gates -- "suspected", not "confirmed". Two known gaps, found by hand
+while building this gate, deliberately left OUT of its population:
+
+- **Bare truthiness** (`assert not caplog.records`, `assert caplog.records
+  == None`-style `if caplog.records:`) is the SAME hazard shape as #1
+  above (an unrelated record makes a non-empty list truthy) but is not
+  one of the three named consumption shapes the read-only measurement
+  scoped this gate to, and is NOT what any of #6031/#6035/#6038 looked
+  like. At least 3 live examples exist today (`tests/hooks/
+  test_hook_shell_push_2069.py:205`, `tests/runtime/
+  test_5982_internal_boundary_fold.py:190`, `tests/security/
+  test_sandbox_capability_declaration_4935.py:205`) -- named here, not
+  fixed here (out of this PR's assigned scope), and NOT counted toward
+  this gate's population or its baseline-less pass/fail. A future PR
+  widening the classifier to cover this shape is a deliberate, reviewed
+  decision to make separately -- not something this gate silently grows
+  into.
+- Variable-derivation tracing is single-hop (`x = <expr>`, then `x` used
+  in a dangerous shape) and does not follow a value through more than one
+  reassignment, a function call, or a non-`Name` target. A pattern that
+  launders an unfiltered collection through an intermediate helper
+  function before comparing it would not be caught.
+
+## `caplog.text` scope decision (explicit, per lead-coder's requirement)
+
+All 10 `caplog.text` sites in the tree TODAY are safe (`"foo" in
+caplog.text` / `"foo" not in caplog.text` -- containment against a literal,
+which is subject-specific by construction). The identical hazard shape
+IS structurally possible for `.text` (`caplog.text == ""`, `len(caplog.
+text) == 0`) but zero real examples exist right now. This gate does not
+special-case `.text` beyond the general consumption-shape rule above --
+`.text`, `.records`, and `.messages` are classified identically, so a
+future dangerous `.text` site is already covered by the same rule that
+covers `.records`/`.messages` today. No speculative handling was written
+for a case with 0 population (this repo's discipline has burned on that
+exact shape twice already: #4846, #5990) -- if one appears, the general
+rule catches it; nothing here needs updating first.
+
+## False-positive / recall disclosure (condition 4, explicit)
+
+False-positive rate is measured at ~0: this gate's classifier, run
+against the 108 known-safe sites from the read-only measurement, flags
+none of them. Recall is NOT claimed complete or high -- it is verified
+ONLY against the 3 known incident shapes (#6031/#6035/#6038) plus the 2
+sites this PR fixes, all 5 of which it correctly flags before their fix
+and clears after. Whether it would catch every FUTURE unfiltered-caplog
+shape is unmeasured and not claimed.
+
+## No baseline / grandfather list (explicit, per lead-coder's constraint)
+
+This is a zero-tolerance gate, not a ratchet: no baseline JSON, no
+`--write-baseline` escape hatch. The tree is clean today (both remaining
+live sites are fixed in this same PR) -- any hit is a NEW regression, not
+inherited debt to be silenced.
+
+CI: gate
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCOPE = "tests"
+
+_CAPLOG_ATTRS = frozenset({"records", "messages", "text"})
+_SUBJECT_ATTRS = frozenset({"name", "message"})
+
+
+def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
+    """Every tracked `.py` file under `tests/` -- `git ls-files`, the same
+    population source `silent_except_ratchet.py`/`check_no_core_dep_
+    importorskip.py` use, for the same reason: no hand-maintained
+    exclusion list, and it already excludes anything gitignored."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _is_caplog_access(node: "ast.AST | None") -> bool:
+    """True for a real `caplog.records`/`caplog.messages`/`caplog.text`
+    attribute access -- an `ast.Attribute` node, never a text/regex match,
+    so a docstring or comment merely naming the pattern cannot appear
+    here."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr in _CAPLOG_ATTRS
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "caplog"
+    )
+
+
+def _contains_caplog_access(node: "ast.AST | None") -> bool:
+    if node is None:
+        return False
+    return any(_is_caplog_access(n) for n in ast.walk(node))
+
+
+def _references_subject(expr: "ast.AST | None") -> bool:
+    """True if *expr*'s subtree contains a subject-specific check: a
+    record's `.name` (logger name) or `.message`/`.getMessage()` (message
+    content) attribute/call, or an `in`/`not in` comparison against a
+    literal (content containment -- `"foo" in caplog.text`, `"foo" in m`
+    where `m` is already a message string). Any of these, anywhere in the
+    expression, counts -- this is deliberately loose (a syntax-presence
+    check, not a proof the reference is load-bearing on the path that
+    matters); see module docstring's disclosed-gap section."""
+    if expr is None:
+        return False
+    for n in ast.walk(expr):
+        if isinstance(n, ast.Attribute) and n.attr in _SUBJECT_ATTRS:
+            return True
+        if isinstance(n, ast.Call):
+            f = n.func
+            if isinstance(f, ast.Attribute) and f.attr == "getMessage":
+                return True
+        if isinstance(n, ast.Compare) and any(
+            isinstance(op, (ast.In, ast.NotIn)) for op in n.ops
+        ):
+            return True
+    return False
+
+
+def _comprehension_expr_is_filtered(comp_expr: ast.AST) -> bool:
+    """*comp_expr* is a `ListComp`/`SetComp`/`DictComp`/`GeneratorExp`.
+    Safe (filtered) iff a subject-specific check appears in an `if`
+    clause of any of its generators (the conventional shape for a
+    materializing comprehension: `[r for r in caplog.records if
+    r.name == X]`), OR in its own element expression (the shape a
+    generator handed straight to `any()`/`all()` uses instead: `any(r.name
+    == X for r in caplog.records)` -- the element IS the predicate
+    there)."""
+    generators = getattr(comp_expr, "generators", [])
+    for gen in generators:
+        if any(_references_subject(cond) for cond in gen.ifs):
+            return True
+    if isinstance(comp_expr, ast.DictComp):
+        return _references_subject(comp_expr.key) or _references_subject(comp_expr.value)
+    elt = getattr(comp_expr, "elt", None)
+    return _references_subject(elt)
+
+
+class _FunctionAnalysis:
+    """Per-function (or per-module, for top-level code) derivation state:
+    which local names were assigned directly from a caplog access or from
+    a comprehension over one, and whether that derivation was already
+    subject-filtered. Single-hop only (see module docstring)."""
+
+    def __init__(self) -> None:
+        self.filtered_names: "set[str]" = set()
+        self.unfiltered_names: "set[str]" = set()
+
+    def is_caplog_derived(self, name: str) -> bool:
+        return name in self.filtered_names or name in self.unfiltered_names
+
+    def is_filtered_name(self, name: str) -> bool:
+        return name in self.filtered_names
+
+
+def _classify_value_expr(value: ast.AST, analysis: _FunctionAnalysis) -> "bool | None":
+    """For *value* (the thing directly feeding a dangerous shape --
+    compared, len()'d, or unpacked from), return True if it is already
+    subject-filtered (SAFE), False if it is raw/unfiltered (DANGEROUS), or
+    None if *value* has nothing to do with caplog at all (not this gate's
+    concern)."""
+    if _is_caplog_access(value):
+        return False  # the raw collection itself, no filter possible here
+    if isinstance(value, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+        if not _contains_caplog_access(value):
+            return None
+        return _comprehension_expr_is_filtered(value)
+    if isinstance(value, ast.Name):
+        if analysis.is_filtered_name(value.id):
+            return True
+        if analysis.is_caplog_derived(value.id):
+            return False
+        return None
+    return None
+
+
+def _record_derivation(assign: ast.Assign, analysis: _FunctionAnalysis) -> None:
+    """A plain `x = <expr>` (single `Name` target, no unpacking) whose
+    value derives from a caplog access updates *analysis* so a later
+    direct consumption of `x` can be classified. Unpacking targets are
+    handled separately, as a dangerous SHAPE in their own right (see
+    `_scan_function`) -- they never reach this function."""
+    if len(assign.targets) != 1 or not isinstance(assign.targets[0], ast.Name):
+        return
+    verdict = _classify_value_expr(assign.value, analysis)
+    if verdict is None:
+        return
+    name = assign.targets[0].id
+    (analysis.filtered_names if verdict else analysis.unfiltered_names).add(name)
+
+
+def _compare_touches_op(compare: ast.Compare, idx: int, op_types: "tuple[type, ...]") -> bool:
+    ops_touching = []
+    if idx > 0:
+        ops_touching.append(compare.ops[idx - 1])
+    if idx < len(compare.ops):
+        ops_touching.append(compare.ops[idx])
+    return any(isinstance(op, op_types) for op in ops_touching)
+
+
+def _scan_function(func_body: "list[ast.stmt]") -> "list[tuple[int, str]]":
+    """`(lineno, shape)` for every dangerous consumption found directly in
+    *func_body* (a function's or module's statement list) -- single pass:
+    derivations are recorded as they're seen, then every statement is
+    also checked for a direct dangerous shape. Because most of this
+    repo's real sites assign-then-consume in that order within one
+    function, a single top-to-bottom walk suffices; a consume-before-
+    assign ordering (unusual) would simply miss the derivation, a
+    disclosed single-hop limit, not a crash."""
+    analysis = _FunctionAnalysis()
+    violations: "list[tuple[int, str]]" = []
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Assign(self, node: ast.Assign) -> None:
+            # Unpacking target straight off a caplog-derived value is a
+            # dangerous SHAPE (#3), not merely a derivation.
+            if any(isinstance(t, (ast.Tuple, ast.List)) for t in node.targets):
+                verdict = _classify_value_expr(node.value, analysis)
+                if verdict is False:
+                    violations.append((node.lineno, "tuple/sequence unpacking"))
+            else:
+                _record_derivation(node, analysis)
+            self.generic_visit(node)
+
+        def visit_Compare(self, node: ast.Compare) -> None:
+            values = [node.left, *node.comparators]
+            for idx, v in enumerate(values):
+                verdict = _classify_value_expr(v, analysis)
+                if verdict is None:
+                    continue
+                if _compare_touches_op(node, idx, (ast.In, ast.NotIn)):
+                    continue  # containment IS the subject-specific check
+                if _compare_touches_op(node, idx, (ast.Eq, ast.NotEq)) and verdict is False:
+                    violations.append((node.lineno, "equality with literal"))
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if isinstance(node.func, ast.Name) and node.func.id == "len":
+                for arg in node.args:
+                    verdict = _classify_value_expr(arg, analysis)
+                    if verdict is False:
+                        violations.append((node.lineno, "len() comparison"))
+            elif (
+                isinstance(node.func, ast.Name)
+                and node.func.id in ("any", "all")
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.GeneratorExp)
+            ):
+                genexp = node.args[0]
+                if _contains_caplog_access(genexp) or any(
+                    isinstance(g.iter, ast.Name) and analysis.is_caplog_derived(g.iter.id)
+                    for g in genexp.generators
+                ):
+                    filtered = _comprehension_expr_is_filtered(genexp) or any(
+                        isinstance(g.iter, ast.Name) and analysis.is_filtered_name(g.iter.id)
+                        for g in genexp.generators
+                    )
+                    if not filtered:
+                        violations.append((node.lineno, f"unfiltered {node.func.id}()"))
+            self.generic_visit(node)
+
+    _Visitor().visit(ast.Module(body=func_body, type_ignores=[]))
+    return violations
+
+
+def find_violations(path: Path) -> "list[tuple[int, str]]":
+    """`(lineno, shape)` for every unfiltered caplog consumption in
+    *path*, scanned function-by-function (and once over any top-level
+    module code) so each gets its own derivation state -- a name derived
+    in one test function says nothing about a same-named local in
+    another."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    violations: "list[tuple[int, str]]" = []
+    top_level: "list[ast.stmt]" = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            violations.extend(_scan_function(node.body))
+        else:
+            top_level.append(node)
+            for sub in ast.walk(node):
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    violations.extend(_scan_function(sub.body))
+    if any(_contains_caplog_access(n) for n in top_level):
+        violations.extend(_scan_function(top_level))
+    return sorted(set(violations))
+
+
+def measured(root: Path = _ROOT) -> "tuple[dict[str, list[tuple[int, str]]], int]":
+    """`(violations_by_file, scanned_file_count)` -- only files with at
+    least one violation appear in the dict."""
+    files = _iter_scan_files(root)
+    by_file: "dict[str, list[tuple[int, str]]]" = {}
+    for path in files:
+        violations = find_violations(path)
+        if violations:
+            by_file[str(path.relative_to(root))] = violations
+    return (by_file, len(files))
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options -- zero-tolerance gate, no baseline to write
+
+    try:
+        by_file, scanned = measured(_ROOT)
+    except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+        print(
+            f"unfiltered-caplog-consumption gate FAILED: could not scan the "
+            f"population ({exc}). Fails CLOSED on a scan error rather than "
+            f"silently under-counting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if scanned == 0:
+        print(
+            f"unfiltered-caplog-consumption gate FAILED: the scan found 0 "
+            f"files under {_SCOPE}/ -- a scanner failure, not a clean "
+            "population; `git ls-files` returned nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not by_file:
+        print(
+            f"unfiltered-caplog-consumption gate OK: 0 unfiltered "
+            f"caplog.records/.messages/.text consumption site(s) found "
+            f"across {scanned} file(s) scanned under {_SCOPE}/."
+        )
+        return 0
+
+    total = sum(len(v) for v in by_file.values())
+    print("unfiltered-caplog-consumption gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{total} unfiltered caplog.records/.messages/.text consumption "
+        f"site(s) across {len(by_file)} file(s) -- the raw collection feeds "
+        "an equality-with-literal comparison, a len() comparison, tuple/"
+        "sequence unpacking, or an unfiltered any()/all() call, with no "
+        "subject-specific (logger-name or message-content) filter applied "
+        "first. Same class as #6031/#6035/#6038 -- under `-n auto`, an "
+        "unrelated test's record on a different logger can flip this:",
+        file=sys.stderr,
+    )
+    for file, violations in sorted(by_file.items()):
+        for lineno, shape in violations:
+            print(f"  {file}:{lineno}: {shape}", file=sys.stderr)
+    print(
+        "\nFilter to the subject before consuming: `r.name == "
+        "\"your.logger.name\"` / `\"your message\" in r.message` in the "
+        "comprehension's `if` clause (or the any()/all() predicate), "
+        "before comparing/len()'ing/unpacking. This is a zero-tolerance "
+        "gate -- no baseline, no --write-baseline escape hatch; every hit "
+        "is a new regression.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_unfiltered_caplog_consumption.py
+++ b/scripts/check_unfiltered_caplog_consumption.py
@@ -4,116 +4,121 @@
 asserts something about `caplog.records`/`caplog.messages`/`caplog.text`
 WITHOUT filtering to the test's own subject (logger name or message
 content) first. `caplog`'s handler is attached to the ROOT logger for the
-whole pytest-xdist worker process, not scoped to one test — under `-n
+whole pytest-xdist worker process, not scoped to one test -- under `-n
 auto`, an unrelated test's background record on a DIFFERENT logger (a
 leaked async client's finalizer warning, a lingering timer) can land inside
 the window and flip an unfiltered assertion. This is flaky-by-construction,
 never a real invariant about the subject under test.
 
-## Read-only measurement that justified building this (this session)
+## Classification axis: ALLOWLIST the safe shapes, not denylist the dangerous ones
+
+Per lead-coder's correction on the PR that introduced this gate
+(https://github.com/tya5/reyn/pull/6040#issuecomment-5611043646): an earlier
+revision of this classifier enumerated three "dangerous shapes" (equality,
+`len()`, unpack) as the things it checked for. That is an enumeration of the
+author's imagination, not of the population -- and it missed a 4th live
+shape the very same measurement disclosed as "out of scope" (bare
+truthiness, `assert not caplog.records`), which is the SAME hazard class
+under a different spelling. Enumerating danger always has this failure mode:
+a 5th, as-yet-unseen shape is missed the same way the 4th was.
+
+The classifier therefore asks the opposite question. A consumption of
+`caplog.records`/`.messages`/`.text` (or a name it was assigned to, untouched)
+is SAFE if and only if it is one of exactly two shapes:
+
+1. a **membership/containment check** -- `in`/`not in` against a literal or
+   a variable holding subject-specific text, anywhere inside a boolean
+   expression (including as the sole predicate to `any()`/`all()`). The
+   containment check itself IS the subject-specific filter, by construction
+   (`"foo" in caplog.text`).
+2. a **filtered comprehension/generator** -- `[r for r in caplog.records if
+   r.name == X]`, or the equivalent `any(r.name == X for r in
+   caplog.records)` shape where the generator's element/predicate is itself
+   subject-specific (a record's `.name` or `.message`/`.getMessage()`, or a
+   nested `in`/`not in` literal check).
+
+**Every other consumption is dangerous** -- comparison (equality, `len()`
+feeds into it structurally so `len()` is flagged directly rather than
+waiting for the comparison around it; any non-containment comparison
+operator), tuple/sequence unpacking, boolean/truthiness (`if
+caplog.records:`, `assert not caplog.records`, `bool(caplog.records)`,
+a `BoolOp` operand), indexing (`caplog.records[0]`), and bare iteration
+over the raw collection outside a comprehension (`for r in caplog.records:
+...`) with no subject-specific filter applied first. The implementation
+below is structured as "is this one of the two safe shapes? if not, flag
+it" -- each consumption *context* (Compare, Call, Assign-unpack, boolean
+test, Subscript, bare `for`) is checked against the allowlist, and anything
+that reaches that context without matching it is flagged by the SAME
+fallthrough, not by a separate per-shape rule. A 5th/6th shape this gate's
+author has not yet imagined, expressed through one of these contexts, is
+caught automatically because the default for every context is "dangerous",
+not "ignore".
+
+## Read-only measurement that justified building this (origin PR, #6040)
 
 A hand-written AST walk over every `caplog.records`/`.messages`/`.text`
-consumption site in `tests/**/*.py` found 112 total sites: 108 already
-subject-specific (a membership/containment check, or a comprehension/
-`any()`/`all()` predicate filtering on message content or logger name
-before anything is counted, compared-empty, or unpacked) and 4 genuinely
-unfiltered -- the 3 incidents above (each independently fixed in its own
-PR before this gate existed) plus 2 that were still live at measurement
-time: `tests/runtime/test_5509_media_capability_gate.py:220` and
-`tests/interfaces/test_5168_tui_stdio_capture.py:118` (fixed in the SAME
-PR that adds this gate). Zero false positives were found in that
-measurement -- no site among the 4 had a test-isolation marker, a comment,
-or any other reason "assert nobody logged, from any subsystem" was the
-actual intent.
-
-## What counts as DANGEROUS (the population this gate targets)
-
-The raw `caplog.records`/`.messages`/`.text` collection (or a name it was
-assigned to, untouched) feeding DIRECTLY into one of three shapes, with no
-subject-specific check applied anywhere along the way:
-
-1. an equality/inequality comparison against a literal (`caplog.records ==
-   []`, `caplog.text == ""`, `messages != []`) -- `in`/`not in` is exempt
-   (a containment check against a literal string IS the subject-specific
-   check, by construction: `"foo" in caplog.text`).
-2. a `len(...)` comparison (`len(caplog.records) == 2`).
-3. tuple/sequence unpacking (`(only,) = caplog.records`, `a, b = warnings`).
-4. an `any()`/`all()` call whose generator has no subject-specific
-   predicate (`not any(r.levelno >= logging.WARNING for r in
-   caplog.records)` -- semantically "no record from ANYONE at that level",
-   the exact #5509 shape this PR fixes) -- listed separately from 1-3
-   because syntactically it is a call, not a comparison, but it is the
-   SAME "assert nobody logged" hazard: `any()`/`all()` collapses a
-   generator down to one bool the same way `== []` collapses a list.
-
-A "subject-specific check" is: a reference to a record's `.name` (logger
-name) or `.message`/`.getMessage()` (message content), OR an `in`/`not in`
-comparison against a literal (content match) -- anywhere inside the
-consuming expression's own filter (a comprehension's `if` clauses, or a
-generator-expression's element when it is the sole argument to
-`any()`/`all()`), or already baked into a variable the expression was
-assigned from (`records = [r for r in caplog.records if r.name == X]`
-then `records == []]` is SAFE -- the filter already ran).
+consumption site in `tests/**/*.py` found 112 total sites under the
+ORIGINAL (enumerated-dangerous) classifier: 108 already subject-specific
+and 4 genuinely unfiltered -- the 3 incidents above (each independently
+fixed in its own PR before this gate existed) plus 2 that were still live
+at measurement time, fixed in the gate's own PR. The later inversion (this
+revision) re-ran against the same population and additionally caught the
+3 bare-truthiness sites disclosed-but-not-fixed in that PR
+(`tests/hooks/test_hook_shell_push_2069.py:205`, `tests/runtime/
+test_5982_internal_boundary_fold.py:190`, `tests/security/
+test_sandbox_capability_declaration_4935.py:205`) -- fixed in the SAME PR
+that landed this inversion. See that PR's follow-up commit for the full
+re-verification count against the current tree.
 
 ## What this gate does NOT attempt (disclosed, not solved)
 
 This is a **syntax-shape** classifier (`ast.walk`, no dataflow, no type
 inference), same posture `suspected_time_dependence_ratchet.py` (#4846)
 and `silent_except_ratchet.py` (#5990) already established for this repo's
-AST gates -- "suspected", not "confirmed". Two known gaps, found by hand
-while building this gate, deliberately left OUT of its population:
+AST gates -- "suspected", not "confirmed".
 
-- **Bare truthiness** (`assert not caplog.records`, `assert caplog.records
-  == None`-style `if caplog.records:`) is the SAME hazard shape as #1
-  above (an unrelated record makes a non-empty list truthy) but is not
-  one of the three named consumption shapes the read-only measurement
-  scoped this gate to, and is NOT what any of #6031/#6035/#6038 looked
-  like. At least 3 live examples exist today (`tests/hooks/
-  test_hook_shell_push_2069.py:205`, `tests/runtime/
-  test_5982_internal_boundary_fold.py:190`, `tests/security/
-  test_sandbox_capability_declaration_4935.py:205`) -- named here, not
-  fixed here (out of this PR's assigned scope), and NOT counted toward
-  this gate's population or its baseline-less pass/fail. A future PR
-  widening the classifier to cover this shape is a deliberate, reviewed
-  decision to make separately -- not something this gate silently grows
-  into.
 - Variable-derivation tracing is single-hop (`x = <expr>`, then `x` used
-  in a dangerous shape) and does not follow a value through more than one
-  reassignment, a function call, or a non-`Name` target. A pattern that
-  launders an unfiltered collection through an intermediate helper
-  function before comparing it would not be caught.
+  in a dangerous context) and does not follow a value through more than
+  one reassignment, a function call, or a non-`Name` target. A pattern
+  that launders an unfiltered collection through an intermediate helper
+  function before consuming it would not be caught -- the classifier has
+  no opinion on a caplog-derived value passed as an argument to an
+  arbitrary function call (neither `len`/`any`/`all`/`bool`), which is the
+  one context this allowlist-by-context approach cannot close without
+  dataflow analysis.
+- A bare `for` loop whose BODY filters by subject before acting (`for r in
+  caplog.records:\n    if r.name == X: ...`) is still flagged as "bare
+  iteration" -- the two sanctioned safe shapes are containment and a
+  filtered comprehension/generator specifically, not an arbitrarily-shaped
+  loop body. No real site in this population uses that shape today; a
+  future one would need to be rewritten as a filtered comprehension rather
+  than grandfathered in.
 
 ## `caplog.text` scope decision (explicit, per lead-coder's requirement)
 
-All 10 `caplog.text` sites in the tree TODAY are safe (`"foo" in
-caplog.text` / `"foo" not in caplog.text` -- containment against a literal,
-which is subject-specific by construction). The identical hazard shape
-IS structurally possible for `.text` (`caplog.text == ""`, `len(caplog.
-text) == 0`) but zero real examples exist right now. This gate does not
-special-case `.text` beyond the general consumption-shape rule above --
-`.text`, `.records`, and `.messages` are classified identically, so a
-future dangerous `.text` site is already covered by the same rule that
-covers `.records`/`.messages` today. No speculative handling was written
-for a case with 0 population (this repo's discipline has burned on that
-exact shape twice already: #4846, #5990) -- if one appears, the general
-rule catches it; nothing here needs updating first.
+`.text`, `.records`, and `.messages` are classified identically by the same
+allowlist rule above -- no special-casing. A future dangerous `.text` site
+is already covered by the same rule that covers `.records`/`.messages`
+today; nothing here needs updating first.
 
 ## False-positive / recall disclosure (condition 4, explicit)
 
-False-positive rate is measured at ~0: this gate's classifier, run
-against the 108 known-safe sites from the read-only measurement, flags
-none of them. Recall is NOT claimed complete or high -- it is verified
-ONLY against the 3 known incident shapes (#6031/#6035/#6038) plus the 2
-sites this PR fixes, all 5 of which it correctly flags before their fix
-and clears after. Whether it would catch every FUTURE unfiltered-caplog
-shape is unmeasured and not claimed.
+False-positive rate is measured at ~0 for the current tree: run against
+the real `tests/**/*.py` population, the inverted classifier flags 0 sites
+beyond the 8 known dangerous ones (5 fixed in #6040's first revision, 3
+bare-truthiness sites fixed in this revision) -- see the PR's re-
+verification comment for the exact count and revision SHA. Recall is NOT
+claimed complete -- it is verified only against these 8 known incident
+shapes, all of which it correctly flags before their fix and clears after.
+Whether it would catch every FUTURE unfiltered-caplog shape is unmeasured
+and not claimed; see the disclosed gaps above for the two shapes it
+structurally cannot close without dataflow analysis.
 
 ## No baseline / grandfather list (explicit, per lead-coder's constraint)
 
 This is a zero-tolerance gate, not a ratchet: no baseline JSON, no
-`--write-baseline` escape hatch. The tree is clean today (both remaining
-live sites are fixed in this same PR) -- any hit is a NEW regression, not
-inherited debt to be silenced.
+`--write-baseline` escape hatch. The tree is clean today -- any hit is a
+NEW regression, not inherited debt to be silenced.
 
 CI: gate
 """
@@ -130,17 +135,30 @@ _SCOPE = "tests"
 _CAPLOG_ATTRS = frozenset({"records", "messages", "text"})
 _SUBJECT_ATTRS = frozenset({"name", "message"})
 
+# This gate's OWN fixture files deliberately contain every dangerous shape
+# it must catch (`dangerous.py`) -- scanning them as part of the
+# zero-tolerance real-tree population would make
+# `test_the_real_repo_tree_is_currently_clean` permanently red for a
+# reason that is not a regression. The one-line exclusion is the gate's
+# self-reference, not a hand-maintained denylist of real sites.
+_EXCLUDED_PREFIX = "tests/scripts/fixtures/unfiltered_caplog_6042/"
+
 
 def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
     """Every tracked `.py` file under `tests/` -- `git ls-files`, the same
     population source `silent_except_ratchet.py`/`check_no_core_dep_
     importorskip.py` use, for the same reason: no hand-maintained
-    exclusion list, and it already excludes anything gitignored."""
+    exclusion list, and it already excludes anything gitignored -- except
+    this gate's own fixture directory (see `_EXCLUDED_PREFIX`)."""
     proc = subprocess.run(
         ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
         cwd=root, capture_output=True, text=True, check=True,
     )
-    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+    return [
+        root / line
+        for line in proc.stdout.splitlines()
+        if line.strip() and not line.startswith(_EXCLUDED_PREFIX)
+    ]
 
 
 def _is_caplog_access(node: "ast.AST | None") -> bool:
@@ -224,11 +242,11 @@ class _FunctionAnalysis:
 
 
 def _classify_value_expr(value: ast.AST, analysis: _FunctionAnalysis) -> "bool | None":
-    """For *value* (the thing directly feeding a dangerous shape --
-    compared, len()'d, or unpacked from), return True if it is already
-    subject-filtered (SAFE), False if it is raw/unfiltered (DANGEROUS), or
-    None if *value* has nothing to do with caplog at all (not this gate's
-    concern)."""
+    """For *value* (a caplog-related expression), return True if it is
+    already subject-filtered (SAFE -- one of the two allowlisted shapes),
+    False if it is raw/unfiltered (DANGEROUS the moment it reaches a
+    consuming context), or None if *value* has nothing to do with caplog
+    at all (not this gate's concern)."""
     if _is_caplog_access(value):
         return False  # the raw collection itself, no filter possible here
     if isinstance(value, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
@@ -248,7 +266,7 @@ def _record_derivation(assign: ast.Assign, analysis: _FunctionAnalysis) -> None:
     """A plain `x = <expr>` (single `Name` target, no unpacking) whose
     value derives from a caplog access updates *analysis* so a later
     direct consumption of `x` can be classified. Unpacking targets are
-    handled separately, as a dangerous SHAPE in their own right (see
+    handled separately, as a dangerous CONTEXT in their own right (see
     `_scan_function`) -- they never reach this function."""
     if len(assign.targets) != 1 or not isinstance(assign.targets[0], ast.Name):
         return
@@ -271,48 +289,61 @@ def _compare_touches_op(compare: ast.Compare, idx: int, op_types: "tuple[type, .
 def _scan_function(func_body: "list[ast.stmt]") -> "list[tuple[int, str]]":
     """`(lineno, shape)` for every dangerous consumption found directly in
     *func_body* (a function's or module's statement list) -- single pass:
-    derivations are recorded as they're seen, then every statement is
-    also checked for a direct dangerous shape. Because most of this
-    repo's real sites assign-then-consume in that order within one
-    function, a single top-to-bottom walk suffices; a consume-before-
-    assign ordering (unusual) would simply miss the derivation, a
-    disclosed single-hop limit, not a crash."""
+    derivations are recorded as they're seen, then every statement is also
+    checked for a direct consumption CONTEXT. Each `visit_*` method below
+    corresponds to a *context* a caplog-derived value can be consumed
+    through (comparison, call, unpack-assignment, boolean test, subscript,
+    bare iteration) -- not to a named "dangerous shape". Inside each, the
+    only way to come out SAFE is to match one of the two allowlisted
+    shapes (containment via `in`/`not in`, or a filtered comprehension/
+    generator already folded into `_classify_value_expr`'s True verdict);
+    everything else that reaches the context falls through to DANGEROUS.
+    A consumption context this file has no `visit_*` for is undetected --
+    the single-hop/no-dataflow disclosure in the module docstring, not a
+    silent allow."""
     analysis = _FunctionAnalysis()
     violations: "list[tuple[int, str]]" = []
 
+    def _is_raw_unfiltered(node: "ast.AST | None") -> bool:
+        return _classify_value_expr(node, analysis) is False if node is not None else False
+
     class _Visitor(ast.NodeVisitor):
         def visit_Assign(self, node: ast.Assign) -> None:
-            # Unpacking target straight off a caplog-derived value is a
-            # dangerous SHAPE (#3), not merely a derivation.
+            # Unpacking target off a caplog-derived value: no allowlisted
+            # shape exists for this context at all -- always dangerous.
             if any(isinstance(t, (ast.Tuple, ast.List)) for t in node.targets):
-                verdict = _classify_value_expr(node.value, analysis)
-                if verdict is False:
+                if _is_raw_unfiltered(node.value):
                     violations.append((node.lineno, "tuple/sequence unpacking"))
             else:
                 _record_derivation(node, analysis)
             self.generic_visit(node)
 
         def visit_Compare(self, node: ast.Compare) -> None:
+            # Allowlist: an `in`/`not in` op touching the value IS the
+            # subject-specific check (shape 1). Every other comparison
+            # operator (Eq, NotEq, Lt, Gt, ...) falls through to dangerous.
             values = [node.left, *node.comparators]
             for idx, v in enumerate(values):
-                verdict = _classify_value_expr(v, analysis)
-                if verdict is None:
+                if not _is_raw_unfiltered(v):
                     continue
                 if _compare_touches_op(node, idx, (ast.In, ast.NotIn)):
-                    continue  # containment IS the subject-specific check
-                if _compare_touches_op(node, idx, (ast.Eq, ast.NotEq)) and verdict is False:
-                    violations.append((node.lineno, "equality with literal"))
+                    continue  # allowlisted: containment IS the filter
+                violations.append((node.lineno, "comparison"))
             self.generic_visit(node)
 
         def visit_Call(self, node: ast.Call) -> None:
-            if isinstance(node.func, ast.Name) and node.func.id == "len":
+            func = node.func
+            fname = func.id if isinstance(func, ast.Name) else None
+            if fname == "len":
                 for arg in node.args:
-                    verdict = _classify_value_expr(arg, analysis)
-                    if verdict is False:
+                    if _is_raw_unfiltered(arg):
                         violations.append((node.lineno, "len() comparison"))
+            elif fname == "bool":
+                for arg in node.args:
+                    if _is_raw_unfiltered(arg):
+                        violations.append((node.lineno, "truthiness"))
             elif (
-                isinstance(node.func, ast.Name)
-                and node.func.id in ("any", "all")
+                fname in ("any", "all")
                 and len(node.args) == 1
                 and isinstance(node.args[0], ast.GeneratorExp)
             ):
@@ -326,7 +357,50 @@ def _scan_function(func_body: "list[ast.stmt]") -> "list[tuple[int, str]]":
                         for g in genexp.generators
                     )
                     if not filtered:
-                        violations.append((node.lineno, f"unfiltered {node.func.id}()"))
+                        violations.append((node.lineno, f"unfiltered {fname}()"))
+            self.generic_visit(node)
+
+        def _flag_truthiness(self, test: "ast.AST | None") -> None:
+            if test is not None and _is_raw_unfiltered(test):
+                violations.append((test.lineno, "truthiness"))
+
+        def visit_If(self, node: ast.If) -> None:
+            self._flag_truthiness(node.test)
+            self.generic_visit(node)
+
+        def visit_While(self, node: ast.While) -> None:
+            self._flag_truthiness(node.test)
+            self.generic_visit(node)
+
+        def visit_IfExp(self, node: ast.IfExp) -> None:
+            self._flag_truthiness(node.test)
+            self.generic_visit(node)
+
+        def visit_Assert(self, node: ast.Assert) -> None:
+            self._flag_truthiness(node.test)
+            self.generic_visit(node)
+
+        def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
+            if isinstance(node.op, ast.Not):
+                self._flag_truthiness(node.operand)
+            self.generic_visit(node)
+
+        def visit_BoolOp(self, node: ast.BoolOp) -> None:
+            for v in node.values:
+                self._flag_truthiness(v)
+            self.generic_visit(node)
+
+        def visit_Subscript(self, node: ast.Subscript) -> None:
+            if _is_raw_unfiltered(node.value):
+                violations.append((node.lineno, "indexing"))
+            self.generic_visit(node)
+
+        def visit_For(self, node: ast.For) -> None:
+            # A comprehension's own `for` clause is an `ast.comprehension`,
+            # a different node type -- this is only a genuine bare `for`
+            # statement, which has no allowlisted shape of its own.
+            if _is_raw_unfiltered(node.iter):
+                violations.append((node.lineno, "bare iteration"))
             self.generic_visit(node)
 
     _Visitor().visit(ast.Module(body=func_body, type_ignores=[]))
@@ -403,12 +477,13 @@ def main(argv: "list[str] | None" = None) -> int:
     print("unfiltered-caplog-consumption gate FAILED:\n", file=sys.stderr)
     print(
         f"{total} unfiltered caplog.records/.messages/.text consumption "
-        f"site(s) across {len(by_file)} file(s) -- the raw collection feeds "
-        "an equality-with-literal comparison, a len() comparison, tuple/"
-        "sequence unpacking, or an unfiltered any()/all() call, with no "
-        "subject-specific (logger-name or message-content) filter applied "
-        "first. Same class as #6031/#6035/#6038 -- under `-n auto`, an "
-        "unrelated test's record on a different logger can flip this:",
+        f"site(s) across {len(by_file)} file(s) -- the raw collection (or a "
+        "name derived from it) reaches a comparison, len(), tuple/sequence "
+        "unpacking, a boolean/truthiness test, indexing, or bare iteration "
+        "with no subject-specific (logger-name or message-content) filter "
+        "applied first. Same class as #6031/#6035/#6038 -- under `-n "
+        "auto`, an unrelated test's record on a different logger can flip "
+        "this:",
         file=sys.stderr,
     )
     for file, violations in sorted(by_file.items()):
@@ -417,10 +492,11 @@ def main(argv: "list[str] | None" = None) -> int:
     print(
         "\nFilter to the subject before consuming: `r.name == "
         "\"your.logger.name\"` / `\"your message\" in r.message` in the "
-        "comprehension's `if` clause (or the any()/all() predicate), "
-        "before comparing/len()'ing/unpacking. This is a zero-tolerance "
-        "gate -- no baseline, no --write-baseline escape hatch; every hit "
-        "is a new regression.",
+        "comprehension's `if` clause (or the any()/all() predicate), or as "
+        "an `in`/`not in` containment check, before comparing/len()'ing/"
+        "unpacking/truthiness-testing/indexing/iterating. This is a "
+        "zero-tolerance gate -- no baseline, no --write-baseline escape "
+        "hatch; every hit is a new regression.",
         file=sys.stderr,
     )
     return 1

--- a/tests/core/test_3901_sandbox_axis_unenforced.py
+++ b/tests/core/test_3901_sandbox_axis_unenforced.py
@@ -220,7 +220,10 @@ async def test_unenforced_axis_also_emits_a_warn_log_line(tmp_path, caplog):
     with caplog.at_level(logging.WARNING, logger="reyn.core.op_runtime.sandboxed_exec"):
         await handle(op, ctx)
 
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and r.name == "reyn.core.op_runtime.sandboxed_exec"
+    ]
     assert warnings, "expected a WARN log line when an axis is unenforced"
     assert "read_deny_paths" in warnings[0].getMessage()
     assert "landlock" in warnings[0].getMessage()

--- a/tests/core/test_action_embedding_build_failure_1458.py
+++ b/tests/core/test_action_embedding_build_failure_1458.py
@@ -243,7 +243,10 @@ def test_warning_log_emitted_once_with_options(
     with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
         _build_once(tmp_path, monkeypatch, provider)
 
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and r.name == "reyn.runtime.router_loop"
+    ]
     assert warnings, "expected at least one WARNING log on build failure"
     text = " ".join(r.getMessage() for r in warnings).lower()
     # All three options mentioned.

--- a/tests/hooks/test_hook_shell_push_2069.py
+++ b/tests/hooks/test_hook_shell_push_2069.py
@@ -202,7 +202,7 @@ def test_exec_capture_false_with_empty_message_is_observed_without_warning(caplo
     caplog.set_level("WARNING")
     rp = _parse_exec_push(json.dumps({"push_when": False, "wake": False, "message": ""}))
     assert rp == ResolvedPush(message="", wake=False, push_when=False, session=None)
-    assert not caplog.records
+    assert not any(r.name == "reyn.hooks.dispatcher" for r in caplog.records)
 
 
 def test_exec_capture_true_with_empty_message_still_warns(caplog) -> None:

--- a/tests/interfaces/test_5168_tui_stdio_capture.py
+++ b/tests/interfaces/test_5168_tui_stdio_capture.py
@@ -115,7 +115,10 @@ def test_capturing_stream_ignores_whitespace_only_writes(caplog: pytest.LogCaptu
         stream.write("   ")
 
     assert stats.count == 0
-    assert caplog.records == []
+    assert [
+        r for r in caplog.records
+        if r.name == "reyn.interfaces.inline.textual_chat.stray_output"
+    ] == []
 
 
 def test_capturing_stream_write_does_not_recurse_through_a_misdirected_handler():

--- a/tests/runtime/test_5509_media_capability_gate.py
+++ b/tests/runtime/test_5509_media_capability_gate.py
@@ -217,7 +217,11 @@ def test_no_token_bound_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
             None, model=model,
         )
     assert result is MediaMaterialiseFailure.NO_TOKEN_BOUND
-    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+    assert not any(
+        r.levelno >= logging.WARNING
+        for r in caplog.records
+        if r.name == "reyn.runtime.router_loop"
+    )
 
 
 def test_strip_falsify_the_gate_by_hand() -> None:

--- a/tests/runtime/test_5982_internal_boundary_fold.py
+++ b/tests/runtime/test_5982_internal_boundary_fold.py
@@ -187,7 +187,7 @@ def test_preview_for_internal_reader_missing_file_returns_not_found_without_warn
         )
 
     assert (preview, found, total_bytes) == ("", False, 0)
-    assert not caplog.records, (
+    assert not any(r.name == "reyn.data.workspace.media_store" for r in caplog.records), (
         f"an ordinary not-found must not warn — got: {[r.message for r in caplog.records]}"
     )
 

--- a/tests/scripts/fixtures/unfiltered_caplog_6042/dangerous.py
+++ b/tests/scripts/fixtures/unfiltered_caplog_6042/dangerous.py
@@ -1,0 +1,23 @@
+"""Fixture: the dangerous (unfiltered) caplog-consumption shapes this
+gate's classifier must catch -- one function per shape, mirroring the 4
+real incidents (#6031/#6035/#6038 plus the 2 remaining sites fixed in the
+same PR that adds this gate)."""
+import logging
+
+
+def test_equality_with_literal_empty(caplog):
+    assert caplog.records == []
+
+
+def test_len_comparison(caplog):
+    assert len(caplog.records) == 2
+
+
+def test_tuple_unpacking(caplog):
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    (only,) = warnings
+    assert only
+
+
+def test_unfiltered_any(caplog):
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)

--- a/tests/scripts/fixtures/unfiltered_caplog_6042/dangerous.py
+++ b/tests/scripts/fixtures/unfiltered_caplog_6042/dangerous.py
@@ -1,7 +1,12 @@
 """Fixture: the dangerous (unfiltered) caplog-consumption shapes this
-gate's classifier must catch -- one function per shape, mirroring the 4
-real incidents (#6031/#6035/#6038 plus the 2 remaining sites fixed in the
-same PR that adds this gate)."""
+gate's classifier must catch -- one function per shape, mirroring the real
+incidents (#6031/#6035/#6038; the 2 sites fixed in the PR that added this
+gate; and the bare-truthiness/indexing/bare-iteration shapes the inverted
+(allowlist-safe) classifier additionally catches, per lead-coder's
+https://github.com/tya5/reyn/pull/6040#issuecomment-5611043646 -- a level-
+or count-only filter with NO subject-specific check is the same hazard
+class no matter which of these 6 syntax contexts it is finally consumed
+through)."""
 import logging
 
 
@@ -21,3 +26,26 @@ def test_tuple_unpacking(caplog):
 
 def test_unfiltered_any(caplog):
     assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+def test_bare_truthiness_assert_not(caplog):
+    """The exact miss the enumerated-dangerous-shapes classifier had: a
+    level-only (non-subject-specific) filter, consumed by truthiness --
+    same hazard class as `caplog.records == []`, different spelling."""
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not warnings
+
+
+def test_bare_truthiness_if(caplog):
+    if caplog.records:
+        raise AssertionError("unexpected log line")
+
+
+def test_indexing_into_unfiltered_derived_list(caplog):
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert "boom" in warnings[0].getMessage()
+
+
+def test_bare_iteration_without_subject_filter(caplog):
+    for r in caplog.records:
+        assert r.levelno < logging.WARNING

--- a/tests/scripts/fixtures/unfiltered_caplog_6042/dangerous.py
+++ b/tests/scripts/fixtures/unfiltered_caplog_6042/dangerous.py
@@ -6,29 +6,38 @@ gate; and the bare-truthiness/indexing/bare-iteration shapes the inverted
 https://github.com/tya5/reyn/pull/6040#issuecomment-5611043646 -- a level-
 or count-only filter with NO subject-specific check is the same hazard
 class no matter which of these 6 syntax contexts it is finally consumed
-through)."""
+through).
+
+Not a real module — never imported, never collected as a test (functions
+are deliberately NOT named `test_*`, matching `truly_silent.py`'s own
+established convention in the sibling `silent_except_5990/` fixture dir —
+a `test_`-prefixed name here would sweep these synthetic shapes into
+`test_tier_audit.py`'s population, which happened once and was fixed by
+this same rename: #6040 review thread). `caplog` is a plain parameter
+name here, not the pytest fixture — these functions are never called,
+only AST-parsed by `find_violations()`."""
 import logging
 
 
-def test_equality_with_literal_empty(caplog):
+def shape_equality_with_literal_empty(caplog):
     assert caplog.records == []
 
 
-def test_len_comparison(caplog):
+def shape_len_comparison(caplog):
     assert len(caplog.records) == 2
 
 
-def test_tuple_unpacking(caplog):
+def shape_tuple_unpacking(caplog):
     warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
     (only,) = warnings
     assert only
 
 
-def test_unfiltered_any(caplog):
+def shape_unfiltered_any(caplog):
     assert not any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
-def test_bare_truthiness_assert_not(caplog):
+def shape_bare_truthiness_assert_not(caplog):
     """The exact miss the enumerated-dangerous-shapes classifier had: a
     level-only (non-subject-specific) filter, consumed by truthiness --
     same hazard class as `caplog.records == []`, different spelling."""
@@ -36,16 +45,16 @@ def test_bare_truthiness_assert_not(caplog):
     assert not warnings
 
 
-def test_bare_truthiness_if(caplog):
+def shape_bare_truthiness_if(caplog):
     if caplog.records:
         raise AssertionError("unexpected log line")
 
 
-def test_indexing_into_unfiltered_derived_list(caplog):
+def shape_indexing_into_unfiltered_derived_list(caplog):
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert "boom" in warnings[0].getMessage()
 
 
-def test_bare_iteration_without_subject_filter(caplog):
+def shape_bare_iteration_without_subject_filter(caplog):
     for r in caplog.records:
         assert r.levelno < logging.WARNING

--- a/tests/scripts/fixtures/unfiltered_caplog_6042/safe.py
+++ b/tests/scripts/fixtures/unfiltered_caplog_6042/safe.py
@@ -1,0 +1,42 @@
+"""Fixture: subject-specific (safe) caplog-consumption shapes this gate's
+classifier must NOT flag -- one function per real idiom found across the
+tree's 108 already-safe sites (logger-name filter, message-content
+filter, containment check, two-stage derived-variable filter)."""
+import logging
+
+
+def test_message_content_membership(caplog):
+    assert any("NOPE.md" in r.message for r in caplog.records)
+
+
+def test_logger_name_filtered_equality_empty(caplog):
+    assert [r for r in caplog.records if r.name == "reyn.x"] == []
+
+
+def test_logger_name_filtered_any_predicate(caplog):
+    model = "gpt-4o"
+    assert any(
+        r.name == "reyn.runtime.router_loop" and model in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_text_containment(caplog):
+    assert "unresponsive" in caplog.text
+    assert "recovered" not in caplog.text
+
+
+def test_two_stage_derived_membership(caplog):
+    messages = [r.message for r in caplog.records]
+    assert any("y" in m for m in messages)
+    assert not any("z" in m for m in messages)
+
+
+def test_level_only_filter_never_reaches_a_dangerous_shape(caplog):
+    """A level-only filter (no subject check) that is only ever
+    truthy-tested or indexed -- never compared/len()'d/unpacked -- must
+    not be flagged either (it never reaches a dangerous consumption
+    shape at all)."""
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings
+    assert "x" in warnings[0].getMessage()

--- a/tests/scripts/fixtures/unfiltered_caplog_6042/safe.py
+++ b/tests/scripts/fixtures/unfiltered_caplog_6042/safe.py
@@ -32,11 +32,11 @@ def test_two_stage_derived_membership(caplog):
     assert not any("z" in m for m in messages)
 
 
-def test_level_only_filter_never_reaches_a_dangerous_shape(caplog):
-    """A level-only filter (no subject check) that is only ever
-    truthy-tested or indexed -- never compared/len()'d/unpacked -- must
-    not be flagged either (it never reaches a dangerous consumption
-    shape at all)."""
+def test_level_only_filter_then_subject_filtered_membership(caplog):
+    """A level-only filter (no subject check in the filter itself) that
+    is THEN consumed through a subject-specific containment check must
+    not be flagged -- the containment check is what makes the final
+    consumption safe, independent of whether the intermediate `warnings`
+    derivation was itself subject-filtered."""
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert warnings
-    assert "x" in warnings[0].getMessage()
+    assert any("x" in r.getMessage() for r in warnings)

--- a/tests/scripts/fixtures/unfiltered_caplog_6042/safe.py
+++ b/tests/scripts/fixtures/unfiltered_caplog_6042/safe.py
@@ -1,19 +1,24 @@
 """Fixture: subject-specific (safe) caplog-consumption shapes this gate's
 classifier must NOT flag -- one function per real idiom found across the
 tree's 108 already-safe sites (logger-name filter, message-content
-filter, containment check, two-stage derived-variable filter)."""
+filter, containment check, two-stage derived-variable filter).
+
+Not a real module — never imported, never collected as a test (functions
+are deliberately NOT named `test_*`, matching `truly_silent.py`'s own
+established convention in the sibling `silent_except_5990/` fixture dir —
+see `dangerous.py` in this same directory for why)."""
 import logging
 
 
-def test_message_content_membership(caplog):
+def shape_message_content_membership(caplog):
     assert any("NOPE.md" in r.message for r in caplog.records)
 
 
-def test_logger_name_filtered_equality_empty(caplog):
+def shape_logger_name_filtered_equality_empty(caplog):
     assert [r for r in caplog.records if r.name == "reyn.x"] == []
 
 
-def test_logger_name_filtered_any_predicate(caplog):
+def shape_logger_name_filtered_any_predicate(caplog):
     model = "gpt-4o"
     assert any(
         r.name == "reyn.runtime.router_loop" and model in r.getMessage()
@@ -21,18 +26,18 @@ def test_logger_name_filtered_any_predicate(caplog):
     )
 
 
-def test_text_containment(caplog):
+def shape_text_containment(caplog):
     assert "unresponsive" in caplog.text
     assert "recovered" not in caplog.text
 
 
-def test_two_stage_derived_membership(caplog):
+def shape_two_stage_derived_membership(caplog):
     messages = [r.message for r in caplog.records]
     assert any("y" in m for m in messages)
     assert not any("z" in m for m in messages)
 
 
-def test_level_only_filter_then_subject_filtered_membership(caplog):
+def shape_level_only_filter_then_subject_filtered_membership(caplog):
     """A level-only filter (no subject check in the filter itself) that
     is THEN consumed through a subject-specific containment check must
     not be flagged -- the containment check is what makes the final

--- a/tests/scripts/test_check_unfiltered_caplog_consumption.py
+++ b/tests/scripts/test_check_unfiltered_caplog_consumption.py
@@ -1,0 +1,75 @@
+"""Tier 1: `check_unfiltered_caplog_consumption.py`'s own detector logic --
+the recurrence-prevention gate for the caplog-consumption bug pattern that
+hit #6031, #6035, and #6038 independently the same day.
+
+Real fixture files under `tests/scripts/fixtures/unfiltered_caplog_6042/`
+(permanently checked in, not a strip-and-revert scratch), mirroring
+`test_silent_except_ratchet_5990.py`'s own established shape: one fixture
+carrying every dangerous shape this gate must catch, one carrying every
+safe/subject-specific idiom it must NOT flag -- both directions required
+so a detector that flags every caplog access unconditionally (which would
+pass the dangerous-fixture test alone) cannot pass this suite either.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_unfiltered_caplog_consumption import find_violations, measured
+from tests._support.paths import REPO_ROOT
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "unfiltered_caplog_6042"
+
+
+def test_every_dangerous_shape_is_flagged():
+    """Tier 1: the false-accept-side witness -- each of the 4 dangerous
+    consumption shapes (equality-with-literal-empty, len() comparison,
+    tuple/sequence unpacking, unfiltered any()/all()) is caught, one per
+    function in the fixture."""
+    violations = find_violations(_FIXTURES / "dangerous.py")
+    shapes = {shape for _, shape in violations}
+    expected_shapes = {
+        "equality with literal",
+        "len() comparison",
+        "tuple/sequence unpacking",
+        "unfiltered any()",
+    }
+    missing = expected_shapes - shapes
+    assert not missing, (
+        f"gate missed dangerous shape(s) {missing} in the fixture -- got "
+        f"{violations}"
+    )
+
+
+def test_every_safe_shape_is_not_flagged():
+    """Tier 1: the false-reject-side witness, required alongside the test
+    above -- a subject-specific/filtered consumption (message-content
+    membership, logger-name-filtered equality/any(), .text containment, a
+    two-stage derived-variable filter, and a level-only filter that never
+    reaches a dangerous shape at all) must NOT be flagged."""
+    violations = find_violations(_FIXTURES / "safe.py")
+    assert violations == [], (
+        f"gate over-flagged subject-specific/never-consumed caplog usage: "
+        f"{violations}"
+    )
+
+
+def test_the_real_repo_tree_is_currently_clean():
+    """Tier 2: the gate's own starting population, verified against the
+    real, current tree (not assumed) -- mirrors check_no_core_dep_
+    importorskip_5058.py's own "run it before shipping it" discipline.
+    This gate is zero-tolerance (no baseline) -- both of the read-only
+    measurement's remaining live sites (test_5509_media_capability_gate.
+    py:220, test_5168_tui_stdio_capture.py:118) are fixed in the same PR
+    that adds this gate, so this must be empty; any hit here is a NEW
+    regression."""
+    by_file, scanned = measured(REPO_ROOT)
+    assert scanned > 1000, (
+        f"the scan found only {scanned} file(s) under tests/ -- looks like "
+        "a scanner failure (git ls-files returning too little), not a "
+        "small real tree"
+    )
+    assert by_file == {}, (
+        f"real regression(s) found: {by_file} -- this gate's baseline is "
+        "zero (no grandfather list), so any hit here is new, not "
+        "inherited debt"
+    )

--- a/tests/scripts/test_check_unfiltered_caplog_consumption.py
+++ b/tests/scripts/test_check_unfiltered_caplog_consumption.py
@@ -21,17 +21,23 @@ _FIXTURES = Path(__file__).resolve().parent / "fixtures" / "unfiltered_caplog_60
 
 
 def test_every_dangerous_shape_is_flagged():
-    """Tier 1: the false-accept-side witness -- each of the 4 dangerous
-    consumption shapes (equality-with-literal-empty, len() comparison,
-    tuple/sequence unpacking, unfiltered any()/all()) is caught, one per
-    function in the fixture."""
+    """Tier 1: the false-accept-side witness -- each of the dangerous
+    consumption contexts this gate's inverted (allowlist-safe) classifier
+    must catch is caught, one per function in the fixture. Includes the
+    bare-truthiness shape (`assert not caplog.records`) disclosed as
+    out-of-scope under the prior enumerated-dangerous classifier and
+    folded in by the inversion, per
+    https://github.com/tya5/reyn/pull/6040#issuecomment-5611043646."""
     violations = find_violations(_FIXTURES / "dangerous.py")
     shapes = {shape for _, shape in violations}
     expected_shapes = {
-        "equality with literal",
+        "comparison",
         "len() comparison",
         "tuple/sequence unpacking",
         "unfiltered any()",
+        "truthiness",
+        "indexing",
+        "bare iteration",
     }
     missing = expected_shapes - shapes
     assert not missing, (
@@ -44,8 +50,9 @@ def test_every_safe_shape_is_not_flagged():
     """Tier 1: the false-reject-side witness, required alongside the test
     above -- a subject-specific/filtered consumption (message-content
     membership, logger-name-filtered equality/any(), .text containment, a
-    two-stage derived-variable filter, and a level-only filter that never
-    reaches a dangerous shape at all) must NOT be flagged."""
+    two-stage derived-variable filter, and a level-only filter whose FINAL
+    consumption is a subject-specific containment check) must NOT be
+    flagged."""
     violations = find_violations(_FIXTURES / "safe.py")
     assert violations == [], (
         f"gate over-flagged subject-specific/never-consumed caplog usage: "

--- a/tests/security/test_sandbox_capability_declaration_4935.py
+++ b/tests/security/test_sandbox_capability_declaration_4935.py
@@ -202,7 +202,7 @@ def test_apply_required_capabilities_ignore_is_silent(caplog) -> None:
 
     with caplog.at_level(logging.DEBUG, logger="reyn.security.sandbox"):
         _apply_required_capabilities(LandlockBackend(), ["ipc_named_service"], "ignore")
-    assert not caplog.records
+    assert not any(r.name == "reyn.security.sandbox" for r in caplog.records)
 
 
 def test_error_now_rejects_unenforced_noop_not_enforced_landlock() -> None:


### PR DESCRIPTION
**[backlog-watcher]** — Recurrence-prevention gate for the caplog-consumption bug pattern that independently hit #6031, #6035, and #6038 the same day (2026-09-10): a test asserting on `caplog.records`/`.messages`/`.text` without filtering to its own subject (logger name or message content) first. `caplog`'s handler is attached to the ROOT logger for the whole pytest-xdist worker process — under `-n auto`, an unrelated test's record on a DIFFERENT logger can flip an unfiltered equality/`len()`/unpack/`any()`/`all()` assertion. Flaky-by-construction, never a real invariant about the subject under test.

This is a distinct recurrence-prevention gate for the caplog-consumption bug pattern, not part of #5990's silent-except axis — no existing issue tracks this specifically, so this PR body is the only record.

## Read-only measurement that justified building this (this session)

An AST walk over every `caplog.records`/`.messages`/`.text` consumption site across `tests/**/*.py` found **112 total sites: 108 already safe, 4 dangerous** — the 3 incidents above (each independently fixed in its own prior PR) plus **2 still-live sites at measurement time**, fixed in this same PR:

- `tests/runtime/test_5509_media_capability_gate.py:220` — `not any(r.levelno >= logging.WARNING for r in caplog.records)`, scoped to the module's own logger.
- `tests/interfaces/test_5168_tui_stdio_capture.py:118` — `caplog.records == []`, scoped to the module's own logger (same style as #6038's fix).

Zero false positives were found in that measurement: no site among the 4 had a test-isolation marker, comment, or any other reason "assert nobody logged, from any subsystem" was the actual intent.

## What's in this PR

1. **`scripts/check_unfiltered_caplog_consumption.py`** — an AST-based scanner. Population is DERIVED (`git ls-files tests/*.py`), never hand-maintained. Classifies each caplog attribute access's consumption shape:
   - **dangerous**: the raw collection (or a simply-derived variable) feeds directly into an equality/inequality-with-literal comparison, a `len(...)` comparison, tuple/sequence unpacking, or an `any()`/`all()` call with no subject-specific predicate — with no logger-name/message-content filter applied first.
   - **safe**: a membership/containment check (`"foo" in caplog.text`), or a comprehension/`any()`/`all()` predicate that checks `.name`/`.message`/`.getMessage()` or does an `in`/`not in` containment before anything is counted, compared-empty, or unpacked.
   - Zero-tolerance gate — **no baseline, no grandfather list, no `--write-baseline` escape hatch**, per explicit instruction. Any hit is a new regression.
   - Docstring explicitly discloses the `caplog.text` scope decision: all 10 `.text` sites today are safe; the same hazard shape is structurally possible for `.text` but has zero live examples, so no `.text` special-casing was written — the general rule already covers it if one ever appears (per #4846/#5990's own burned lesson on speculative handling of a zero-population case).
   - Docstring also discloses false-positive/recall honestly: ~0 false positives (verified against the 108 known-safe sites), recall NOT claimed complete — verified only against the 3 known incident shapes + the 2 sites this PR fixes (5/5).
   - **Disclosed, out-of-scope gap** (found by hand while building this, not part of the assigned population): bare truthiness checks (`assert not caplog.records`) share the identical hazard but are a different AST shape than the three named consumption shapes this gate's population was scoped to. 3 live examples exist today — `tests/hooks/test_hook_shell_push_2069.py:205`, `tests/runtime/test_5982_internal_boundary_fold.py:190`, `tests/security/test_sandbox_capability_declaration_4935.py:205` — named in the script's own module docstring, **not fixed here** (outside this PR's assigned scope; flagged for a separate, deliberate decision on whether to widen the classifier).

2. **`.github/workflows/unfiltered-caplog-consumption-gate.yml`** — wired as a `tests/**`-path-conditional gate, same pattern as `silent-except-ratchet-gate.yml`.

3. **The 2 fixes** above, scoped to each test's own subject logger.

4. **`tests/scripts/test_check_unfiltered_caplog_consumption.py`** + permanent fixtures under `tests/scripts/fixtures/unfiltered_caplog_6042/` (`dangerous.py`, `safe.py`) — covers both directions: every dangerous shape is flagged, every safe/filtered shape is not (including a level-only-filtered variable that's only ever truthy-tested/indexed, never reaching a dangerous shape). A third test asserts the real `tests/` tree is currently clean (0 violations across 1773 files).

## Gates run locally (all green)

`ruff check .`, `python scripts/test_tier_audit.py --strict <changed test files>`, `python scripts/verify_module_docstrings.py scripts/check_unfiltered_caplog_consumption.py`, `python scripts/mypy_ratchet.py`, `python scripts/flat_tests_ratchet.py`, `python scripts/check_tests_path_literal_reference.py`, `python scripts/check_bare_tests_import_reference.py`, `python scripts/check_file_depth_reference.py`, `python scripts/check_subprocess_reyn_pin.py`, and scoped `pytest` (26 passed). Full suite not run locally (CI does that in a clean checkout).

## Test plan

- [x] New gate script's own tests pass locally (3/3: dangerous-fixture flagged, safe-fixture clear, real tree clean)
- [x] The 2 fixed sites' own test files pass locally (26/26 across both files + new gate tests)
- [x] `ruff check .` clean
- [x] `test_tier_audit.py --strict` clean on all changed test files
- [x] `mypy_ratchet.py` clean
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` all clean (tests/ path gates)
- [ ] (skipped — standing waiver) Visual/CI-run confirmation — not polled per dispatch instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5