### PR TITLE
fix(#6043): reyn.log installs regardless of is_interactive; only terminal output stays conditional

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -577,6 +577,26 @@ def _run_remote(
     _setup_interactive_logging(
         _find_project_root(Path.cwd()) or Path.cwd(), is_interactive=is_interactive,
     )
+    # #6043 ruling ②: the 3 individual booleans feeding is_interactive are
+    # otherwise only screen-visible (the AND collapses them) — record them
+    # on a branch-independent surface (reyn.log) so an owner-reported
+    # "TUI looks live but is_interactive came out False" report is
+    # diagnosable without reproducing it live. Placed AFTER
+    # _setup_interactive_logging (immediately above) so the real
+    # RotatingFileHandler is already installed and this line lands in
+    # reyn.log directly, regardless of is_interactive.
+    # level=WARNING, not INFO: this module's `logger` has no explicit
+    # level of its own, so it inherits root's basicConfig(level=WARNING)
+    # — an INFO call here would be silently dropped unless this logger's
+    # level were lowered globally, which would also unmute every OTHER
+    # info-level call in this module. This line fires exactly once per
+    # process startup (not in a loop), so it does not reopen #5977's
+    # closed log-flood gap despite the WARNING level.
+    logger.warning(
+        "startup tty probe: cui=%s stdin_isatty=%s stdout_isatty=%s -> "
+        "is_interactive=%s",
+        getattr(args, "cui", False), stdin_isatty, stdout_isatty, is_interactive,
+    )
     renderer = make_renderer(is_interactive)
     run_async(
         run_remote(
@@ -695,10 +715,12 @@ def _run(args: argparse.Namespace) -> None:
     # the plain renderer there. This single predicate gates BOTH the log redirect
     # and the renderer choice (below) so "inline CUI active ⟺ logging redirected"
     # stays invariant — they must not diverge.
+    stdin_isatty = sys.stdin.isatty()
+    stdout_isatty = sys.stdout.isatty()
     is_interactive = _inline_interactive(
         cui=getattr(args, "cui", False),
-        stdin_isatty=sys.stdin.isatty(),
-        stdout_isatty=sys.stdout.isatty(),
+        stdin_isatty=stdin_isatty,
+        stdout_isatty=stdout_isatty,
     )
     # Route the root logger to a file so library warnings and caught-exception
     # tracebacks (e.g. an LLM APIConnectionError that session.py logs via
@@ -711,6 +733,18 @@ def _run(args: argparse.Namespace) -> None:
     # docstring. (Restores the redirect the Textual TUI had; dropped in the
     # inline-CUI cutover #2195.)
     _setup_interactive_logging(project_root, is_interactive=is_interactive)
+    # #6043 ruling ②: see _run_remote's own copy of this comment for the
+    # full rationale (branch-independent surface, placed AFTER
+    # _setup_interactive_logging so the real RotatingFileHandler is
+    # already installed and this line lands in reyn.log directly.
+    # WARNING level because this module's `logger` inherits root's
+    # basicConfig(level=WARNING) and this fires once per startup, not in
+    # a loop, so it doesn't reopen #5977).
+    logger.warning(
+        "startup tty probe: cui=%s stdin_isatty=%s stdout_isatty=%s -> "
+        "is_interactive=%s",
+        getattr(args, "cui", False), stdin_isatty, stdout_isatty, is_interactive,
+    )
 
     with _startup_stage("config"):
         session_cfg = InvocationContext.from_args(args)

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -326,15 +326,41 @@ def _renderer_is_interactive(*, is_interactive: bool, render_mode: str) -> bool:
     return is_interactive and render_mode != "plain"
 
 
-def _setup_interactive_logging(project_root: Path) -> None:
-    """Route root-logger output to .reyn/logs/reyn.log for the interactive CUI.
+def _setup_interactive_logging(project_root: Path, *, is_interactive: bool = True) -> None:
+    """Route root-logger output to .reyn/logs/reyn.log — ALWAYS, regardless
+    of *is_interactive*. Called once, before load_project_context (which
+    may emit WARNING records), so the file handler is in place before the
+    first log call.
 
-    The inline CUI owns the terminal; a log record reaching a StreamHandler
-    (stderr) would print into the live chat region — at best noise (litellm
-    warnings), at worst an alarming full traceback from a caught error. Sending
-    logs to a file keeps the UI clean while preserving them for debugging. Called
-    once, before load_project_context (which may emit WARNING records), so the
-    file handler is in place before the first log call.
+    #6043 (owner-hit — a raw ``logging`` line corrupting the interactive
+    CUI's screen, between the sent-queue and the input box; lead-coder's
+    own root-cause question, answered by re-reading this function's own
+    prior docstring): this function used to hold TWO separate facts as
+    ONE decision, both gated by the SAME ``is_interactive`` check —
+    "whether to write to ``reyn.log`` at all" and "whether to ALSO print
+    to the terminal." Only ONE of those two facts actually depends on
+    whether the inline CUI owns the terminal:
+
+    - **Suppressing terminal output** DOES depend on ``is_interactive`` —
+      the inline CUI owns the terminal; a log record reaching a
+      StreamHandler(stderr) would print into the live chat region — at
+      best noise (litellm warnings), at worst an alarming full traceback
+      from a caught error.
+    - **Writing to ``reyn.log``** does NOT — "not interactive" and "don't
+      keep a record" are different facts, and CI / a non-TTY run is
+      exactly when a record is MOST needed (nobody is watching the
+      terminal live). The only reasoning this function's own comments
+      ever gave for the previous all-or-nothing gate was the FIRST fact
+      ("--cui / non-TTY keep logging on stderr (debuggable / pipeable)")
+      — a real reason to keep stderr as A destination, never a stated
+      reason to make it the ONLY one.
+
+    Now: the file handler installs unconditionally. When *is_interactive*
+    is ``False`` (``--cui`` / non-TTY), a second handler ALSO prints to
+    stderr — preserving the one behaviour this module's own comments
+    actually justified (debuggable/pipeable) — while ``reyn.log`` gets
+    the record either way. When *is_interactive* is ``True``, ``reyn.log``
+    is the ONLY destination, exactly as before.
 
     Deliberately does NOT import litellm (perf: ``import litellm`` costs
     ~1.5s and this runs on the startup path, before the input box renders).
@@ -353,10 +379,16 @@ def _setup_interactive_logging(project_root: Path) -> None:
     described. This closes that declared-vs-implemented gap — it does not
     change WHERE any warning's root cause lives (#4365 tracks a real
     litellm client-cleanup gap this does NOT fix, only reroutes the
-    resulting warning's ink). Scoped to the same ``is_interactive`` guard
-    as the rest of this function — both of this module's two call sites
-    are gated by it, so an embedder or non-interactive run never has its
-    own warnings redirected.
+    resulting warning's ink).
+
+    #6043: this call now ALWAYS runs (the function itself is no longer
+    gated by ``is_interactive`` at either call site) — so a bare
+    ``warnings.warn`` is captured into ``reyn.log`` on every invocation,
+    not only the interactive one. This history paragraph used to say the
+    opposite ("scoped to the same is_interactive guard ... an embedder
+    or non-interactive run never has its own warnings redirected") —
+    that was true of the OLD all-or-nothing gate, not of this fixed
+    version; kept here as history, not restated as the current claim.
 
     #5873 (owner-hit — "放置してるだけで reyn.log 肥大化してシステム止まら
     ないようにしてね"): the handler is now a ``RotatingFileHandler``, not a
@@ -401,10 +433,23 @@ def _setup_interactive_logging(project_root: Path) -> None:
     handler.setFormatter(
         logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     )
+    handlers: "list[logging.Handler]" = [handler]
+    if not is_interactive:
+        # #6043: the ONE behaviour this function's own comments actually
+        # justified ("--cui / non-TTY keep logging on stderr — debuggable
+        # / pipeable") — preserved, but no longer as the reason reyn.log
+        # goes unwritten. The interactive path (is_interactive=True)
+        # deliberately does NOT get this handler: the inline CUI owns the
+        # terminal, and a record reaching stderr there is #6043's own bug.
+        handlers.append(logging.StreamHandler())
     logging.basicConfig(
         level=logging.WARNING,
-        handlers=[handler],
-        force=True,  # safe: the interactive path has no prior logging setup
+        handlers=handlers,
+        # Safe unconditionally: this function now always runs as the
+        # first thing that could configure logging (both call sites
+        # dropped their own `if is_interactive:` gate) — there is no
+        # prior setup for `force=True` to ever actually be overriding.
+        force=True,
     )
     logging.captureWarnings(True)
     # #5873 follow-up (architect, #5877 re-co-vet): declare the path
@@ -428,10 +473,13 @@ def _apply_logs_config(logs_cfg: "LogsConfig") -> None:
     a handler-identity change synchronization gap other readers rely on
     (see ``_setup_interactive_logging``'s own docstring on why the class
     itself, ``RotatingFileHandler`` — a ``logging.FileHandler`` subclass —
-    stays fixed regardless of config). A no-op when the interactive log
-    redirect was never installed (no ``RotatingFileHandler`` on the root
-    logger — e.g. ``--cui``/non-TTY runs, which never call
-    ``_setup_interactive_logging`` at all)."""
+    stays fixed regardless of config). #6043: ``_setup_interactive_logging``
+    now always installs the handler (both call sites dropped their own
+    ``is_interactive`` gate on calling it) — this function's own former
+    "no-op when the redirect was never installed (--cui/non-TTY runs)"
+    case no longer exists; the loop below still finds nothing to do only
+    if some OTHER caller ever removed the handler entirely, not because
+    of ``--cui``/non-TTY specifically."""
     from logging.handlers import RotatingFileHandler
 
     for handler in logging.root.handlers:
@@ -490,11 +538,16 @@ def _run_remote(
         stdin_isatty=stdin_isatty,
         stdout_isatty=stdout_isatty,
     )
-    # The inline CUI owns the terminal; route library warnings / tracebacks to a
-    # log file so they don't corrupt the live region (same rationale as local).
-    if is_interactive:
-        from reyn.config import _find_project_root
-        _setup_interactive_logging(_find_project_root(Path.cwd()) or Path.cwd())
+    # #6043: always installs the reyn.log handler now — only the ALSO-
+    # print-to-stderr half depends on is_interactive (the inline CUI
+    # owns the terminal; route library warnings / tracebacks to a log
+    # file so they don't corrupt the live region — same rationale as
+    # local, but no longer the reason a non-interactive run goes
+    # unlogged).
+    from reyn.config import _find_project_root
+    _setup_interactive_logging(
+        _find_project_root(Path.cwd()) or Path.cwd(), is_interactive=is_interactive,
+    )
     renderer = make_renderer(is_interactive)
     run_async(
         run_remote(
@@ -621,20 +674,24 @@ def _run(args: argparse.Namespace) -> None:
     # Route the root logger to a file so library warnings and caught-exception
     # tracebacks (e.g. an LLM APIConnectionError that session.py logs via
     # logger.exception) don't leak into — and corrupt/alarm — the chat UI.
-    # --cui / non-TTY keep logging on stderr (debuggable / pipeable). (Restores
-    # the redirect the Textual TUI had; dropped in the inline-CUI cutover #2195.)
-    if is_interactive:
-        _setup_interactive_logging(project_root)
+    # #6043: this now ALSO runs for --cui / non-TTY — "not interactive" and
+    # "don't keep a record" are different facts, and CI / a non-TTY run is
+    # exactly when a record is most needed (nobody is watching the terminal
+    # live). Only the ALSO-print-to-stderr half (debuggable/pipeable) stays
+    # conditional on is_interactive — see _setup_interactive_logging's own
+    # docstring. (Restores the redirect the Textual TUI had; dropped in the
+    # inline-CUI cutover #2195.)
+    _setup_interactive_logging(project_root, is_interactive=is_interactive)
 
     with _startup_stage("config"):
         session_cfg = InvocationContext.from_args(args)
     # #5873: now that the real reyn.yaml `logs:` config is known, refine
     # the RotatingFileHandler _setup_interactive_logging installed above
     # (with hardcoded defaults) to the operator's own configured
-    # max_bytes/backup_count. A no-op when the log redirect was never
-    # installed (--cui / non-TTY runs).
-    if is_interactive:
-        _apply_logs_config(session_cfg.config.logs)
+    # max_bytes/backup_count. #6043: no longer gated on is_interactive —
+    # the handler is ALWAYS installed now, so this refinement always has
+    # something real to refine.
+    _apply_logs_config(session_cfg.config.logs)
     # #3905: no per-surface startup credential check here (never was, since
     # #2708 P3.2b moved it onto the single LLM funnel) — and #3905 removed
     # that funnel-level pre-check too (an unnecessary hardcode, owner ruling).

--- a/tests/interfaces/test_agui_remote_inline_p3.py
+++ b/tests/interfaces/test_agui_remote_inline_p3.py
@@ -320,6 +320,31 @@ def test_run_remote_selects_inline_renderer_on_interactive_tty(tmp_path, monkeyp
     assert isinstance(forced["renderer"], ConsoleChatRenderer)
 
 
+def test_run_remote_logs_the_tty_probe_line(tmp_path, monkeypatch) -> None:
+    """Tier 2: #6043 ruling ② — the 3 individual booleans feeding
+    `is_interactive` (`cui` / `stdin_isatty` / `stdout_isatty`) are
+    otherwise only screen-visible (the AND in `_inline_interactive`
+    collapses them into one bool); an owner report of "TUI looks live
+    but logging still acts non-interactive" needs them on a durable,
+    branch-independent surface. This pins that `_run_remote` logs all 4
+    values (the 3 inputs + the resolved `is_interactive`) to reyn.log.
+
+    Strip-falsifier (verified by hand: the `logger.warning("startup tty
+    probe: ...")` call removed from `_run_remote`): this test goes red
+    — reyn.log has no "startup tty probe" line at all."""
+    _capture_remote_renderer(
+        _connect_args(), stdin_isatty=True, stdout_isatty=False,
+        tmp_path=tmp_path, monkeypatch=monkeypatch,
+    )
+    log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+    contents = log_file.read_text()
+    assert "startup tty probe" in contents
+    assert "cui=False" in contents
+    assert "stdin_isatty=True" in contents
+    assert "stdout_isatty=False" in contents
+    assert "is_interactive=False" in contents
+
+
 # --- shared driver: one body drives the remote transport to termination --------
 
 

--- a/tests/interfaces/test_inline_interactive_logging.py
+++ b/tests/interfaces/test_inline_interactive_logging.py
@@ -253,3 +253,119 @@ def test_existing_file_handler_readers_still_find_the_rotating_handler(
         logging.captureWarnings(False)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
+
+
+# ── #6043: reyn.log installs regardless of is_interactive ──────────────────
+
+
+def test_the_file_handler_installs_even_when_not_interactive(tmp_path) -> None:
+    """Tier 2: #6043 — lead-coder's own root-cause ruling: "not
+    interactive" and "don't keep a record" are different facts. A
+    `--cui`/non-TTY run (`is_interactive=False`) must still get the
+    `RotatingFileHandler` on root — CI / a non-TTY run is exactly when a
+    durable record is MOST needed, nobody is watching the terminal live.
+
+    Strip-falsifier (verified by hand: `is_interactive=False` reverted
+    to making this function a no-op, the pre-#6043 shape): this test
+    goes red — no `.reyn/logs/reyn.log` file, no `RotatingFileHandler`
+    on root."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path, is_interactive=False)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+        targets = [getattr(h, "baseFilename", None) for h in root.handlers]
+
+        assert str(log_file) in targets, (
+            "#6043 REGRESSION: is_interactive=False must still install "
+            "the reyn.log RotatingFileHandler"
+        )
+
+        logging.getLogger("reyn.canary").warning("not-interactive-marker-91fa")
+        for h in root.handlers:
+            h.flush()
+        assert "not-interactive-marker-91fa" in log_file.read_text()
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_a_non_interactive_run_also_still_prints_to_stderr(tmp_path, capsys) -> None:
+    """Tier 2: #6043 — the ONE behaviour this module's own comments ever
+    actually justified ("--cui / non-TTY keep logging on stderr —
+    debuggable / pipeable") must be PRESERVED, not silently dropped
+    while fixing the missing-file-record half. `is_interactive=False`
+    must ALSO print to stderr, not just to the file.
+
+    Strip-falsifier (verified by hand: the `if not is_interactive:
+    handlers.append(...)` branch removed): this test goes red — the
+    marker reaches the file but never stderr."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path, is_interactive=False)
+        logging.getLogger("reyn.canary").warning("stderr-preserved-marker-c410")
+        for h in root.handlers:
+            h.flush()
+
+        captured = capsys.readouterr()
+        assert "stderr-preserved-marker-c410" in captured.err, (
+            "#6043 REGRESSION: is_interactive=False must still ALSO print "
+            "to stderr (the pre-existing debuggable/pipeable behaviour) — "
+            f"got {captured.err!r}"
+        )
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_the_interactive_path_still_never_prints_to_stderr(tmp_path, capsys) -> None:
+    """Tier 2: falsification contrast — `is_interactive=True` (the
+    default, matching every OTHER test in this file) must NOT gain a
+    stderr handler; #6043's own bug was exactly a stray stderr write
+    corrupting the live region. Non-regression guard for the fix above."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path)
+        logging.getLogger("reyn.canary").warning("interactive-no-stderr-marker")
+        for h in root.handlers:
+            h.flush()
+
+        captured = capsys.readouterr()
+        assert "interactive-no-stderr-marker" not in captured.err, (
+            "#6043 REGRESSION: the interactive path must never print to "
+            f"stderr — got {captured.err!r}"
+        )
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_apply_logs_config_still_refines_the_non_interactive_handler(tmp_path) -> None:
+    """Tier 2: #6043 — `_apply_logs_config` is no longer gated on
+    `is_interactive` at its own call site (chat.py); confirm it still
+    finds and refines the handler `is_interactive=False` installed —
+    the real config values must reach the non-interactive path too, not
+    only the interactive one."""
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    try:
+        _setup_interactive_logging(tmp_path, is_interactive=False)
+        _apply_logs_config(LogsConfig(max_bytes=4096, backup_count=1))
+
+        from logging.handlers import RotatingFileHandler
+
+        rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+        assert rotating and rotating[0].maxBytes == 4096, (
+            f"#6043 REGRESSION: expected exactly one RotatingFileHandler "
+            f"with the refined max_bytes — got {rotating!r}"
+        )
+        assert rotating[0].backupCount == 1
+    finally:
+        logging.captureWarnings(False)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)


### PR DESCRIPTION
**[tui-coder]** — Closes #6043. lead-coder's own裁定: https://github.com/tya5/reyn/issues/6043#issuecomment-5611279813 (root-cause investigation posted at https://github.com/tya5/reyn/issues/6043#issuecomment-5611185481)

## The root cause (lead-coder's own question, answered by re-reading the function's own comments)

`_setup_interactive_logging()` held TWO separate facts as ONE decision, both gated by the SAME `is_interactive` check: "whether to write to `reyn.log` at all" and "whether to ALSO print to the terminal." The only stated reasoning anywhere in this function's own comments (`--cui`/non-TTY keep logging on stderr — debuggable/pipeable) justifies the SECOND fact only — never "don't write to the file either." "Not interactive" and "don't keep a record" are different facts; CI and non-TTY runs are exactly when a durable record is most needed.

## Fix

`RotatingFileHandler` installs unconditionally now (both call sites in `chat.py` dropped their own `if is_interactive:` gate on calling this function, and `_apply_logs_config`'s own gate too). Only the ADDITIONAL stderr mirror stays conditional on `is_interactive=False` — preserving the one behaviour this module ever justified, and never added when `is_interactive=True` (the interactive CUI owning the terminal being exactly #6043's own bug shape).

## Investigation trail (posted to #6043 as it happened)

Verified by direct reproduction that the *correct* sequence (redirect-before-config-load) already captured #6038's warnings into `reyn.log`, not stderr — ruling out a simple ordering bug. Traced `_inline_interactive()`'s `not cui and stdin_isatty and stdout_isatty` AND-condition as the likely divergence on owner's git-bash/Windows environment: if either TTY check evaluates `False` there, `is_interactive` becomes `False`, and the OLD code skipped the file handler entirely — meaning every WARNING+ record (not just #6038's new ones) would have always gone to raw stderr via `logging.lastResort` for that session, with no `reyn.log` record at all. This PR closes that gap regardless of which way `is_interactive` resolves for owner.

## Tests

4 new (`test_inline_interactive_logging.py`): file handler installs when not interactive; stderr mirror preserved when not interactive (the pre-existing debuggable/pipeable behaviour); stderr mirror absent when interactive (#6043's own non-regression guard); `_apply_logs_config` still refines the non-interactive handler. Docstrings on 2 functions corrected where they asserted the old all-or-nothing gate as current fact. Strip-falsified by hand, 3 separate strips (stderr-mirror addition / stderr-mirror absence on the interactive path / the file handler's own unconditional install) — all 3 independently confirmed to bite.

## Test plan
- [x] `ruff check .`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `silent_except_ratchet.py` — all green.
- [x] Scoped pytest: `test_inline_interactive_logging.py` (11), `test_litellm_lazy_load.py` + `test_config_warning_chrome_4194.py` (23, neighborhood) — 34 passed.
- [x] (skipped — Visual, standing waiver)

review: lead-coder. Pushing without waiting on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
