### PR TITLE
fix(#6014): main invariant sweep -- install reyn so the 3 import-requiring gates can run

### DIFF
--- a/.github/workflows/main-invariant-sweep.yml
+++ b/.github/workflows/main-invariant-sweep.yml
@@ -100,6 +100,32 @@ name: main invariant sweep
 # (#4239) is unchanged and still in force — what changed is only that
 # nothing mechanical asserts it anymore. re-open trigger: a token with
 # `administration: read` becomes available.
+#
+# #6014 (2026-09-10): this workflow had NO `pip install` step at all, and
+# that absence was an UNWRITTEN contract — every gate enumerated here
+# happened to be stdlib-only, so nothing ever needed one. `52344e916`
+# added 3 gates that import `reyn` itself, and every run since failed
+# with `ModuleNotFoundError: No module named 'reyn'` (28 of 28 runs,
+# ~20h, read off each run's own step list). The install step below makes
+# the requirement explicit instead of accidental.
+#
+# Two things that were NOT the cause, recorded because both were asserted
+# before those step lists were opened:
+#   - The other gates did NOT go silent. All 28 failing runs show
+#     success=9 / failure=3 — `if: ${{ !cancelled() }}` on every step
+#     (see the step section below) contained the failure exactly as
+#     #4257 intended. A job-level red does not imply step-level silence,
+#     and the job conclusion alone cannot tell them apart.
+#   - The 3 gates reported NO invariant violation. They never got far
+#     enough to look: all 3 died on their own `import reyn` line. A gate
+#     that never reached its subject says nothing about that subject —
+#     the "green over an empty collection" hazard, wearing red's colour.
+#
+# Rejected, with the reason, so it is not re-proposed: splitting this
+# into a static job and an install-requiring job. Its only stated benefit
+# — "the install-free gates keep reporting when install breaks" — is
+# already delivered by step-level `!cancelled()` above, so the split
+# bought nothing this file did not already have.
 on:
   schedule:
     # GitHub's own scheduler is best-effort under load — "roughly hourly",
@@ -131,9 +157,30 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: pip
 
-      # Every step below is stdlib-only (ast / pathlib / sys) — no pip
-      # install needed, same as their per-PR counterparts.
+      # #6014: FIRST, ahead of every gate — deliberately not "just before
+      # the 3 that need it". Nothing enforces step order, so a step
+      # inserted above them later would silently reopen the same hole;
+      # installing at the head closes the class rather than the instance
+      # (lead-coder ruling on #6014).
+      #
+      # `-c ci-constraints.txt` (#5831): the same reproducibility pin
+      # every other job that installs project dependencies uses — see
+      # test.yml's "Install dependencies" step for why.
+      #
+      # Base install, no extras: the 3 gates below import
+      # `reyn.security.permissions.approval_ledger`,
+      # `reyn.hooks.schema_registry` and `reyn.interfaces.repl.read_model`,
+      # all reachable from the base dependency set. Extras would widen
+      # what a resolver failure can take down with no gate asking for it.
+      - name: Install reyn (the gates below that import it need this)
+        run: pip install -e . -c ci-constraints.txt
+
+      # Most steps below are stdlib-only (ast / pathlib / sys), same as
+      # their per-PR counterparts; the last 3 import `reyn` itself and
+      # need the install above. Do not read "no install needed" off the
+      # first nine and drop that step — #6014 is what that costs.
       # Any non-zero exit fails its own step (default `run:` behaviour),
       # which reddens the job overall — a single red gate is enough,
       # #4257's own test-plan requirement ("a red gate you can't fail is a
@@ -185,8 +232,15 @@ jobs:
       # written, but never actually run against the real tree since the
       # day each landed (their own `tests/` coverage only drives the
       # detector against a synthetic `tmp_path` fixture, never the real
-      # tree). All 3 measured rc=0 against main before being added here
-      # (see #6014's own issue body and comment thread).
+      # tree).
+      #
+      # The "all 3 measured rc=0 against main" that justified adding them
+      # was taken in an environment where `reyn` was already importable —
+      # not in this workflow's environment, which had no install at all.
+      # The measurement was true and the conclusion drawn from it was
+      # false: an rc=0 carries the interpreter it was taken on as much as
+      # the tree. The install step above is what makes these 3 lines mean
+      # what they say.
       - name: approval-ledger-import-boundary
         if: ${{ !cancelled() }}
         run: python scripts/check_approval_ledger_import_boundary.py

--- a/.github/workflows/main-invariant-sweep.yml
+++ b/.github/workflows/main-invariant-sweep.yml
@@ -174,8 +174,48 @@ jobs:
       # `reyn.hooks.schema_registry` and `reyn.interfaces.repl.read_model`,
       # all reachable from the base dependency set. Extras would widen
       # what a resolver failure can take down with no gate asking for it.
+      #
+      # `timeout 8m` (#3670's idiom, #6014's reason): this is the first
+      # step in this file that can HANG — `textual-flowview` is a
+      # `git+https` dependency, so a clone can stall indefinitely, and pip
+      # resolution can backtrack. Installing at the head (above) is what
+      # makes that matter: a hang here burns the job's own
+      # `timeout-minutes: 10`, and a job killed by `timeout-minutes`
+      # reports `cancelled`, not `failure` — which makes
+      # `if: ${{ !cancelled() }}` on every gate below FALSE and skips all
+      # twelve. That is strictly worse than a red gate: a red one is
+      # legible, a skipped one says nothing at all. `timeout` turns the
+      # same hang into an ordinary non-zero step exit (124), so the job
+      # is never `cancelled` and every gate below still runs and reports.
+      #
+      # Where 8m comes from — derived, not picked:
+      #   budget                                              600s
+      #   - everything else, worst case within the 28 red runs -32s
+      #       (sum of each step's own observed maximum, which is
+      #        pessimistic on purpose: no single run was that slow —
+      #        the worst OBSERVED whole-job total was 24s)
+      #   - the 3 gates below actually doing their work            -5s
+      #       (they died on `import reyn` in all 28 of those runs, so
+      #        their real cost is absent from the measurement above;
+      #        0.15-0.36s each measured locally, 5s is CI headroom)
+      #   - margin                                              -83s
+      #   = 480s = 8m
+      #
+      # The margin exists because an observed maximum is not an upper
+      # bound: 28 runs sample ONE tree state, the API reports step
+      # durations at 1-second granularity, and a loaded runner is slower
+      # than any of them. 8m is also ~3x a cold install of this
+      # dependency set, so it fires on a hang and never on a slow-but-
+      # working one.
+      #
+      # `cache: pip` above makes the two cases differ a lot: a WARM run
+      # reinstalls from cached wheels, a COLD one (first run after this
+      # file, `pyproject.toml` or `ci-constraints.txt` changes, or after
+      # the cache expires) downloads and builds everything AND clones
+      # `textual-flowview` over the network. 8m is sized for the cold
+      # case — do not re-derive it from a warm run's duration.
       - name: Install reyn (the gates below that import it need this)
-        run: pip install -e . -c ci-constraints.txt
+        run: timeout 8m pip install -e . -c ci-constraints.txt
 
       # Most steps below are stdlib-only (ast / pathlib / sys), same as
       # their per-PR counterparts; the last 3 import `reyn` itself and


### PR DESCRIPTION
**[architect]** — part of #6014. **lead-coder 裁定 (A)**: https://github.com/tya5/reyn/issues/6014#issuecomment-5612309936

## 何を直すか

**この workflow には `pip install` が 1 行もありませんでした。** 列挙されている gate が偶然すべて stdlib-only だっただけで、**その不在は決定ではなく 明文化されていない契約**でした。`52344e916` が `reyn` 自身を import する gate を 3 本足し、**以後 全 run が `ModuleNotFoundError: No module named 'reyn'` で落ちていました**（**赤い run 28 本 全数**、約 20 時間）。

**base install を 1 step、job の 先頭に置きます。** ⚠️ **「3 本の直前」ではありません** — **step 順序は何も強制しないので、次に step を足す人が同じ穴を開け直します**（穴でなくクラスを閉じる）。

## 🔴 訂正 2 件 — **私（architect）が #6014 に書いた偽の前提**

**どちらも run の step 一覧を開く前に書いたものです。** **file の comment に訂正を残しました**（次の読者が引き継がないように）:

1. 🔴 **「他の gate も黙った」は偽。** **28/28 が success=9 / failure=3。** 全 step の `if: ${{ !cancelled() }}` が **#4257 の意図どおり**封じ込めていました。⭐ **job の赤は step の沈黙を意味しません。**
2. 🔴 **「3 本が不変条件違反を報告している」も偽。** **3 本とも自分の `import reyn` 行で死んでいて、主題に到達していません。** ⚠️ **主題に届かなかった gate は、その主題について何も言っていません** — 「空集合の上の緑」が赤い色を着ているだけです。

**∴ job 分割は採りませんでした**（lead-coder 裁定）: **唯一の利点「install が壊れても静的 gate は報告を続ける」は、step 単位の `!cancelled()` が既に与えている**ので、**分割は既に持っている物しか買えません。**

## 依存 — **base install で足ります**（推測ではなく metadata）

3 本が import するのは `reyn.security.permissions.approval_ledger` / `reyn.hooks.schema_registry` / `reyn.interfaces.repl.read_model`。

- **`prompt_toolkit`** — **pyproject の base dependency**（宣言済み）
- **`jinja2`** — **`litellm` の 無条件 requirement**（`litellm -> jinja2>=3.1.6,<4.0`、extra marker 無し）で、**litellm は base dependency** ∴ **transitively 入ります**
- **ci-constraints.txt が両方を pin しています**（`Jinja2==3.1.6` / `prompt_toolkit==3.0.53`）

⚠️ **extras は入れません** — **どの gate も求めていないのに、resolver の失敗が巻き込める範囲だけが広がります。**

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `python scripts/check_tests_path_literal_reference.py` — OK (119 baselined)
- [x] **YAML parse + step 構造の確認** — install step が `checkout`/`setup-python` の直後・全 gate の前、**`if:` 無し**（＝先頭で必ず走る）／**gate 12 本は全て `if: ${{ !cancelled() }}` のまま**
- [x] **3 本を deps 在りで実行**（tree `b02492a30`、`PYTHONPATH=src`、依存を持つ interpreter）— **3 本とも rc=0、かつ空でない主張を印字**:
  - `approval_ledger.py imports no reyn-internal module (stdlib-only boundary intact).`
  - `all 9 declarable hook kinds have a registered non-LLM-turn reachability witness.`
  - `every placeholder-shaped key is covered by _WIRE_KEYS, ... _WIRE_KEYS is a verified subset of project_status's unconditional keys, ...`
- [x] **strip-falsify — 別途の strip は不要**: ⭐ **`main` 自身が strip 済みの状態**です（install 無し）。**その状態での観測が 28/28 の `ModuleNotFoundError`** ∴ **positive control は history に既に在ります。**
- [ ] (skipped — 実行は CI) **本 PR の受入 1 本: 3 本が *実際に走って* 何を言うか。** ⚠️ **上の local 実行は「deps が在るとき」を示すだけで、CI の環境を示しません** — **測定は tree と同じだけ interpreter も背負います**（この PR が直している当の誤りです）。

## install の hang を塞ぎます — **この PR が作った曝露です**

**この job には元から `timeout-minutes: 10` が在りました。** ⚠️ **しかし判別子は「元から在ったか」ではなく「この PR が曝露を増やしたか」**です（lead-coder）。**install を先頭に置いたことで、`timeout-minutes` の内側の いちばん先頭に、この file 初の hang し得る step が来ました**（`textual-flowview` は **git+https 依存**＝clone が stall し得る／pip の backtrack もあり得る）。

🔴 **`timeout-minutes` に殺された job は `failure` ではなく `cancelled` を報告します**（#3670）∴ **`if: ${{ !cancelled() }}` が false になり、gate 12 本が全部 skip されます。** ⚠️ **今日の 3 本の赤より悪い形です — 赤は読めますが、skip は何も言いません。**

**`timeout 8m` で包みました**（#3670 既定の処方）。**hang は step の通常の非零 exit (124) になり、job は `cancelled` にならず、12 本は走って報告を続けます。**

### `8m` の導出 — **発明ではありません**

| | s |
|---|---|
| **予算**（`timeout-minutes: 10`） | **600** |
| **− 他の全 step、28 赤 run 内の最悪** | **−32** |
| **− 3 本が *実際に働く* 分** | **−5** |
| **− 余白** | **−83** |
| **= ** | **480 = `8m`** |

- **−32s** は ⭐ **各 step の 観測最大の 単純和**で、**意図的に悲観的**です — **どの 1 run もそこまで遅くありません**（**観測された whole-job 最大は 24s**）。
- **−5s**: ⚠️ **28 run のどれでも 3 本は `import reyn` で死んでいる** ∴ **その実コストは上の測定に入っていません。** **local 実測 0.15 / 0.17 / 0.36s**、**5s は CI 分の余裕**です。
- **余白 83s の理由**: 🔴 **観測最大は上界ではありません** — **28 run は tree 1 状態の標本**、**API の step 所要は 1 秒粒度**、**負荷の高い runner はそのどれよりも遅い**。
- **`8m` は この依存集合の cold install の約 3 倍**です ∴ **hang でだけ鳴り、遅いだけの正常な install では鳴りません。**
- ⚠️ **`cache: pip` の cold / warm で install 時間は大きく違います**: **warm は cached wheel から、cold は download + build に加えて `textual-flowview` の clone。** 🔴 **`8m` は cold 側に合わせてあります — warm run の実測から取り直さないでください**（file の comment にも同じ注記を置きました）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow
