### PR TITLE
fix(main red): isolate logging.root's handlers/level between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ import asyncio
 import copy
 import faulthandler
 import importlib.util
+import logging
 import os
 import sys
 import warnings
@@ -717,6 +718,54 @@ def _clear_find_project_root_cache() -> Iterator[None]:
     _find_project_root_uncached.cache_clear()
     yield
     _find_project_root_uncached.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_root_logging_handlers() -> Iterator[None]:
+    """Save + restore ``logging.getLogger()``'s own ``handlers``/``level``,
+    and turn ``captureWarnings`` back off, around every test (main-red,
+    2026-09-10, CI finding).
+
+    ``chat._setup_interactive_logging`` calls ``logging.basicConfig(...,
+    force=True)`` — REPLACING root's entire handler list, including (as of
+    #6045) attaching a bare ``logging.StreamHandler()`` when
+    ``is_interactive=False``, which binds WHATEVER ``sys.stderr`` object
+    is live at that exact call — under pytest's default ``fd``/``sys``
+    capture, that is THIS test's own per-test capture stream, not a
+    process-lifetime one. Every test in ``tests/`` that calls this
+    function (or drives ``chat._run``/``_run_remote`` directly) already
+    saves+restores ``root.handlers``/``level`` itself — this fixture is a
+    second, process-level net for the SAME class of hole
+    ``_isolate_stall_trace_file_handler_registration`` below already
+    closed for ``stall_trace``'s own registered path: a process-global a
+    test can mutate is this file's own responsibility to isolate, not
+    every individual caller's.
+
+    Real incident this closes: `test_stderr_summary_bypasses_a_rebound_
+    sys_stderr` (`test_5939_pr1_cache_release_and_forensics.py`) and
+    `test_with_no_target_ever_attached_the_exit_fallback_reaches_stderr`
+    (`test_5989_early_log_buffer.py`) both failed on `main` under `-n
+    auto`, in different xdist workers, neither reproducible by re-running
+    either test file alone or together with every other direct caller of
+    `_setup_interactive_logging` found by hand — consistent with a THIRD
+    test (never identified) elsewhere on the same worker leaving a bare
+    `StreamHandler()` attached to root whose own bound stream pytest later
+    closed at ITS OWN per-test teardown, independent of whether the
+    leaking test itself ever restored `root.handlers` (a python-level
+    restore does not undo pytest's own fd/stream lifecycle). Both target
+    tests' OWN claims were re-verified as still true in isolation before
+    writing this fixture — the fix is closing the class of hole, not
+    rewriting either test."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    yield
+    for handler in root.handlers:
+        if handler not in saved_handlers:
+            handler.close()
+    root.handlers[:] = saved_handlers
+    root.setLevel(saved_level)
+    logging.captureWarnings(False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/dev/test_isolate_root_logging_handlers_main_red.py
+++ b/tests/dev/test_isolate_root_logging_handlers_main_red.py
@@ -1,0 +1,138 @@
+"""Tier 2: main-red 2026-09-10 (CI finding) — `tests/conftest.py`'s
+`_isolate_root_logging_handlers` autouse fixture actually detaches a
+stray handler a test leaves on the root logger, and restores root's own
+level.
+
+The fixture ALSO calls `logging.captureWarnings(False)` in its own
+teardown, matching every individual `_setup_interactive_logging` caller's
+own manual cleanup — deliberately NOT given a dedicated test here: tried
+by hand first (the same `pytester` shape below), and pytest's OWN
+built-in warnings plugin already wraps each test's setup+call+teardown in
+its own `warnings.catch_warnings()`, which independently resets
+`warnings.showwarning` regardless of this fixture — so a test built this
+way stayed green with that specific line commented out (a Q4 violation:
+green with nothing of THIS fixture's own to bite on). The line stays (it
+is still correct production-cleanup-parity, and free), the false witness
+does not.
+
+Owner-visible background: `main` went red with 2 unrelated-looking
+failures (`test_stderr_summary_bypasses_a_rebound_sys_stderr` in
+`test_5939_pr1_cache_release_and_forensics.py`, and
+`test_with_no_target_ever_attached_the_exit_fallback_reaches_stderr` in
+`test_5989_early_log_buffer.py`) after #6045 (`chat._setup_interactive_
+logging` now attaches a bare `logging.StreamHandler()` — binding WHATEVER
+`sys.stderr` is live at that exact call — whenever `is_interactive=False`)
+landed. Both target tests' OWN claims re-verified as still true in
+isolation (their properties were never false): the actual mechanism is a
+stray `StreamHandler` left attached to root by SOME test elsewhere,
+surfacing as a "Logging error" traceback (a `ValueError: I/O operation on
+closed file` inside a completely unrelated test's own `emit()`, since
+pytest's own per-test capture stream that handler was bound to gets
+closed at THAT test's teardown) or a live write into a LATER test's own
+monkeypatched `sys.stderr`. Every individual caller of
+`_setup_interactive_logging` in `tests/` already saves+restores
+`root.handlers` itself — this fixture is the SAME process-level net
+`_isolate_stall_trace_file_handler_registration` (this file's own
+sibling autouse fixture) already provides for a different process-global
+(`stall_trace`'s registered path): a process-global a test can mutate is
+this file's own responsibility to isolate, not every individual caller's.
+
+Real, isolated inner pytest sessions throughout (`pytester`'s own
+subprocess seam — the SAME technique
+`test_isolate_litellm_process_globals_5918.py`'s own witness uses for a
+different conftest fixture), never a mock of pytest's own fixture
+machinery: the actual `tests/conftest.py` fixture, actual `logging`
+module."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+#: Same shape as test_isolate_litellm_process_globals_5918.py's own
+#: `_INNER_CONFTEST`: puts the repo root + src on sys.path then imports
+#: the REAL autouse fixture from the REAL tests/conftest.py — pytest
+#: activates any @pytest.fixture-decorated callable present in a conftest
+#: module's namespace, imported or not.
+_INNER_CONFTEST = """
+import sys
+sys.path.insert(0, {repo_root!r})
+sys.path.insert(0, {src_root!r})
+from tests.conftest import _isolate_root_logging_handlers  # noqa: F401
+"""
+
+#: test_a leaves a stray StreamHandler attached to root, bound to a
+#: throwaway StringIO — the EXACT shape #6045's `is_interactive=False`
+#: branch creates (a bare `logging.StreamHandler()`, no ownership
+#: tracking of its own) — WITHOUT any cleanup of its own, simulating a
+#: caller that never restores `root.handlers`. test_b, a SEPARATE test in
+#: the SAME inner session, checks root is clean — so the fixture's own
+#: per-test before/after hooks are the only thing that could have cleaned
+#: up between them, nothing else runs.
+_INNER_TEST_POLLUTION = """
+import io
+import logging
+
+_STRAY_STREAM = []
+_LEVEL_BEFORE_POLLUTION = []
+
+def test_a_leaves_a_stray_handler_and_a_changed_level_without_cleaning_up():
+    root = logging.getLogger()
+    _LEVEL_BEFORE_POLLUTION.append(root.level)
+    stream = io.StringIO()
+    _STRAY_STREAM.append(stream)
+    root.addHandler(logging.StreamHandler(stream))
+    root.setLevel(logging.DEBUG)
+    assert any(
+        isinstance(h, logging.StreamHandler) and h.stream is stream for h in root.handlers
+    )  # sanity
+
+def test_b_starts_with_no_stray_handler_original_level_and_capture_warnings_off():
+    assert _STRAY_STREAM, "setup: test_a must run first, in this same process"
+    root = logging.getLogger()
+    assert not any(
+        isinstance(h, logging.StreamHandler) and h.stream is _STRAY_STREAM[-1]
+        for h in root.handlers
+    ), (
+        "test_a's own stray StreamHandler leaked into test_b -- the isolation "
+        "fixture must DETACH any handler a test adds, not just leave root's "
+        "handler list for a later caller to inherit (main-red's own shape: a "
+        "LATER, unrelated test's teardown closes the stream this handler still "
+        "references, so ITS write raises there instead)"
+    )
+    assert root.level == _LEVEL_BEFORE_POLLUTION[-1], (
+        f"root.level leaked from test_a ({logging.DEBUG}) into test_b -- the "
+        f"isolation fixture must restore it to what it was BEFORE test_a ran "
+        f"({_LEVEL_BEFORE_POLLUTION[-1]!r})"
+    )
+"""
+
+
+def test_isolation_detaches_a_stray_handler_and_restores_level(
+    pytester: pytest.Pytester,
+) -> None:
+    """Tier 2: main-red acceptance ① (a stray handler does not survive
+    into the next test) + ② (root's own level is restored) — driven
+    together since both are the SAME fixture's before/after halves, in
+    ONE real isolated inner pytest session so ordering is guaranteed
+    (pytester's own subprocess, not `-n auto` — the outer suite's own
+    parallelism is exactly what this fixture exists to make irrelevant,
+    so the WITNESS must not depend on it either).
+
+    Strip (①): comment out the `for handler in root.handlers: ... handler
+    .close()` / `root.handlers[:] = saved_handlers` lines in the fixture
+    — `test_b` goes red (the stray handler is still attached).
+    Strip (②): comment out `root.setLevel(saved_level)` — `test_b` goes
+    red (`root.level` stays `DEBUG`)."""
+    import reyn
+
+    repo_root = Path(reyn.__file__).resolve().parents[2]
+    src_root = str(repo_root / "src")
+
+    pytester.makeconftest(_INNER_CONFTEST.format(repo_root=str(repo_root), src_root=src_root))
+    pytester.makepyfile(test_inner=_INNER_TEST_POLLUTION)
+
+    result = pytester.runpytest_subprocess("test_inner.py")
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
**[tui-coder]** — fix(main red): isolate `logging.root`'s handlers/level between tests.

## Root cause (verified, not the two hypotheses first proposed)

Two failures on `main`, in different xdist workers:
- `test_stderr_summary_bypasses_a_rebound_sys_stderr` — `tests/runtime/test_5939_pr1_cache_release_and_forensics.py` (e2e-coder's PR-1)
- `test_with_no_target_ever_attached_the_exit_fallback_reaches_stderr` — `tests/runtime/test_5989_early_log_buffer.py` (mine, #6037)

Both trace to the **same** mechanism: #6045 (`chat._setup_interactive_logging` now attaches a bare `logging.StreamHandler()` — binding whatever `sys.stderr` is live at that exact call — whenever `is_interactive=False`) creates a stray root handler. If it ever lingers past its own test (a caller missing a restore, or `-n auto`'s own worker-assignment nondeterminism), a LATER, unrelated test's capture-stream teardown closes the stream that stray handler still references. The next time anything logs through root, the stray handler's own `emit()` raises `ValueError: I/O operation on closed file`, and `logging`'s own `Handler.handleError()` fallback writes the traceback into whatever `sys.stderr` currently is — landing inside a completely unrelated test's own monkeypatched stream.

I checked the actual code, not just the CI traceback, to rule out the "the mirror itself binds the wrong stream" hypothesis lead-coder raised: `process_memory_release._write_stderr_summary` writes **directly** to `sys.__stderr__` — it never touches `sys.stderr`, so #6045's `is_interactive=False` mirror cannot be corrupting THAT specific path. The failing assertion in each test is root-logger propagation reaching a stray, broken handler elsewhere on the same logger hierarchy — not either test's own subject function misbehaving.

**Both tests' own claims re-verified as still true** — standalone, and together with every direct caller of `_setup_interactive_logging` I found by hand (`test_5989_early_log_buffer.py`, `test_inline_interactive_logging.py`, `test_agui_remote_inline_p3.py`, `test_litellm_lazy_load.py`, `test_loop_probe_3539.py`, `test_3671_stall_trace_startup_wiring.py`) — none reproduce the failure serially, consistent with an `-n auto` worker-assignment-dependent leak from a third, unidentified test rather than a direct two-file interaction.

## Fix

At the class level, not per-test: a new autouse `_isolate_root_logging_handlers` fixture in `tests/conftest.py`, mirroring the **existing** `_isolate_stall_trace_file_handler_registration` precedent (#5879 — same "process-global a test can mutate is this file's own responsibility to isolate" reasoning). Detaches (closing where the handler owns its own stream, e.g. a `RotatingFileHandler`) any handler a test leaves on root, restores root's own level, and turns `captureWarnings` back off.

This does **not** require finding the exact single leaking test — it closes the whole class, matching lead-coder's own broader concern that today's 2 known failures may not be the full population of "tests that assume nothing reaches stderr by default."

**Neither target test's own code changed** — both properties they guard were verified still true; what was missing was process-level test isolation for the new handler-creation site #6045 introduced.

## Tests

New `tests/dev/test_isolate_root_logging_handlers_main_red.py`, `pytester`-subprocess-driven (same technique as `test_isolate_litellm_process_globals_5918.py`) — the real `conftest.py` fixture, real `logging` module, no mocks. One test survives after I wrote and then removed a second one whose own witness (`warnings.showwarning` identity) turned out to already be reset by pytest's own built-in warnings plugin independent of this fixture — caught by hand while stripping it (a Q4 false-witness, not claimed; the `captureWarnings(False)` line itself stays, as harmless production-parity). Strip-falsified by hand (in-file `Edit` → run → `Edit` back, no `git checkout`/`stash`/`restore`): commenting out either the detach block or the level-restore line turns the remaining test red on that specific claim.

Full gate suite green (`ruff`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, the `tests/`-path-conditional gates). Scoped pytest green: both originally-failing test files + every direct `_setup_interactive_logging` caller + the new isolation test + the litellm-isolation sibling, together (52 passed).

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the changed/new test files
- [x] scoped pytest, all listed above
- [x] (skipped — Visual, standing waiver 2026-08-08)

part of #6037 / part of #5939 — no closing keyword; this is a test-infrastructure fix for a shared class of hole, not a feature closing either issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
