### PR TITLE
fix(#6008): memoize the ambient PATH read so policy and exec see the same value

### DIFF
--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -75,11 +75,11 @@ separately).
 from __future__ import annotations
 
 import logging
-import os
 from typing import Callable
 
 from reyn.schemas.models import SandboxedExecIROp
 from reyn.security.sandbox import SandboxPolicy
+from reyn.security.sandbox.backend import ambient_path
 from reyn.security.sandbox.launcher import resolve_backend, run_and_classify
 from reyn.security.sandbox.policy import (
     deny_narrowed_write_grants,
@@ -135,7 +135,7 @@ async def run_sandboxed_exec(
     # BLOCKING ③'s own point, carried forward: the binary policy approves
     # and the binary that runs must be resolved from the SAME PATH/cwd.
     cwd = str(ctx.workspace.base_dir)
-    env_path = os.environ.get("PATH")
+    env_path = ambient_path()  # #6008: memoized, one real read per process
 
     # #6007 BLOCKING (architect co-vet, issuecomment-5580912677): `op.cmd`
     # is read into `cmd_text` here, ONCE, and reused below for both the

--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -94,15 +94,16 @@ that will actually matter once 段4 lands.
    recording what happened either way (``exec_threat_scanned`` when the
    scan ran, ``exec_threat_scan_skipped`` when it did not) — see
    :func:`_check_segment`.
-3. **``argv[0]`` resolution read ambient ``os.environ["PATH"]``, not the
-   env a sandboxed run will actually see.** ``sandbox/seatbelt.py:425``
-   only falls back to ``os.environ`` when the caller passes no explicit
-   PATH — 段4's own sandbox env can differ, and resolving against the
-   wrong one reproduces the EXACT class #5984 found 4 instances of, one
-   layer down: the binary this module approves and the binary that
-   actually runs could be two different files. :func:`check_exec_plan_
-   policy` now takes BOTH ``env_path`` AND ``cwd`` (a version-manager's
-   per-directory config is read from ``cwd`` too — the same resolution
+3. **``argv[0]`` resolution read the ambient PATH directly, not the
+   env a sandboxed run will actually see.** A sandbox backend's own
+   env-building only falls back to the ambient PATH when the caller
+   passes no explicit one — 段4's own sandbox env can differ, and
+   resolving against the wrong one reproduces the EXACT class #5984
+   found 4 instances of, one layer down: the binary this module approves
+   and the binary that actually runs could be two different files.
+   :func:`check_exec_plan_policy` now takes BOTH ``env_path`` AND ``cwd``
+   (a version-manager's per-directory config is read from ``cwd`` too —
+   the same resolution
    input, same risk) as REQUIRED keyword-only arguments (no internal
    fallback to ``os.environ``, no internal derivation from
    ``ctx.workspace``) — every caller, present and future, must decide and
@@ -233,7 +234,9 @@ async def check_exec_plan_policy(
     sandboxed run will actually see — BOTH REQUIRED, keyword-only, no
     internal fallback (#5991 BLOCKING ③, this module's own docstring):
     every caller must decide the real values (``sandboxed_exec.py``'s own
-    ``env_path = os.environ.get("PATH")`` / ``cwd = str(ctx.workspace.
+    ``env_path = ambient_path()`` (#6008 — the process-lifetime-memoized
+    accessor in ``sandbox/backend.py``, the SAME one every sandbox
+    backend's own env-building calls) / ``cwd = str(ctx.workspace.
     base_dir)``, once 段4 wires this module in, is the pair to reuse)
     rather than let this function silently resolve against values that
     may not match what actually executes.

--- a/src/reyn/security/sandbox/backend.py
+++ b/src/reyn/security/sandbox/backend.py
@@ -389,6 +389,61 @@ def all_concrete_backend_classes() -> "tuple[type, ...]":
     return (SeatbeltBackend, LandlockBackend, NoopBackend, DockerEnvironmentBackend)
 
 
+_ambient_path_read = False
+_ambient_path_cache: "str | None" = None
+
+
+def ambient_path() -> "str | None":
+    """The process's own ambient ``PATH`` — read from the real environment
+    exactly ONCE per process, then memoized for the rest of this process's
+    life (#6008, architect ruling).
+
+    WHY THIS EXISTS: ``check_exec_plan_policy`` (policy) and a sandbox
+    backend's own env-building (``noop_backend.py``/``seatbelt.py``/
+    ``landlock.py``, exec) each used to read the ambient ``PATH``
+    independently, with an ``await`` (a real suspension point — the
+    policy check itself) between the two reads. Nothing in reyn ever
+    WRITES this variable (measured, architect: a `git grep` across `src/`
+    for env-mutating calls — `[...]=`/`setdefault`/`update`/`pop` — found
+    zero touching `PATH`, only `LITELLM_*`/`TIKTOKEN_*`/`REYN_*`/`OTEL_*`
+    names) — but a plugin or third-party library sharing this process
+    could, between the two reads, and #5838's own invariant ("the value
+    policy checked is the value exec uses") would then silently not
+    hold: policy would approve a binary resolved against one PATH, exec
+    would run a binary resolved against another.
+
+    WHY MEMOIZE-ON-FIRST-USE, NOT AN EXPLICIT STARTUP INIT (rejected,
+    architect): an explicit "read PATH here, at boot" call site creates
+    exactly one thing to forget to call before some other, less obvious
+    path reaches policy/exec first — memoizing inside the accessor itself
+    means every caller, in any order, converges on the SAME single real
+    read with no init step to skip.
+
+    WHY NOT A CALLER-SUPPLIED ``env`` PARAMETER (rejected, architect):
+    ``launcher.py`` deliberately has no caller-controlled arbitrary-env
+    escape hatch; threading one through here would reopen exactly that
+    closed hole for the sake of this one field.
+
+    ⚠️ COST, STATED (this is the point, not a side effect): once ANY
+    caller has read this, a change to the ambient PATH for the rest of
+    this process's life is invisible to every future caller here — a
+    running reyn process will not pick up a new PATH without a restart.
+    That is the correct direction for THIS invariant: the requirement is
+    "policy and exec see the SAME value", not "both see the latest
+    value".
+
+    Disclosed, not closed: this only bounds reyn's own two read sites (see
+    the module-level cache variables just above this function). A caller
+    that reaches into the environment directly, or a stdlib call that
+    reads it internally (e.g. ``shutil.which()`` with no explicit
+    ``path=``), is outside this accessor's reach."""
+    global _ambient_path_read, _ambient_path_cache
+    if not _ambient_path_read:
+        _ambient_path_cache = os.environ.get("PATH")
+        _ambient_path_read = True
+    return _ambient_path_cache
+
+
 def find_posix_true_binary() -> "list[str] | None":
     """#4364 PR-2: locate a known-good, args-free, always-exit-0 binary —
     the shared positive-control lookup Seatbelt and Landlock both need for

--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import platform
 import signal
 import subprocess
@@ -42,6 +41,7 @@ from ..backend import (
     AxisEnforcementDeclaration,
     SandboxResult,
     WrappedCommand,
+    ambient_path,
 )
 from ..capability import CapabilityDeclaration, CapabilitySupport
 
@@ -445,8 +445,10 @@ class LandlockBackend:
 
         executable, shim_argv = build_landlock_exec_argv(policy, argv[0], list(argv[1:]))
         env = resolve_passthrough_env(policy)
-        if "PATH" not in env and "PATH" in os.environ:
-            env["PATH"] = os.environ["PATH"]
+        if "PATH" not in env:
+            path = ambient_path()  # #6008: memoized, one real read per process
+            if path is not None:
+                env["PATH"] = path
         return WrappedCommand(argv=[executable, *shim_argv], env=env, cleanup=None)
 
     async def run(
@@ -484,8 +486,10 @@ class LandlockBackend:
         # (#3075) — mirrors NoopBackend/SeatbeltBackend exactly via the shared
         # resolve_passthrough_env chokepoint.
         env = resolve_passthrough_env(policy)
-        if "PATH" not in env and "PATH" in os.environ:
-            env["PATH"] = os.environ["PATH"]
+        if "PATH" not in env:
+            path = ambient_path()  # #6008: memoized, one real read per process
+            if path is not None:
+                env["PATH"] = path
         # #4204 bucket E: see NoopBackend.run's matching comment — a direct
         # exec (no shell) never resets $PWD the way a real shell would, so
         # the whole parent env's stale value would otherwise leak through

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -42,6 +42,7 @@ from reyn.security.sandbox.backend import (
     AxisEnforcementDeclaration,
     SandboxResult,
     WrappedCommand,
+    ambient_path,
 )
 from reyn.security.sandbox.capability import CapabilityDeclaration, CapabilitySupport
 
@@ -616,8 +617,10 @@ class SeatbeltBackend:
                 pass
 
         env = resolve_passthrough_env(policy)
-        if "PATH" not in env and "PATH" in os.environ:
-            env["PATH"] = os.environ["PATH"]
+        if "PATH" not in env:
+            path = ambient_path()  # #6008: memoized, one real read per process
+            if path is not None:
+                env["PATH"] = path
 
         return WrappedCommand(
             argv=["sandbox-exec", "-f", profile_path, *argv],
@@ -656,8 +659,10 @@ class SeatbeltBackend:
         # Build env from passthrough allowlist ∪ the standard proxy/CA env
         # (#3075); fall back PATH if not listed.
         env = resolve_passthrough_env(policy)
-        if "PATH" not in env and "PATH" in os.environ:
-            env["PATH"] = os.environ["PATH"]
+        if "PATH" not in env:
+            path = ambient_path()  # #6008: memoized, one real read per process
+            if path is not None:
+                env["PATH"] = path
         # #4204 bucket E: see NoopBackend.run's matching comment — a direct
         # exec (no shell) never resets $PWD the way a real shell would, so
         # the whole parent env's stale value would otherwise leak through

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import signal
 import subprocess
 from typing import TYPE_CHECKING, Callable
@@ -23,6 +22,7 @@ from .backend import (
     AxisEnforcementDeclaration,
     SandboxResult,
     WrappedCommand,
+    ambient_path,
 )
 from .capability import CapabilityDeclaration, CapabilitySupport
 from .policy import POST_KILL_DRAIN_GRACE_SECONDS, SandboxPolicy, resolve_passthrough_env
@@ -58,8 +58,10 @@ def _build_env(policy: SandboxPolicy) -> dict[str, str]:
     # minus policy.env_deny_names (compat default, owner ruling B) — no
     # longer a curated union with a standard proxy/CA set.
     env = resolve_passthrough_env(policy)
-    if "PATH" not in env and "PATH" in os.environ:
-        env["PATH"] = os.environ["PATH"]
+    if "PATH" not in env:
+        path = ambient_path()  # #6008: memoized, one real read per process
+        if path is not None:
+            env["PATH"] = path
     return env
 
 

--- a/tests/security/test_6008_ambient_path_memoize.py
+++ b/tests/security/test_6008_ambient_path_memoize.py
@@ -1,0 +1,136 @@
+"""Tier 2: #6008 -- `ambient_path()` (`sandbox/backend.py`) reads the
+process's own ambient PATH exactly once and memoizes it, so
+`check_exec_plan_policy` (policy) and a sandbox backend's own env-building
+(exec) -- previously two independent `os.environ` reads separated by a
+real suspension point (the policy `await`) -- structurally converge on the
+SAME value, never two different ones (#5838's own invariant: the value
+policy checked is the value exec uses).
+
+Real ``OpContext``/``EventLog``/``Workspace`` + the REAL default sandbox
+backend throughout for the end-to-end witness below -- no mocks (CLAUDE.md
+testing policy). Mirrors ``tests/core/test_5838_stage4_shc_exec.py``'s own
+``test_the_real_childs_path_matches_sandboxed_execs_own_env_path`` (#6007),
+which this issue's own module docstring names as the exact gap: that test
+observed the two sides HAPPENED to agree; this file adds the test that a
+change occurring BETWEEN the two reads no longer causes them to diverge.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import reyn.security.sandbox.backend as backend_module
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import SandboxedExecIROp
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.security.sandbox.backend import ambient_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_ambient_path_cache():
+    """#6008: `ambient_path()`'s cache is a module-level, process-lifetime
+    flag+value pair by design (memoize-once, not per-call) -- without
+    resetting it, whichever test in the WHOLE pytest session calls it
+    FIRST freezes the value for every other test in the same process,
+    silently defeating any test here that means to observe a fresh read."""
+    backend_module._ambient_path_read = False
+    backend_module._ambient_path_cache = None
+    yield
+    backend_module._ambient_path_read = False
+    backend_module._ambient_path_cache = None
+
+
+def _make_ctx(tmp_path: Path) -> "tuple[OpContext, list]":
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=project_root)
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        # env_deny_names=["PATH"]: resolve_passthrough_env (#3901 PR-B ④)
+        # copies the WHOLE of live os.environ by default, PATH included --
+        # so a default policy's child would get PATH from LIVE os.environ
+        # directly, never reaching ambient_path()'s own fallback branch at
+        # all. Denying PATH here forces the ONLY source of PATH in the
+        # child to be that fallback -- the exact branch #6008 changed --
+        # so this test actually exercises the fixed code, not passthrough.
+        default_sandbox_policy={"env_deny_names": ["PATH"]},
+        contextual_permission=None,
+        sandbox_backend=None,
+    )
+    return ctx, []
+
+
+def test_ambient_path_reads_the_real_environment_exactly_once_and_memoizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the accessor's own core claim, isolated from any caller.
+    First call returns the REAL, currently-set PATH; a SUBSEQUENT
+    environment change is invisible to every later call in this process.
+
+    Strip-falsifier: revert `ambient_path()` to a bare
+    `os.environ.get("PATH")` (no memoization) and this goes red -- the
+    second call would return the newly-set value instead of the first
+    one."""
+    monkeypatch.setenv("PATH", "/original/marker/path")
+    first = ambient_path()
+    assert first == "/original/marker/path"
+
+    monkeypatch.setenv("PATH", "/a/completely/different/path")
+    second = ambient_path()
+
+    assert second == first, (
+        "a PATH change after the first read must not be visible to a "
+        "later caller -- that is the whole point of memoizing"
+    )
+    assert second != "/a/completely/different/path"
+
+
+@pytest.mark.asyncio
+async def test_a_path_change_between_policys_read_and_execs_read_no_longer_diverges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the load-bearing end-to-end witness (#6008's own acceptance
+    -- "the value policy used and the real child's own $PATH are the
+    same, observed from a real subprocess, both sides measured, neither
+    side re-deriving the other").
+
+    Simulates the exact hazard #6008 closes: `ambient_path()` is warmed
+    (as `run_sandboxed_exec`'s own policy-check path would do) BEFORE a
+    real environment change (a plugin/third-party library sharing this
+    process, mutating PATH after policy already read it) -- then a REAL
+    command is spawned through the REAL default sandbox backend, and its
+    OWN reported `$PATH` (a genuinely independent measurement: the
+    backend's own `resolve_passthrough_env` + PATH-fallback plumbing,
+    not a second call to `ambient_path()`) must still equal the WARMED
+    value, never the value PATH was changed to afterward.
+
+    Strip-falsifier: revert the 5 call sites in `noop_backend.py`/
+    `seatbelt.py`/`landlock.py`/`sandboxed_exec.py` to raw
+    `os.environ.get("PATH")` and this goes red on Linux/macOS CI (no
+    memoization left anywhere to freeze the value) -- the spawned
+    child's own `$PATH` would show the LATER value instead."""
+    monkeypatch.setenv("PATH", "/original/marker/path:/usr/bin:/bin")
+    warmed = ambient_path()  # simulates the policy-check path's own read
+    assert warmed == "/original/marker/path:/usr/bin:/bin"
+
+    # A plugin/third-party library mutating the ambient environment AFTER
+    # policy already read it -- the exact class #6008 exists for.
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    ctx, _ = _make_ctx(tmp_path)
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["/bin/sh", "-c", "echo $PATH"])
+    result = await execute_op(op, ctx)
+
+    assert result["status"] == "ok"
+    assert result["stdout"].strip() == warmed, (
+        "the real child's own $PATH must match the value policy already "
+        "saw before the environment changed, not the post-change value"
+    )


### PR DESCRIPTION
**[docs-maintainer]** — Closes #6008. (Dispatched to coder-smith originally; reassigned to me by lead-coder when coder-smith's session was unresponsive — see #6008's own comment thread.)

## What

`check_exec_plan_policy` (policy) and each sandbox backend's own env-building (exec) independently read `os.environ["PATH"]`, with a real suspension point (the policy check's own `await`) between the two reads. #5838's own invariant — "the value policy checked is the value exec uses" — rested on an unstated "nobody mutates `os.environ` mid-call" assumption.

## Design (architect ruling, already settled before this PR)

A single `ambient_path()` accessor in `sandbox/backend.py` reads `os.environ["PATH"]` exactly once per process and memoizes it. Policy's `env_path` local and every backend's PATH fallback now call this same accessor — structurally one real read, not two independent ones that happen to agree today.

Rejected alternatives (both architect, recorded in the accessor's own docstring):
- An explicit startup init point — creates a "forgot to call it before some path reaches policy/exec first" hazard a memoize-on-first-use has none of.
- A caller-supplied `env` parameter — reopens the caller-controlled arbitrary-env escape hatch `launcher.py` deliberately has none of.

**Cost, stated** (the issue's own requirement): once any caller has read this, a `PATH` change for the rest of this process's life is invisible everywhere here — a running reyn process needs a restart to pick up a new `PATH`. That's the correct direction for this invariant.

## Verified

- `git grep -c 'os\.environ\[.PATH.\]\|os\.environ\.get(.PATH.)' -- src/reyn/security src/reyn/core/op_runtime` now returns exactly **1** (the accessor's own real read in `backend.py`).
- New test (`tests/security/test_6008_ambient_path_memoize.py`) spawns a REAL command through the REAL default sandbox backend, changes `PATH` via `monkeypatch` AFTER warming the accessor (the exact hazard this closes), and asserts the real child's own `$PATH` still equals the warmed value — both sides measured independently (the child's PATH comes from the backend's own real env-building plumbing, not a second call to `ambient_path()`).
- Strip-falsified: reverting `ambient_path()` to a bare `os.environ.get("PATH")` turns both new tests red.
- Two now-stale docstring mentions in `exec_plan_policy.py` (naming the old direct read) updated in the same PR.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/verify_module_docstrings.py <changed src>`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/test_tier_audit.py --strict tests/security/test_6008_ambient_path_memoize.py`
- [x] `python scripts/check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` / `check_tests_path_literal_reference.py`
- [x] pytest scoped to diff — `test_6008_ambient_path_memoize.py` (2 new, strip-falsified) + full sibling suites (`test_5838_stage3_exec_plan_policy.py`, `test_5838_stage4_shc_exec.py`, `test_op_sandboxed_exec.py`, `test_sandbox_seatbelt.py`, `test_sandbox_landlock.py`, `test_landlock_exec_shim_1344e.py`) — 106 passed, 2 skipped
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
