### PR TITLE
docs(part of #5989): turn_end fires per loop iteration, not per operator turn

### DIFF
--- a/docs/concepts/runtime/hooks.md
+++ b/docs/concepts/runtime/hooks.md
@@ -34,7 +34,7 @@ valid in one is not necessarily valid in the other:
 | `session_start` | `builtin:lifecycle:session_start` | session opens | ✅ | ✅ |
 | `session_end` | `builtin:lifecycle:session_end` | session closes | ✅ | ✅ |
 | `turn_start` | `builtin:lifecycle:turn_start` | a turn begins | ✅ | ✅ |
-| `turn_end` | `builtin:lifecycle:turn_end` | a turn's terminal `stop_reason` | ✅ | ✅ |
+| `turn_end` | `builtin:lifecycle:turn_end` | one `_run_router_loop` iteration reaches a terminal `stop_reason` — see [Lifecycle points](#lifecycle-points) below for why this is not the same thing as "the operator's own turn" | ✅ | ✅ |
 | `mcp_resource_updated` | `builtin:external:mcp_resource_updated` | a subscribed MCP resource pushes an update | ✅ | ✅ |
 | `file_changed` | `builtin:external:file_changed` | a watched path changes ([`fs_watch`](../../reference/config/reyn-yaml.md#fs_watch-block) required) | ✅ | ✅ |
 | `cron_fired` | `builtin:external:cron_fired` | a `cron:` job fires (either `action`, #5209) | ✅ | ✅ |
@@ -228,7 +228,17 @@ the first turn begins.
 
 Implementation anchors:
 
-- `turn_end` fires at the terminal `stop_reason`
+- 🔴 **`turn_end` fires once per `_run_router_loop` ITERATION, not once per
+  operator-submitted turn.** `Session._run_router_loop` has more than one
+  caller (`session.py`) — including agent-to-agent message injection, not
+  only the local operator's own submitted message — and `turn_end`
+  dispatches unconditionally, in the same `finally` block, on EVERY one of
+  them. An operator hitting `turn_end` fire repeatedly for what reads as
+  "one" conversational turn is not a duplicate-emit bug; it is this row's
+  own name reading as narrower than what it actually covers. If your hook
+  needs "the operator's own turn ended, exactly once", filter on the
+  firing event's own fields (`chain_id`, `user_text`) rather than assuming
+  the point name alone answers that.
 
 ## External-event points
 


### PR DESCRIPTION
**[docs-maintainer]** — part of #5989.

## What

Owner reported `turn_end` "firing repeatedly" for what read as one conversational turn. Root cause (architect's own history-check + this PR's own read of the emit site): `Session._run_router_loop` has more than one caller — including agent-to-agent message injection, not only the operator's own submitted message — and `turn_end` dispatches unconditionally, in the same `finally` block, on EVERY loop iteration. Not a duplicate-emit defect: `hooks.md`'s own wording ("a turn's terminal `stop_reason`") read as narrower than what the mechanism actually covers.

## ⚠️ Target corrected from the original dispatch

The original ask named `docs/reference/runtime/events.md`. Verified (not assumed) that's the wrong file: `turn_end` is a **hook lifecycle point** (`src/reyn/hooks/schema_registry.py`), a separate, non-audit-event vocabulary — that page's own intro already distinguishes this ("Not the op values ... a different axis") — and `turn_end` does not appear in `AUDIT_EVENT_KINDS` (`event_schema.py`), so there is no row to add there. This PR instead corrects the two places that actually describe `turn_end`: `hooks.md`'s own `on:`-value table and its "Lifecycle points" implementation-anchor list.

## Deliberately untouched

`turn_start` / `session_start` / `session_end` — only `turn_end`'s own wording misled anyone tonight; widening this PR to the sibling three would be the same "fill everything while I'm in here" scope creep rejected earlier today for a different issue.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — 0 dangling into published pages, including the new in-page `#lifecycle-points` self-link
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
