### PR TITLE
feat(part of #5990): stage 2-2 -- a new gate for the except-return-reachability axis, marker-derived population

### DIFF
--- a/.github/workflows/silent-except-return-reachability-gate.yml
+++ b/.github/workflows/silent-except-return-reachability-gate.yml
@@ -1,0 +1,47 @@
+name: silent-except-return-reachability
+
+# #5990 stage 2-2: reject any `except` block under src/reyn/** whose body is
+# assign-only (no log, no raise, nothing but an assignment) AND whose bound
+# name reaches this function's own `return` -- an unexpected exception
+# silently becoming fabricated output data. A DIFFERENT axis from
+# `silent-except-ratchet-gate.yml`'s own (that one asks "does the handler
+# report anything", scoped to src/reyn/interfaces/ only; this one asks "does
+# the fabricated value reach a caller", scoped to src/reyn/** and with no
+# exception-type restriction) -- see
+# scripts/check_silent_except_return_reachability.py's own module docstring
+# for the full design and why the two gates stay independent.
+#
+# Population = every violation-side site MINUS every site carrying a valid
+# `# SILENT-EXCEPT-RETURN-OK: <category> -- <reason>` marker (lead-coder's
+# explicit rejection of both a numeric baseline and a hand-maintained
+# allowlist for this gate) -- no baseline file, nothing to grandfather.
+#
+# `paths: src/reyn/**` matches this gate's own scope exactly -- a change
+# outside that tree cannot add or remove a site this script counts.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/**"
+
+permissions:
+  contents: read
+
+jobs:
+  silent-except-return-reachability:
+    name: silent-except-return-reachability
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_silent_except_return_reachability.py is stdlib-only
+      # (ast / re / subprocess / pathlib). No pip install needed.
+      - name: Check every violation-side site under src/reyn/ carries a marker
+        run: |
+          python scripts/check_silent_except_return_reachability.py

--- a/scripts/check_silent_except_return_reachability.py
+++ b/scripts/check_silent_except_return_reachability.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""#5990 stage 2-2 — a gate over the OTHER silent-except axis: not "does the
+handler body itself report anything" (`silent_except_ratchet.py`'s own axis,
+`src/reyn/interfaces/` only, `Exception`/`BaseException` only), but **"does
+the value the handler assigns become this function's own return value"** —
+an `except` block (ANY type — a bare `except:`, a narrow `ImportError`, a
+tuple, `Exception`/`BaseException` itself; see the algorithm section for why
+this axis has no type restriction at all) whose body is ASSIGN-ONLY (every
+statement a plain `ast.Assign`, nothing else — no log call, no raise,
+nothing) is not necessarily silent in the sense the OTHER gate measures, but
+if the name(s) it binds flow into a `return` in the SAME enclosing function,
+an unexpected exception silently became **fabricated output data** — the
+caller receives a value indistinguishable from a real one. Scope:
+`src/reyn/**`, the WHOLE tree (this axis is not `interfaces/`-specific —
+backlog-watcher's own #5990 census found it distributed across
+`runtime/`/`llm/`/`core/`/`mcp/`/`tools/` etc., heavier OUTSIDE `interfaces/`
+than inside it).
+
+## Why this is a DIFFERENT gate, not an extension of `silent_except_ratchet.py`
+
+lead-coder's own correction (#5990, 2026-09-10): the two axes measure
+different properties and can each flag a site the other does not — a
+handler can report visibly (passing the OTHER gate) while still fabricating
+a return value (failing THIS one), or vice versa. Conflating them into one
+gate's population would blur which property a given red line is actually
+about. `silent_except_ratchet.py` is untouched by this file.
+
+## The algorithm (backlog-watcher's own #5990 census, operationalized)
+
+For each `except` handler — ANY caught type(s), no restriction (backlog-
+watcher's own census: narrower than the OTHER gate's own
+`Exception`/`BaseException`-only population, e.g. it is what makes the
+"expected platform `ImportError`" category below have sites to mark at
+all) — whose body is assign-only:
+
+1. Collect the name(s) its `Assign` statement(s) bind (the LHS targets —
+   `canonical = repr(payload)` binds ``canonical``; a tuple target like
+   `stdout_b, stderr_b, _trunc = b"", b"", False` binds all three).
+2. Find the nearest enclosing `def`/`async def` (a MODULE-level handler —
+   no enclosing function — is trivially correct-side: there is no `return`
+   to reach, per backlog-watcher's own census).
+3. Within that function's own body ONLY (never descending into a NESTED
+   `def`/`async def`/`lambda` — a bound name shadowed or re-purposed inside
+   an inner function is a different scope entirely), collect every
+   `Return` node's value expression.
+4. If ANY such expression contains a `Name` reference to one of the bound
+   names ANYWHERE inside it (not just as the return's direct value — e.g.
+   `return SandboxResult(stdout=stdout_b, ...)` counts, matching the #5990
+   census's own "drain sites" finding) — VIOLATION-SIDE: the handler's
+   fabricated value reaches a caller as this function's own return.
+
+Deliberately narrower than the axis's own EARLIER, broader phrasing
+(#5990 §30: "reaches a `return` (or `yield`, or a store to an object that
+outlives the function)") — the census that actually produced the 34/20
+site counts this gate's population must match used the Return-only
+version; widening later would silently change the population every commit
+onward, exactly the drift #5990's own memory pin about measurement carrying
+its own tree names.
+
+## Marker — the population minus a REASON, not a numeric grandfather
+
+lead-coder's explicit rejection of BOTH a numeric baseline ("N sites
+allowed" lets someone fix an old one and add a new one for free — the
+count never moves) AND a hand-maintained allowlist (a second table this
+repo's own "derive, never maintain" discipline already forbids) for THIS
+gate. Population = every violation-side site found by the algorithm above,
+MINUS every site carrying a valid marker:
+
+    except Exception:
+        # SILENT-EXCEPT-RETURN-OK: <category> -- <specific reason>
+        canonical = repr(payload)
+
+The marker comment must appear somewhere between the `except` line and the
+handler's own last line (inclusive) — same physical block the violation
+was found in, so a marker cannot silently "cover" an unrelated site
+elsewhere in the file. `.strip()`-matched (unlike `check_subprocess_reyn_
+pin.py`'s own `# EXEMPT:`, which is column-0-anchored) so it reads naturally
+at the handler's own indentation.
+
+`<category>` must be one of the FIVE reasons #6057's own PR body already
+used, verbatim, when it read #5990's original 34-site population by hand
+and judged 20 of them out-of-class (lead-coder's explicit instruction: this
+IS the vocabulary, not a fresh invention):
+
+  - `internal-hash-fallback` — a digest/hash computation's own fallback
+    when the canonical form can't be produced (e.g. an unhashable value);
+    the fallback is itself a valid, if less ideal, hash input.
+  - `expected-import-error` — a platform-specific optional backend's
+    absence (e.g. Linux-only `landlock`/`seccomp` modules unavailable on
+    macOS/Windows) — the exception IS the expected signal, not a failure.
+  - `external-content-caller-cannot-act` — parsing untrusted third-party
+    content (an HTTP response body, a subprocess's own stdout) where no
+    operator-facing action exists for a parse failure beyond "degrade the
+    displayed content."
+  - `reported-elsewhere` — the failure is already visible through a
+    DIFFERENT channel in the same call graph: caught and returned/stored
+    as data one level up, an audit-event already emitted at the true
+    origin, a retry loop whose own eventual give-up path reports, or an
+    adjacent branch in the SAME function already logs it.
+  - `low-stakes-display-value` — a documented, explicitly non-authoritative
+    display number (a progress percentage, an estimate) where silent
+    degradation to a placeholder is the intentionally chosen UX, not an
+    oversight.
+
+Both directions are gate failures (lead-coder: "「意図的」で全部通る marker
+は gate ではなく署名欄です" — a marker that always passes regardless of its
+own content is a signature line, not a gate):
+
+  1. A violation-side site with NO marker at all — a new, unreviewed one.
+  2. A violation-side site WITH a marker whose category is not one of the
+     five above (a typo, an invented reason) — the marker exists but does
+     not actually justify anything a future reader could act on.
+
+## What this gate does NOT attempt
+
+Same disclosed limits as `silent_except_ratchet.py`'s own AST-only
+approach: a marker's mere PRESENCE in the handler's line range is not
+proof the judgement behind it was correct, only that someone made one and
+wrote it down where the next reader (and this gate) can see it. This gate
+enforces "reviewed and categorized", not "correctly reviewed" — the same
+"suspected, not confirmed" posture every AST-syntax gate in this repo
+already carries.
+
+CI: gate
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCOPE = "src/reyn"
+
+#: #6057's own PR body vocabulary (lead-coder's explicit instruction: reuse
+#: it verbatim, not invent a new one) — see module docstring for each
+#: category's own meaning.
+_VOCABULARY = frozenset({
+    "internal-hash-fallback",
+    "expected-import-error",
+    "external-content-caller-cannot-act",
+    "reported-elsewhere",
+    "low-stakes-display-value",
+})
+
+#: `.strip()`-matched against one physical line at a time (never
+#: `.search()` over a whole file) — same anti-spoofing anchor
+#: `scripts/_markers.py`'s `fixed_comment_marker` establishes for `#
+#: EXEMPT:`, adapted to tolerate normal code indentation (this marker lives
+#: INSIDE an indented handler body, unlike `# EXEMPT:`'s own column-0 file
+#: level placement) and to capture a REASON as a second group, not just a
+#: category name.
+_MARKER_RE = re.compile(r"^#\s*SILENT-EXCEPT-RETURN-OK:\s*([a-z0-9][a-z0-9-]*)\s*--\s*(\S.*)$")
+#: The bare directive, used only to distinguish "no marker attempted at
+#: all" from "a marker was attempted but is malformed/mis-categorized" —
+#: two different violation messages, not the same one.
+_DIRECTIVE_RE = re.compile(r"^#\s*SILENT-EXCEPT-RETURN-OK:")
+
+
+def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
+    """Every tracked `.py` file under `src/reyn/` — `git ls-files`, same
+    population source and single-`*` pathspec (git's default glob is NOT
+    `FNM_PATHNAME`-scoped, so `*` already crosses `/`) every other
+    whole-tree ratchet in this repo uses; no hand-maintained exclusion
+    list."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _assign_target_names(target: ast.expr) -> "set[str]":
+    """Every `Name` bound by one `Assign` target — a plain name, or the
+    elements of a `Tuple`/`List` target (`a, b = ...`)."""
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: "set[str]" = set()
+        for elt in target.elts:
+            names |= _assign_target_names(elt)
+        return names
+    return set()
+
+
+def _handler_bound_names(node: ast.ExceptHandler) -> "frozenset[str] | None":
+    """The names this handler's body binds, iff the body is ASSIGN-ONLY —
+    every statement a plain `ast.Assign` (an `AugAssign`/`AnnAssign`, a
+    `raise`, a call, an `if`, ANYTHING else disqualifies the whole body,
+    matching the census's own "assign-only" predicate exactly). Returns
+    `None` for a non-assign-only body (not this gate's population at
+    all — it either reports visibly or has real control flow, either of
+    which is a different question `silent_except_ratchet.py`'s own axis
+    already covers, not this one)."""
+    names: "set[str]" = set()
+    for stmt in node.body:
+        if not isinstance(stmt, ast.Assign):
+            return None
+        for target in stmt.targets:
+            names |= _assign_target_names(target)
+    return frozenset(names) if names else None
+
+
+def _collect_returns_within_function(func: "ast.FunctionDef | ast.AsyncFunctionDef") -> "list[ast.Return]":
+    """Every `Return` node inside *func*'s own body — NEVER descending
+    into a nested `def`/`async def`/`lambda` (a name bound in the outer
+    function is a different, unrelated binding inside an inner scope,
+    even if it shares the same spelling)."""
+    returns: "list[ast.Return]" = []
+
+    def walk(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            if isinstance(child, ast.Return):
+                returns.append(child)
+            walk(child)
+
+    walk(func)
+    return returns
+
+
+def _return_references_any(ret: ast.Return, names: "frozenset[str]") -> bool:
+    """True iff *ret*'s own value expression contains a `Name` reference
+    to any of *names* ANYWHERE inside it — not just as the direct return
+    value (`return canonical`) but also nested (`return SandboxResult
+    (stdout=stdout_b, ...)`), matching the #5990 census's own "drain
+    sites" finding (the bound names flow into a constructor call, not a
+    bare return of the name itself)."""
+    if ret.value is None:
+        return False
+    for node in ast.walk(ret.value):
+        if isinstance(node, ast.Name) and node.id in names:
+            return True
+    return False
+
+
+class _Site:
+    """One violation-side `except` handler this gate's axis found —
+    line range for marker association, plus enough identity for a
+    human-readable report."""
+
+    __slots__ = ("path", "lineno", "end_lineno")
+
+    def __init__(self, path: Path, lineno: int, end_lineno: int) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.end_lineno = end_lineno
+
+
+def _handler_end_lineno(node: ast.ExceptHandler) -> int:
+    """The last line number touched by *node*'s own body — the upper
+    bound of where a marker for this SPECIFIC site may live (so a marker
+    cannot silently cover an unrelated handler elsewhere in the file)."""
+    end = node.lineno
+    for child in ast.walk(node):
+        child_end = getattr(child, "end_lineno", None)
+        if child_end is not None and child_end > end:
+            end = child_end
+    return end
+
+
+def find_violation_sites(path: Path) -> "list[_Site]":
+    """Every violation-side site in *path*: an assign-only `except
+    Exception`/`except BaseException` handler whose bound name(s) reach a
+    `return` in the enclosing function. Raises `SyntaxError` (propagated,
+    never swallowed) on a parse failure — same fail-CLOSED discipline
+    `silent_except_ratchet.py` already established (#5990): a population
+    scan that silently under-counts on its OWN failure is the exact defect
+    this whole gate family exists to prevent, recurring one layer up."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+
+    sites: "list[_Site]" = []
+    func_stack: "list[ast.FunctionDef | ast.AsyncFunctionDef]" = []
+
+    def visit(node: ast.AST) -> None:
+        is_func = isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        if is_func:
+            func_stack.append(node)  # type: ignore[arg-type]
+        if isinstance(node, ast.ExceptHandler):
+            # #5990 §30's own axis has NO exception-type restriction (any
+            # type — `ImportError`, a narrow tuple, even a bare `except:`
+            # — counts if the body is assign-only and return-reachable;
+            # backlog-watcher's own census explicitly notes this is
+            # BROADER than `silent_except_ratchet.py`'s own
+            # Exception/BaseException-only population). The "expected
+            # platform ImportError" category (sandbox/seccomp backends)
+            # only has sites to mark BECAUSE this axis has no such
+            # restriction.
+            bound = _handler_bound_names(node)
+            if bound:
+                enclosing = func_stack[-1] if func_stack else None
+                if enclosing is not None:
+                    returns = _collect_returns_within_function(enclosing)
+                    if any(_return_references_any(r, bound) for r in returns):
+                        sites.append(_Site(path, node.lineno, _handler_end_lineno(node)))
+                # enclosing is None (module-level handler): trivially
+                # correct-side, per the census's own finding — no
+                # `return` exists to reach.
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+        if is_func:
+            func_stack.pop()
+
+    visit(tree)
+    return sites
+
+
+def _site_marker(site: "_Site", lines: "list[str]") -> "tuple[str, str] | Exception | None":
+    """The marker covering *site*, read from *lines* (1-indexed via
+    `site.lineno`/`site.end_lineno`, so `lines[i-1]`).
+
+    Returns:
+      - `(category, reason)` — a valid, vocabulary-matching marker.
+      - a `ValueError` instance (not raised) — a `# SILENT-EXCEPT-RETURN-
+        OK:` directive is present but malformed or names a category
+        outside the vocabulary. Returned rather than raised so the caller
+        can report EVERY such site in one pass, not stop at the first.
+      - `None` — no marker attempted at all in this site's own line
+        range."""
+    for lineno in range(site.lineno, site.end_lineno + 1):
+        if lineno - 1 >= len(lines):
+            break
+        stripped = lines[lineno - 1].strip()
+        full_match = _MARKER_RE.match(stripped)
+        if full_match:
+            category, reason = full_match.group(1), full_match.group(2)
+            if category not in _VOCABULARY:
+                return ValueError(
+                    f"line {lineno}: marker category {category!r} is not in "
+                    f"the vocabulary ({sorted(_VOCABULARY)})"
+                )
+            return (category, reason)
+        if _DIRECTIVE_RE.match(stripped):
+            return ValueError(
+                f"line {lineno}: `# SILENT-EXCEPT-RETURN-OK:` marker present "
+                f"but malformed — expected `# SILENT-EXCEPT-RETURN-OK: "
+                f"<category> -- <reason>`"
+            )
+    return None
+
+
+def measured(root: Path = _ROOT) -> "tuple[list[tuple[Path, int, 'Exception | None']], int]":
+    """`(unresolved_sites, scanned_file_count)`: `unresolved_sites` is
+    `(path, lineno, problem)` for every violation-side site that is either
+    unmarked (`problem is None`) or mis-marked (`problem` is the
+    `ValueError` explaining why)."""
+    files = _iter_scan_files(root)
+    unresolved: "list[tuple[Path, int, Exception | None]]" = []
+    for path in files:
+        sites = find_violation_sites(path)
+        if not sites:
+            continue
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for site in sites:
+            outcome = _site_marker(site, lines)
+            if outcome is None or isinstance(outcome, Exception):
+                unresolved.append((path, site.lineno, outcome))
+    return (unresolved, len(files))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    build_parser().parse_args(argv)
+
+    try:
+        unresolved, scanned = measured(_ROOT)
+    except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+        print(
+            f"silent-except-return-reachability gate FAILED: could not scan "
+            f"the population ({exc}). Fails CLOSED on a scan error rather "
+            f"than silently under-counting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if scanned == 0:
+        print(
+            f"silent-except-return-reachability gate FAILED: the scan found "
+            f"0 files under {_SCOPE}/ — a scanner failure, not a clean "
+            f"population; `git ls-files` returned nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if unresolved:
+        print("silent-except-return-reachability gate FAILED:\n", file=sys.stderr)
+        for path, lineno, problem in sorted(unresolved, key=lambda t: (str(t[0]), t[1])):
+            rel = path.relative_to(_ROOT)
+            if problem is None:
+                print(f"  {rel}:{lineno}: no marker found", file=sys.stderr)
+            else:
+                print(f"  {rel}:{lineno}: {problem}", file=sys.stderr)
+        print(
+            "\nAn `except` block here is "
+            "assign-only (no log, no raise, nothing but an assignment) AND "
+            "the name(s) it assigns reach this function's own `return` — an "
+            "unexpected exception can silently become fabricated output "
+            "data. Either fix it (report the failure, or stop returning the "
+            "fabricated value), or — if this IS a reviewed, intentional "
+            "shape — add a marker in the handler's own line range:\n"
+            "  # SILENT-EXCEPT-RETURN-OK: <category> -- <specific reason>\n"
+            "<category> must be one of: " + ", ".join(sorted(_VOCABULARY)) + ".\n"
+            "See scripts/check_silent_except_return_reachability.py's own "
+            "module docstring for what each category means and why no "
+            "'intentional' catch-all is accepted.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"silent-except-return-reachability gate OK: every violation-side "
+        f"site under {_SCOPE}/ carries a valid marker ({scanned} file(s) "
+        f"scanned)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -148,6 +148,7 @@ def _response_dict(resp: Any) -> dict:
     try:
         body = raw.decode("utf-8")
     except UnicodeDecodeError:
+        # SILENT-EXCEPT-RETURN-OK: external-content-caller-cannot-act -- decoding an untrusted HTTP response body; no operator action exists for a malformed byte sequence beyond a replace-decode
         body = raw.decode("utf-8", errors="replace")
     status = getattr(resp, "status", None) or resp.getcode()
     return {"status": int(status), "body": body, "headers": headers}

--- a/src/reyn/core/context_builder.py
+++ b/src/reyn/core/context_builder.py
@@ -129,5 +129,6 @@ def byte_safe_prefix(text: str, max_bytes: int) -> str:
         try:
             return truncated.decode("utf-8")
         except UnicodeDecodeError:
+            # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- a bounded (4-iteration) backoff loop; a mid-codepoint cut is expected here by design, not a masked failure, and the loop's own final `return ""` is the documented worst case if every backoff attempt still fails
             truncated = truncated[:-1]
     return ""

--- a/src/reyn/core/dispatch/dispatcher.py
+++ b/src/reyn/core/dispatch/dispatcher.py
@@ -526,6 +526,7 @@ def _compute_args_hash(args: dict) -> str:
     try:
         canonical = json.dumps(args, sort_keys=True, default=str)
     except Exception:  # noqa: BLE001 — fall back to repr for unhashable args
+        # SILENT-EXCEPT-RETURN-OK: internal-hash-fallback -- repr() is itself a valid, if less ideal, canonical form to hash when json.dumps can't serialize the args
         canonical = repr(sorted(args.items()))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
 
@@ -594,6 +595,7 @@ def _compute_llm_args_hash(
             payload, sort_keys=True, default=str, ensure_ascii=False,
         )
     except Exception:  # noqa: BLE001 — fall back to repr for unhashable values
+        # SILENT-EXCEPT-RETURN-OK: internal-hash-fallback -- repr() is itself a valid, if less ideal, canonical form to hash when json.dumps can't serialize the payload
         canonical = repr(payload)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
 

--- a/src/reyn/core/kernel/sub_loop_memo_key.py
+++ b/src/reyn/core/kernel/sub_loop_memo_key.py
@@ -56,5 +56,6 @@ def compute_sub_loop_args_hash(
             payload, sort_keys=True, default=str, ensure_ascii=False,
         )
     except Exception:  # noqa: BLE001 — fallback for unhashable values
+        # SILENT-EXCEPT-RETURN-OK: internal-hash-fallback -- repr() is itself a valid, if less ideal, canonical form to hash when json.dumps can't serialize the payload
         canonical = repr(payload)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -190,6 +190,7 @@ def _generate_web_fetch_preview(
             parser.feed(raw_html)
             html_preview = parser.result()
         except Exception:
+            # SILENT-EXCEPT-RETURN-OK: external-content-caller-cannot-act -- parsing untrusted fetched HTML; no operator action exists for a malformed page beyond degrading the preview to empty fields
             html_preview = {
                 "title": "", "outline": [],
                 "first_paragraph": "", "link_count": 0,

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -1514,6 +1514,7 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
                     continue
                 return item_idx, result, durable, None
             except Exception as exc:  # noqa: BLE001 - item-failure boundary (on_error policy)
+                # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- the caught exception object itself is retained and returned as the function's own `last_exc` output, not discarded
                 last_exc = exc
         return item_idx, None, False, last_exc
 
@@ -1716,6 +1717,7 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
                     continue
                 return name, result, durable, None
             except Exception as exc:  # noqa: BLE001 - branch-failure boundary (on_error policy)
+                # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- the caught exception object itself is retained and returned as the function's own `last_exc` output, not discarded
                 last_exc = exc
         return name, None, False, last_exc
 

--- a/src/reyn/dev/testing/replay_key_diff.py
+++ b/src/reyn/dev/testing/replay_key_diff.py
@@ -40,6 +40,7 @@ def _digest(value: Any) -> str:
     try:
         payload = json.dumps(value, sort_keys=True, ensure_ascii=False, default=repr)
     except Exception:  # noqa: BLE001 — a fingerprint must never be the failure
+        # SILENT-EXCEPT-RETURN-OK: internal-hash-fallback -- repr() is itself a valid, if less ideal, canonical form to hash when the payload can't be serialized normally
         payload = repr(value)
     return hashlib.sha256(payload.encode()).hexdigest()[:_DIGEST_CHARS]
 

--- a/src/reyn/interfaces/cli/commands/support_bundle.py
+++ b/src/reyn/interfaces/cli/commands/support_bundle.py
@@ -191,6 +191,7 @@ def _meta(session, since_raw, manifest) -> dict:
             "api_base_set": bool(getattr(_llm, "api_base", "")),
         }
     except Exception as exc:  # never let config-load break the bundle
+        # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- the exception text itself is embedded into the bundle's own returned data (`_unavailable`), not discarded
         config_summary = {"_unavailable": str(exc)}
     return _redact_secrets({
         "reyn_version": reyn_version,

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -100,6 +100,7 @@ async def post_control(
             body = resp.json()
             reason = str(body.get("detail") or body.get("error") or body) if isinstance(body, dict) else str(body)
         except Exception:  # noqa: BLE001 — a non-JSON refusal still has a status
+            # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- the refusal is already reported via ControlOutcome.refused(status_code, ...) below regardless of whether this best-effort reason parses
             reason = (resp.text or "").strip() or None
         return ControlOutcome.refused(resp.status_code, reason)
     try:

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -585,6 +585,7 @@ def ensure_litellm_ready(
                     # own issue comment for the full trace).
                     result = litellm
                 except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
+                    # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- the `finally` block below's own warn-once logger.warning() call fires whenever result stays None, a few lines down in this same function
                     result = None
         finally:
             if result is not None:

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -677,6 +677,7 @@ async def _close_stack_after_init_failure(exc: BaseException, stack: "Any") -> B
     try:
         await stack.aclose()
     except BaseException as close_exc:
+        # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- this function's whole purpose is to determine and return the "real" exception; capturing close_exc here IS the reporting, not a swallow
         real_exc = close_exc
     else:
         if isinstance(exc, asyncio.CancelledError):

--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -913,6 +913,7 @@ class CompactionController:
             # `failed` below carries the ONE bit of fact the caller
             # actually needs (an attempt genuinely failed) without
             # propagating the exception object itself.
+            # SILENT-EXCEPT-RETURN-OK: reported-elsewhere -- compaction_failed is already emitted at the failure's own origin (see the comment above)
             failed = True
         finally:
             self._compacting = False

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -12420,10 +12420,12 @@ class Session:
         try:
             window_tokens = int(self.raw_context_window().get("window", 0) or 0)
         except Exception:  # noqa: BLE001 — a display number, never the operation
+            # SILENT-EXCEPT-RETURN-OK: low-stakes-display-value -- documented above: a display number, never the operation, not worth failing a compaction over
             window_tokens = 0
         try:
             window_used_tokens = int(getattr(self.last_call_usage, "prompt_tokens", 0) or 0)
         except Exception:  # noqa: BLE001
+            # SILENT-EXCEPT-RETURN-OK: low-stakes-display-value -- same display-number rationale as window_tokens above, the SAME comment block covers both
             window_used_tokens = 0
 
         # Chat middle-compression: the conversational turns newly covered by the

--- a/src/reyn/security/sandbox/__init__.py
+++ b/src/reyn/security/sandbox/__init__.py
@@ -310,10 +310,12 @@ def select_backend(
     try:
         from .backends.seatbelt import SeatbeltBackend  # type: ignore[import]
     except ImportError:
+        # SILENT-EXCEPT-RETURN-OK: expected-import-error -- SeatbeltBackend is macOS-only; its absence on any other platform is the expected signal, not a failure
         SeatbeltBackend = None  # type: ignore[misc,assignment]
     try:
         from .backends.landlock import LandlockBackend  # type: ignore[import]
     except ImportError:
+        # SILENT-EXCEPT-RETURN-OK: expected-import-error -- LandlockBackend is Linux-only; its absence on any other platform is the expected signal, not a failure
         LandlockBackend = None  # type: ignore[misc,assignment]
 
     backend_name = "auto" if config is None else config.backend

--- a/src/reyn/security/sandbox/backends/seccomp.py
+++ b/src/reyn/security/sandbox/backends/seccomp.py
@@ -415,6 +415,7 @@ def is_available() -> bool:
         import pyseccomp  # noqa: F401
         _AVAILABLE = True
     except ImportError:
+        # SILENT-EXCEPT-RETURN-OK: expected-import-error -- pyseccomp is a Linux-only optional dependency; its absence is the expected signal, not a failure
         _AVAILABLE = False
 
     return _AVAILABLE

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -324,6 +324,7 @@ async def build_resource_caller_state(host: Any) -> "RouterCallerState":
             for e in entries.values()
         ]
     except Exception:
+        # SILENT-EXCEPT-RETURN-OK: low-stakes-display-value -- documented above: same degrade-to-None convention as the RouterLoop original, a catalog enumeration field, not the operation itself
         rag_sources = None
 
     return RouterCallerState(

--- a/tests/scripts/fixtures/silent_except_return_5990/correct_side.py
+++ b/tests/scripts/fixtures/silent_except_return_5990/correct_side.py
@@ -1,0 +1,51 @@
+"""#5990 stage 2-2 fixture: correct-side shapes the axis must NOT flag,
+even unmarked — each function/module-level site below is a deliberate
+NEGATIVE control, one per reason the axis excludes it."""
+from __future__ import annotations
+
+try:
+    _MODULE_LEVEL_FALLBACK = "x"
+except Exception:
+    # No enclosing function -- nothing to "return" to. Correct-side by
+    # construction, per backlog-watcher's own #5990 census finding.
+    _MODULE_LEVEL_FALLBACK = "y"
+
+
+def not_assign_only() -> str:
+    """The handler body is NOT assign-only (a `raise` follows the
+    assign) -- outside this axis's population entirely (a different
+    question `silent_except_ratchet.py`'s own axis covers)."""
+    try:
+        value = "x"
+    except Exception:
+        value = "y"
+        raise
+    return value
+
+
+def bound_name_never_returned() -> str:
+    """Assign-only handler, but the bound name never reaches a
+    `return` in this function -- correct-side: the fabricated value
+    stays local."""
+    try:
+        _unused = "x"  # noqa: F841
+    except Exception:
+        _unused = "y"  # noqa: F841
+    return "a completely different, hardcoded value"
+
+
+def shadowed_in_nested_function() -> str:
+    """The bound name IS returned, but only from a NESTED function's
+    own (unrelated) local variable of the same spelling -- the outer
+    function's own `return` never references the handler's binding."""
+    try:
+        canonical = "x"
+    except Exception:
+        canonical = "y"
+
+    def _inner() -> str:
+        canonical = "shadowed, not the outer binding"  # noqa: F841
+        return canonical
+
+    _inner()
+    return "outer value, unrelated to the except handler above"

--- a/tests/scripts/fixtures/silent_except_return_5990/violation_marked_invalid.py
+++ b/tests/scripts/fixtures/silent_except_return_5990/violation_marked_invalid.py
@@ -1,0 +1,14 @@
+"""#5990 stage 2-2 fixture: a marker IS present, but names a category
+outside the fixed 5-slug vocabulary — must be flagged, with a DIFFERENT
+message than "no marker found" (a typo/invented reason is not the same
+failure as never having tried)."""
+from __future__ import annotations
+
+
+def compute_key(payload: object) -> str:
+    try:
+        canonical = repr(payload)
+    except Exception:
+        # SILENT-EXCEPT-RETURN-OK: made-up-reason -- not in the vocabulary
+        canonical = "fallback"
+    return canonical

--- a/tests/scripts/fixtures/silent_except_return_5990/violation_marked_ok.py
+++ b/tests/scripts/fixtures/silent_except_return_5990/violation_marked_ok.py
@@ -1,0 +1,13 @@
+"""#5990 stage 2-2 fixture: the SAME violation-side shape as
+`violation_unmarked.py`, but carrying a valid, vocabulary-matching marker —
+must NOT be flagged."""
+from __future__ import annotations
+
+
+def compute_key(payload: object) -> str:
+    try:
+        canonical = repr(payload)
+    except Exception:
+        # SILENT-EXCEPT-RETURN-OK: internal-hash-fallback -- repr() is a valid fallback canonical form
+        canonical = "fallback"
+    return canonical

--- a/tests/scripts/fixtures/silent_except_return_5990/violation_unmarked.py
+++ b/tests/scripts/fixtures/silent_except_return_5990/violation_unmarked.py
@@ -1,0 +1,12 @@
+"""#5990 stage 2-2 fixture: an assign-only except handler whose bound name
+reaches this function's own `return`, with NO marker — the violation-side
+shape `check_silent_except_return_reachability.py` must flag."""
+from __future__ import annotations
+
+
+def compute_key(payload: object) -> str:
+    try:
+        canonical = repr(payload)
+    except Exception:
+        canonical = "fallback"
+    return canonical

--- a/tests/scripts/test_check_silent_except_return_reachability.py
+++ b/tests/scripts/test_check_silent_except_return_reachability.py
@@ -1,0 +1,176 @@
+"""Tier 1: `check_silent_except_return_reachability.py`'s own detector logic
+(#5990 stage 2-2).
+
+Real fixture files (`tests/scripts/fixtures/silent_except_return_5990/`),
+never a strip-and-revert scratch — same discipline
+`test_silent_except_ratchet_5990.py` already established for the sibling
+gate, per lead-coder's own review of THAT gate's design.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_silent_except_return_reachability import (
+    _VOCABULARY,
+    _site_marker,
+    find_violation_sites,
+    measured,
+)
+from tests._support.paths import REPO_ROOT
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "silent_except_return_5990"
+
+
+def test_a_return_reaching_assign_only_handler_is_a_violation_site():
+    """Tier 1: the false-accept-side witness — an assign-only handler
+    whose bound name reaches this function's own `return` is found,
+    regardless of whether it carries a marker."""
+    sites = find_violation_sites(_FIXTURES / "violation_unmarked.py")
+    assert any(s.lineno == 10 for s in sites), (
+        "the fixture's own except Exception: handler (line 10) was not found"
+    )
+
+
+def test_module_level_handler_is_correct_side():
+    """Tier 1: the false-reject-side witness — a module-level handler (no
+    enclosing function) has nothing to `return` to, so it is never
+    flagged even though its body is assign-only."""
+    sites = find_violation_sites(_FIXTURES / "correct_side.py")
+    lines = {s.lineno for s in sites}
+    assert 7 not in lines, "the module-level handler must not be flagged"
+
+
+def test_non_assign_only_body_is_correct_side():
+    """Tier 1: a handler body containing anything besides a plain
+    `Assign` (here, a `raise` after the assign) is outside this axis's
+    population entirely."""
+    sites = find_violation_sites(_FIXTURES / "correct_side.py")
+    lines = {s.lineno for s in sites}
+    assert 20 not in lines, "a non-assign-only body must not be flagged"
+
+
+def test_a_bound_name_that_never_reaches_return_is_correct_side():
+    """Tier 1: assign-only, but the function's own `return` never
+    references the bound name — correct-side."""
+    sites = find_violation_sites(_FIXTURES / "correct_side.py")
+    lines = {s.lineno for s in sites}
+    assert 32 not in lines, "a bound name that never reaches return must not be flagged"
+
+
+def test_a_name_shadowed_inside_a_nested_function_is_correct_side():
+    """Tier 1: the outer function's own `return` never references the
+    handler's binding — a same-spelled local inside a NESTED function
+    must not count (a different scope entirely)."""
+    sites = find_violation_sites(_FIXTURES / "correct_side.py")
+    lines = {s.lineno for s in sites}
+    assert 46 not in lines, "a name shadowed inside a nested function must not be flagged"
+
+
+def test_correct_side_fixture_has_exactly_zero_violation_sites():
+    """Tier 1: integration — every one of `correct_side.py`'s 4 functions
+    is a deliberate negative control; none should ever be flagged."""
+    assert find_violation_sites(_FIXTURES / "correct_side.py") == []
+
+
+def _resolve(fixture_name: str) -> "tuple[str, 'Exception | None'] | None":
+    """One fixture file's own single violation site, run through
+    `_site_marker` directly — `measured()`'s own population scan is
+    scoped to `src/reyn` (`git ls-files -- src/reyn/*.py`), so it never
+    sees these `tests/` fixtures; exercising `_site_marker` directly is
+    the correct level for a fixture-driven unit test, not `measured`
+    itself (that function's own real-tree behaviour is covered
+    separately below, against `src/reyn` itself)."""
+    path = _FIXTURES / fixture_name
+    sites = find_violation_sites(path)
+    assert len(sites) == 1, f"{fixture_name} fixture drifted — expected exactly 1 violation site"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return _site_marker(sites[0], lines)
+
+
+def test_a_valid_marker_excludes_the_site_from_measured_output():
+    """Tier 2: the accept criterion's own ⑵ direction — a violation-side
+    site carrying a CORRECTLY-formed, vocabulary-matching marker resolves
+    to `(category, reason)`, not a problem. Without this test, a detector
+    that flags every except unconditionally (which would ALSO pass the
+    false-accept test above) could still pass the suite."""
+    outcome = _resolve("violation_marked_ok.py")
+    assert isinstance(outcome, tuple), (
+        "a correctly-marked site must resolve to (category, reason), not a problem"
+    )
+
+
+def test_an_unmarked_site_appears_in_measured_output():
+    """Tier 2: the accept criterion's own ⑴ direction — a violation-side
+    site with NO marker at all resolves to `None` (distinct from a
+    malformed-marker problem, which resolves to an `Exception`)."""
+    outcome = _resolve("violation_unmarked.py")
+    assert outcome is None, "an unmarked site must resolve to None, not a marker-format error"
+
+
+def test_a_marker_with_an_invalid_category_appears_in_measured_output():
+    """Tier 2: the SECOND gate direction lead-coder's ruling names
+    explicitly — a marker IS present but names a category outside the
+    fixed vocabulary. This must ALSO be flagged, as a DIFFERENT outcome
+    (an `Exception`, not `None`) than the unmarked case above — a marker
+    that always passes regardless of its own content would be a
+    signature line, not a gate."""
+    outcome = _resolve("violation_marked_invalid.py")
+    assert isinstance(outcome, Exception), "a malformed/mis-categorized marker must still be flagged"
+    assert "made-up-reason" in str(outcome)
+
+
+def test_site_marker_reads_category_and_reason_from_a_valid_marker():
+    """Tier 1: `_site_marker`'s own direct contract — a valid marker
+    yields `(category, reason)`, both non-empty."""
+    site = find_violation_sites(_FIXTURES / "violation_marked_ok.py")[0]
+    lines = (_FIXTURES / "violation_marked_ok.py").read_text(encoding="utf-8").splitlines()
+    result = _site_marker(site, lines)
+    assert isinstance(result, tuple)
+    category, reason = result
+    assert category == "internal-hash-fallback"
+    assert reason.strip()
+
+
+def test_vocabulary_has_exactly_the_five_categories_6057_used():
+    """Tier 2: pins the vocabulary itself — lead-coder's explicit
+    instruction was to reuse #6057's own PR-body categories verbatim, not
+    invent a new set. A future edit that silently adds/removes a category
+    should have to touch THIS test, not slip through unnoticed."""
+    assert _VOCABULARY == frozenset({
+        "internal-hash-fallback",
+        "expected-import-error",
+        "external-content-caller-cannot-act",
+        "reported-elsewhere",
+        "low-stakes-display-value",
+    })
+
+
+def test_a_file_that_fails_to_parse_raises_rather_than_counting_zero(tmp_path: Path) -> None:
+    """Tier 2: same fail-CLOSED discipline `silent_except_ratchet.py`
+    already established (#5990) — a file this script cannot parse must
+    propagate the parse error, not silently contribute 0 to the
+    population.
+
+    NON-VACUITY (strip-falsified by hand, in-file Edit -> run -> Edit
+    back): wrapping `ast.parse` in a `try/except: return []` shape makes
+    this assertion fail — it would return an empty list instead of
+    raising."""
+    import pytest
+
+    broken = tmp_path / "broken.py"
+    broken.write_text("def f(:\n    pass\n", encoding="utf-8")
+    with pytest.raises(SyntaxError):
+        find_violation_sites(broken)
+
+
+def test_the_real_scan_against_the_current_tree_is_fully_resolved() -> None:
+    """Tier 1: the load-bearing witness — running the real detector
+    against the real repo tree, right now, finds nothing unresolved.
+    Mirrors `silent_except_ratchet.py`'s own identically-shaped
+    real-tree test."""
+    unresolved, scanned = measured(REPO_ROOT)
+    assert scanned > 0, "the scan found 0 files — a scanner failure, not a clean population"
+    assert unresolved == [], (
+        f"{len(unresolved)} violation-side site(s) under src/reyn/ have no "
+        f"valid marker: {unresolved}"
+    )


### PR DESCRIPTION
**[tui-coder]** — part of #5990 (stage 2-2, corrected ruling → https://github.com/tya5/reyn/issues/5990#issuecomment-5613733521)

A NEW, independent gate for the "except-return-reachability" axis — `silent_except_ratchet.py` (its own `src/reyn/interfaces/`-scoped axis, 90 sites) is untouched.

## The axis

An `except` block (ANY caught type — no `Exception`/`BaseException` restriction) whose body is assign-only (every statement a plain `ast.Assign`) AND whose bound name(s) reach a `return` in the SAME enclosing function (never descending into a nested `def`/`lambda`). An unexpected exception here silently becomes **fabricated output data**, not merely an unreported failure.

## Population — re-derived, not trusted from #6057's own number

lead-coder's explicit instruction, given twice this session after two earlier framings turned out wrong: derive the population at start of work, don't reuse an old count. Ran the real detector against current `origin/main`: **20 sites** (same count as #6057's own "20 out-of-class", though a couple of individual files moved since — verified by running the detector, not by assuming the old list still applies).

## Marker mechanism

```python
except Exception:
    # SILENT-EXCEPT-RETURN-OK: <category> -- <specific reason>
    canonical = repr(payload)
```

No numeric baseline (lead-coder: "20 sites allowed" lets someone fix an old one and add a new one for free — the count never moves) and no hand-maintained allowlist (a second table this repo's own "derive, never maintain" discipline forbids). Population = axis match **minus** valid-marker sites, derived every run.

`<category>` is one of the 5 slugs #6057's own PR body already used, reused verbatim per lead-coder's instruction:
- `internal-hash-fallback`
- `expected-import-error`
- `external-content-caller-cannot-act`
- `reported-elsewhere`
- `low-stakes-display-value`

**Both directions are gate failures** (lead-coder: "「意図的」で全部通る marker は gate ではなく署名欄です"):
1. A violation-side site with no marker at all.
2. A marker present but its category is not in the vocabulary.

All 20 real sites marked in this PR — each read individually against the code actually at that line today, not mechanically copied from #6057's own one-line PR-body summaries (a few of which condensed a 9-reason breakdown into the 5-slug vocabulary lead-coder asked for).

## Tests

13 new tests (`tests/scripts/test_check_silent_except_return_reachability.py`), real fixture files (`tests/scripts/fixtures/silent_except_return_5990/`, never a strip-and-revert scratch — matching lead-coder's own review of the sibling gate's design). Both accept directions witnessed directly:
- an unmarked violation-side site → problem
- a correctly-marked one → no problem
- an invalid-category marker → a DIFFERENT problem than "no marker at all"

4 correct-side negative controls (module-level handler, non-assign-only body, bound name never returned, name shadowed inside a nested function) confirm the detector discriminates rather than flagging everything.

Strip-falsified by hand (in-file Edit → run → Edit back, no `git stash`/checkout) against the REAL tree (`replay_key_diff.py:42`), both directions: removing the marker → red; swapping in an invented category → red with the correct "not in vocabulary" message.

## CI

New `.github/workflows/silent-except-return-reachability-gate.yml`, `pull_request` + `paths: src/reyn/**`, mirroring the sibling gate's own per-PR shape.

## Gates

`ruff`, `test_tier_audit.py --strict`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py`, the `tests/`-path-conditional gates, `check_fastmcp_import_boundary.py`, and BOTH silent-except gates themselves — `silent_except_ratchet.py`'s own 90/38 population confirmed byte-identical (every edit in this PR is a pure comment insertion, zero AST-node effect on its axis).

## Test plan
- [x] `pytest tests/scripts/test_check_silent_except_return_reachability.py` (13/13)
- [x] Full gate suite listed above, all green
- [x] (skipped — Visual, standing waiver)

part of #5990 — the existing 90-site `silent_except_ratchet.py` population stays a separate, later stage (explicitly out of scope here per lead-coder's own correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
