### PR TITLE
fix(part of #5989): stdio MCP errlog must never fall through to the SDK's own default

### DIFF
--- a/scripts/check_subprocess_reyn_pin_baseline.json
+++ b/scripts/check_subprocess_reyn_pin_baseline.json
@@ -31,7 +31,6 @@
   "tests/mcp/test_4686_subscription_visibility.py",
   "tests/mcp/test_5280_mcp_reconnect_failed_event.py",
   "tests/mcp/test_mcp_client.py",
-  "tests/mcp/test_mcp_client_stderr_capture.py",
   "tests/mcp/test_mcp_structured_client_p1.py",
   "tests/mcp/test_mcp_unsandboxed_audit_3821.py",
   "tests/runtime/test_2714_mcp_shutdown_teardown.py",

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1046,6 +1046,17 @@ class MCPClient:
         # underlying anyio subprocess), but ``tempfile.TemporaryFile``
         # does. Lazily created in ``_open_stdio``; closed in ``close``.
         self._stderr_capture: Any = None  # tempfile.TemporaryFile | None
+        # #5989: the SAFE-FALLBACK sink for the child's stderr when
+        # ``self._stderr_capture`` above could not be opened (tempfile
+        # failure) — see ``_initialize_stdio``'s own comment for why this
+        # must NEVER be left unset. Kept as a SEPARATE attribute from
+        # ``_stderr_capture`` deliberately: that property's own documented
+        # contract (None initially / after close, tests assert on it
+        # directly) stays exactly what it was BEFORE this fix — a
+        # devnull placeholder standing in for it here would be a second,
+        # silent meaning for the same "None" a caller already reads as
+        # "no diagnostics available".
+        self._devnull_errlog: Any = None  # opened os.devnull TextIO | None
         # #1344 / #2620: cleanup callable for whatever resource the sandbox
         # backend's ``wrap_command()`` allocated for a stdio MCP server's
         # subprocess wrap (e.g. Seatbelt's temp ``.sb`` profile file), if any.
@@ -1281,8 +1292,55 @@ class MCPClient:
             # an errlog= TextIO directly (a real fileno, same requirement).
             try:
                 self._stderr_capture = tempfile.TemporaryFile(mode="w+t", encoding="utf-8")
-            except Exception:  # noqa: BLE001 — temp-file failure is non-fatal
+            except OSError as e:
+                # #5989 (lead-coder finding): the #5990 shape ("swallow, fall
+                # back to a default that is WORSE than failing loud") — the
+                # OLD `except Exception: pass` left `self._stderr_capture`
+                # None and said nothing, so the `errlog=` kwarg below was
+                # OMITTED entirely. `mcp.client.stdio.stdio_client`'s own
+                # `errlog` parameter default is `sys.stderr`, bound ONCE at
+                # SDK import time — before reyn's interactive-TUI path ever
+                # redirects `sys.stderr` (#5989's own established finding:
+                # Textual's `redirect_stdout`/`redirect_stderr` only rebinds
+                # the IN-PROCESS `sys.stdout`/`sys.stderr` objects; a CHILD
+                # process's inherited fd 2 is untouched by that rebinding
+                # regardless). A tempfile failure therefore handed the
+                # child's raw stderr straight to the operator's own real
+                # terminal — silently, and specifically on the platform
+                # (Windows) where a tempfile open is more likely to fail.
+                # Reported (not swallowed), and NEVER left to default to the
+                # SDK's own choice — see the `errlog=` construction below for
+                # the os.devnull fallback this failure routes into instead.
                 self._stderr_capture = None
+                logger.warning(
+                    "MCP server %r: could not open a stderr-capture tempfile "
+                    "(%s) -- init-failure diagnostics for this server's "
+                    "stderr will be unavailable. NOT falling back to the "
+                    "mcp SDK's own default (which would hand the "
+                    "subprocess's stderr to the operator's own terminal) -- "
+                    "routing it to os.devnull instead. See #5989.",
+                    self._server_name, e,
+                )
+                try:
+                    self._devnull_errlog = open(  # noqa: SIM115 — lifetime is this connection's, closed in close_stderr_capture()
+                        os.devnull, mode="w", encoding="utf-8",
+                    )
+                except OSError as devnull_e:
+                    # #5989: both sinks failed -- there is genuinely nowhere
+                    # safe to route the child's stderr. Refusing to start
+                    # the server is the ONLY remaining option that does not
+                    # hand the operator's terminal to a third-party
+                    # subprocess (lead-coder ruling: os.devnull OR fail
+                    # loud, never silently default).
+                    self._devnull_errlog = None
+                    raise MCPError(
+                        f"stdio MCP server {self._server_name!r}: could not "
+                        f"obtain any safe sink for the subprocess's stderr "
+                        f"(tempfile failed: {e}; os.devnull also failed: "
+                        f"{devnull_e}) -- refusing to start it with the "
+                        f"mcp SDK's own default, which would hand its "
+                        f"stderr to the operator's own terminal"
+                    ) from devnull_e
             # The SDK performs the spawn; Reyn chooses only these hand-off
             # parameters. ``env=None`` is intentional: MCP is a third-party
             # server trust path, distinct from Reyn-owned sandbox children, so
@@ -1304,9 +1362,33 @@ class MCPClient:
             # generator's `.gen.ag_frame` after `Client` has entered it —
             # same technique, same object, just entered by a different
             # caller (live-verified, see this PR's commit message).
-            stdio_cm = stdio_client(
-                params, **({"errlog": self._stderr_capture} if self._stderr_capture else {}),
-            )
+            # #5989: `errlog=` is ALWAYS supplied now, never omitted — the
+            # tempfile branch above guarantees one of `_stderr_capture` /
+            # `_devnull_errlog` is a real, open file (or this method has
+            # already raised) before reaching here, so `stdio_client`'s OWN
+            # `errlog: TextIO = sys.stderr` default (bound at
+            # `mcp.client.stdio` import time, which reyn's own lazy import
+            # above can make happen WHILE Textual owns the terminal) is
+            # NEVER reached — closing both the "child's stderr reaches the
+            # operator's real terminal" case AND the "errlog is Textual's
+            # own fileno()==-1 _PrintCapture, so the child fails to spawn
+            # at all" case the SAME import-timing hazard could otherwise
+            # produce depending on WHEN the first stdio connection happens.
+            errlog = self._stderr_capture if self._stderr_capture is not None else self._devnull_errlog
+            if errlog is None:
+                # Unreachable in practice — the tempfile except block above
+                # already raises MCPError whenever neither sink could be
+                # opened — but an `assert` here would be stripped under
+                # `-O`, and the one thing this whole fix must never do is
+                # silently fall through to `stdio_client`'s own default.
+                raise MCPError(
+                    f"stdio MCP server {self._server_name!r}: no stderr "
+                    f"sink available for the subprocess (internal "
+                    f"invariant violated) -- refusing to start it with the "
+                    f"mcp SDK's own default, which would hand its stderr "
+                    f"to the operator's own terminal"
+                )
+            stdio_cm = stdio_client(params, errlog=errlog)
             elicitation_callback = None
             if self._elicitation_handler is not None:
                 elicitation_callback = _adapt_elicitation_handler(self._elicitation_handler)
@@ -2218,7 +2300,14 @@ class MCPClient:
     def close_stderr_capture(self) -> None:
         """Close + delete the stderr temp file + the #1344/#2620 sandbox wrap's
         cleanup resource (e.g. Seatbelt's temp ``.sb`` profile), if any.
-        Idempotent — called at every teardown path."""
+        Idempotent — called at every teardown path.
+
+        #5989: also closes ``self._devnull_errlog`` (the tempfile-failure
+        safe-fallback sink, see ``_initialize_stdio``) — a SEPARATE ``if``
+        from ``_stderr_capture``'s own, not an ``elif``: the two are
+        mutually exclusive in practice (only one is ever opened per
+        connection) but nothing enforces that as an invariant, and closing
+        both unconditionally costs nothing when one is already None."""
         # #1344/#2620: invoke the sandbox backend's wrap_command() cleanup
         # (Seatbelt: unlink the temp .sb profile; Noop/Landlock: no-op).
         # Best-effort; a leaked temp file must not break teardown.
@@ -2230,13 +2319,19 @@ class MCPClient:
             except OSError:
                 pass
         capture = self._stderr_capture
-        if capture is None:
-            return
-        self._stderr_capture = None
-        try:
-            capture.close()
-        except Exception:  # noqa: BLE001
-            pass
+        if capture is not None:
+            self._stderr_capture = None
+            try:
+                capture.close()
+            except Exception:  # noqa: BLE001
+                pass
+        devnull_errlog = self._devnull_errlog
+        if devnull_errlog is not None:
+            self._devnull_errlog = None
+            try:
+                devnull_errlog.close()
+            except Exception:  # noqa: BLE001
+                pass
 
     # ── transport dispatch ──────────────────────────────────────────────────
 

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -245,3 +245,83 @@ def test_initialize_failure_with_real_subprocess_captures_its_actual_stderr() ->
         f"message via the official SDK's errlog plumbing: {msg!r}"
     )
     assert client.stderr_capture is None
+
+
+# ── 6. #5989: a tempfile failure must never hand errlog to the SDK's own
+#      default (= the operator's own terminal, via stdio_client's own
+#      `errlog: TextIO = sys.stderr` bound at mcp.client.stdio import
+#      time) ─────────────────────────────────────────────────────────────
+
+
+def test_tempfile_failure_falls_back_to_devnull_never_the_sdks_own_default(
+    monkeypatch, tmp_path,
+) -> None:
+    """Tier 2: #5989 -- lead-coder's own corrected accept (architect caught
+    the ORIGINAL one's vacuous-green risk): "the child's stderr never
+    reaches the terminal" is ALSO true when the child fails to SPAWN at
+    all -- exactly the failure mode a broken ``errlog`` (e.g. Textual's own
+    ``_PrintCapture``, whose ``fileno()`` returns -1) would produce. A test
+    that only asserted "didn't reach the terminal" would go green for that
+    wrong reason too (six-questions #4: green over an empty/never-happened
+    case).
+
+    Forces ``tempfile.TemporaryFile`` to fail, then proves BOTH real
+    properties, not just one:
+
+    1. **Present sibling** -- the REAL child subprocess actually started
+       and ran: it writes a marker file via a side channel (argv/pathlib)
+       independent of stdio/errlog entirely. A broken errlog would make
+       the SDK's own subprocess spawn raise before the child's code ever
+       runs, and this marker would never appear.
+    2. The ``errlog`` object reyn handed ``stdio_client`` was NOT its own
+       ``sys.stderr``-bound default -- a real, distinct file this client
+       itself opened (``self._devnull_errlog``, not ``self._stderr_capture``,
+       not ``sys.stderr`` itself).
+
+    ``stdio_client`` is wrapped (spy), not faked -- it still calls the REAL
+    SDK function with the SAME ``errlog`` it received, so the subprocess
+    spawn is the genuine one, not simulated."""
+    marker = tmp_path / "started.marker"
+    client = MCPClient({
+        "type": "stdio",
+        "command": sys.executable,
+        "args": [
+            "-c",
+            f"import pathlib; pathlib.Path({str(marker)!r}).write_text('started'); "
+            "import sys; sys.stderr.write('should-not-reach-the-terminal\\n'); sys.exit(1)",
+        ],
+    })
+
+    def _broken_tempfile(*args, **kwargs):
+        raise OSError("simulated tempfile failure (e.g. disk full, no writable /tmp)")
+
+    monkeypatch.setattr("reyn.mcp.client.tempfile.TemporaryFile", _broken_tempfile)
+
+    from mcp.client.stdio import stdio_client as _real_stdio_client
+
+    captured: dict = {}
+
+    def _spying_stdio_client(params, errlog=None):
+        captured["errlog"] = errlog
+        return _real_stdio_client(params, errlog=errlog)
+
+    monkeypatch.setattr("mcp.client.stdio.stdio_client", _spying_stdio_client)
+
+    import asyncio
+    with pytest.raises(MCPError):
+        asyncio.run(client.initialize())
+
+    assert marker.exists(), (
+        "the real child process never ran -- a broken errlog (the exact "
+        "class of hazard architect caught in the original accept) would "
+        "make the SDK's own subprocess spawn fail before the child's code "
+        "ever executes, which is a vacuous green on 'stderr never reached "
+        "the terminal' for the WRONG reason"
+    )
+    assert captured.get("errlog") is not None, (
+        "errlog= must never be omitted -- an omitted errlog falls through "
+        "to stdio_client's own default, which IS the operator's terminal"
+    )
+    assert captured["errlog"] is not sys.stderr and captured["errlog"] is not sys.__stderr__, (
+        "must be reyn's own devnull sink, never the real terminal stream"
+    )

--- a/tests/mcp/test_mcp_client_stderr_capture.py
+++ b/tests/mcp/test_mcp_client_stderr_capture.py
@@ -196,6 +196,7 @@ def test_initialize_failure_includes_stderr_tail_in_error(monkeypatch) -> None:
     assert client.stderr_capture is None
 
 
+# EXEMPT: the spawned child imports only pathlib/sys -- it never touches reyn
 def test_initialize_failure_with_real_subprocess_captures_its_actual_stderr() -> None:
     """Tier 2: #4285 — the subject is reyn's own boundary contract with the
     ``mcp`` SDK, NOT the SDK's own redirect implementation.


### PR DESCRIPTION
**[tui-coder]** — part of #5989.

## Root cause (lead-coder finding, confirmed)

`mcp.client.stdio.stdio_client`'s own `errlog: TextIO = sys.stderr` default is bound **once**, at `mcp.client.stdio` import time. reyn imports it lazily inside `_initialize_stdio`, so the binding timing depends on when the first stdio MCP connection happens:

| first import | `errlog` binds to | result |
|---|---|---|
| before the TUI starts | the real terminal | child's stderr reaches the operator's terminal directly (bypasses every in-process redirect — a child's inherited fd 2 is untouched by `contextlib.redirect_stderr`) |
| while the TUI is running | Textual's own `_PrintCapture` (`fileno()` → -1) | the subprocess spawn itself breaks — the MCP server fails to start (architect's own catch, see below) |

reyn already tried to avoid the SDK default by always passing its own `errlog` (a `tempfile.TemporaryFile`, originally for diagnostic readback on init failure) — but a `tempfile.TemporaryFile()` failure was silently swallowed (`except Exception: pass`), leaving `self._stderr_capture` `None`, which made the `errlog=` kwarg get **omitted** — falling straight through to the SDK default above. The #5990 shape: a caught failure silently degrading into a default that is *worse* than failing loud. Plausible on the owner's own Windows/git-bash environment specifically.

## Fix

- The tempfile failure is now **reported** (`logger.warning`), never swallowed.
- `errlog=` is now **always** supplied: `os.devnull` (a real, open file with a real fileno — same requirement the temp file has) is the fallback sink, tracked in a new `self._devnull_errlog` (kept separate from `self._stderr_capture` so that attribute's own existing "`None` = no diagnostics" contract — and every existing test asserting on it — stays unchanged).
- If even `os.devnull` fails to open, the connection now fails loud with an `MCPError` naming both failures, rather than silently defaulting to the SDK's own choice. `sys.__stderr__` was explicitly **not** chosen as a fallback — same terminal, same problem.

**Side effect** (recorded, not silently passed along per lead-coder's instruction): this also closes the "MCP server fails to spawn entirely if `mcp.client.stdio` is first imported while the TUI is running" defect architect caught while reviewing this PR's own first accept criterion — `errlog` is now always reyn's own real-fd file, never the SDK's own import-time-bound default, regardless of when that import happens.

## Tests

One new test, `test_tempfile_failure_falls_back_to_devnull_never_the_sdks_own_default`. Accept criteria was corrected mid-review (architect caught the original accept's vacuous-green risk: "child's stderr never reached the terminal" is *also* true when the child fails to spawn at all). Drives a **real** subprocess through a wrapped (not faked) `stdio_client`, asserting both:
1. **present sibling** — the child actually started and ran (writes a marker file via argv/pathlib, a side channel independent of stdio/errlog — a broken errlog would prevent this from ever appearing).
2. the `errlog` object handed to the SDK was reyn's own devnull sink, never `sys.stderr`/`sys.__stderr__`.

Strip-falsified by hand (in-file Edit → run → Edit back, no `git stash`/checkout): reverting the `errlog=` construction to the old form turns the test red.

## Gates

`ruff`, `check_fastmcp_import_boundary.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, and the `tests/`-path-conditional gates all green. Related sweep (`tests/mcp/test_mcp_client.py`, 16 tests) green.

## Test plan
- [x] `pytest tests/mcp/test_mcp_client_stderr_capture.py` (10/10, including the new one)
- [x] `pytest tests/mcp/test_mcp_client.py` (16/16, unrelated regression check)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
