### PR TITLE
fix(#5978): gate -- faulthandler timer API has exactly one caller

### DIFF
--- a/.github/workflows/faulthandler-timer-api-single-caller-gate.yml
+++ b/.github/workflows/faulthandler-timer-api-single-caller-gate.yml
@@ -1,0 +1,47 @@
+name: faulthandler timer API single-caller gate
+
+# Regression-prevention gate for #5978: the set of modules calling
+# faulthandler's timer API (faulthandler.dump_traceback_later(...) /
+# faulthandler.cancel_dump_traceback_later()) must be exactly
+# {src/reyn/runtime/stall_trace.py}. This gate is ALREADY GREEN -- it is a
+# ratchet against a future SECOND caller appearing, not a cleanup. See
+# scripts/check_faulthandler_timer_api_single_caller.py's own module
+# docstring for the full design and the #5978 issue-thread scope
+# narrowing that led to this exact gate shape.
+#
+# `paths: src/**` matches this gate's own scan scope exactly -- this
+# gate's population lives entirely under src/, so a change outside that
+# tree cannot add or remove a faulthandler-timer-API call site this
+# script counts.
+on:
+  pull_request:
+    paths:
+      - "src/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+
+permissions:
+  contents: read
+
+jobs:
+  faulthandler-timer-api-single-caller:
+    name: faulthandler timer API single-caller gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_faulthandler_timer_api_single_caller.py is
+      # stdlib-only (ast / subprocess / pathlib). No pip install needed.
+      - name: Check faulthandler timer API has a single caller
+        run: |
+          python scripts/check_faulthandler_timer_api_single_caller.py

--- a/scripts/check_faulthandler_timer_api_single_caller.py
+++ b/scripts/check_faulthandler_timer_api_single_caller.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Regression-prevention gate for #5978: the set of modules that call
+``faulthandler``'s timer API (``faulthandler.dump_traceback_later(...)`` /
+``faulthandler.cancel_dump_traceback_later()``) must be EXACTLY
+``{src/reyn/runtime/stall_trace.py}`` -- no other module may call either
+function.
+
+**This gate starts already GREEN.** It is a regression ratchet, not a
+cleanup -- nothing in the tree is fixed by adding it. Read-only measurement
+against ``origin/main`` at the time this gate was written:
+
+```
+$ git grep -nE '^[^#]*faulthandler\\.(dump_traceback_later|cancel_dump_traceback_later)\\(' origin/main -- src
+src/reyn/runtime/stall_trace.py:284
+src/reyn/runtime/stall_trace.py:291
+```
+
+Exactly 2 call sites, both already inside the one sanctioned caller. This
+gate exists to catch a SECOND caller being ADDED in the future, not to
+remove one that exists today.
+
+## Why this gate, and not a broader one (#5978's settled scope)
+
+#5978 originally asked for something broader: derive the population of
+ALL diagnostic write-outs (snapshots/streams/dumps) and bound each one
+structurally. The architect's ruling on that issue found that goal NOT
+achievable -- write-mode opens (`os.open` / `open(..., "a"|"w")`) are
+scattered across 20+ modules mixing event-log records, caches, plugins,
+and CI tooling, and "diagnostic vs. not" is a *purpose*, not something
+written in the source; a gate over that population would need a
+hand-maintained exclusion list, which is exactly what this repo's
+"derive the population, never hand-maintain a table" discipline forbids.
+
+What IS derivable is not the *purpose* but a *mechanism name* that
+happens to have exactly one real caller today: ``faulthandler``'s timer
+API. That gives a population with no exclusion list at all -- "every
+module that calls this exact name" -- so this gate's scope is narrowed
+to that one mechanism, per the issue thread's final agreement between
+lead-coder and architect (see #5978's last two comments).
+
+## Population and detection
+
+Population: every tracked ``.py`` file under ``src/`` (``git ls-files``,
+no hand-maintained exclusion list -- the same population-derivation
+pattern as ``check_unfiltered_caplog_consumption.py`` /
+``silent_except_ratchet.py``). Detection: an AST walk for a ``Call`` node
+whose function is an attribute access ``faulthandler.dump_traceback_
+later`` or ``faulthandler.cancel_dump_traceback_later`` where the base
+name is literally ``faulthandler`` (i.e. the module was imported as
+``import faulthandler`` and called via that name, the only import shape
+this repo uses for it). This is a syntax-shape classifier, not dataflow --
+an aliased import (``import faulthandler as fh``) or an indirection
+through a rebound reference would not be caught; no such shape exists in
+the current tree (verified by the grep above, which has the same blind
+spot and still found exactly 2 lines).
+
+## CI wiring
+
+Runs on every push to ``src/**`` (not gated to ``tests/**`` -- this
+gate's population lives entirely under ``src/``, and the population is
+tiny, so a plain ``src/**``-path trigger is the lightest correct choice;
+there is no reason to also run it on doc-only or tests-only changes).
+
+CI: gate
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCOPE = "src"
+
+_TIMER_API_NAMES = frozenset({"dump_traceback_later", "cancel_dump_traceback_later"})
+_SOLE_CALLER = "src/reyn/runtime/stall_trace.py"
+
+
+def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
+    """Every tracked `.py` file under `src/` -- `git ls-files`, so the
+    population is exactly what's checked in and nothing is hand-excluded."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _is_faulthandler_timer_call(node: ast.AST) -> bool:
+    """True for a `Call` node shaped `faulthandler.dump_traceback_later(...)`
+    or `faulthandler.cancel_dump_traceback_later(...)` -- a real `ast.Call`
+    over an `ast.Attribute` whose base is the bare name `faulthandler`,
+    never a text/regex match, so a docstring or comment merely naming the
+    API cannot trigger this."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in _TIMER_API_NAMES
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "faulthandler"
+    )
+
+
+def find_violations(path: Path) -> "list[tuple[int, str]]":
+    """`(lineno, api_name)` for every `faulthandler` timer-API call site in
+    *path*."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    violations: "list[tuple[int, str]]" = []
+    for node in ast.walk(tree):
+        if _is_faulthandler_timer_call(node):
+            attr = node.func.attr  # type: ignore[attr-defined]
+            violations.append((node.lineno, attr))
+    return sorted(violations)
+
+
+def measured(root: Path = _ROOT) -> "dict[str, list[tuple[int, str]]]":
+    """File (relative to *root*) -> call sites, for every tracked `src/`
+    file with at least one `faulthandler` timer-API call -- including the
+    one sanctioned caller. Callers that want only the VIOLATIONS should
+    exclude `_SOLE_CALLER` from the result (see `main`)."""
+    by_file: "dict[str, list[tuple[int, str]]]" = {}
+    for path in _iter_scan_files(root):
+        violations = find_violations(path)
+        if violations:
+            by_file[str(path.relative_to(root))] = violations
+    return by_file
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options -- population has no exclusion list to configure
+
+    try:
+        by_file = measured(_ROOT)
+    except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+        print(
+            f"faulthandler-timer-api-single-caller gate FAILED: could not "
+            f"scan the population ({exc}). Fails CLOSED on a scan error "
+            "rather than silently under-counting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not by_file:
+        print(
+            "faulthandler-timer-api-single-caller gate FAILED: found 0 "
+            f"callers of faulthandler's timer API under {_SCOPE}/ at all -- "
+            f"expected exactly one, {_SOLE_CALLER}. Either the sole caller "
+            "was removed (update this gate's expectation deliberately) or "
+            "the scan itself is broken.",
+            file=sys.stderr,
+        )
+        return 1
+
+    others = {f: v for f, v in by_file.items() if f != _SOLE_CALLER}
+    if others:
+        total = sum(len(v) for v in others.values())
+        print(
+            "faulthandler-timer-api-single-caller gate FAILED:\n",
+            file=sys.stderr,
+        )
+        print(
+            f"{total} faulthandler timer-API call site(s) outside the one "
+            f"sanctioned caller ({_SOLE_CALLER}). The invariant (#5978) is "
+            "that ONLY that module may call "
+            "faulthandler.dump_traceback_later()/cancel_dump_traceback_"
+            "later() -- it owns the one process-wide timer and documents "
+            "its own re-arm/handoff contract; a second independent caller "
+            "would silently race it for the same global timer:",
+            file=sys.stderr,
+        )
+        for file, violations in sorted(others.items()):
+            for lineno, api in violations:
+                print(f"  {file}:{lineno}: faulthandler.{api}(...)", file=sys.stderr)
+        print(
+            f"\nRoute the new call through {_SOLE_CALLER} instead (add a "
+            "function there, or call its existing arm()/disarm()) rather "
+            "than calling faulthandler's timer API directly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"faulthandler-timer-api-single-caller gate OK: {_SOLE_CALLER} is "
+        f"the only caller of faulthandler's timer API under {_SCOPE}/ "
+        f"({len(by_file[_SOLE_CALLER])} call site(s), as expected)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_faulthandler_timer_api_single_caller.py
+++ b/tests/scripts/test_check_faulthandler_timer_api_single_caller.py
@@ -1,0 +1,143 @@
+"""Tier 1: `check_faulthandler_timer_api_single_caller.py`'s own detector
+logic -- the #5978 regression ratchet for "the set of modules calling
+faulthandler's timer API (`faulthandler.dump_traceback_later`/
+`faulthandler.cancel_dump_traceback_later`) is exactly
+`{src/reyn/runtime/stall_trace.py}`".
+
+Both directions are witnessed, same shape as
+`test_check_unfiltered_caplog_consumption.py` / `test_silent_except_
+ratchet_5990.py`: a real tmp git repo (no MagicMock) standing in for the
+`src/` population, once with exactly one caller module (matching real
+`stall_trace.py`'s shape) and once with a second module also calling the
+timer API -- the gate must pass the first and fail the second, naming the
+offending file.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.check_faulthandler_timer_api_single_caller import (
+    _SOLE_CALLER,
+    find_violations,
+    measured,
+)
+from tests._support.paths import REPO_ROOT
+
+_SOLE_CALLER_BODY = '''\
+"""Stand-in for the real sole caller."""
+import faulthandler
+
+
+def arm(seconds: float) -> None:
+    faulthandler.dump_traceback_later(seconds, repeat=False)
+
+
+def disarm() -> None:
+    faulthandler.cancel_dump_traceback_later()
+'''
+
+_SECOND_CALLER_BODY = '''\
+"""A second module that should never exist for real -- this is the
+violation shape the gate must catch."""
+import faulthandler
+
+
+def watch(seconds: float) -> None:
+    faulthandler.dump_traceback_later(seconds)
+'''
+
+
+def _make_git_tree(tmp_path: Path, *, second_caller: bool) -> Path:
+    """A real tmp git repo with `src/reyn/runtime/stall_trace.py` (the
+    sole sanctioned caller) and, if *second_caller*, an additional
+    `src/reyn/other_module.py` that ALSO calls the timer API -- `git
+    ls-files` needs the files staged (not necessarily committed) to be
+    counted, matching the production population source exactly."""
+    root = tmp_path / "repo"
+    sole_caller_path = root / _SOLE_CALLER
+    sole_caller_path.parent.mkdir(parents=True)
+    sole_caller_path.write_text(_SOLE_CALLER_BODY, encoding="utf-8")
+
+    if second_caller:
+        other = root / "src" / "reyn" / "other_module.py"
+        other.write_text(_SECOND_CALLER_BODY, encoding="utf-8")
+
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    return root
+
+
+def test_exactly_one_caller_module_passes(tmp_path: Path) -> None:
+    """Tier 1: the false-accept-side witness -- a tree shaped like the
+    real one (only `stall_trace.py` calls the timer API) reports zero
+    violations."""
+    root = _make_git_tree(tmp_path, second_caller=False)
+    by_file = measured(root)
+    others = {f: v for f, v in by_file.items() if f != _SOLE_CALLER}
+    assert others == {}, f"gate falsely flagged the sole sanctioned caller's tree: {others}"
+    assert by_file[_SOLE_CALLER], "the sole caller's own call sites went undetected"
+
+
+def test_a_second_caller_module_fails_naming_the_file(tmp_path: Path) -> None:
+    """Tier 1: the false-reject-side witness, required alongside the test
+    above -- a SECOND module calling the timer API must be flagged, and
+    the offending file must be named (not merely "something failed")."""
+    root = _make_git_tree(tmp_path, second_caller=True)
+    by_file = measured(root)
+    others = {f: v for f, v in by_file.items() if f != _SOLE_CALLER}
+    assert "src/reyn/other_module.py" in others, (
+        f"gate missed the second caller module entirely: {by_file}"
+    )
+    lineno, api = others["src/reyn/other_module.py"][0]
+    assert api == "dump_traceback_later"
+    assert lineno > 0
+
+
+def test_find_violations_detects_both_timer_api_names(tmp_path: Path) -> None:
+    """Tier 1: both `dump_traceback_later` and `cancel_dump_traceback_
+    later` are detected by name, on a single real file -- not just
+    whichever one the fixtures above happen to exercise."""
+    f = tmp_path / "both.py"
+    f.write_text(
+        "import faulthandler\n"
+        "faulthandler.dump_traceback_later(5)\n"
+        "faulthandler.cancel_dump_traceback_later()\n",
+        encoding="utf-8",
+    )
+    violations = find_violations(f)
+    apis = {api for _, api in violations}
+    assert apis == {"dump_traceback_later", "cancel_dump_traceback_later"}
+
+
+def test_a_docstring_or_comment_naming_the_api_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 1: the classifier is AST-based (a real `Call` node), not a
+    text/regex match -- a docstring or comment merely naming the API must
+    not be flagged."""
+    f = tmp_path / "prose_only.py"
+    f.write_text(
+        '"""Mentions faulthandler.dump_traceback_later(...) in prose."""\n'
+        "# faulthandler.cancel_dump_traceback_later() is also just a comment here.\n",
+        encoding="utf-8",
+    )
+    assert find_violations(f) == []
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population, verified against the
+    real, current tree (not assumed) -- this is the "already green"
+    witness: `src/reyn/runtime/stall_trace.py` must be the ONLY caller of
+    faulthandler's timer API under `src/` today. Any other hit here is a
+    real regression, not inherited debt (there is no baseline for this
+    gate)."""
+    by_file = measured(REPO_ROOT)
+    others = {f: v for f, v in by_file.items() if f != _SOLE_CALLER}
+    assert others == {}, (
+        f"real regression(s) found -- a module other than {_SOLE_CALLER} "
+        f"now calls faulthandler's timer API: {others}"
+    )
+    assert _SOLE_CALLER in by_file, (
+        f"{_SOLE_CALLER} itself no longer calls faulthandler's timer API -- "
+        "either it was refactored away (update this gate deliberately) or "
+        "the scan is broken"
+    )


### PR DESCRIPTION
**[backlog-watcher]** — Closes #5978.

## What this adds

`scripts/check_faulthandler_timer_api_single_caller.py`: an AST-scan gate asserting that the set of modules calling `faulthandler`'s timer API (`faulthandler.dump_traceback_later(...)` / `faulthandler.cancel_dump_traceback_later()`) is exactly `{src/reyn/runtime/stall_trace.py}` — no other module may call either function. Population is derived fresh each run (`git ls-files -- src/*.py`, no hand-maintained exclusion list).

## ⚠️ This gate starts ALREADY GREEN

This is a **regression ratchet**, not a cleanup — nothing in the tree is fixed by this PR. Read-only measurement against `origin/main` (verified again just now against this branch's base):

```
$ git grep -nE '^[^#]*faulthandler\.(dump_traceback_later|cancel_dump_traceback_later)\(' origin/main -- src
src/reyn/runtime/stall_trace.py:284
src/reyn/runtime/stall_trace.py:291
```

Exactly 2 call sites, both already inside the one sanctioned caller. The gate exists to catch a SECOND caller being added in the future, not to remove one that exists today. Please do not read this PR as "something was fixed" — it wasn't; the invariant already held and this makes it enforced.

## Why this exact, narrow scope (per the issue thread's settled scope)

#5978 originally asked for a broader structural bound over ALL diagnostic write-outs. Architect's ruling (quoted in the issue): that population is not derivable without a hand-maintained exclusion list (write-mode opens span 20+ modules mixing records/cache/plugins/CI, and "diagnostic vs. not" is a *purpose*, not something written in source). What IS derivable is not the purpose but a *mechanism name* with exactly one real caller today — `faulthandler`'s timer API — so the gate is scoped to that mechanism only. lead-coder + architect agreed this is the full resolution for #5978 and the issue closes once this lands.

## CI wiring

New workflow `.github/workflows/faulthandler-timer-api-single-caller-gate.yml`, triggered on `src/**` changes (pull_request) and on push to `main` touching `src/**` — this gate's population lives entirely under `src/`, so a `tests/**`-path trigger would be the wrong scope; the population is tiny so a plain path-conditional trigger is the lightest correct choice.

## Tests (both directions, real tmp git repos, no `MagicMock`)

- `test_exactly_one_caller_module_passes` — a tree shaped like the real one (only `stall_trace.py` calls the timer API) → gate passes.
- `test_a_second_caller_module_fails_naming_the_file` — a SECOND module calling the timer API → gate fails, naming the offending file.
- `test_find_violations_detects_both_timer_api_names` — both `dump_traceback_later` and `cancel_dump_traceback_later` are detected.
- `test_a_docstring_or_comment_naming_the_api_is_not_flagged` — AST-based, not a text/regex match.
- `test_the_real_repo_tree_is_currently_clean` — the "already green" witness against the real `src/` tree.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict tests/scripts/test_check_faulthandler_timer_api_single_caller.py`
- [x] `python scripts/verify_module_docstrings.py scripts/check_faulthandler_timer_api_single_caller.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `python scripts/check_bare_tests_import_reference.py`
- [x] `python scripts/check_file_depth_reference.py`
- [x] `python scripts/check_subprocess_reyn_pin.py`
- [x] `python scripts/check_no_core_dep_importorskip.py`
- [x] `python scripts/suspected_time_dependence_ratchet.py`
- [x] `pytest tests/scripts/test_check_faulthandler_timer_api_single_caller.py` (5 passed)
- [x] (skipped — Visual, standing waiver) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5