### PR TITLE
fix(part of #6000): re-arm the stall-dump watchdog every threshold_ms/2, not every tick

### DIFF
--- a/src/reyn/runtime/loop_tripwire.py
+++ b/src/reyn/runtime/loop_tripwire.py
@@ -1065,6 +1065,49 @@ async def watch_event_loop(
     the wake-up landed, feed :class:`LoopTripwire`, re-arm the dead-man's
     switch, and hand the once-per-episode notices to the caller.
 
+    **#6000 (architect measurement, platform-independent of the Windows
+    question this issue otherwise turns on): re-arming ``stack_dump``
+    every ``tick_seconds`` (50 ms) makes ``faulthandler.dump_traceback_
+    later`` tear down and recreate its own OS thread ~20 times/second —
+    ~72,000 thread churns/hour — and ``cancel_dump_traceback_later``
+    (called internally on every re-arm) BLOCKS the event-loop thread on
+    ``PyThread_acquire_lock(thread.running, 1)`` until the outgoing
+    thread's own join completes. The mechanism meant to detect the loop
+    stalling was adding to the very lateness it watches for, on every
+    single tick, whether or not a stall was ever happening.
+
+    Fixed: re-arm at most once every ``tripwire.threshold_ms / 2``
+    (:data:`_stack_dump_rearm_interval_seconds` below), not every tick.
+    ``armed_last_tick`` still carries "is a timer currently pending"
+    across ticks where the interval hasn't elapsed — the underlying
+    ``faulthandler`` timer stays pending regardless of whether THIS tick
+    chose to refresh it, so skipping a refresh does not un-arm anything.
+
+    Why HALF the threshold, not some other fraction: each successful
+    re-arm resets the pending timer to fire ``threshold_ms`` in the
+    future FROM THAT MOMENT (``dump_traceback_later`` always commits to
+    a fresh full-length countdown, never an increment). Spacing re-arms
+    ``threshold_ms / 2`` apart means the CURRENTLY pending timer always
+    has at least ``threshold_ms / 2`` of remaining slack at the moment
+    the NEXT re-arm is due — since a healthy loop's own tick cadence
+    (``tick_seconds``, normally far below ``threshold_ms / 2``) reaches
+    that due moment long before the pending timer could expire on its
+    own, the timer can only ever actually fire because of a genuine
+    stall, never because a re-arm merely ran a little late.
+
+    Detection-delay bound for a genuine, permanent stall (derived, not
+    copied from the issue's own first-pass estimate — verified against
+    ``dump_traceback_later``'s actual "full reset per call" semantics,
+    see this module's own #6000 history): the pending timer active when
+    the stall begins was itself armed somewhere between 0 and
+    ``threshold_ms / 2`` before the stall's own onset (the most recent
+    due re-arm before onset), so it fires between
+    ``threshold_ms - threshold_ms / 2`` and ``threshold_ms`` after the
+    stall started — i.e. within ``(threshold_ms / 2, threshold_ms]``.
+    This is NOT slower than the old every-tick cadence's own ~
+    ``threshold_ms`` delay (same upper bound), only occasionally faster;
+    what changes is thread churn, not worst-case detection latency.
+
     ``on_stall(lateness_ms)`` fires the FIRST tick of each stall episode
     (``LoopTripwire.observe``'s own once-only return); ``on_recovered()``
     fires once when the episode ends. ``turn_active`` (if the caller has
@@ -1097,10 +1140,19 @@ async def watch_event_loop(
     # lands — see the block below for why this is a flag consumed on a
     # LATER tick, never truncated the moment the fire is detected.
     pending_truncate = False
+    # #6000: half the tripwire's own threshold — see this function's own
+    # docstring for the derivation. Reads `tripwire.threshold_ms` (not a
+    # module constant) so a changed REYN_TRIPWIRE_MS changes this too,
+    # the same single-source-of-truth reasoning #6021 already applied to
+    # `StallDumpArm`'s own `seconds=` argument.
+    stack_dump_rearm_interval_seconds = tripwire.threshold_ms / 1000 / 2
+    last_stack_dump_rearm_at: "float | None" = None
     if stack_dump is not None and tripwire.should_arm_stack_dump():
         # Arm for the FIRST wait too — a stall on the very first tick would
         # otherwise go undumped (#5870 stage 1).
         armed_last_tick = stack_dump.rearm()
+        if armed_last_tick:
+            last_stack_dump_rearm_at = last
     try:
         while True:
             await sleep(tick_seconds)
@@ -1154,9 +1206,27 @@ async def watch_event_loop(
             # previous pending timer; a fire detected THIS tick has
             # already closed via `record_stack_dump()` above, so it never
             # re-arms a further timer for the SAME still-ongoing episode.
-            armed_last_tick = bool(
-                stack_dump is not None and tripwire.should_arm_stack_dump() and stack_dump.rearm()
-            )
+            #
+            # #6000: unlike the suppression above, "not yet due" does NOT
+            # touch `armed_last_tick` — the previous re-arm's own timer is
+            # still genuinely pending (this function's own docstring: a
+            # skipped refresh doesn't un-arm anything), so the "is there a
+            # pending arm to read back" flag must survive unchanged across
+            # ticks where the interval hasn't elapsed yet, exactly as it
+            # already does across every tick within a single stall episode
+            # once suppressed. Only `should_arm_stack_dump()` being False
+            # forces the flag to False — the one case where the caller
+            # deliberately stopped wanting a pending timer at all.
+            if stack_dump is None or not tripwire.should_arm_stack_dump():
+                armed_last_tick = False
+            elif (
+                last_stack_dump_rearm_at is None
+                or (now - last_stack_dump_rearm_at) >= stack_dump_rearm_interval_seconds
+            ):
+                armed_last_tick = stack_dump.rearm()
+                if armed_last_tick:
+                    last_stack_dump_rearm_at = now
+            # else: not yet due — armed_last_tick keeps its prior value.
             if fired is not None:
                 on_stall(fired)
             elif tripwire.consume_recovered() and on_recovered is not None:

--- a/tests/runtime/test_5977_stall_dump_suppression.py
+++ b/tests/runtime/test_5977_stall_dump_suppression.py
@@ -165,7 +165,16 @@ async def test_watch_event_loop_dumps_at_most_once_per_stall_episode(tmp_path: P
     converge either way). See
     ``test_watch_event_loop_never_arms_a_second_timer_before_recording_the_first_dump``
     below, which ends WHILE STILL IN THE STALL (no recovery tick), for
-    the script that actually separates the two orderings."""
+    the script that actually separates the two orderings.
+
+    #6000 (unrelated axis, same call-count witness): ``rearm_calls`` no
+    longer means "once per healthy tick" even on a build with ①'s own
+    gate correctly applied — ``watch_event_loop`` also throttles calling
+    ``StallDumpArm.rearm()`` to at most once every ``threshold_ms / 2``
+    (250 / 2 = 125 ms here), so the healthy tick at 0.05 (only 50 ms
+    after the initial arm) is skipped too, not just the suppressed
+    second over-threshold tick — see this test's own updated assertion
+    below for the arithmetic."""
     arm, path = _open_arm(tmp_path, label="t1")
     rearm_wrapper, rearm_calls = _counting(arm.rearm)
     arm.rearm = rearm_wrapper  # type: ignore[method-assign]
@@ -191,9 +200,12 @@ async def test_watch_event_loop_dumps_at_most_once_per_stall_episode(tmp_path: P
     assert final_content == markers[-1], (
         "the file must hold ONLY the last dump's marker (no earlier content lingering)"
     )
-    assert rearm_calls[0] == 3, (
-        "initial arm + the ONE tick that dumped — the second over-threshold "
-        "tick's re-arm must be skipped, not just its readback ignored"
+    assert rearm_calls[0] == 2, (
+        "#6000: init + the recovery tick's own fresh-episode re-arm — the "
+        "tick BETWEEN onset and recovery (0.05, healthy, not yet due for "
+        "its #6000 interval re-arm at this threshold) and the SECOND "
+        "over-threshold tick (0.85, suppressed by ①'s gate) must both be "
+        "skipped, not just have their readback ignored"
     )
 
 
@@ -310,14 +322,18 @@ async def test_watch_event_loop_never_arms_a_second_timer_before_recording_the_f
 
     Correct (decide re-arm AFTER ``observe()``): the tick that detects
     dump#1 (0.45) has ALREADY closed the episode's allowance by the time
-    it decides whether to re-arm, so it does not — 2 total ``rearm()``
-    calls (init + the one healthy tick). Buggy (decide BEFORE
-    ``observe()``, checking "should I arm" and "did the arm I just made
-    fire" together): the SAME tick both re-arms unconditionally AND
-    detects the fire — a 3rd, uncancelled call, a real live timer left
-    pending for no reason. Strip-falsify (verified by hand, both
-    directions): swapping the re-arm decision back to before ``observe()``
-    in ``watch_event_loop`` turns this 2 into 3."""
+    it decides whether to re-arm, so it does not — only the INITIAL arm
+    ever lands; the healthy tick at 0.05 is also skipped, but for a
+    SEPARATE reason (#6000: not yet due for its own ``threshold_ms / 2``
+    interval re-arm at this threshold — 50 ms < 125 ms). 1 total
+    ``rearm()`` call. Buggy (decide BEFORE ``observe()``, checking
+    "should I arm" and "did the arm I just made fire" together): the
+    0.45 tick both re-arms (using the STALE pre-``observe()``
+    ``should_arm_stack_dump()`` reading, and by 0.45 the #6000 interval
+    IS due) AND detects the fire — a 2nd, uncancelled call, a real live
+    timer left pending for no reason. Strip-falsify (verified by hand):
+    swapping the re-arm decision back to before ``observe()`` in
+    ``watch_event_loop`` turns this 1 into 2."""
     arm, path = _open_arm(tmp_path, label="t4")
     rearm_wrapper, rearm_calls = _counting(arm.rearm)
     arm.rearm = rearm_wrapper  # type: ignore[method-assign]
@@ -341,9 +357,65 @@ async def test_watch_event_loop_never_arms_a_second_timer_before_recording_the_f
 
     assert markers == [b"dump #1\n"]
     assert final_content == markers[-1]
-    assert rearm_calls[0] == 2, (
+    assert rearm_calls[0] == 1, (
         "the tick that detects the first dump must not ALSO arm a second, "
-        "uncancelled timer for the still-ongoing stall"
+        "uncancelled timer for the still-ongoing stall — only the initial "
+        "arm should ever land for this script"
+    )
+
+
+@pytest.mark.asyncio
+async def test_healthy_ticks_rearm_at_most_once_per_half_threshold_not_every_tick(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #6000 — architect's own real-machine measurement:
+    re-arming ``StallDumpArm`` every ``tick_seconds`` (50 ms) makes
+    ``faulthandler.dump_traceback_later`` tear down and recreate its own
+    OS thread ~20 times/second, and the internal
+    ``cancel_dump_traceback_later`` BLOCKS the event-loop thread on the
+    outgoing thread's own join — the watchdog was adding to the very
+    lateness it exists to detect, on every healthy tick, not only during
+    a real stall.
+
+    Clock script: 6 entirely healthy ticks (50 ms apart, never exceeding
+    ``threshold_ms``), 250 ms of coverage at threshold_ms=250 (so the
+    #6000 re-arm interval is 125 ms). A rearm is due every 125 ms —
+    roughly every OTHER tick, not every tick — so this asserts strictly
+    FEWER ``rearm()`` calls than ticks: init + 2 due re-arms (at the
+    ticks landing at/after 0.15 and 0.30) = 3, not init + 6 = 7 (the old
+    every-tick cadence's own count for this same script).
+
+    Strip-falsify (verified by hand: the ``(now - last_stack_dump_rearm_
+    at) >= stack_dump_rearm_interval_seconds`` gate in
+    ``watch_event_loop`` temporarily forced to always-``True``, restoring
+    the pre-#6000 every-tick cadence): ``rearm_calls[0]`` goes from 3 to
+    7 for this exact script."""
+    arm, path = _open_arm(tmp_path, label="t6000")
+    rearm_wrapper, rearm_calls = _counting(arm.rearm)
+    arm.rearm = rearm_wrapper  # type: ignore[method-assign]
+
+    clock = _ScriptedClock([0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30])
+    tripwire = LoopTripwire(threshold_ms=250.0)
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await watch_event_loop(
+                tripwire,
+                on_stall=lambda _ms: None,
+                stack_dump=arm,
+                tick_seconds=0.05,
+                clock=clock,
+                sleep=clock.sleep,
+            )
+    finally:
+        arm.close()
+
+    assert rearm_calls[0] == 3, (
+        f"expected init + 2 due re-arms (every ~125ms) over 6 healthy "
+        f"50ms ticks, not one re-arm per tick — got {rearm_calls[0]}"
+    )
+    assert rearm_calls[0] < 7, (
+        "#6000 REGRESSION: re-arming on every tick regardless of the "
+        "#6000 interval would give 7 (init + 6 ticks) for this script"
     )
 
 


### PR DESCRIPTION
**[tui-coder]** — part of #6000: re-arm the stall-dump watchdog every `threshold_ms/2`, not every tick.

## Root cause (architect, platform-independent of the Windows question #6000 otherwise turns on)

architect fetched and read `Modules/faulthandler.c` (main, verbatim source, not run locally) → https://github.com/tya5/reyn/issues/6000#issuecomment-5611014649

```c
dump_traceback_later():
    cancel_dump_traceback_later();   // PyThread_acquire_lock(thread.running, 1) -- waits for the outgoing thread's own join
    PyThread_start_new_thread(faulthandler_thread, NULL)
```

`watch_event_loop` re-armed `StallDumpArm` unconditionally every `tick_seconds` (50ms) — ~20 thread churns/second, ~72,000/hour, and the `cancel_dump_traceback_later` call **blocks the event-loop thread** on the outgoing thread's own join. The mechanism meant to detect the loop stalling was adding to the very lateness it watches for, every single tick, whether or not a stall was ever happening. This may also explain the owner's own "250ms で常時発火する" report.

## Fix

`watch_event_loop` now re-arms `stack_dump` at most once every `tripwire.threshold_ms / 2` seconds — derived from the **same** `LoopTripwire` instance the caller already built from `REYN_TRIPWIRE_MS` (the #6021 single-source-of-truth pattern), so changing the threshold changes this interval too, no separate constant to desync. `armed_last_tick` still carries "is a timer currently pending" unchanged across ticks where the interval hasn't elapsed — the underlying `faulthandler` timer stays genuinely pending regardless of whether a given tick chose to refresh it.

## Why half, and the actual detection-delay bound

⚠️ I derived this myself against `dump_traceback_later`'s real semantics rather than copying the issue's own first-pass estimate, and the result differs from what was proposed in the dispatch — noting that explicitly rather than silently matching a number I hadn't verified.

`dump_traceback_later` always commits to a **fresh full-length** countdown on each call (never an increment) — confirmed by architect's own C read above. So:

- Spacing re-arms `threshold_ms/2` apart guarantees the currently-pending timer always has ≥ `threshold_ms/2` of slack remaining at the moment the next re-arm is due. A healthy loop's own tick cadence (`tick_seconds`, far below `threshold_ms/2`) always reaches that due-moment before the pending timer could expire on its own — the timer only fires on a genuine stall.
- For a **permanent** stall: the pending timer live when the stall begins was itself armed somewhere between 0 and `threshold_ms/2` *before* the stall's own onset, so it fires **within `(threshold_ms/2, threshold_ms]` after the stall starts** — the same upper bound as the old every-tick cadence (never slower), sometimes faster. This is documented in `watch_event_loop`'s own docstring.

This does **not** claim to fix the crash — independent value either way, per architect's own framing (owner: crash may or may not stop; the thread-churn/self-blocking defect is real regardless).

## Tests

- 3 existing tests in `test_5977_stall_dump_suppression.py` had their `rearm()` call-count assertions updated (pinned to the old every-tick cadence; underlying claims — per-episode suppression, before/after-`observe()` ordering — unchanged, still pass, still discriminate a reintroduced ordering bug — verified by hand for both).
- 1 new test: `test_healthy_ticks_rearm_at_most_once_per_half_threshold_not_every_tick` — 6 healthy 50ms ticks over a 250ms threshold produce 3 `rearm()` calls, not 7.
- Strip-falsified by hand (in-file `Edit` → run → `Edit` back, no `git checkout`/`stash`/`restore`): forcing the interval gate to always-`True` (restoring the pre-fix every-tick cadence) turned all 3 updated assertions + the new test red simultaneously.

Full gate suite green (`ruff`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, the `tests/`-path-conditional gates). Diff-scoped pytest green (`test_5977_stall_dump_suppression.py`, `test_5998_disarm_before_reset.py`, `test_6000_fd_number_never_released.py`, `test_5898_loop_tripwire.py`, `test_5985_stall_dump_sweep.py`, `test_loop_probe_3539.py`, `test_3671_stall_trace_startup_wiring.py`).

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the changed test file
- [x] scoped pytest, all listed above
- [x] (skipped — Visual, standing waiver 2026-08-08)

part of #6000 — crash reproduction/root-cause still pending the owner's own `REYN_TRIPWIRE_MS` A/B test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
