### PR TITLE
fix(part of #5990): report 14 silent-except sites, same convention as #6038

### DIFF
--- a/src/reyn/core/op_runtime/embed.py
+++ b/src/reyn/core/op_runtime/embed.py
@@ -56,6 +56,7 @@ ephemeral-attachment content policy is Phase 3 per the FP-0057 design doc
 """
 from __future__ import annotations
 
+import logging
 import os
 
 from reyn.core.cancellable import Cancelled, race_cancellable
@@ -65,6 +66,8 @@ from reyn.security.secret_redaction import redact_secrets
 
 from . import register
 from .context import OpContext
+
+_log = logging.getLogger(__name__)
 
 
 def _resolve_provider():
@@ -86,6 +89,11 @@ def _resolve_provider():
             from reyn.config import load_config
             cfg = load_config().embedding
         except Exception:
+            _log.warning(
+                "reyn.yaml could not be loaded while resolving the "
+                "embedding config; falling back to the litellm provider's "
+                "own defaults", exc_info=True,
+            )
             cfg = None
         return get_provider(name, config=cfg or {})
     return get_provider(name, config={})

--- a/src/reyn/interfaces/cli/commands/embeddings.py
+++ b/src/reyn/interfaces/cli/commands/embeddings.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import shutil
 import sqlite3
 from dataclasses import dataclass
@@ -41,6 +42,8 @@ from typing import Any
 from reyn.config import load_config
 from reyn.data.index.backend import cache_dir_for_source
 from reyn.tools.action_index import DEFAULT_ACTION_SOURCE
+
+_log = logging.getLogger(__name__)
 
 # ── data shape ────────────────────────────────────────────────────────────────
 
@@ -132,6 +135,12 @@ def _read_index_state(index_dir: Path) -> tuple[int, str]:
         finally:
             con.close()
     except (sqlite3.DatabaseError, OSError):
+        _log.warning(
+            "the action-index cache at %s exists but could not be read "
+            "(corrupted or an OS-level read failure) -- reporting 0 "
+            "indexed actions, which may understate the real count",
+            db_path, exc_info=True,
+        )
         n = 0
     try:
         import datetime as _dt
@@ -141,6 +150,11 @@ def _read_index_state(index_dir: Path) -> tuple[int, str]:
         )
         last_built = ts.replace(microsecond=0).isoformat()
     except OSError:
+        _log.warning(
+            "the action-index cache at %s exists but its mtime could not "
+            "be read -- reporting '(never)', which may not be accurate",
+            db_path, exc_info=True,
+        )
         last_built = "(never)"
     return n, last_built
 

--- a/src/reyn/interfaces/cli/commands/support_bundle.py
+++ b/src/reyn/interfaces/cli/commands/support_bundle.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import zipfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+
+_log = logging.getLogger(__name__)
 
 
 def register(sub) -> None:
@@ -172,6 +175,10 @@ def _meta(session, since_raw, manifest) -> dict:
         from importlib.metadata import version as _v
         reyn_version = _v("reyn")
     except Exception:
+        _log.warning(
+            "reyn's own installed version could not be determined for "
+            "the support bundle's meta.json", exc_info=True,
+        )
         reyn_version = "unknown"
     config_summary: dict = {}
     try:

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -13,6 +13,7 @@ never reaches an always-loaded module.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from typing import TYPE_CHECKING, Callable
 
@@ -46,6 +47,8 @@ from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
 from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
 from ._meta_keys import RUNNING_SINCE_KEY as _RUNNING_SINCE_KEY
 from .gutter import _is_retrieval_tool
+
+_log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -387,6 +390,11 @@ def _result_detail_lines(msg: "OutboxMessage") -> "list[str]":
     try:
         text = json.dumps(result, ensure_ascii=False, indent=2)
     except Exception:
+        _log.warning(
+            "a tool result of type %s was not JSON-serializable; "
+            "falling back to its own str()", type(result).__name__,
+            exc_info=True,
+        )
         text = str(result)
     return text.splitlines() or [text]
 

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -1,6 +1,7 @@
 """Pluggable chat UI backends for reyn chat."""
 from __future__ import annotations
 
+import logging
 import re
 import sys
 import time
@@ -11,6 +12,8 @@ from prompt_toolkit.formatted_text import HTML, AnyFormattedText
 from reyn.interfaces import palette
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.outbox import OutboxMessage
+
+_log = logging.getLogger(__name__)
 
 
 def _meta_prefix(meta: dict) -> str:
@@ -614,6 +617,10 @@ def summarize_tool_result(tool, result) -> str:
     try:
         summary = _summarize_result(tool, result)
     except Exception:
+        _log.warning(
+            "summarizing tool %r's own result failed; falling back to a "
+            "short repr", tool, exc_info=True,
+        )
         summary = _short(result, 80)
     return get_neutralizer("terminal").neutralize(summary)[0]
 

--- a/src/reyn/interfaces/web/routers/web_data.py
+++ b/src/reyn/interfaces/web/routers/web_data.py
@@ -24,12 +24,15 @@ read from disk and passed through opaquely.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends
 
 from reyn.interfaces.web.deps import get_project_root, get_registry
+
+_log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["web"])
 
@@ -203,6 +206,10 @@ async def web_data(
         registry = get_registry()
         agents = _build_agents(registry)
     except Exception:
+        _log.warning(
+            "AGENTS could not be built for /web/data (registry not ready "
+            "or a build failure); returning an empty list", exc_info=True,
+        )
         agents = []
 
     library = _build_library(project_root)

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -56,6 +56,12 @@ def resolve_call_timeout(config: dict) -> "float | None":
         try:
             timeout = float(ct)
         except (TypeError, ValueError):
+            import logging
+            logging.getLogger(__name__).warning(
+                "mcp server call_timeout_seconds=%r is invalid (not a "
+                "number); using the default %r",
+                ct, _DEFAULT_MCP_CALL_TIMEOUT_SECONDS,
+            )
             timeout = _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
     if timeout is not None and timeout <= 0:
         return None

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3677,6 +3677,11 @@ class RouterLoop:
         try:
             args = json.loads(tc["function"]["arguments"])
         except (json.JSONDecodeError, KeyError):
+            logger.warning(
+                "tool call %r arguments were not valid JSON (%r); "
+                "treating as no arguments",
+                raw_name, tc.get("function", {}).get("arguments"),
+            )
             args = {}
 
         if name not in self._catalog:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5961,6 +5961,10 @@ class Session:
                 # "SR5b: silently ignored" branch.
                 audit_events.add_subscriber(otel_exporter, kinds=HANDLED_EVENT_TYPES)
         except Exception:  # noqa: BLE001 — OTEL attach must never break session init
+            logger.warning(
+                "observability.otel export could not be attached; the "
+                "session continues without it", exc_info=True,
+            )
             otel_exporter = None
         return _AuditEventBundle(
             event_store=event_store,
@@ -6369,6 +6373,13 @@ class Session:
                 # dependency / malformed config), fall through to "no index"
                 # so the rest of the session continues without
                 # search_actions rather than refusing to start.
+                logger.warning(
+                    "embedding.index.actions is enabled but the "
+                    "action-embedding provider/index could not be built "
+                    "(missing dependency or malformed embedding config); "
+                    "search_actions stays unavailable this session",
+                    exc_info=True,
+                )
                 embedding_provider = None
                 action_embedding_index = None
                 embedding_model_class = None

--- a/src/reyn/security/secrets/oauth.py
+++ b/src/reyn/security/secrets/oauth.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import stat
 import warnings
@@ -34,6 +35,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 # Refresh buffer: if a token expires within this window we refresh
 # proactively so the caller never sees a 401. RFC 6749 §6 doesn't
@@ -549,6 +552,12 @@ async def _poll_token(
     try:
         body: dict[str, Any] = resp.json()
     except ValueError:
+        # Never log the response body itself here — a token endpoint's
+        # non-JSON reply can legitimately be (or embed) sensitive text.
+        _log.warning(
+            "oauth token endpoint %r returned a non-JSON body (status %s)",
+            provider.token_url, resp.status_code,
+        )
         body = {}
     return resp.status_code, body
 

--- a/src/reyn/tools/exec.py
+++ b/src/reyn/tools/exec.py
@@ -169,6 +169,14 @@ async def op_context_from_tool_context(ctx: ToolContext) -> Any:
             try:
                 resolved_backend = get_default_backend(SandboxConfig(backend=backend_name))
             except ValueError:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "router_state.sandbox_backend=%r is not a known "
+                    "sandbox backend name; this op_context's own "
+                    "early-resolved backend stays unset (a later "
+                    "resolution seam may still pick one)",
+                    backend_name,
+                )
                 resolved_backend = None
 
     # Use op_context_factory if provided, else minimal synthesis.

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -30,6 +30,7 @@ present that drops the search tool → guaranteed ``Execute`` exit). ``execute``
 from __future__ import annotations
 
 import json
+import logging
 
 from reyn.prompt.retrieval import SEARCH_SP_NON_TERMINAL, SEARCH_SP_TERMINAL
 from reyn.tools.encoders import encoder_for_transport
@@ -53,6 +54,7 @@ from reyn.tools.schemes._retrieval_exposure import retrieval_sp_facts
 from reyn.tools.transport import Transport
 
 _SEARCH_TOOL_NAME = "search_actions"
+_log = logging.getLogger(__name__)
 
 
 def _search_sp(*, terminal: bool) -> str:
@@ -226,6 +228,11 @@ class RetrievalScheme:
                 try:
                     args = json.loads(tc["function"].get("arguments", "{}"))
                 except (json.JSONDecodeError, KeyError, TypeError):
+                    _log.warning(
+                        "search_actions tool call arguments were not valid "
+                        "JSON (%r); treating as no arguments",
+                        tc.get("function", {}).get("arguments"),
+                    )
                     args = {}
                 return RePresent(refinement={"query": args.get("query", "")})
         return Execute(actions=ops.resolve(llm_response, tool_catalog))

--- a/tests/core/test_5990_stage2_embed_resolve_provider.py
+++ b/tests/core/test_5990_stage2_embed_resolve_provider.py
@@ -1,0 +1,45 @@
+"""Tier 2: #5990 (part of, stage 2) — `op_runtime.embed._resolve_provider`'s
+own `except Exception: cfg = None` swallowed a `reyn.yaml` load failure
+with no visible report. Now warns before falling back to the litellm
+provider's own defaults, same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+
+import reyn.core.op_runtime.embed as embed_module
+
+_LOGGER_NAME = "reyn.core.op_runtime.embed"
+
+
+def test_config_load_failure_warns_and_falls_back_to_provider_defaults(
+    monkeypatch, caplog,
+) -> None:
+    """Tier 2: `load_config()` raising while resolving the embedding
+    config warns AND `_resolve_provider` still returns a provider (no
+    exception propagates).
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from `_resolve_provider`'s `except Exception`): this test
+    goes red — no record at all."""
+    import reyn.config as config_module
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated reyn.yaml load failure")
+
+    monkeypatch.setattr(config_module, "load_config", _raise)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        provider = embed_module._resolve_provider()
+
+    assert provider is not None
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("reyn.yaml" in r.message for r in records)
+
+
+def test_normal_config_load_does_not_warn(caplog) -> None:
+    """Tier 2: negative control -- a normal (non-raising) config load
+    never reaches the except branch, so no warning fires."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        embed_module._resolve_provider()
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/interfaces/test_5990_stage2_embeddings_index_state.py
+++ b/tests/interfaces/test_5990_stage2_embeddings_index_state.py
@@ -75,7 +75,14 @@ def test_mtime_read_failure_warns_and_reports_never_built(tmp_path, monkeypatch,
         # Order-based instead, version-independent: the FIRST stat() on
         # `db_path` is always `.exists()`'s own (called once, before any
         # try block); only the SECOND ONWARD is the mtime read this test
-        # targets.
+        # targets. Depends on `_read_index_state` calling `.exists()` on
+        # `db_path` EXACTLY once before the mtime read (true today) --
+        # if production ever added a SECOND `.exists()` call, this would
+        # intercept THAT one instead and stay green without ever
+        # exercising the mtime `except OSError:` this test claims to
+        # cover; a future change adding another `.exists()`/`.stat()`
+        # call on `db_path` earlier in the function needs a different
+        # discriminator here.
         nonlocal calls_on_db_path
         if self == db_path:
             calls_on_db_path += 1

--- a/tests/interfaces/test_5990_stage2_embeddings_index_state.py
+++ b/tests/interfaces/test_5990_stage2_embeddings_index_state.py
@@ -61,13 +61,26 @@ def test_mtime_read_failure_warns_and_reports_never_built(tmp_path, monkeypatch,
         con.close()
 
     real_stat = pathlib.Path.stat
+    calls_on_db_path = 0
 
     def _stat(self, *args, **kwargs):
-        # `Path.exists()` calls `self.stat(follow_symlinks=...)` internally
-        # -- only fail the PLAIN `db_path.stat()` call `_read_index_state`
-        # itself makes (no kwargs), not the earlier `.exists()` check.
-        if self == db_path and not kwargs:
-            raise OSError("simulated stat failure")
+        # `Path.exists()` calls `self.stat(...)` internally too -- on
+        # Python 3.11 with NO `follow_symlinks` kwarg at all (that
+        # parameter was only added in 3.12), so filtering by "no kwargs"
+        # (an earlier version of this test did that, and it broke under
+        # 3.11 in CI: `.exists()`'s own stat call has no kwargs there
+        # either, so it got intercepted too, and `.exists()` re-raised
+        # before `_read_index_state` ever reached either `try` block --
+        # a Python-version-dependent test bug, not a production one).
+        # Order-based instead, version-independent: the FIRST stat() on
+        # `db_path` is always `.exists()`'s own (called once, before any
+        # try block); only the SECOND ONWARD is the mtime read this test
+        # targets.
+        nonlocal calls_on_db_path
+        if self == db_path:
+            calls_on_db_path += 1
+            if calls_on_db_path > 1:
+                raise OSError("simulated stat failure")
         return real_stat(self, *args, **kwargs)
 
     monkeypatch.setattr(pathlib.Path, "stat", _stat)

--- a/tests/interfaces/test_5990_stage2_embeddings_index_state.py
+++ b/tests/interfaces/test_5990_stage2_embeddings_index_state.py
@@ -1,0 +1,99 @@
+"""Tier 1: #5990 (part of, stage 2) — `embeddings._read_index_state`'s own
+`except (sqlite3.DatabaseError, OSError): n = 0` and
+`except OSError: last_built = "(never)"` each swallowed a read failure
+with no visible report -- an operator reading `reyn embeddings status`
+would see "0 rows" / "(never)" with no way to tell a genuinely empty
+index apart from a corrupted one. Now each warns before falling back,
+same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.interfaces.cli.commands.embeddings import _read_index_state
+
+_LOGGER_NAME = "reyn.interfaces.cli.commands.embeddings"
+
+
+def test_corrupted_index_db_warns_and_reports_zero_rows(tmp_path, caplog) -> None:
+    """Tier 1: a present but corrupted `index.db` (not a valid SQLite
+    file) warns AND `_read_index_state` still returns `(0, ...)` rather
+    than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from the `sqlite3.DatabaseError, OSError` branch): this test
+    goes red — no record at all."""
+    (tmp_path / "index.db").write_bytes(b"not a real sqlite file")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        n, _last_built = _read_index_state(tmp_path)
+    assert n == 0
+    assert any("could not be read" in r.message for r in caplog.records)
+
+
+def test_absent_index_db_does_not_warn(tmp_path, caplog) -> None:
+    """Tier 1: negative control -- no `index.db` at all is the documented
+    `(0, "(never)")` case and must not warn (that path returns before
+    ever reaching either `try`)."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        n, last_built = _read_index_state(tmp_path)
+    assert (n, last_built) == (0, "(never)")
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []
+
+
+def test_mtime_read_failure_warns_and_reports_never_built(tmp_path, monkeypatch, caplog) -> None:
+    """Tier 1: `index.db`'s own mtime read failing (an OS-level race
+    between the earlier `.exists()` check and this `.stat()` call) warns
+    AND `_read_index_state` still returns `"(never)"` for `last_built`
+    rather than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from the second `except OSError`): this test goes red — no
+    record at all."""
+    import pathlib
+    import sqlite3
+
+    db_path = tmp_path / "index.db"
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute("CREATE TABLE chunks (id INTEGER PRIMARY KEY)")
+        con.commit()
+    finally:
+        con.close()
+
+    real_stat = pathlib.Path.stat
+
+    def _stat(self, *args, **kwargs):
+        # `Path.exists()` calls `self.stat(follow_symlinks=...)` internally
+        # -- only fail the PLAIN `db_path.stat()` call `_read_index_state`
+        # itself makes (no kwargs), not the earlier `.exists()` check.
+        if self == db_path and not kwargs:
+            raise OSError("simulated stat failure")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "stat", _stat)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        _n, last_built = _read_index_state(tmp_path)
+    assert last_built == "(never)"
+    assert any("mtime could not be read" in r.message for r in caplog.records)
+
+
+def test_well_formed_index_db_does_not_warn(tmp_path, caplog) -> None:
+    """Tier 1: negative control -- a real, readable SQLite file with a
+    `chunks` table parses through with no warning at all."""
+    import sqlite3
+
+    db_path = tmp_path / "index.db"
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute("CREATE TABLE chunks (id INTEGER PRIMARY KEY)")
+        con.execute("INSERT INTO chunks DEFAULT VALUES")
+        con.commit()
+    finally:
+        con.close()
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        n, last_built = _read_index_state(tmp_path)
+    assert n == 1
+    assert last_built != "(never)"
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/interfaces/test_5990_stage2_presenter_result_lines.py
+++ b/tests/interfaces/test_5990_stage2_presenter_result_lines.py
@@ -1,0 +1,51 @@
+"""Tier 2: #5990 (part of, stage 2) — `presenter._result_detail_lines`'s
+own `except Exception: text = str(result)` swallowed a
+non-JSON-serializable tool result with no visible report. Now warns
+before falling back to `str(result)`, same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.interfaces.inline.textual_chat._meta_keys import RESULT_META_KEY
+from reyn.interfaces.inline.textual_chat.presenter import _result_detail_lines
+from reyn.runtime.outbox import OutboxMessage
+
+_LOGGER_NAME = "reyn.interfaces.inline.textual_chat.presenter"
+
+
+class _Unserializable:
+    """A plain object with no `__repr__` override -- `json.dumps` cannot
+    encode it and raises `TypeError`."""
+
+
+def _settled_tool(result: object) -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started", text="some_tool",
+        meta={RESULT_META_KEY: {"result": result}},
+    )
+
+
+def test_non_serializable_result_warns_and_falls_back_to_str(caplog) -> None:
+    """Tier 2: a tool result that `json.dumps` cannot encode warns AND
+    `_result_detail_lines` still returns `str(result)`'s own lines
+    rather than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from `_result_detail_lines`'s second `except Exception`):
+    this test goes red — no record at all."""
+    msg = _settled_tool(_Unserializable())
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        lines = _result_detail_lines(msg)
+    assert lines and "_Unserializable" in lines[0]
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("not JSON-serializable" in r.message for r in records)
+
+
+def test_serializable_result_does_not_warn(caplog) -> None:
+    """Tier 2: negative control -- a JSON-serializable non-dict result
+    (a list) parses through with no warning at all."""
+    msg = _settled_tool([1, 2, 3])
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        _result_detail_lines(msg)
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/interfaces/test_5990_stage2_renderer_summarize.py
+++ b/tests/interfaces/test_5990_stage2_renderer_summarize.py
@@ -1,0 +1,41 @@
+"""Tier 2: #5990 (part of, stage 2) — `renderer.summarize_tool_result`'s
+own `except Exception: summary = _short(result, 80)` swallowed a
+summarization failure with no visible report. Now warns before falling
+back to a short repr, same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+
+import reyn.interfaces.repl.renderer as renderer_module
+
+_LOGGER_NAME = "reyn.interfaces.repl.renderer"
+
+
+def test_summarize_failure_warns_and_falls_back_to_short_repr(monkeypatch, caplog) -> None:
+    """Tier 2: `_summarize_result` raising warns AND
+    `summarize_tool_result` still returns a (neutralized) short repr
+    rather than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from `summarize_tool_result`'s `except Exception`): this
+    test goes red — no record at all."""
+    def _raise(tool, result):
+        raise RuntimeError("simulated summarization failure")
+
+    monkeypatch.setattr(renderer_module, "_summarize_result", _raise)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        summary = renderer_module.summarize_tool_result("read_file", "some result")
+
+    assert summary  # a non-empty fallback string, never an exception
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("read_file" in r.message for r in records)
+
+
+def test_normal_summarize_does_not_warn(caplog) -> None:
+    """Tier 2: negative control -- a normal (non-raising) summarization
+    never reaches the except branch, so no warning fires."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        renderer_module.summarize_tool_result("read_file", "some result")
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/interfaces/test_5990_stage2_support_bundle_meta.py
+++ b/tests/interfaces/test_5990_stage2_support_bundle_meta.py
@@ -1,0 +1,46 @@
+"""Tier 2: #5990 (part of, stage 2) — `support_bundle._meta`'s own
+`except Exception: reyn_version = "unknown"` swallowed a version-
+detection failure with no visible report. Now warns before falling
+back, same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.interfaces.cli.commands.support_bundle import _meta
+
+_LOGGER_NAME = "reyn.interfaces.cli.commands.support_bundle"
+
+
+def test_version_detection_failure_warns_and_falls_back_to_unknown(
+    monkeypatch, caplog,
+) -> None:
+    """Tier 2: `importlib.metadata.version("reyn")` raising warns AND
+    `_meta` still returns `reyn_version: "unknown"` rather than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from `_meta`'s first `except Exception`): this test goes red
+    — no record at all."""
+    import importlib.metadata
+
+    def _raise(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _raise)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        meta = _meta(session=None, since_raw=None, manifest=[])
+
+    assert meta["reyn_version"] == "unknown"
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("installed version" in r.message for r in records)
+
+
+def test_normal_version_detection_does_not_warn(caplog) -> None:
+    """Tier 2: negative control -- a normal (installed, non-raising)
+    version lookup never reaches the except branch, so no warning
+    fires."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        meta = _meta(session=None, since_raw=None, manifest=[])
+    assert meta["reyn_version"] != "unknown"
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/interfaces/test_5990_stage2_web_data_agents.py
+++ b/tests/interfaces/test_5990_stage2_web_data_agents.py
@@ -1,0 +1,51 @@
+"""Tier 2: #5990 (part of, stage 2) — the `/web/data` `web_data` endpoint's
+own `except Exception: agents = []` swallowed a registry-build failure
+with no visible report. Now warns before falling back to an empty agent
+list, same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import reyn.interfaces.web.routers.web_data as web_data_module
+
+_LOGGER_NAME = "reyn.interfaces.web.routers.web_data"
+
+
+@pytest.mark.asyncio
+async def test_registry_build_failure_warns_and_falls_back_to_empty_agents(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: `_build_agents` raising warns AND `web_data` still returns
+    `AGENTS: []` rather than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call
+    removed from `web_data`'s `except Exception`): this test goes red —
+    no record at all."""
+    def _raise(registry):
+        raise RuntimeError("simulated registry build failure")
+
+    monkeypatch.setattr(web_data_module, "_build_agents", _raise)
+    monkeypatch.setattr(web_data_module, "get_registry", lambda: object())
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        result = await web_data_module.web_data(project_root=tmp_path)
+
+    assert result["AGENTS"] == []
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("AGENTS" in r.message for r in records)
+
+
+@pytest.mark.asyncio
+async def test_normal_registry_does_not_warn(tmp_path, monkeypatch, caplog) -> None:
+    """Tier 2: negative control -- a normal (non-raising) registry build
+    never reaches the except branch, so no warning fires."""
+    monkeypatch.setattr(web_data_module, "get_registry", lambda: object())
+    monkeypatch.setattr(web_data_module, "_build_agents", lambda registry: [])
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        await web_data_module.web_data(project_root=tmp_path)
+
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/mcp/test_5990_stage2_gateway_call_timeout.py
+++ b/tests/mcp/test_5990_stage2_gateway_call_timeout.py
@@ -1,0 +1,34 @@
+"""Tier 1: #5990 (part of, stage 2) — `mcp.gateway.resolve_call_timeout`'s
+own `except (TypeError, ValueError): timeout = default` swallowed a
+malformed `call_timeout_seconds` server config value with no visible
+report. Now warns before falling back, same convention #6038 established
+for `config/`'s own parse-error sites.
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.mcp.gateway import _DEFAULT_MCP_CALL_TIMEOUT_SECONDS, resolve_call_timeout
+
+_LOGGER_NAME = "reyn.mcp.gateway"
+
+
+def test_malformed_call_timeout_warns_and_falls_back(caplog) -> None:
+    """Tier 1: a non-numeric `call_timeout_seconds` warns AND the default
+    timeout is still what is returned.
+
+    Strip-falsify (verified by hand: the `logging.getLogger(__name__).
+    warning(...)` call removed): this test goes red — no record at all."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        timeout = resolve_call_timeout({"call_timeout_seconds": "oops"})
+    assert timeout == _DEFAULT_MCP_CALL_TIMEOUT_SECONDS
+    assert any("call_timeout_seconds" in r.message for r in caplog.records)
+
+
+def test_well_formed_call_timeout_does_not_warn(caplog) -> None:
+    """Tier 1: negative control — a well-formed numeric value parses
+    through with no warning at all."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        timeout = resolve_call_timeout({"call_timeout_seconds": 30})
+    assert timeout == 30.0
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/runtime/test_5990_stage2_router_loop_tool_call_args.py
+++ b/tests/runtime/test_5990_stage2_router_loop_tool_call_args.py
@@ -1,0 +1,71 @@
+"""Tier 2: #5990 (part of, stage 2) — `RouterLoop._resolve_tool_call`'s
+own `except (json.JSONDecodeError, KeyError): args = {}` swallowed a
+malformed tool-call `arguments` string with no visible report. Now warns
+before falling back to no-args, same convention #6038 established.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from reyn.runtime.router_loop import RouterLoop
+
+_LOGGER_NAME = "reyn.runtime.router_loop"
+
+
+class _RecordingEvents:
+    def __init__(self) -> None:
+        self.events: "list[tuple[str, dict]]" = []
+
+    def emit(self, type: str, **data: Any) -> None:
+        self.events.append((type, dict(data)))
+
+
+class _ResolveShim:
+    """Minimal RouterLoop surface to exercise the real `_resolve_tool_call`
+    -- same shape as test_provider_tool_namespace_strip_1989.py's own
+    `_ResolveShim`, duplicated per this repo's own test-isolation
+    convention rather than imported across test files."""
+
+    chain_id = "test-chain"
+    _resolve_tool_call = RouterLoop._resolve_tool_call
+    _maybe_salvage_action_direct_call = RouterLoop._maybe_salvage_action_direct_call
+
+    def __init__(self, catalog) -> None:
+        self._catalog = catalog
+        self._dispatch_catalog = None
+
+        class _Host:
+            events = _RecordingEvents()
+        self.host = _Host()
+
+
+def _tc(name, arguments):
+    return {"function": {"name": name, "arguments": arguments}}
+
+
+def test_malformed_tool_call_arguments_warns_and_falls_back_to_no_args(caplog) -> None:
+    """Tier 2: malformed JSON in a tool call's own `arguments` string warns
+    AND resolution still falls back to `{}` rather than raising.
+
+    Strip-falsify (verified by hand: the `logger.warning(...)` call
+    removed from `_resolve_tool_call`): this test goes red — no record at
+    all, though `args` still comes back `{}` either way (the SAME false-
+    green risk #6038's own review caught once already -- the message
+    assertion is the real witness here, not just the return value)."""
+    shim = _ResolveShim(catalog={"invoke_action": object()})
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        name, args, raw_name = shim._resolve_tool_call(_tc("invoke_action", "{not json"))
+    assert name == "invoke_action"
+    assert args == {}
+    assert any("not valid JSON" in r.message for r in caplog.records)
+
+
+def test_well_formed_tool_call_arguments_do_not_warn(caplog) -> None:
+    """Tier 2: negative control -- well-formed JSON arguments parse through
+    with no warning at all."""
+    shim = _ResolveShim(catalog={"invoke_action": object()})
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        name, args, raw_name = shim._resolve_tool_call(_tc("invoke_action", '{"x": 1}'))
+    assert args == {"x": 1}
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/runtime/test_5990_stage2_session_audit_bundle_silent_except.py
+++ b/tests/runtime/test_5990_stage2_session_audit_bundle_silent_except.py
@@ -1,0 +1,58 @@
+"""Tier 2: #5990 (part of, stage 2) — `Session._build_audit_event_bundle`'s
+own `except Exception: otel_exporter = None` swallowed an OTEL-attach
+failure with no visible report. Now warns before falling through to
+"no OTEL export this session", same convention #6038 established.
+
+Real Session construction (`make_session`) throughout -- only the ONE
+collaborator whose failure is under test (`build_otel_exporter`) is
+monkeypatched to raise, on its own real module attribute (the exact seam
+`session.py`'s own local import reads at call time).
+"""
+from __future__ import annotations
+
+import logging
+
+from tests._support.agent_session import make_session
+
+_LOGGER_NAME = "reyn.runtime.session"
+
+
+def test_otel_attach_failure_warns_and_session_still_starts(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: `build_otel_exporter` raising during a REAL Session's own
+    construction warns AND the session still starts with no OTEL exporter
+    attached, rather than failing to construct.
+
+    Strip-falsify (verified by hand: the `logger.warning(...)` call
+    removed from `_build_audit_event_bundle`'s `except Exception`): this
+    test goes red — no record at all."""
+    import reyn.observability.otel_exporter as otel_module
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated OTEL attach failure")
+
+    monkeypatch.setattr(otel_module, "build_otel_exporter", _raise)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        session = make_session(
+            agent_name="test-agent-5990-stage2-otel",
+            workspace_base_dir=tmp_path,
+        )
+
+    assert session is not None  # construction itself must not raise
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("otel" in r.message.lower() for r in records)
+
+
+def test_normal_session_construction_does_not_warn(tmp_path, caplog) -> None:
+    """Tier 2: negative control -- a real Session with no OTEL endpoint
+    configured (the default) never raises inside the try, so no warning
+    fires."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        make_session(
+            agent_name="test-agent-5990-stage2-otel-control",
+            workspace_base_dir=tmp_path,
+        )
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert not any("otel" in r.message.lower() for r in records)

--- a/tests/runtime/test_5990_stage2_session_retrieval_bundle_silent_except.py
+++ b/tests/runtime/test_5990_stage2_session_retrieval_bundle_silent_except.py
@@ -1,0 +1,68 @@
+"""Tier 2: #5990 (part of, stage 2) — `Session._build_retrieval_bundle`'s
+own `except Exception: embedding_provider = None; ...` swallowed a
+provider/index construction failure (missing dependency or malformed
+`embedding:` config) with no visible report. Now warns before falling
+through to "no search_actions this session", same convention #6038
+established.
+
+Real Session construction (`make_session`, the same helper 280+ other
+tests use) throughout -- only the ONE collaborator whose failure is
+under test (`ActionEmbeddingIndex`) is monkeypatched to raise, on its
+own real module attribute (the exact seam `session.py`'s own local
+import reads at call time).
+"""
+from __future__ import annotations
+
+import logging
+
+from reyn.config.embedding import EmbeddingConfig
+from tests._support.agent_session import make_session
+
+_LOGGER_NAME = "reyn.runtime.session"
+
+
+def test_action_index_construction_failure_warns_and_degrades_to_no_index(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Tier 2: `ActionEmbeddingIndex` raising during a REAL Session's own
+    construction warns AND the session still comes up with no
+    search_actions (read via the public `RouterHostAdapter` surface,
+    the SAME method `RouterLoop.run()` itself calls every turn) rather
+    than failing to start.
+
+    Strip-falsify (verified by hand: the `logger.warning(...)` call
+    removed from `_build_retrieval_bundle`'s `except Exception`): this
+    test goes red — no record at all (the degrade itself still happens
+    either way, so the return-value assertion alone is not a witness —
+    matching test-review Q3's own "was handed X is not used X" shape)."""
+    import reyn.tools.action_index as action_index_module
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated action-index construction failure")
+
+    monkeypatch.setattr(action_index_module, "ActionEmbeddingIndex", _raise)
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        session = make_session(
+            agent_name="test-agent-5990-stage2",
+            workspace_base_dir=tmp_path,
+            embedding_config=EmbeddingConfig(enabled=True),
+        )
+
+    router_host = session._router_host
+    idx = router_host.get_action_embedding_index()
+    assert idx is None
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("action-embedding provider/index" in r.message for r in records)
+
+
+def test_well_formed_embedding_config_does_not_warn(tmp_path, caplog) -> None:
+    """Tier 2: negative control -- a real Session with embedding.enabled
+    left at its own default (off) never reaches the construction branch
+    at all, so no warning fires."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        make_session(
+            agent_name="test-agent-5990-stage2-control",
+            workspace_base_dir=tmp_path,
+        )
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/security/test_5990_stage2_oauth_poll_token.py
+++ b/tests/security/test_5990_stage2_oauth_poll_token.py
@@ -1,0 +1,77 @@
+"""Tier 2: #5990 (part of, stage 2) — `oauth._poll_token`'s own `except
+ValueError: body = {}` swallowed a non-JSON response from the OAuth
+token endpoint with no visible report. Now warns (status + URL only,
+never the response BODY -- a token endpoint's non-JSON reply can
+legitimately be or embed sensitive text) before falling back to an
+empty body, same convention #6038 established.
+
+Policy: `httpx.MockTransport` Fake (a real httpx transport returning
+canned responses), real `_poll_token`. No MagicMock.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from reyn.security.secrets.oauth import OAuthProviderConfig, _poll_token
+
+_LOGGER_NAME = "reyn.security.secrets.oauth"
+_TOKEN_URL = "https://example.com/token"
+
+
+def _provider() -> OAuthProviderConfig:
+    return OAuthProviderConfig(
+        name="github",
+        client_id="cid",
+        device_authorization_url="https://example.com/device",
+        token_url=_TOKEN_URL,
+        scopes=["repo"],
+        client_secret=None,
+        audience=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_json_token_response_warns_and_falls_back_to_empty_body(caplog) -> None:
+    """Tier 2: a non-JSON token-endpoint response warns (status + URL, no
+    body content) AND `_poll_token` still returns `(status, {})` rather
+    than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call removed
+    from `_poll_token`): this test goes red — no record at all."""
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="Bad Gateway")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            status, body = await _poll_token(_provider(), "device123", client)
+    finally:
+        await client.aclose()
+    assert status == 502
+    assert body == {}
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any(_TOKEN_URL in r.message and "502" in r.message for r in records)
+    assert not any("Bad Gateway" in r.message for r in records), (
+        "the response body itself must never be logged -- it can carry sensitive text"
+    )
+
+
+@pytest.mark.asyncio
+async def test_well_formed_json_token_response_does_not_warn(caplog) -> None:
+    """Tier 2: negative control -- a well-formed JSON response parses
+    through with no warning at all."""
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": "AT_x"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            status, body = await _poll_token(_provider(), "device123", client)
+    finally:
+        await client.aclose()
+    assert status == 200
+    assert body == {"access_token": "AT_x"}
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/tools/test_5990_stage2_exec_sandbox_backend.py
+++ b/tests/tools/test_5990_stage2_exec_sandbox_backend.py
@@ -1,0 +1,72 @@
+"""Tier 2: #5990 (part of, stage 2) — `exec.op_context_from_tool_context`'s
+own `except ValueError: resolved_backend = None` swallowed an unknown
+`router_state.sandbox_backend` name with no visible report -- a security-
+relevant silent-degrade (a requested sandbox backend not applying).
+Now warns before falling back, same convention #6038 established.
+
+Real Session/RouterCallerState/OpContext throughout, same construction as
+test_5820_write_scope_single_source.py's own established pattern in this
+directory -- no mocks.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from reyn.config import SandboxConfig
+from reyn.core.events.state_log import StateLog
+from reyn.tools.exec import op_context_from_tool_context
+from reyn.tools.types import RouterCallerState, ToolContext
+from tests._support.agent_session import make_session
+
+_LOGGER_NAME = "reyn.tools.exec"
+
+
+def _real_session_ctx(tmp_path):
+    session = make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        sandbox_config=SandboxConfig(mode="strict", backend="noop", policy={}),
+    )
+    return session._make_router_op_context()
+
+
+@pytest.mark.asyncio
+async def test_unknown_sandbox_backend_name_warns_and_leaves_resolved_backend_unset(
+    tmp_path, caplog,
+) -> None:
+    """Tier 2: an unknown `sandbox_backend` name on `router_state` warns
+    AND `op_context_from_tool_context` still returns a context (no
+    exception) with no early-resolved backend instance.
+
+    Strip-falsify (verified by hand: the `logging.getLogger(__name__).
+    warning(...)` call removed from the bridge's `except ValueError`):
+    this test goes red — no record at all."""
+    real_ctx = _real_session_ctx(tmp_path)
+    rs = RouterCallerState(op_context_factory=lambda: real_ctx, sandbox_backend="not-a-real-backend")
+    tool_ctx = ToolContext(
+        events=real_ctx.events, permission_resolver=real_ctx.permission_resolver,
+        workspace=real_ctx.workspace, caller_kind="router", router_state=rs,
+    )
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        bridged_ctx = await op_context_from_tool_context(tool_ctx)
+    assert bridged_ctx is not None
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert any("not-a-real-backend" in r.message for r in records)
+
+
+@pytest.mark.asyncio
+async def test_known_sandbox_backend_name_does_not_warn(tmp_path, caplog) -> None:
+    """Tier 2: negative control -- a known backend name ("noop") resolves
+    through with no warning at all."""
+    real_ctx = _real_session_ctx(tmp_path)
+    rs = RouterCallerState(op_context_factory=lambda: real_ctx, sandbox_backend="noop")
+    tool_ctx = ToolContext(
+        events=real_ctx.events, permission_resolver=real_ctx.permission_resolver,
+        workspace=real_ctx.workspace, caller_kind="router", router_state=rs,
+    )
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        await op_context_from_tool_context(tool_ctx)
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []

--- a/tests/tools/test_5990_stage2_retrieval_tool_call_args.py
+++ b/tests/tools/test_5990_stage2_retrieval_tool_call_args.py
@@ -1,0 +1,66 @@
+"""Tier 2: #5990 (part of, stage 2) — `RetrievalScheme.interpret`'s own
+`except (json.JSONDecodeError, KeyError, TypeError): args = {}` swallowed
+a malformed `search_actions` tool-call `arguments` string with no visible
+report. Now warns before falling back to an empty query, same convention
+#6038 established.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from reyn.tools.schemes.retrieval import RetrievalScheme
+
+_LOGGER_NAME = "reyn.tools.schemes.retrieval"
+
+
+@dataclass
+class _FakeLLMResponse:
+    tool_calls: "list[dict] | None"
+
+
+def _search_call(arguments: str) -> dict:
+    return {"function": {"name": "search_actions", "arguments": arguments}}
+
+
+class _UnusedOps:
+    """A `SchemeOps`-shaped stand-in whose methods are never actually
+    called on this code path (the malformed-arguments branch returns a
+    `RePresent` before ever reaching `ops.resolve`) — satisfies the
+    static Protocol type only, not exercised at runtime."""
+
+    def present(self, available, layer_ctx): ...
+    def resolve(self, llm_response, tool_catalog): ...
+
+    async def dispatch(self, actions, *, call_id=None): ...
+    def feedback(self, result): ...
+    def base_tools(self, available, layer_ctx): ...
+
+    async def catalog_entries(self): ...
+    async def search_actions(self, query, *, top_k=10): ...
+
+
+def test_malformed_search_arguments_warns_and_falls_back_to_empty_query(caplog) -> None:
+    """Tier 2: malformed JSON in `search_actions`'s own tool-call
+    arguments warns AND `interpret` still returns a `RePresent` with an
+    empty query rather than raising.
+
+    Strip-falsify (verified by hand: the `_log.warning(...)` call removed
+    from `RetrievalScheme.interpret`): this test goes red — no record."""
+    scheme = RetrievalScheme()
+    response = _FakeLLMResponse(tool_calls=[_search_call("{not json")])
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        interp = scheme.interpret(response, tool_catalog={}, ops=_UnusedOps())
+    assert interp.refinement == {"query": ""}
+    assert any("not valid JSON" in r.message for r in caplog.records)
+
+
+def test_well_formed_search_arguments_do_not_warn(caplog) -> None:
+    """Tier 2: negative control -- well-formed JSON arguments parse
+    through with no warning at all."""
+    scheme = RetrievalScheme()
+    response = _FakeLLMResponse(tool_calls=[_search_call('{"query": "hello"}')])
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        interp = scheme.interpret(response, tool_catalog={}, ops=_UnusedOps())
+    assert interp.refinement == {"query": "hello"}
+    assert [r for r in caplog.records if r.name == _LOGGER_NAME] == []


### PR DESCRIPTION
**[tui-coder]** — part of #5990: report 14 silent-except sites, same convention as #6038.

## Population, derived not hand-maintained

Re-ran backlog-watcher's own axis (assign-only `except` handler body, bound name reaches a `Return` in the enclosing function) against current `origin/main` myself: **34** violation-side sites, matching lead-coder's own arithmetic (58 − 24 after #6038's `config/` landing) exactly, `session.py` = 4 confirmed.

## 14 fixed here

Same `logging.getLogger(__name__).warning(...)`-before-fallback convention #6038 established:

- `mcp/gateway.py` — malformed `call_timeout_seconds`
- `runtime/router_loop.py` + `tools/schemes/retrieval.py` — malformed LLM tool-call arguments JSON (2 sites)
- `security/secrets/oauth.py` — non-JSON OAuth token response (status/URL only — **never** the body, which can carry sensitive text)
- `tools/exec.py` — an unknown `sandbox_backend` name (security-relevant: a requested sandbox silently not applying)
- `runtime/session.py` — OTEL attach failure, action-embedding index construction failure (2 sites)
- `core/op_runtime/embed.py` — `reyn.yaml` load failure
- `interfaces/cli/commands/embeddings.py` — action-index cache read + mtime failure (2 sites)
- `interfaces/web/routers/web_data.py` — registry build failure
- `interfaces/repl/renderer.py` + `interfaces/inline/textual_chat/presenter.py` — tool-result rendering fallback (safe to log now that #6043 made the interactive path file-only)
- `interfaces/cli/commands/support_bundle.py` — version detection failure

## 20 NOT touched — judged out-of-class, not a silent remainder

Read each one's own surrounding code rather than mechanically applying the template to every axis match (CLAUDE.md's "no band-aid" instruction, repeated all night in this arc):

- **Internal hash/digest fallbacks, explicitly `noqa`'d as intentional**: `dispatcher.py` ×2, `sub_loop_memo_key.py`, `replay_key_diff.py`
- **A documented retry-backoff loop, not a silent default**: `context_builder.py`
- **Parsing untrusted third-party content, no operator fix available**: `api/safe/http.py` (UTF-8 replace-decode), `op_runtime/web.py` (HTML-preview parse)
- **Exception already captured and returned up the call chain**: `pipeline/executor.py` ×2, `mcp/client.py`
- **Already reported via a DIFFERENT channel in the SAME function** (a second warning would duplicate it): `litellm_bootstrap.py` (its own existing warn-once path a few lines below), `compaction_controller.py` (its own audit-event at origin), `support_bundle.py`'s `config_summary` (already embeds `str(exc)` into the bundle's own returned data)
- **Expected platform-specific `ImportError` for an optional backend**: `sandbox/__init__.py` ×2, `seccomp.py`
- **Explicitly-documented low-stakes display metric** ("a display number, never the operation"): `session.py`'s `window_tokens`/`window_used_tokens` ×2
- **Documented intentional degrade matching a prior established pattern**: `tools/types.py`'s `rag_sources`
- **An inner fallback for an already-reported outer failure**: `remote_client.py`

## Tests

14 new (one per site, #6038's own convention: caplog at the module's own logger, asserting BOTH the warning fires AND the default/fallback is still what ships, plus a negative control per file). Real collaborators throughout — real `Session` via `make_session`, real `httpx.MockTransport`, real SQLite files — only the ONE collaborator whose failure is under test is monkeypatched to raise, on its own real module attribute, never a MagicMock.

Strip-falsified by hand for **all 14, individually** (in-file `Edit` → run → `Edit` back, no `git checkout`/`stash`/`restore`) — each site's own warning call removed turns its own test red, restored turns it back green.

## `silent_except_ratchet.py` (the existing `src/reyn/interfaces/` gate)

5 of the 12 touched files are under `interfaces/` (embeddings.py, support_bundle.py, presenter.py, renderer.py, web_data.py) — all 5 sites there are now reported. The gate's own population went **down** (90 silent sites remain, all baseline-covered) — **not re-tightened to 0 in this PR**, per lead-coder's explicit instruction (that's the next stage, after the full 34-site population lands).

Full gate suite green (`ruff`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, the `tests/`-path-conditional gates, `silent_except_ratchet.py`). Scoped pytest green: all 14 new files (28 tests) + every existing test file touching the same functions I could find (89 + 21 passed across two runs).

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on all 13 new test files
- [x] scoped pytest, all listed above
- [x] (skipped — Visual, standing waiver 2026-08-08)

part of #5990 — 20 sites explicitly judged out-of-class above (not a silent remainder); ratchet-to-0 and any further population sweep are lead-coder's own next stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
