### PR TITLE
fix(#6050): MediaStore forgets its own deletes -- fuse unlink+bookkeeping into one method

### DIFF
--- a/.github/workflows/media-store-unlink-single-caller-gate.yml
+++ b/.github/workflows/media-store-unlink-single-caller-gate.yml
@@ -1,0 +1,46 @@
+name: media_store.py unlink single-caller gate
+
+# Regression-prevention gate for #6050: the only place inside
+# src/reyn/data/workspace/media_store.py allowed to call Path.unlink() is
+# MediaStore._unlink_tracked itself. This gate is ALREADY GREEN -- this PR
+# collapsed the two pre-existing call sites into the one sanctioned caller
+# before adding it, so it is a ratchet against a future THIRD call site
+# appearing, not a cleanup. See
+# scripts/check_media_store_unlink_single_caller.py's own module docstring
+# for the full design (mirrors #5978/PR #6054's
+# faulthandler-timer-api-single-caller gate shape).
+#
+# `paths: src/reyn/data/workspace/media_store.py` matches this gate's own
+# scan scope exactly -- its population is this one file.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/data/workspace/media_store.py"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/reyn/data/workspace/media_store.py"
+
+permissions:
+  contents: read
+
+jobs:
+  media-store-unlink-single-caller:
+    name: media_store.py unlink single-caller gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_media_store_unlink_single_caller.py is stdlib-only
+      # (ast / pathlib). No pip install needed.
+      - name: Check media_store.py's own .unlink() has a single caller
+        run: |
+          python scripts/check_media_store_unlink_single_caller.py

--- a/scripts/check_media_store_unlink_single_caller.py
+++ b/scripts/check_media_store_unlink_single_caller.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Regression-prevention gate for #6050: the only place inside
+``src/reyn/data/workspace/media_store.py`` allowed to call
+``Path.unlink()`` is ``MediaStore._unlink_tracked`` itself.
+
+**This gate starts already GREEN.** It is a regression ratchet, not a
+cleanup — this PR itself collapsed the two pre-existing call sites
+(``_evict_history_content_over_cap`` write-time-cap eviction,
+``_evict_cross_session_over_cap`` project-wide eviction) into the one
+sanctioned caller before adding this gate. Read-only measurement at the
+time this gate was written:
+
+```
+$ git grep -nE '\\.unlink\\(' -- src/reyn/data/workspace/media_store.py
+src/reyn/data/workspace/media_store.py:<lineno>:        path.unlink()
+```
+
+Exactly 1 call site, inside ``_unlink_tracked`` itself.
+
+## Why this gate exists (#6050's own root cause)
+
+Two eviction call sites each called ``path.unlink()`` directly and never
+called ``.discard()`` on ``_history_content_spill_paths``/
+``_unspilled_paths`` afterward — a file THIS process's own eviction
+deleted stayed tracked as "known" forever. The fix (#6050) fuses
+deletion and bookkeeping into one method (``_unlink_tracked``, which
+calls ``self._forget(path)`` on every successful delete) so a FUTURE
+3rd eviction path added to this class inherits correct bookkeeping by
+construction, rather than needing to remember its own ``.discard()`` —
+the exact thing both existing call sites independently forgot. This
+gate is what stops a 3rd ``path.unlink()`` call site from reopening
+that gap; without it, "route unlink through ``_unlink_tracked``" is a
+convention someone has to remember, not something CI enforces (the
+same "collapse the delete口 so it cannot be split apart again" shape
+``#5978``/PR #6054 already established for ``faulthandler``'s timer
+API — this gate's own structure mirrors that one directly).
+
+## Population and detection
+
+Population: the single file ``src/reyn/data/workspace/media_store.py``
+(#6050's own scope is this one class, not a repo-wide sweep — a
+broader "every ``Path.unlink()`` call anywhere in ``src/``" population
+would need to distinguish this store's OWN tracked-path bookkeeping
+concern from every other module's unrelated file-deletion, which is a
+*purpose* judgement this gate does not attempt; see
+``check_faulthandler_timer_api_single_caller.py``'s own docstring for
+why a narrow, syntactically-derivable population beats a
+hand-maintained exclusion list over a broad one). Detection: an AST
+walk for a ``Call`` node whose function is an attribute access
+``<expr>.unlink`` (i.e. ``.attr == "unlink"``, regardless of the base
+expression — a bare ``Path.unlink()`` this file's own code always
+writes as ``path.unlink()``, never aliased or wrapped). This is a
+syntax-shape classifier, not dataflow — a call reached only through an
+indirection (a rebound reference, a method passed by name) would not
+be caught; no such shape exists in the current file (verified by the
+grep above).
+
+## CI wiring
+
+Runs on every push touching this one file (not a repo-wide trigger —
+the population is exactly one file, so a path-scoped trigger on that
+file alone is the lightest correct choice).
+
+CI: gate
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TARGET = "src/reyn/data/workspace/media_store.py"
+_SOLE_CALLER_METHOD = "_unlink_tracked"
+
+
+def _is_unlink_call(node: ast.AST) -> bool:
+    """True for a `Call` node shaped `<expr>.unlink(...)` — any base
+    expression, matching `.attr == "unlink"` only (never a text/regex
+    match, so a docstring or comment merely naming `.unlink()` cannot
+    trigger this)."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "unlink"
+    )
+
+
+def find_violations(path: Path) -> "list[tuple[int, str]]":
+    """`(lineno, enclosing_function_name)` for every `.unlink(...)` call
+    site in *path* whose nearest enclosing function/method is NOT
+    `_SOLE_CALLER_METHOD` (module-level top, if any, reports as `"<module>"`)."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    violations: "list[tuple[int, str]]" = []
+
+    def walk(node: ast.AST, enclosing: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                walk(child, child.name)
+                continue
+            if _is_unlink_call(child) and enclosing != _SOLE_CALLER_METHOD:
+                assert isinstance(child, ast.Call)  # narrowed by _is_unlink_call
+                violations.append((child.lineno, enclosing))
+            walk(child, enclosing)
+
+    walk(tree, "<module>")
+    return sorted(violations)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv  # no options -- population is one fixed file
+
+    target = _ROOT / _TARGET
+    try:
+        violations = find_violations(target)
+    except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+        print(
+            f"media-store-unlink-single-caller gate FAILED: could not scan "
+            f"{_TARGET} ({exc}). Fails CLOSED on a scan error rather than "
+            "silently under-counting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if violations:
+        print(
+            "media-store-unlink-single-caller gate FAILED:\n", file=sys.stderr,
+        )
+        print(
+            f"{len(violations)} `.unlink()` call site(s) in {_TARGET} outside "
+            f"the one sanctioned caller ({_SOLE_CALLER_METHOD}). The "
+            "invariant (#6050) is that ONLY that method may call "
+            "Path.unlink() in this file — it fuses deletion with "
+            "MediaStore._forget(path) so the tracked-path sets can never "
+            "drift from disk again; a second independent unlink call site "
+            "would reopen the exact bookkeeping gap #6050 fixed:",
+            file=sys.stderr,
+        )
+        for lineno, enclosing in violations:
+            print(f"  {_TARGET}:{lineno}: inside {enclosing}()", file=sys.stderr)
+        print(
+            f"\nRoute the new delete through self.{_SOLE_CALLER_METHOD}(path) "
+            "instead of calling .unlink() directly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"media-store-unlink-single-caller gate OK: {_SOLE_CALLER_METHOD} is "
+        f"the only caller of .unlink() in {_TARGET}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_media_store_unlink_single_caller.py
+++ b/scripts/check_media_store_unlink_single_caller.py
@@ -86,26 +86,46 @@ def _is_unlink_call(node: ast.AST) -> bool:
     )
 
 
-def find_violations(path: Path) -> "list[tuple[int, str]]":
-    """`(lineno, enclosing_function_name)` for every `.unlink(...)` call
-    site in *path* whose nearest enclosing function/method is NOT
-    `_SOLE_CALLER_METHOD` (module-level top, if any, reports as `"<module>"`)."""
+def find_calls(path: Path) -> "tuple[list[tuple[int, str]], list[int]]":
+    """`(violations, sanctioned_linenos)` for every `.unlink(...)` call
+    site in *path* — *violations* are `(lineno, enclosing_function_name)`
+    pairs whose nearest enclosing function/method is NOT
+    `_SOLE_CALLER_METHOD` (module-level top, if any, reports as
+    `"<module>"`); *sanctioned_linenos* are the call sites that ARE
+    inside it.
+
+    #6050 BLOCKING (lead-coder review): an earlier version of this gate
+    returned violations ONLY — if `_SOLE_CALLER_METHOD` itself were
+    renamed or deleted, every remaining `.unlink()` call (there would be
+    none) trivially satisfies "not inside a DIFFERENT function named
+    `_unlink_tracked`", so `violations` comes back empty and the gate
+    would claim "OK: _unlink_tracked is the only caller" — true of an
+    EMPTY set, false of the invariant this gate exists to state. Callers
+    now also check *sanctioned_linenos* is non-empty (the same
+    zero-population fail-closed shape `check_faulthandler_timer_api_
+    single_caller.py`'s own `if not by_file: return 1` already
+    established, and the exact property this gate's own PR review
+    flagged as "the class of bug #6050 itself fixes, now in gate form")."""
     text = path.read_text(encoding="utf-8")
     tree = ast.parse(text, filename=str(path))
     violations: "list[tuple[int, str]]" = []
+    sanctioned: "list[int]" = []
 
     def walk(node: ast.AST, enclosing: str) -> None:
         for child in ast.iter_child_nodes(node):
             if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 walk(child, child.name)
                 continue
-            if _is_unlink_call(child) and enclosing != _SOLE_CALLER_METHOD:
+            if _is_unlink_call(child):
                 assert isinstance(child, ast.Call)  # narrowed by _is_unlink_call
-                violations.append((child.lineno, enclosing))
+                if enclosing == _SOLE_CALLER_METHOD:
+                    sanctioned.append(child.lineno)
+                else:
+                    violations.append((child.lineno, enclosing))
             walk(child, enclosing)
 
     walk(tree, "<module>")
-    return sorted(violations)
+    return sorted(violations), sorted(sanctioned)
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -113,12 +133,26 @@ def main(argv: "list[str] | None" = None) -> int:
 
     target = _ROOT / _TARGET
     try:
-        violations = find_violations(target)
+        violations, sanctioned = find_calls(target)
     except (OSError, UnicodeDecodeError, SyntaxError) as exc:
         print(
             f"media-store-unlink-single-caller gate FAILED: could not scan "
             f"{_TARGET} ({exc}). Fails CLOSED on a scan error rather than "
             "silently under-counting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not sanctioned:
+        print(
+            f"media-store-unlink-single-caller gate FAILED: found 0 "
+            f".unlink() call(s) inside {_SOLE_CALLER_METHOD}() -- expected "
+            "at least 1. Either the sanctioned caller itself was renamed "
+            "or removed (update this gate's _SOLE_CALLER_METHOD "
+            "deliberately) or the scan itself is broken -- in neither case "
+            "is 'no caller found anywhere' the same claim as 'the one "
+            "sanctioned caller is the only one', so this fails closed "
+            "rather than reporting a vacuous OK.",
             file=sys.stderr,
         )
         return 1
@@ -148,7 +182,8 @@ def main(argv: "list[str] | None" = None) -> int:
 
     print(
         f"media-store-unlink-single-caller gate OK: {_SOLE_CALLER_METHOD} is "
-        f"the only caller of .unlink() in {_TARGET}."
+        f"the only caller of .unlink() in {_TARGET} "
+        f"({len(sanctioned)} call site(s), as expected)."
     )
     return 0
 

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -1226,15 +1226,18 @@ class MediaStore:
         write, no race window) and never removes a legitimately-tracked
         entry, live or still-queued.
 
-        This IS a genuine, previously-unpruned gap, not a no-op: neither
-        eviction call site (``_evict_cross_session_over_cap`` nor the
-        write-time-cap path) ever calls ``.discard()`` on these sets after
-        ``path.unlink()`` — a file this SAME process deleted stays
-        tracked here forever until this method (or a fresh
-        ``MediaStore`` construction, which re-derives from the manifest
-        and self-prunes there) runs. Filed separately, deliberately NOT
-        fixed here (different subject from this PR's own "release what
-        the ladder asks for"): https://github.com/tya5/reyn/issues/6050.
+        #6050 (fixed after this method landed): both eviction call sites
+        now route their own ``Path.unlink()`` through
+        :meth:`_unlink_tracked`, which calls :meth:`_forget` on every
+        successful delete — a file THIS process's own eviction removes no
+        longer lingers in these sets waiting for this method (or a fresh
+        ``MediaStore`` construction) to catch up. This method still earns
+        its keep for the OTHER source of drift these sets have: a file
+        removed by something OTHER than this store's own eviction (an
+        operator ``rm``, an external cleanup tool) — #6050's own fix
+        cannot see that, since nothing here calls unlink for it; existence
+        is still checked live against the filesystem for exactly that
+        reason.
 
         Returns ``(entries_before, entries_after)`` — the union of both
         sets' sizes, before and after the prune."""
@@ -1245,6 +1248,67 @@ class MediaStore:
         self._unspilled_paths = {p for p in self._unspilled_paths if p.exists()}
         after = len(self._history_content_spill_paths | self._unspilled_paths)
         return before, after
+
+    def _resolve_tracked_path(self, path: "str | Path") -> Path:
+        """The ONE resolution rule every tracked-path site uses (#6050):
+        relative → against ``project_root``, then ``.resolve()``;
+        absolute → ``.resolve()`` directly. Both
+        :meth:`is_history_content_spill`/:meth:`is_unspilled_file`/
+        :meth:`is_known_file` (the read side, this store's own public
+        surface for "does this set know about *path*") and :meth:`_forget`
+        (the write side) call this SAME method rather than each keeping
+        their own copy of the resolution — the two sides diverging is
+        exactly how a raw, un-resolved path silently no-ops a
+        ``.discard()`` against a set that only ever holds resolved ones
+        (#6050's own root cause: eviction's candidates come from
+        :func:`_eviction_order`'s raw ``rglob`` entries, never resolved;
+        a symlink anywhere on the path to root — e.g. macOS's own
+        ``/tmp`` → ``/private/tmp`` — would make the un-resolved and
+        resolved forms compare unequal)."""
+        p = Path(path)
+        if not p.is_absolute():
+            return (self._project_root / p).resolve()
+        return p.resolve()
+
+    def _forget(self, path: "str | Path") -> None:
+        """Remove *path* from BOTH tracked-path sets, resolved via
+        :meth:`_resolve_tracked_path` — the same resolution every read
+        site uses (#6050). Only :meth:`_unlink_tracked` calls this;
+        never call it directly against a path this store has not
+        actually deleted (this method does not check the filesystem —
+        it is pure bookkeeping, callable even for a path that was never
+        tracked at all, a no-op ``.discard()`` in that case)."""
+        resolved = self._resolve_tracked_path(path)
+        self._history_content_spill_paths.discard(resolved)
+        self._unspilled_paths.discard(resolved)
+
+    def _unlink_tracked(self, path: Path) -> int:
+        """The ONE place in this class allowed to call ``Path.unlink()``
+        (#6050) — CI-enforced by
+        ``scripts/check_media_store_unlink_single_caller.py``, the same
+        "collapse the delete口 so a 3rd caller cannot reopen the gap"
+        shape ``#5978``/PR #6054 already established for
+        ``faulthandler``'s timer API.
+
+        Deletion and bookkeeping are fused so they cannot be split apart
+        again: on success, :meth:`_forget` runs UNCONDITIONALLY, in the
+        same call, so a future eviction path added to this class gets
+        the bookkeeping for free rather than needing to remember its own
+        ``.discard()`` (the exact gap #6050 was filed for — TWO existing
+        call sites both independently forgot it).
+
+        Raises ``OSError`` on failure, mirroring ``Path.stat()``/
+        ``Path.unlink()``'s own contract — the sets stay untouched (the
+        file still exists, or its absence is itself the OSError), so a
+        caller's existing ``except OSError`` + ``logger.warning`` handling
+        (kept at each call site, not moved here — the log text names a
+        different issue number per caller) is unaffected. Returns the
+        file's own size in bytes, read BEFORE the unlink (matching what
+        both existing callers already did inline)."""
+        size = path.stat().st_size
+        path.unlink()
+        self._forget(path)
+        return size
 
     def is_history_content_spill(self, path: "str | Path") -> bool:
         """#4381 (renamed #5564): whether *path* is a file THIS store
@@ -1271,11 +1335,7 @@ class MediaStore:
         path it recorded (against ``project_root`` when relative), so a
         caller may pass either the project-relative path a tool result
         block carries or an absolute one."""
-        p = Path(path)
-        if not p.is_absolute():
-            p = (self._project_root / p).resolve()
-        else:
-            p = p.resolve()
+        p = self._resolve_tracked_path(path)
         return p in self._history_content_spill_paths
 
     # ── Image storage (= .reyn/media/) ────────────────────────────────
@@ -1633,13 +1693,10 @@ class MediaStore:
         see :func:`cross_session_eviction_candidates`'s own docstring for
         why that is deliberately not implemented here.
 
-        Resolves *path* the same way :meth:`is_history_content_spill`
-        does (relative → against ``project_root``), for the same reason."""
-        p = Path(path)
-        if not p.is_absolute():
-            p = (self._project_root / p).resolve()
-        else:
-            p = p.resolve()
+        Resolves *path* via :meth:`_resolve_tracked_path` — the same
+        resolution :meth:`is_history_content_spill` uses, for the same
+        reason."""
+        p = self._resolve_tracked_path(path)
         return p in self._unspilled_paths
 
     def is_known_file(self, path: "str | Path") -> bool:
@@ -1657,13 +1714,10 @@ class MediaStore:
         KNOWN un-spilled file — see :meth:`is_unspilled_file`'s sibling
         exclusion.
 
-        Resolves *path* the same way :meth:`is_history_content_spill`
-        does (relative → against ``project_root``), for the same reason."""
-        p = Path(path)
-        if not p.is_absolute():
-            p = (self._project_root / p).resolve()
-        else:
-            p = p.resolve()
+        Resolves *path* via :meth:`_resolve_tracked_path` — the same
+        resolution :meth:`is_history_content_spill` uses, for the same
+        reason."""
+        p = self._resolve_tracked_path(path)
         return p in self._history_content_spill_paths
 
     def is_open_turn_file(self, path: Path, *, current_chain_id: str) -> bool:
@@ -1755,8 +1809,7 @@ class MediaStore:
             if not self.is_known_file(path):
                 continue
             try:
-                size = path.stat().st_size
-                path.unlink()
+                size = self._unlink_tracked(path)
             except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
                 logger.warning(
                     "#5364 §1.6: eviction of %s under the history-content "
@@ -1968,8 +2021,7 @@ class MediaStore:
             if total <= max_bytes:
                 return
             try:
-                size = path.stat().st_size
-                path.unlink()
+                size = self._unlink_tracked(path)
             except OSError as e:  # noqa: BLE001 — best-effort; LOG (don't silently swallow)
                 logger.warning(
                     "#5366 §3: cross-session eviction of %s under the "

--- a/tests/data/test_6050_media_store_forgets_own_deletes.py
+++ b/tests/data/test_6050_media_store_forgets_own_deletes.py
@@ -1,0 +1,164 @@
+"""Tier 2: #6050 — ``MediaStore``'s own eviction now forgets what it
+deletes. Both `path.unlink()` call sites (write-time-cap
+``_evict_history_content_over_cap``, project-wide
+``_evict_cross_session_over_cap``) used to leave a file THIS SAME
+process deleted still tracked in ``_history_content_spill_paths``/
+``_unspilled_paths`` forever — the set kept asserting the file "is
+known" after this store's own eviction removed it. Fixed by collapsing
+every ``Path.unlink()`` call in this class into ONE method
+(``MediaStore._unlink_tracked``), which fuses the delete with
+``self._forget(path)`` so bookkeeping cannot be split from deletion
+again (CI-enforced: ``scripts/check_media_store_unlink_single_caller.py``).
+
+Architect's own scoping (issue #6050, tree ``b02492a30``):
+
+- Only ``_history_content_spill_paths`` gets a real bounding subject
+  from this fix (the storage cap: cap deletes a file, the set forgets
+  it in the SAME call, so the set's own size tracks live files). NOT
+  ``_unspilled_paths`` — an un-spilled file is `continue`'d past every
+  eviction call site (never a candidate), so it never reaches
+  ``_unlink_tracked`` and never gets forgotten either. Separate
+  subject (#5896 stage ①, already disclosed there and warned about via
+  ``_note_cap_state`` — not this issue's scope, not re-claimed here).
+- The read-side consumer population for the "stale set answers about a
+  DELETED file" face has NO reachable caller today (architect's own
+  ``git grep`` census: all 3 read methods' own candidates come from
+  live disk enumeration or a post-read-success path, never a
+  since-deleted one) — so this PR does NOT claim "a wrong answer is
+  observed today". What IS bound is the set's own SIZE (the ``band``
+  axis label this issue carries): without this fix, a long-running
+  process's own eviction could only ever GROW these sets, no matter
+  how many files it deleted.
+
+Real ``MediaStore`` throughout, real on-disk writes — same idiom as
+``tests/data/test_5364_history_content_cap_eviction.py`` (this file's
+own established sibling), no fakes. Never asserts on
+``_history_content_spill_paths``/``_unspilled_paths`` directly (CLAUDE.md:
+no private-state assertions) — only through the public
+``is_known_file``/``is_history_content_spill``/``is_unspilled_file``
+read surface, matching architect's own explicit instruction.
+"""
+from __future__ import annotations
+
+import os
+
+from reyn.data.workspace.media_store import (
+    MediaStore,
+    MediaStoreConfig,
+    history_content_root_for,
+)
+
+
+def _bump_all_mtimes_forward(directory) -> None:
+    """Same determinism helper this file's own #5364 sibling uses --
+    force every existing file further into the past relative to
+    whatever gets written next, so eviction order (oldest-mtime-first)
+    is deterministic across a fast test loop."""
+    for path in directory.rglob("*"):
+        if path.is_file():
+            st = path.stat()
+            os.utime(path, (st.st_atime, st.st_mtime - 1))
+
+
+def test_eviction_forgets_the_deleted_file_without_the_ladder_ever_running(
+    tmp_path,
+) -> None:
+    """Tier 2: #6050 accept ⑴ (lead-coder's own specified witness) --
+    write-time-cap eviction (driven by a normal `save_tool_result` that
+    pushes the session over cap) deletes the OLDEST spill and, in that
+    SAME call, `is_known_file` stops recognizing it -- WITHOUT the
+    `#5939` memory ladder's own `clear_spill_path_cache()` ever running
+    (not called anywhere in this test -- the docstring's own claim that
+    THIS mechanism, not the ladder, is what forgets).
+
+    - Vacuity guard: `not evicted.exists()` first -- if nothing were
+      actually deleted, "is_known_file returns False" would be true of
+      an unwritten path too, trivially.
+    - Present-sibling guard: `is_known_file(survivor) is True` -- without
+      it, a build that always returns False (an empty/broken set) would
+      also pass the primary assertion.
+    """
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=50),
+        project_root=tmp_path, agent_name="alice", session_id="main",
+    )
+
+    evicted_block = store.save_tool_result(
+        "payload number 0 " * 2, mime_type="text/plain", seq=0,
+    )
+    _bump_all_mtimes_forward(store.history_content_dir)
+    survivor_block = store.save_tool_result(
+        "payload number 1 " * 2, mime_type="text/plain", seq=1,
+    )
+
+    evicted = tmp_path / evicted_block["path"]
+    survivor = tmp_path / survivor_block["path"]
+
+    # Vacuity guard: the eviction genuinely happened.
+    assert not evicted.exists(), "setup: the older write must actually be evicted"
+
+    # #6050's own subject.
+    assert store.is_known_file(evicted) is False, (
+        "#6050 REGRESSION: a file this store's OWN eviction just deleted "
+        "must stop being 'known' in the SAME call, without the memory "
+        "ladder's clear_spill_path_cache() ever running"
+    )
+
+    # Present-sibling guard: is_known_file is not just always False.
+    assert store.is_known_file(survivor) is True, (
+        "the SURVIVING file must still read as known -- otherwise the "
+        "primary assertion above would pass even with an empty/broken set"
+    )
+
+
+def test_eviction_forgets_the_deleted_file_through_a_symlinked_agent_directory(
+    tmp_path,
+) -> None:
+    """Tier 2: #6050 accept ⑵ (lead-coder's own specified witness) --
+    reproduces architect's own root-cause finding directly: `history_
+    content_dir_for` resolves ONLY the shared root
+    (`(project_root / cfg.history_content_dir).resolve()`) and then
+    APPENDS the agent/session segments WITHOUT re-resolving. If the
+    agent segment is itself a symlink (this test's own stand-in for
+    macOS's real `/tmp` -> `/private/tmp`, or any other symlink an
+    operator's own environment introduces on that path), eviction's own
+    `_eviction_order` walks the directory via the UNRESOLVED "alice"
+    segment while the recorded set entry was resolved (`abs_path.
+    resolve()` at write time) THROUGH the symlink to "alice_real" --
+    two textually different `Path` objects naming the same file. A
+    naive `self._history_content_spill_paths.discard(path)` using the
+    raw (unresolved) eviction-loop `path` would silently no-op here --
+    exactly the failure mode issue #6050's own body flagged as a likely
+    real-machine-only bug (the suggested fix "add .discard(path) at both
+    call sites" was explicitly rejected for this reason).
+    """
+    root = history_content_root_for(tmp_path, MediaStoreConfig())
+    root.mkdir(parents=True, exist_ok=True)
+    real_agent_dir = root / "alice_real"
+    real_agent_dir.mkdir()
+    (root / "alice").symlink_to(real_agent_dir)
+
+    store = MediaStore(
+        MediaStoreConfig(history_content_max_bytes=50),
+        project_root=tmp_path, agent_name="alice", session_id="main",
+    )
+
+    evicted_block = store.save_tool_result(
+        "payload number 0 " * 2, mime_type="text/plain", seq=0,
+    )
+    _bump_all_mtimes_forward(store.history_content_dir)
+    survivor_block = store.save_tool_result(
+        "payload number 1 " * 2, mime_type="text/plain", seq=1,
+    )
+
+    evicted = (tmp_path / evicted_block["path"]).resolve()
+    survivor = (tmp_path / survivor_block["path"]).resolve()
+
+    assert not evicted.exists(), "setup: the older write must actually be evicted"
+    assert store.is_known_file(evicted) is False, (
+        "#6050 REGRESSION: the resolution mismatch through a symlinked "
+        "agent directory must not make the discard silently no-op -- "
+        "_unlink_tracked/_forget must resolve the SAME way the read "
+        "side (is_known_file) does"
+    )
+    assert store.is_known_file(survivor) is True

--- a/tests/scripts/test_check_media_store_unlink_single_caller.py
+++ b/tests/scripts/test_check_media_store_unlink_single_caller.py
@@ -1,0 +1,154 @@
+"""Tier 1: `check_media_store_unlink_single_caller.py`'s own detector
+logic -- the #6050 regression ratchet for "the only place inside
+`media_store.py` allowed to call `Path.unlink()` is
+`MediaStore._unlink_tracked`".
+
+Same 2-direction shape as `test_check_faulthandler_timer_api_single_
+caller.py`, PLUS a third direction lead-coder's own review found
+missing from an earlier draft of this gate: a tree where the SANCTIONED
+caller itself was renamed/removed must fail, not report a vacuous OK
+(the exact class of bug #6050's own production fix closes, now
+re-opened at the gate level if left unchecked).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_media_store_unlink_single_caller import (
+    _SOLE_CALLER_METHOD,
+    find_calls,
+    main,
+)
+from tests._support.paths import REPO_ROOT
+
+_SANCTIONED_BODY = '''\
+"""Stand-in for the real sole caller shape."""
+from pathlib import Path
+
+
+class MediaStore:
+    def _unlink_tracked(self, path: Path) -> int:
+        size = path.stat().st_size
+        path.unlink()
+        self._forget(path)
+        return size
+
+    def _forget(self, path: Path) -> None:
+        pass
+'''
+
+_VIOLATION_BODY = '''\
+"""A second unlink call site -- the violation shape this gate must catch."""
+from pathlib import Path
+
+
+class MediaStore:
+    def _unlink_tracked(self, path: Path) -> int:
+        size = path.stat().st_size
+        path.unlink()
+        self._forget(path)
+        return size
+
+    def _evict_something(self, path: Path) -> None:
+        path.unlink()
+
+    def _forget(self, path: Path) -> None:
+        pass
+'''
+
+_NO_SANCTIONED_CALLER_BODY = '''\
+"""_unlink_tracked itself was renamed/removed -- the class of bug this
+gate's own review found: `find_calls` returning violations-only would
+report zero violations here (nothing calls .unlink() outside a function
+named _unlink_tracked, because nothing calls .unlink() at all) and the
+gate would falsely claim "_unlink_tracked is the only caller"."""
+from pathlib import Path
+
+
+class MediaStore:
+    def _forget(self, path: Path) -> None:
+        pass
+'''
+
+
+def test_the_sanctioned_shape_has_no_violations_and_one_sanctioned_call(tmp_path: Path) -> None:
+    """Tier 1: the false-accept-side witness -- a file shaped like the
+    real one (one `.unlink()` call, inside `_unlink_tracked`) reports
+    zero violations and exactly one sanctioned call site."""
+    f = tmp_path / "sanctioned.py"
+    f.write_text(_SANCTIONED_BODY, encoding="utf-8")
+    violations, sanctioned = find_calls(f)
+    assert violations == []
+    assert sanctioned == [8]
+
+
+def test_a_second_unlink_call_site_is_flagged_as_a_violation(tmp_path: Path) -> None:
+    """Tier 1: the false-reject-side witness -- a SECOND `.unlink()` call
+    outside `_unlink_tracked` must be flagged, naming the enclosing
+    method."""
+    f = tmp_path / "violation.py"
+    f.write_text(_VIOLATION_BODY, encoding="utf-8")
+    violations, sanctioned = find_calls(f)
+    assert sanctioned == [8]
+    assert violations == [(13, "_evict_something")]
+
+
+def test_the_sanctioned_caller_being_removed_fails_not_a_vacuous_ok(tmp_path: Path) -> None:
+    """Tier 1: #6050 BLOCKING (lead-coder review) -- a tree where
+    `_unlink_tracked` itself was renamed or deleted must make `main()`
+    fail (exit 1), not report a vacuous OK. `violations` alone would be
+    empty here (nothing calls `.unlink()` at all) -- `sanctioned` being
+    empty too is what `main()` must check separately.
+
+    Strip-falsify (verified by hand: reverting `main()`'s `if not
+    sanctioned: ... return 1` block back to only checking `violations`):
+    this test goes red -- `main()` returns 0 on this exact tree."""
+    f = tmp_path / "media_store.py"
+    f.write_text(_NO_SANCTIONED_CALLER_BODY, encoding="utf-8")
+    violations, sanctioned = find_calls(f)
+    assert violations == [], "setup: no .unlink() call anywhere in this tree at all"
+    assert sanctioned == [], "setup: the sanctioned caller's own call site is genuinely absent"
+
+    import scripts.check_media_store_unlink_single_caller as gate_module
+    original_root, original_target = gate_module._ROOT, gate_module._TARGET
+    try:
+        gate_module._ROOT = tmp_path
+        gate_module._TARGET = "media_store.py"
+        exit_code = main([])
+    finally:
+        gate_module._ROOT, gate_module._TARGET = original_root, original_target
+    assert exit_code == 1, (
+        "main() must fail when the sanctioned caller itself is absent, "
+        "not report 'X is the only caller' vacuously true of an empty set"
+    )
+
+
+def test_a_docstring_or_comment_naming_unlink_is_not_flagged(tmp_path: Path) -> None:
+    """Tier 1: the classifier is AST-based (a real `Call` node), not a
+    text/regex match."""
+    f = tmp_path / "prose_only.py"
+    f.write_text(
+        '"""Mentions .unlink() in prose."""\n'
+        "# path.unlink() is also just a comment here.\n",
+        encoding="utf-8",
+    )
+    violations, sanctioned = find_calls(f)
+    assert violations == []
+    assert sanctioned == []
+
+
+def test_the_real_repo_tree_is_currently_clean() -> None:
+    """Tier 2: the gate's own starting population, verified against the
+    real, current tree (not assumed) -- `_unlink_tracked` is the ONLY
+    caller of `.unlink()` in `media_store.py` today."""
+    target = REPO_ROOT / "src/reyn/data/workspace/media_store.py"
+    violations, sanctioned = find_calls(target)
+    assert violations == [], (
+        f"real regression(s) found -- a method other than "
+        f"{_SOLE_CALLER_METHOD} now calls .unlink(): {violations}"
+    )
+    assert sanctioned, (
+        f"{_SOLE_CALLER_METHOD} itself no longer calls .unlink() -- either "
+        "it was refactored away (update this gate deliberately) or the "
+        "scan is broken"
+    )


### PR DESCRIPTION
**[tui-coder]** — Closes #6050: MediaStore forgets its own deletes.

## Design (architect, adopted by lead-coder — implementer's own note per rule: `src/` is architect's permanent no-touch surface, design only)

The issue's own suggested fix ("add `.discard(path)` at both `path.unlink()` call sites") was rejected for two reasons architect found reading the actual code (tree `b02492a30`):

1. **Likely a silent no-op.** The tracked sets hold `.resolve()`d paths, but `history_content_dir_for` resolves only the shared root and appends `agent`/`session` segments **without** re-resolving. A symlink anywhere on that path — macOS's own `/tmp` → `/private/tmp`, or any operator environment — makes the raw eviction-loop `path` and the resolved set entry compare unequal. Ubuntu CI stays green; only a real machine with that symlink shape ever sees the gap (the exact "measured environment differs from CI" shape lead-coder hit once already, #6035).
2. **A band-aid.** A 3rd eviction call site added later would reopen the same gap.

**Fix**: collapsed every `Path.unlink()` in this class into **one** method, `_unlink_tracked`, which fuses deletion with `self._forget(path)` — resolved via a new shared `_resolve_tracked_path` helper the 3 public read methods (`is_history_content_spill`/`is_unspilled_file`/`is_known_file`) now use too, so read and write sides can no longer diverge. Both call sites replaced with `size = self._unlink_tracked(path)`; each site's own `except OSError` + `logger.warning` (different issue number per site) stays put, unchanged.

**New CI gate** (`scripts/check_media_store_unlink_single_caller.py` + its own workflow), mirroring **#5978/PR #6054's** `faulthandler-timer-api-single-caller` gate shape directly: the ONLY place in this file allowed to call `.unlink()` is `_unlink_tracked` — a future 3rd eviction path inherits correct bookkeeping by construction instead of needing to remember its own `.discard()`.

## Scope — disclosed, not overclaimed (architect's own explicit answers)

- **Only `_history_content_spill_paths` gets a real bounding subject** from this fix (the storage cap: cap deletes a file, the set forgets it in the same call, so the set's own size tracks live files). **`_unspilled_paths` does NOT** — an un-spilled file is `continue`'d past every eviction call site (never a candidate), so it never reaches `_unlink_tracked`. Separate subject, already disclosed by #5896 stage ①'s own `_note_cap_state` warning — not re-claimed as fixed here.
- **No reachable consumer exists today** for "the set answers about a deleted file" specifically — architect's own `git grep` census: all 3 read methods' own candidates come from live disk enumeration or a post-read-success path, never a since-deleted one. This PR does **not** claim a wrong answer is observed today; what's bound is the set's own unbounded-growth-under-deletion shape (the `band` axis label this issue carries).
- **No visibility surface added** for the set's own size — not recommended in this PR (a separate judgement call, per architect).
- **Repair destroys no evidence**: the on-disk manifest is the durable source of truth; `_load_spill_manifest`'s own self-prune redoes this at the next construction regardless.

## Tests

2 new (Tier 2, real `MediaStore` + real on-disk writes, same idiom as `test_5364_history_content_cap_eviction.py` — no fakes, never asserts on the private sets directly, only through `is_known_file`):

1. Write-time-cap eviction forgets its own delete **without** the `#5939` ladder's `clear_spill_path_cache()` ever running (vacuity guard + present-sibling guard, lead-coder's own specified witness).
2. The same through a **symlinked agent directory** (architect's own specified resolution witness) — reproduces the exact real-machine failure mode directly; verified this construction alone fails against the pre-fix code before writing the fix, confirming it's a real reproduction, not a synthetic pass-by-construction.

Strip-falsified by hand (in-file `Edit` → run → `Edit` back, no `git checkout`/`stash`/`restore`): removing `self._forget(path)` from `_unlink_tracked` turns **both** new tests red simultaneously — matching architect's own required combined strip ("if only one goes red, the acceptance design itself is wrong").

Full gate suite green (`ruff`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, the `tests/`-path-conditional gates, `check_ci_role_declared.py`, the new `check_media_store_unlink_single_caller.py` itself). Scoped pytest green: 94 tests across every existing `tests/data/` MediaStore test file + this PR's own 2, plus 23 more in `tests/core/`/`tests/runtime/` touching the same read surface.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` on the new test file
- [x] scoped pytest, all listed above
- [x] (skipped — Visual, standing waiver 2026-08-08)

Closes #6050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
