### PR TITLE
fix(part of #6069): remove 4 general words from _CONTEXT_OVERFLOW_KEYWORDS, report fallback decisions, add structural gate

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1048,8 +1048,45 @@ class ContextOverflowError(Exception):
 #: in — NOT "can shrinking recover from this" (a separate, broader
 #: question #3783 stage 3 addresses; the two must not be merged into one
 #: predicate — see ``is_context_overflow_error``'s own docstring).
+#:
+#: #6069 (architect's own discriminator, revised after withdrawing a first
+#: "provenance" cut — see the issue's own 2nd comment): a partial-string
+#: match is safe ONLY when the spelling can ONLY appear when the condition
+#: is true. The 4 single words this tuple used to also carry — ``context``,
+#: ``token``, ``length``, ``limit`` — are common English words that can
+#: appear in an UNRELATED message for a reason that has nothing to do with
+#: overflow (the real false positive this issue started from:
+#: ``MissingFixture("... safety_limit_no_listener.jsonl ...")`` matched
+#: ``"limit"`` purely because of a fixture FILENAME). Every remaining
+#: element is a multi-word PHRASE — "too long"/"too large" and the ones
+#: added below — which is a materially narrower spelling but NOT an
+#: impossible one to collide with by accident (e.g. a path or filename
+#: that happens to contain the words "context window") — see
+#: ``test_context_overflow_keywords_contain_no_bare_words`` (this module's
+#: own structural gate, scoped to ONLY this one constant) for what is
+#: actually enforced: no single-word (whitespace-free) element, not
+#: "no collision is possible."
+#:
+#: #6069 positive-control (lead-coder's explicit ask, run BEFORE landing
+#: this removal): a real, historical provider overflow message this
+#: keyword set was written to catch — ``"This model's maximum context
+#: length is 128000 tokens."`` (the #5699 owner-incident test's own
+#: non-regression fixture, itself modelled on OpenAI's real API error
+#: text) — contains NEITHER "too long" NOR "too large". It matched ONLY
+#: via the now-removed general words ``"context"``/``"length"``, and after
+#: this removal it no longer matches the keyword fallback at all — a
+#: genuine, disclosed false-negative trade (see
+#: ``test_real_openai_style_overflow_message_without_a_phrase_is_now_
+#: missed`` for the pinned repro, and the PR body for the full writeup).
+#: This is why stage 2 (the structured ``error.code`` field, #5699) and
+#: stage 1/2 (type/status_code) above are checked FIRST, in STRENGTH
+#: order: the real production shape (an un-flattened provider response)
+#: almost always carries ``code: "context_length_exceeded"`` and is caught
+#: there regardless of what this tuple contains. This tuple is the
+#: fallback of last resort for a message whose STRUCTURE was also
+#: stripped by an intermediate proxy — see this function's own docstring.
 _CONTEXT_OVERFLOW_KEYWORDS = (
-    "context", "token", "length", "limit", "too long", "too large",
+    "too long", "too large",
 )
 
 #: #5699 (owner real-machine incident): the OpenAI/litellm structured
@@ -1241,7 +1278,33 @@ def is_context_overflow_error(exc: BaseException) -> bool:
     # below).
     if signal.code in _CONTEXT_OVERFLOW_ERROR_CODES:
         return True
-    return any(kw in signal.message.lower() for kw in _CONTEXT_OVERFLOW_KEYWORDS)
+    # #6069: the fallback path above (type/status_code/structured code) is
+    # where this is no longer reached for a definitive signal; everything
+    # below this point is deciding from free text alone, which is exactly
+    # the thing this function's own docstring calls "fine as a fallback
+    # ... but must never be the ONLY signal when a stronger one is
+    # available". #6069's own incident (a fixture filename matching
+    # "limit") was silent at this exact line — nothing recorded WHICH
+    # spelling matched or on WHAT exception type, so the next false
+    # positive/negative is diagnosable only by re-deriving it from
+    # scratch. Reported here, at the ONE spot every call site funnels
+    # through, rather than at each of this predicate's own callers.
+    matched = [kw for kw in _CONTEXT_OVERFLOW_KEYWORDS if kw in signal.message.lower()]
+    if matched:
+        logger.info(
+            "is_context_overflow_error: keyword fallback classified overflow=True "
+            "via %r on exception type %s",
+            matched,
+            signal.class_name,
+        )
+        return True
+    logger.info(
+        "is_context_overflow_error: keyword fallback classified overflow=False "
+        "-- none of %r matched exception type %s",
+        _CONTEXT_OVERFLOW_KEYWORDS,
+        signal.class_name,
+    )
+    return False
 
 
 class LLMFailureClass(enum.Enum):

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1100,31 +1100,9 @@ class ContextOverflowError(Exception):
 #: there regardless of what this tuple contains. This tuple is the
 #: fallback of last resort for a message whose STRUCTURE was also
 #: stripped by an intermediate proxy — see this function's own docstring.
-#:
-#: ``"context_length_exceeded"`` (#6073 CI failure, 2026-09-10): a 4th
-#: observed shape — this time the message carries the error CODE itself
-#: (litellm's/OpenAI's own ``error.code`` spelling, confirmed present
-#: verbatim in the installed ``litellm`` package source —
-#: ``litellm/types/llms/openai.py``'s own ``code: str  # e.g.,
-#: 'context_length_exceeded'`` — the SAME literal string
-#: ``_CONTEXT_OVERFLOW_ERROR_CODES`` above already recognises when it
-#: arrives as a STRUCTURED ``.code`` attribute) but as free text inside
-#: ``str(exc)`` with no ``.code`` attribute set at all (a plain
-#: ``RuntimeError("context_length_exceeded: too many tokens")`` — no
-#: ``status_code``, no ``.code``, no litellm type to check first; see
-#: ``test_token_axis_fold_persist_policy_controls_compaction``,
-#: ``tests/runtime/test_retry_loop_chat_wiring_1125.py``). No typed
-#: signal exists to wire this to instead: the exception carries nothing
-#: but a message, so the keyword fallback is the only layer that can
-#: catch it. Added VERBATIM (underscore-joined, as litellm/OpenAI
-#: actually spell it) rather than invented — see
-#: ``test_context_overflow_keywords_contain_no_bare_words``'s own
-#: docstring for why this element's lack of whitespace does not make it
-#: a "bare general word" the structural gate below is meant to reject.
 _CONTEXT_OVERFLOW_KEYWORDS = (
     "too long", "too large",
     "maximum context", "context length", "context window",
-    "context_length_exceeded",
 )
 
 #: #5699 (owner real-machine incident): the OpenAI/litellm structured

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1100,9 +1100,31 @@ class ContextOverflowError(Exception):
 #: there regardless of what this tuple contains. This tuple is the
 #: fallback of last resort for a message whose STRUCTURE was also
 #: stripped by an intermediate proxy — see this function's own docstring.
+#:
+#: ``"context_length_exceeded"`` (#6073 CI failure, 2026-09-10): a 4th
+#: observed shape — this time the message carries the error CODE itself
+#: (litellm's/OpenAI's own ``error.code`` spelling, confirmed present
+#: verbatim in the installed ``litellm`` package source —
+#: ``litellm/types/llms/openai.py``'s own ``code: str  # e.g.,
+#: 'context_length_exceeded'`` — the SAME literal string
+#: ``_CONTEXT_OVERFLOW_ERROR_CODES`` above already recognises when it
+#: arrives as a STRUCTURED ``.code`` attribute) but as free text inside
+#: ``str(exc)`` with no ``.code`` attribute set at all (a plain
+#: ``RuntimeError("context_length_exceeded: too many tokens")`` — no
+#: ``status_code``, no ``.code``, no litellm type to check first; see
+#: ``test_token_axis_fold_persist_policy_controls_compaction``,
+#: ``tests/runtime/test_retry_loop_chat_wiring_1125.py``). No typed
+#: signal exists to wire this to instead: the exception carries nothing
+#: but a message, so the keyword fallback is the only layer that can
+#: catch it. Added VERBATIM (underscore-joined, as litellm/OpenAI
+#: actually spell it) rather than invented — see
+#: ``test_context_overflow_keywords_contain_no_bare_words``'s own
+#: docstring for why this element's lack of whitespace does not make it
+#: a "bare general word" the structural gate below is meant to reject.
 _CONTEXT_OVERFLOW_KEYWORDS = (
     "too long", "too large",
     "maximum context", "context length", "context window",
+    "context_length_exceeded",
 )
 
 #: #5699 (owner real-machine incident): the OpenAI/litellm structured

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -1073,11 +1073,26 @@ class ContextOverflowError(Exception):
 #: length is 128000 tokens."`` (the #5699 owner-incident test's own
 #: non-regression fixture, itself modelled on OpenAI's real API error
 #: text) — contains NEITHER "too long" NOR "too large". It matched ONLY
-#: via the now-removed general words ``"context"``/``"length"``, and after
-#: this removal it no longer matches the keyword fallback at all — a
-#: genuine, disclosed false-negative trade (see
-#: ``test_real_openai_style_overflow_message_without_a_phrase_is_now_
-#: missed`` for the pinned repro, and the PR body for the full writeup).
+#: via the now-removed general words ``"context"``/``"length"``. Found by
+#: the positive control BEFORE this removal landed, and FIXED here (not
+#: merely disclosed — architect/lead-coder co-vet, PR #6073): this is the
+#: OpenAI-proxy-flattened-overflow shape the keyword fallback exists for
+#: in the first place, so losing it silently would have reopened the
+#: exact defect this fallback was written to close. Caught by adding the
+#: 3 phrases below, each containing "context" plus an adjoining word from
+#: that one observed message — still a multi-word PHRASE (passes the
+#: structural gate and the architect's own discriminator), not a re-added
+#: bare general word.
+#:
+#: ``"maximum context"`` / ``"context length"`` / ``"context window"`` —
+#: derived STRICTLY from the one message above, the only real observation
+#: on hand when these were added (#6069 PR #6073 review). This list is
+#: NOT exhaustive: it covers only what has been observed so far. Add a
+#: phrase here only from a newly OBSERVED real overflow message (never
+#: invented/imagined ahead of one — #5987's same corpus discipline:
+#: matching against an imagined corpus only measures agreement with the
+#: imagination).
+#:
 #: This is why stage 2 (the structured ``error.code`` field, #5699) and
 #: stage 1/2 (type/status_code) above are checked FIRST, in STRENGTH
 #: order: the real production shape (an un-flattened provider response)
@@ -1087,6 +1102,7 @@ class ContextOverflowError(Exception):
 #: stripped by an intermediate proxy — see this function's own docstring.
 _CONTEXT_OVERFLOW_KEYWORDS = (
     "too long", "too large",
+    "maximum context", "context length", "context window",
 )
 
 #: #5699 (owner real-machine incident): the OpenAI/litellm structured
@@ -1289,16 +1305,30 @@ def is_context_overflow_error(exc: BaseException) -> bool:
     # positive/negative is diagnosable only by re-deriving it from
     # scratch. Reported here, at the ONE spot every call site funnels
     # through, rather than at each of this predicate's own callers.
+    #
+    # #6073 co-vet (architect + lead-coder): ``chat.py``'s shipped default
+    # config sets the ROOT logger to ``WARNING`` (#6045 hit the same trap
+    # today: "info is quiet" actually meant "info is discarded" there) —
+    # an ``INFO`` record here is silently dropped in every shipped run,
+    # so the True-deciding branch (free text ALONE decided a shrink-ladder
+    # entry — a fact that should be visible by default) is ``warning``.
+    # The False branch is left at ``debug``, not raised to the same level:
+    # it fires on EVERY exception that reaches this fallback and matches
+    # nothing (any RETRYABLE/FATAL exception with no typed/status/code
+    # signal funnels through here too), so raising it to ``warning`` would
+    # make it noise that drowns out the one warning that actually matters
+    # — the fix for "too quiet" is narrowing WHEN a level fires, never
+    # lowering the bar below what the shipped config surfaces.
     matched = [kw for kw in _CONTEXT_OVERFLOW_KEYWORDS if kw in signal.message.lower()]
     if matched:
-        logger.info(
+        logger.warning(
             "is_context_overflow_error: keyword fallback classified overflow=True "
             "via %r on exception type %s",
             matched,
             signal.class_name,
         )
         return True
-    logger.info(
+    logger.debug(
         "is_context_overflow_error: keyword fallback classified overflow=False "
         "-- none of %r matched exception type %s",
         _CONTEXT_OVERFLOW_KEYWORDS,

--- a/tests/core/test_3783_stage3_invert_default_to_recover.py
+++ b/tests/core/test_3783_stage3_invert_default_to_recover.py
@@ -6,7 +6,9 @@ Three witnesses, per lead-coder's design (issue #3783 comments):
 
 (a) rescue arm — an exception the OLD keyword predicate did NOT recognise
     (no shared word with "context"/"token"/"length"/"limit"/"too long"/
-    "too large") but which shrinking the input genuinely fixes (the
+    "too large" — the first 4 of those were later removed by #6069, kept
+    here as historical context for what the OLD predicate covered) but
+    which shrinking the input genuinely fixes (the
     motivating live incident: a response cut short by an output cap raises
     a bare ``JSONDecodeError``). Constructed, not reproduced: a small output
     cap + a large input, mirroring the incident's actual mechanism.
@@ -271,13 +273,16 @@ class _AlwaysOverflowRouterLoop:
 
     async def run(self, *, user_text: str, history: list[dict]) -> TokenUsage:
         # The message must match ``is_context_overflow_error``'s keyword
-        # fallback ("context"/"token"/"length"/"limit"/"too long"/"too
-        # large") — the predicate does not special-case ``ContextOverflowError``
-        # by TYPE, only litellm's own ``ContextWindowExceededError``; an
-        # unmatched message here makes ``_run_with_shrink`` re-raise raw
-        # WITHOUT ever entering retry_loop, silently missing this arm's
-        # target code path entirely (caught during test development).
-        raise ContextOverflowError("simulated: context length exceeded")
+        # fallback — #6069 narrowed that fallback to PHRASES only
+        # ("too long"/"too large"; the 4 general words "context"/"token"/
+        # "length"/"limit" were removed), so this message needs a
+        # surviving phrase. The predicate does not special-case
+        # ``ContextOverflowError`` by TYPE, only litellm's own
+        # ``ContextWindowExceededError``; an unmatched message here makes
+        # ``_run_with_shrink`` re-raise raw WITHOUT ever entering
+        # retry_loop, silently missing this arm's target code path
+        # entirely (caught during test development).
+        raise ContextOverflowError("simulated: input too large for this model")
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_6069_overflow_keyword_general_words_removed.py
+++ b/tests/core/test_6069_overflow_keyword_general_words_removed.py
@@ -1,0 +1,209 @@
+"""Tier 2: #6069 — ``_CONTEXT_OVERFLOW_KEYWORDS`` must not partial-match on
+a general, common-English word (a spelling that can appear in a message for
+a reason that has NOTHING to do with overflow) — only on a multi-word
+PHRASE (a materially narrower, though not impossible-to-collide, spelling).
+
+Real false positive this issue started from: a CI run's own
+``reyn.dev.testing.replay.MissingFixture`` (a test-harness "no recorded
+fixture matched this call" error, never a provider overflow) carried a
+fixture FILENAME containing the substring "limit" —
+``safety_limit_no_listener.jsonl`` — and matched
+``is_shrinkable_overflow``'s own keyword fallback purely by coincidence
+(#6070). The architect's discriminator (issue #6069, 2nd comment, after
+withdrawing a first "provenance" cut that conflated WHO wrote a message
+with WHERE its content came from): a partial match is safe only when the
+spelling can ONLY appear when the condition is true. ``context``/``token``/
+``length``/``limit`` fail that test; the phrases (``too long``/``too
+large``) pass it — narrower, not impossible (a PR body's own disclosure:
+a filename containing "context window" could still collide).
+
+Four things pinned here:
+(1) the exact false positive this issue started from → False (acceptance 1)
+(2) a present-sibling positive control (a flattened 3rd-party error with no
+    typed signal, message carrying a surviving phrase) → True — rules out
+    an over-correction that would make this predicate always False
+    (acceptance 2)
+(3) the out-of-scope family sites (router_loop.py's 3 "HTTP 404" sites +
+    "does not support parameter" + "encoding_format") are provably
+    untouched — a witness this PR did not sweep the whole family under one
+    name (acceptance 3)
+(4) the structural gate on ``_CONTEXT_OVERFLOW_KEYWORDS`` itself, plus its
+    own strip-falsify (acceptance 6)
+
+The fallback-reporting acceptance item (5) and the "2 typed signals not
+vacuous" item (4 in the issue's own numbering) are pinned in
+``tests/runtime/test_router_loop_pure_helpers.py`` and
+``tests/core/test_4381_stage1_overflow_classification.py`` respectively
+(the 413/litellm-type checks, already-existing and already covered there);
+see this file's own last test for the fallback-reporting witness anyway,
+via the public ``caplog`` surface (never a private field).
+"""
+from __future__ import annotations
+
+import logging
+
+import litellm
+
+from reyn.dev.testing.replay import MissingFixture
+from reyn.services.compaction.engine import (
+    _CONTEXT_OVERFLOW_KEYWORDS,
+    is_context_overflow_error,
+    is_shrinkable_overflow,
+)
+
+
+def test_missing_fixture_filename_collision_is_no_longer_overflow() -> None:
+    """Tier 2: acceptance 1 — the exact defect #6069/#6070 started from.
+
+    A ``MissingFixture`` whose message carries a fixture FILENAME
+    containing the substring "limit" (a harness detail with nothing to do
+    with overflow) must not classify as context-overflow, and must not
+    enter the shrink ladder."""
+    exc = MissingFixture(
+        "no fixture entry matches this call "
+        "(tests/_fixtures/llm/safety_limit_no_listener.jsonl)"
+    )
+    assert is_context_overflow_error(exc) is False
+    assert is_shrinkable_overflow(exc) is False
+
+
+def test_present_sibling_flattened_third_party_phrase_is_still_overflow() -> None:
+    """Tier 2: acceptance 2 — present sibling. A real, flattened
+    ``litellm.BadRequestError`` (no ``status_code``/type/structured
+    ``code`` signal — the proxy-flattening shape this fallback exists
+    for) whose free-text message carries a surviving PHRASE still
+    classifies as overflow. Without this test, acceptance 1 above could
+    pass trivially with an implementation that always returns False."""
+    exc = litellm.BadRequestError(
+        message="The request is too large for this model's context window.",
+        model="gpt-4", llm_provider="openai",
+    )
+    assert getattr(exc, "status_code", None) != 413
+    assert getattr(exc, "code", None) is None
+    assert is_context_overflow_error(exc) is True
+
+
+def test_strip_falsify_restoring_a_general_word_reclassifies_the_fixture_true() -> None:
+    """Tier 2: strip-falsify (acceptance 6, classification half) — putting
+    "limit" back into a LOCAL copy of the keyword set (never mutating the
+    production constant itself — this module-level tuple is shared, and
+    tests must not mutate shared production state) reproduces the
+    original false positive, confirming this test's own positive-side
+    assertion is not vacuously green regardless of the word list."""
+    exc = MissingFixture("... safety_limit_no_listener.jsonl ...")
+    message = str(exc).lower()
+    assert not any(kw in message for kw in _CONTEXT_OVERFLOW_KEYWORDS), (
+        "sanity: the CURRENT (post-#6069) keyword set must not match this "
+        "message at all"
+    )
+    reverted_keywords = (*_CONTEXT_OVERFLOW_KEYWORDS, "limit")
+    assert any(kw in message for kw in reverted_keywords), (
+        "restoring the removed general word 'limit' must reproduce the "
+        "original false positive on this exact message — confirming "
+        "'limit' (not something else) was what matched before #6069"
+    )
+
+
+def test_out_of_scope_http_404_sites_are_unchanged() -> None:
+    """Tier 2: acceptance 3 — out-of-scope witness. The architect's own
+    ruling excluded the other 5 family sites from this fix (they pass the
+    same discriminator, or are not partial-string-matches at all) — reads
+    each site's own source text directly, never re-implementing its
+    logic, to witness the literal needle strings this PR did not touch."""
+    import inspect
+
+    from reyn.core.op_runtime import mcp_install
+    from reyn.core.registry import client as registry_client
+    from reyn.mcp import registry as mcp_registry
+    from reyn.runtime import router_loop
+
+    assert '"HTTP 404" in str(exc)' in inspect.getsource(mcp_install)
+    assert '"HTTP 404" not in str(exc)' in inspect.getsource(registry_client)
+    assert '"HTTP 404" in str(exc)' in inspect.getsource(mcp_registry)
+    router_loop_src = inspect.getsource(router_loop)
+    assert '"does not support parameter" in str(exc)' in router_loop_src
+    assert '"encoding_format" in str(exc)' in router_loop_src
+
+
+def test_fallback_match_is_reported_not_silent(caplog) -> None:
+    """Tier 2: acceptance 5 — when the keyword fallback is what DECIDES a
+    classification (no typed/status_code/structured-code signal reached
+    first), the matched spelling and the exception's type name are now
+    reported via the public logging surface — never silent, the way the
+    original #6070 false positive was (nothing recorded WHICH spelling
+    matched or on what exception type)."""
+    exc = litellm.BadRequestError(
+        message="the input is too large for this model",
+        model="gpt-4", llm_provider="openai",
+    )
+    with caplog.at_level(logging.INFO, logger="reyn.services.compaction.engine"):
+        assert is_context_overflow_error(exc) is True
+    matched_records = [r for r in caplog.records if "too large" in r.getMessage()]
+    assert matched_records, (
+        "the matched keyword ('too large') must appear in a log record, "
+        "not be silently decided"
+    )
+    assert any("BadRequestError" in r.getMessage() for r in matched_records), (
+        "the exception's type name must also be reported alongside the "
+        "matched spelling"
+    )
+
+
+def test_fallback_no_match_is_also_reported_not_silent(caplog) -> None:
+    """Tier 2: acceptance 5, the False-deciding half — a message that
+    reaches the fallback but matches nothing must also be reported (not
+    only the True case), so a future FALSE NEGATIVE (a real overflow
+    message missing every remaining phrase — see
+    ``tests/runtime/test_5699_compaction_window_fold_parity.py``'s own
+    #6069 positive-control test) is diagnosable via the same surface."""
+    exc = MissingFixture("... safety_limit_no_listener.jsonl ...")
+    with caplog.at_level(logging.INFO, logger="reyn.services.compaction.engine"):
+        assert is_context_overflow_error(exc) is False
+    assert any(
+        "MissingFixture" in r.getMessage() and "False" in r.getMessage()
+        for r in caplog.records
+    ), "the no-match decision must also be reported, not silent"
+
+
+# ---------------------------------------------------------------------------
+# Structural gate: _CONTEXT_OVERFLOW_KEYWORDS may contain no single-word
+# (whitespace-free) element (acceptance 6, gate half)
+# ---------------------------------------------------------------------------
+
+
+def test_context_overflow_keywords_contain_no_bare_words() -> None:
+    """Tier 1: the structural gate itself — every element of
+    ``_CONTEXT_OVERFLOW_KEYWORDS`` must contain whitespace (i.e. be a
+    multi-word PHRASE), scoped to ONLY this one constant, never a
+    general "ban short keywords" rule over the codebase.
+
+    Deliberately STRUCTURAL (checks whether each string contains
+    whitespace), not a hand-maintained list of "banned words" — the
+    point is that nobody can re-add a bare single word to THIS constant,
+    including a word nobody has thought of yet, without this failing.
+
+    Disclosed limit (PR body's own caveat, restated here): whitespace-
+    containing does not mean collision-IMPOSSIBLE — a phrase like "too
+    large" could still theoretically appear in an unrelated message (the
+    architect's own example: a filename containing "context window").
+    This gate raises the bar the discriminator sets; it does not claim
+    to make a false positive impossible."""
+    for kw in _CONTEXT_OVERFLOW_KEYWORDS:
+        assert any(ch.isspace() for ch in kw), (
+            f"{kw!r} is a single word (no whitespace) — "
+            "_CONTEXT_OVERFLOW_KEYWORDS may only contain multi-word "
+            "phrases (see this test's own docstring and the #6069 PR body)"
+        )
+
+
+def test_context_overflow_keywords_gate_is_falsified_by_restoring_a_bare_word() -> None:
+    """Tier 1: strip-falsify (acceptance 6, gate half) — a LOCAL tuple
+    with a general word put back in must fail the SAME structural check
+    the test above runs against production, confirming the gate is
+    sensitive to exactly this shape and not vacuously green regardless
+    of content. Never mutates the production constant."""
+    reverted = (*_CONTEXT_OVERFLOW_KEYWORDS, "limit")
+    assert not all(any(ch.isspace() for ch in kw) for kw in reverted), (
+        "restoring a bare single word must make the structural check go "
+        "red — if it doesn't, the check isn't testing what it claims to"
+    )

--- a/tests/core/test_6069_overflow_keyword_general_words_removed.py
+++ b/tests/core/test_6069_overflow_keyword_general_words_removed.py
@@ -37,17 +37,6 @@ vacuous" item (4 in the issue's own numbering) are pinned in
 (the 413/litellm-type checks, already-existing and already covered there);
 see this file's own last test for the fallback-reporting witness anyway,
 via the public ``caplog`` surface (never a private field).
-
-#6073 follow-up (2026-09-10 CI failure): a 4th real overflow shape —
-``"context_length_exceeded"`` (litellm's/OpenAI's own ``error.code``
-spelling, confirmed in the installed ``litellm`` package source, arriving
-here as free text inside a plain exception's message rather than as the
-already-handled structured ``.code`` attribute) — was added to
-``_CONTEXT_OVERFLOW_KEYWORDS``. It is underscore-joined, not
-whitespace-joined, so the structural gate below was widened from "must
-contain whitespace" to "must contain whitespace OR an underscore" (see
-``_is_multi_component``'s own docstring) rather than silently adding a
-keyword the gate itself would otherwise have rejected.
 """
 from __future__ import annotations
 
@@ -224,60 +213,28 @@ def test_fallback_no_match_is_also_reported_not_silent(caplog) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _is_multi_component(kw: str) -> bool:
-    """Shared by the gate and its falsify-test below: *kw* is either a
-    whitespace-joined PHRASE or an underscore-joined error-CODE-shaped
-    identifier — never a single bare word.
-
-    #6073 (2026-09-10 CI failure, the gate's own first real collision):
-    ``"context_length_exceeded"`` is litellm's/OpenAI's own ``error.code``
-    spelling (confirmed verbatim in the installed ``litellm`` package —
-    ``litellm/types/llms/openai.py``), joined by underscores rather than
-    spaces because that is how the PROVIDER spells its own error code —
-    this module has no authority to re-punctuate a third party's literal
-    identifier into a space-joined phrase just to satisfy this gate's
-    original whitespace check. The architect's own discriminator (#6069,
-    2nd comment) never said "must contain whitespace" — it said "a
-    partial match is safe only when the spelling can ONLY appear when
-    the condition is true"; whitespace was this gate's PROXY for that
-    principle, built when every known phrase happened to be space-joined.
-    An underscore-joined multi-component identifier is exactly as narrow
-    a spelling as a space-joined phrase (arguably narrower: it is a
-    known, fixed provider error-code string, not assembled English) — so
-    the proxy is widened to "contains whitespace OR an underscore",
-    rather than silently bypassed by adding the new keyword without
-    updating the check it must still pass. A single bare word like
-    ``"limit"`` contains neither and still fails both forms of the gate."""
-    return any(ch.isspace() for ch in kw) or "_" in kw
-
-
 def test_context_overflow_keywords_contain_no_bare_words() -> None:
     """Tier 1: the structural gate itself — every element of
-    ``_CONTEXT_OVERFLOW_KEYWORDS`` must be multi-component (a whitespace-
-    joined PHRASE, or an underscore-joined error-code-shaped identifier —
-    see :func:`_is_multi_component`'s own docstring for why underscore
-    joins this gate's "not a bare word" check rather than bypassing it),
-    scoped to ONLY this one constant, never a general "ban short
-    keywords" rule over the codebase.
+    ``_CONTEXT_OVERFLOW_KEYWORDS`` must contain whitespace (i.e. be a
+    multi-word PHRASE), scoped to ONLY this one constant, never a
+    general "ban short keywords" rule over the codebase.
 
-    Deliberately STRUCTURAL (checks each string's own punctuation), not a
-    hand-maintained list of "banned words" — the point is that nobody can
-    re-add a bare single word to THIS constant, including a word nobody
-    has thought of yet, without this failing.
+    Deliberately STRUCTURAL (checks whether each string contains
+    whitespace), not a hand-maintained list of "banned words" — the
+    point is that nobody can re-add a bare single word to THIS constant,
+    including a word nobody has thought of yet, without this failing.
 
-    Disclosed limit (PR body's own caveat, restated here): passing this
-    check does not mean collision-IMPOSSIBLE — a phrase like "too large"
-    could still theoretically appear in an unrelated message (the
+    Disclosed limit (PR body's own caveat, restated here): whitespace-
+    containing does not mean collision-IMPOSSIBLE — a phrase like "too
+    large" could still theoretically appear in an unrelated message (the
     architect's own example: a filename containing "context window").
     This gate raises the bar the discriminator sets; it does not claim
     to make a false positive impossible."""
     for kw in _CONTEXT_OVERFLOW_KEYWORDS:
-        assert _is_multi_component(kw), (
-            f"{kw!r} is a single bare word (no whitespace, no "
-            "underscore) — _CONTEXT_OVERFLOW_KEYWORDS may only contain "
-            "multi-word phrases or underscore-joined error-code-shaped "
-            "identifiers (see this test's own docstring and the #6069 "
-            "PR body)"
+        assert any(ch.isspace() for ch in kw), (
+            f"{kw!r} is a single word (no whitespace) — "
+            "_CONTEXT_OVERFLOW_KEYWORDS may only contain multi-word "
+            "phrases (see this test's own docstring and the #6069 PR body)"
         )
 
 
@@ -288,7 +245,7 @@ def test_context_overflow_keywords_gate_is_falsified_by_restoring_a_bare_word() 
     sensitive to exactly this shape and not vacuously green regardless
     of content. Never mutates the production constant."""
     reverted = (*_CONTEXT_OVERFLOW_KEYWORDS, "limit")
-    assert not all(_is_multi_component(kw) for kw in reverted), (
+    assert not all(any(ch.isspace() for ch in kw) for kw in reverted), (
         "restoring a bare single word must make the structural check go "
         "red — if it doesn't, the check isn't testing what it claims to"
     )

--- a/tests/core/test_6069_overflow_keyword_general_words_removed.py
+++ b/tests/core/test_6069_overflow_keyword_general_words_removed.py
@@ -109,7 +109,31 @@ def test_out_of_scope_http_404_sites_are_unchanged() -> None:
     ruling excluded the other 5 family sites from this fix (they pass the
     same discriminator, or are not partial-string-matches at all) — reads
     each site's own source text directly, never re-implementing its
-    logic, to witness the literal needle strings this PR did not touch."""
+    logic, to witness the literal needle strings this PR did not touch.
+
+    #6073 co-vet (architect's finding): source-pinning means a FUTURE
+    follow-up that converts these 5 sites from a ``"HTTP 404" in
+    str(exc)`` string match to a real status-code check (each site's own
+    exception — ``RegistryError``/``litellm``'s own error types — carries
+    no structured status_code of its own today; adding one is a DIFFERENT
+    PR's scope, not this one's) will make THIS test go red.
+
+    Deliberately kept as a source-pin rather than converted to a
+    behavioural check (option (a) the co-vet also offered): these 5 sites
+    are NOT one shared classifier predicate the way
+    ``is_context_overflow_error`` is — they are 3 different modules
+    (``mcp_install.py``, ``registry/client.py``, ``mcp/registry.py``, plus
+    ``router_loop.py``'s 2 string checks) each doing DIFFERENT things with
+    the match (continue-to-next-URL, raise-with-guidance, emit a
+    parameter-stripping retry) — there is no single function to call and
+    assert True/False against; building a behavioural harness per site
+    would mean faking each site's own I/O boundary (an HTTP client, a
+    litellm call) for a test whose only job is "did the 5 sites move",
+    which is a materially larger test than the question being asked.
+
+    THIS RED IS EXPECTED AND CORRECT, not a regression: when that
+    follow-up lands, delete or rewrite this test in THAT PR — do not
+    resurrect the old string literals to keep it green."""
     import inspect
 
     from reyn.core.op_runtime import mcp_install
@@ -131,12 +155,19 @@ def test_fallback_match_is_reported_not_silent(caplog) -> None:
     first), the matched spelling and the exception's type name are now
     reported via the public logging surface — never silent, the way the
     original #6070 false positive was (nothing recorded WHICH spelling
-    matched or on what exception type)."""
+    matched or on what exception type).
+
+    #6073 co-vet: this is ``logger.warning``, not ``logger.info`` —
+    ``chat.py``'s shipped default config sets the ROOT logger to
+    ``WARNING``, so an ``info`` record here would be silently discarded
+    in every shipped run (the same trap #6045 hit the same day). Asserted
+    at ``logging.WARNING`` here, not ``INFO``, so this test cannot stay
+    green against a regression back to ``info``."""
     exc = litellm.BadRequestError(
         message="the input is too large for this model",
         model="gpt-4", llm_provider="openai",
     )
-    with caplog.at_level(logging.INFO, logger="reyn.services.compaction.engine"):
+    with caplog.at_level(logging.WARNING, logger="reyn.services.compaction.engine"):
         assert is_context_overflow_error(exc) is True
     matched_records = [r for r in caplog.records if "too large" in r.getMessage()]
     assert matched_records, (
@@ -147,17 +178,28 @@ def test_fallback_match_is_reported_not_silent(caplog) -> None:
         "the exception's type name must also be reported alongside the "
         "matched spelling"
     )
+    assert all(r.levelno >= logging.WARNING for r in matched_records), (
+        "the deciding (True) branch must be visible at the shipped "
+        "default root level (WARNING) -- not silently below it"
+    )
 
 
 def test_fallback_no_match_is_also_reported_not_silent(caplog) -> None:
     """Tier 2: acceptance 5, the False-deciding half — a message that
-    reaches the fallback but matches nothing must also be reported (not
-    only the True case), so a future FALSE NEGATIVE (a real overflow
-    message missing every remaining phrase — see
-    ``tests/runtime/test_5699_compaction_window_fold_parity.py``'s own
-    #6069 positive-control test) is diagnosable via the same surface."""
+    reaches the fallback but matches nothing is also reported (not only
+    the True case), so a future false negative is diagnosable via the
+    same surface.
+
+    #6073 co-vet: this half stays at ``logger.debug``, deliberately NOT
+    raised to ``warning`` alongside the True branch above — it fires on
+    EVERY exception that reaches this fallback and matches nothing
+    (every RETRYABLE/FATAL exception lacking a typed/status/code signal
+    funnels through here too), so raising it to ``warning`` would bury
+    the one warning that actually matters in noise. Asserted at
+    ``logging.DEBUG`` here (not ``WARNING``), matching what the
+    production code actually emits."""
     exc = MissingFixture("... safety_limit_no_listener.jsonl ...")
-    with caplog.at_level(logging.INFO, logger="reyn.services.compaction.engine"):
+    with caplog.at_level(logging.DEBUG, logger="reyn.services.compaction.engine"):
         assert is_context_overflow_error(exc) is False
     assert any(
         "MissingFixture" in r.getMessage() and "False" in r.getMessage()

--- a/tests/core/test_6069_overflow_keyword_general_words_removed.py
+++ b/tests/core/test_6069_overflow_keyword_general_words_removed.py
@@ -37,6 +37,17 @@ vacuous" item (4 in the issue's own numbering) are pinned in
 (the 413/litellm-type checks, already-existing and already covered there);
 see this file's own last test for the fallback-reporting witness anyway,
 via the public ``caplog`` surface (never a private field).
+
+#6073 follow-up (2026-09-10 CI failure): a 4th real overflow shape —
+``"context_length_exceeded"`` (litellm's/OpenAI's own ``error.code``
+spelling, confirmed in the installed ``litellm`` package source, arriving
+here as free text inside a plain exception's message rather than as the
+already-handled structured ``.code`` attribute) — was added to
+``_CONTEXT_OVERFLOW_KEYWORDS``. It is underscore-joined, not
+whitespace-joined, so the structural gate below was widened from "must
+contain whitespace" to "must contain whitespace OR an underscore" (see
+``_is_multi_component``'s own docstring) rather than silently adding a
+keyword the gate itself would otherwise have rejected.
 """
 from __future__ import annotations
 
@@ -213,28 +224,60 @@ def test_fallback_no_match_is_also_reported_not_silent(caplog) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _is_multi_component(kw: str) -> bool:
+    """Shared by the gate and its falsify-test below: *kw* is either a
+    whitespace-joined PHRASE or an underscore-joined error-CODE-shaped
+    identifier — never a single bare word.
+
+    #6073 (2026-09-10 CI failure, the gate's own first real collision):
+    ``"context_length_exceeded"`` is litellm's/OpenAI's own ``error.code``
+    spelling (confirmed verbatim in the installed ``litellm`` package —
+    ``litellm/types/llms/openai.py``), joined by underscores rather than
+    spaces because that is how the PROVIDER spells its own error code —
+    this module has no authority to re-punctuate a third party's literal
+    identifier into a space-joined phrase just to satisfy this gate's
+    original whitespace check. The architect's own discriminator (#6069,
+    2nd comment) never said "must contain whitespace" — it said "a
+    partial match is safe only when the spelling can ONLY appear when
+    the condition is true"; whitespace was this gate's PROXY for that
+    principle, built when every known phrase happened to be space-joined.
+    An underscore-joined multi-component identifier is exactly as narrow
+    a spelling as a space-joined phrase (arguably narrower: it is a
+    known, fixed provider error-code string, not assembled English) — so
+    the proxy is widened to "contains whitespace OR an underscore",
+    rather than silently bypassed by adding the new keyword without
+    updating the check it must still pass. A single bare word like
+    ``"limit"`` contains neither and still fails both forms of the gate."""
+    return any(ch.isspace() for ch in kw) or "_" in kw
+
+
 def test_context_overflow_keywords_contain_no_bare_words() -> None:
     """Tier 1: the structural gate itself — every element of
-    ``_CONTEXT_OVERFLOW_KEYWORDS`` must contain whitespace (i.e. be a
-    multi-word PHRASE), scoped to ONLY this one constant, never a
-    general "ban short keywords" rule over the codebase.
+    ``_CONTEXT_OVERFLOW_KEYWORDS`` must be multi-component (a whitespace-
+    joined PHRASE, or an underscore-joined error-code-shaped identifier —
+    see :func:`_is_multi_component`'s own docstring for why underscore
+    joins this gate's "not a bare word" check rather than bypassing it),
+    scoped to ONLY this one constant, never a general "ban short
+    keywords" rule over the codebase.
 
-    Deliberately STRUCTURAL (checks whether each string contains
-    whitespace), not a hand-maintained list of "banned words" — the
-    point is that nobody can re-add a bare single word to THIS constant,
-    including a word nobody has thought of yet, without this failing.
+    Deliberately STRUCTURAL (checks each string's own punctuation), not a
+    hand-maintained list of "banned words" — the point is that nobody can
+    re-add a bare single word to THIS constant, including a word nobody
+    has thought of yet, without this failing.
 
-    Disclosed limit (PR body's own caveat, restated here): whitespace-
-    containing does not mean collision-IMPOSSIBLE — a phrase like "too
-    large" could still theoretically appear in an unrelated message (the
+    Disclosed limit (PR body's own caveat, restated here): passing this
+    check does not mean collision-IMPOSSIBLE — a phrase like "too large"
+    could still theoretically appear in an unrelated message (the
     architect's own example: a filename containing "context window").
     This gate raises the bar the discriminator sets; it does not claim
     to make a false positive impossible."""
     for kw in _CONTEXT_OVERFLOW_KEYWORDS:
-        assert any(ch.isspace() for ch in kw), (
-            f"{kw!r} is a single word (no whitespace) — "
-            "_CONTEXT_OVERFLOW_KEYWORDS may only contain multi-word "
-            "phrases (see this test's own docstring and the #6069 PR body)"
+        assert _is_multi_component(kw), (
+            f"{kw!r} is a single bare word (no whitespace, no "
+            "underscore) — _CONTEXT_OVERFLOW_KEYWORDS may only contain "
+            "multi-word phrases or underscore-joined error-code-shaped "
+            "identifiers (see this test's own docstring and the #6069 "
+            "PR body)"
         )
 
 
@@ -245,7 +288,7 @@ def test_context_overflow_keywords_gate_is_falsified_by_restoring_a_bare_word() 
     sensitive to exactly this shape and not vacuously green regardless
     of content. Never mutates the production constant."""
     reverted = (*_CONTEXT_OVERFLOW_KEYWORDS, "limit")
-    assert not all(any(ch.isspace() for ch in kw) for kw in reverted), (
+    assert not all(_is_multi_component(kw) for kw in reverted), (
         "restoring a bare single word must make the structural check go "
         "red — if it doesn't, the check isn't testing what it claims to"
     )

--- a/tests/runtime/test_5256_quota_not_context_overflow.py
+++ b/tests/runtime/test_5256_quota_not_context_overflow.py
@@ -141,13 +141,18 @@ def test_a_genuine_context_overflow_still_shrinks_unaffected(monkeypatch) -> Non
     class _PlainOverflowError(Exception):
         pass
 
-    exc = _PlainOverflowError("maximum context length exceeded")
+    # #6069: ``_CONTEXT_OVERFLOW_KEYWORDS`` no longer contains the general
+    # word "context"/"length" (see that constant's own docstring) — this
+    # message now needs a remaining PHRASE to still match the keyword
+    # fallback, the same non-vacuity property this test has always
+    # wanted ("a real overflow still shrinks").
+    exc = _PlainOverflowError("the request is too large for this model")
     assert is_quota_exhausted_error(exc) is False
     assert is_context_overflow_error(exc) is True
 
     # #5329 (architect review): this assertion used to pin the OPPOSITE
     # value (True) — documenting a genuine misdiagnosis: the quota
-    # exception's own message ("The usage limit has been reached") DOES
+    # exception's own message ("The usage limit has been reached") DID
     # match is_context_overflow_error's own "limit" keyword fallback, so
     # any call site reaching this predicate WITHOUT its own quota guard
     # first (unlike #5256's outer _run_with_shrink gate, which always
@@ -158,19 +163,36 @@ def test_a_genuine_context_overflow_still_shrinks_unaffected(monkeypatch) -> Non
     # remember its own guard — this now asserts the FIXED value.
 
     # #5329 (architect review, 2nd finding — vacuity): the `is False`
-    # assertion below is green for TWO possible reasons — (a) the new
-    # quota check fired (intended) or (b) someone silently removed
-    # "limit" from _CONTEXT_OVERFLOW_KEYWORDS, making the keyword
-    # fallback a no-op regardless of quota — exactly the class of thing
-    # the ORIGINAL (pre-#5329) comment on this test named as its own
-    # reason to exist. This positive control uses the SAME "limit" text
-    # on a NON-quota exception (no .body) — it must still match True. With
-    # that pinned, the class of exceptions here differs ONLY in .body, so
-    # the `is False` below can only be attributed to the quota check.
-    class _PlainLimitMessageError(Exception):
-        pass
+    # assertion below must be green for ONLY ONE reason — the quota check
+    # firing — not because the message also happens to carry no keyword.
+    # #6069 retired the original form of this control (it used the word
+    # "limit", one of the 4 general words #6069 removed from
+    # ``_CONTEXT_OVERFLOW_KEYWORDS``; with "limit" gone, that exact text
+    # would classify False regardless of the quota guard, making the
+    # control vacuous). Re-built here with a message that carries a
+    # SURVIVING phrase ("too large") plus a quota-shaped ``.body`` — if
+    # the quota guard were ever removed, this would flip to True via the
+    # keyword fallback, same as before; if #6069's phrase instead got
+    # silently stripped too, this would already be covered by
+    # ``test_context_overflow_keywords_contain_no_bare_words`` flagging
+    # the constant directly, not by this test going silently vacuous.
+    class _QuotaErrorWithOverflowPhrase(Exception):
+        """A quota exhaustion (same ``.body`` shape ``is_quota_exhausted_
+        error`` keys on) whose free-text message ALSO carries a surviving
+        overflow phrase — the non-vacuity positive control's shape."""
 
-    assert is_context_overflow_error(
-        _PlainLimitMessageError("The usage limit has been reached"),
-    ) is True
+        def __init__(self) -> None:
+            super().__init__("The request is too large; usage limit reached")
+            self.body = {"type": "usage_limit_reached"}
+
+    positive_control = _QuotaErrorWithOverflowPhrase()
+    assert "too large" in str(positive_control).lower(), (
+        "test premise: the quota-shaped exception's own message must still "
+        "carry a surviving _CONTEXT_OVERFLOW_KEYWORDS phrase"
+    )
+    assert is_context_overflow_error(_PlainOverflowError(str(positive_control))) is True, (
+        "sanity: the SAME text, off a non-quota exception, must still match "
+        "the keyword fallback"
+    )
+    assert is_context_overflow_error(positive_control) is False
     assert is_context_overflow_error(_QuotaExhaustedError()) is False

--- a/tests/runtime/test_5568_classify_200_non_json_retryable.py
+++ b/tests/runtime/test_5568_classify_200_non_json_retryable.py
@@ -67,23 +67,28 @@ from tests._support.agent_session import make_session
 from tests._support.events import collect_events, settle
 
 # A real-shaped SSE body carrying an ``error`` frame whose own text
-# happens to contain an overflow-suggestive keyword ("context window") —
-# deliberately NOT an overflow-keyword-free body: this is what makes the
-# strip-falsify meaningful. Without this fix, `classify_llm_failure`
-# falls through to OVERFLOW, and `is_context_overflow_error`'s own
-# keyword fallback (`_CONTEXT_OVERFLOW_KEYWORDS` includes "context") then
+# happens to contain an overflow-suggestive keyword — deliberately NOT an
+# overflow-keyword-free body: this is what makes the strip-falsify
+# meaningful. Without this fix, `classify_llm_failure` falls through to
+# OVERFLOW, and `is_context_overflow_error`'s own keyword fallback then
 # matches THIS text, so the misclassification actually reproduces — a
 # keyword-free SSE body would pass this test's own assertions even
 # WITHOUT the fix (confirmed directly: reverting the fix and rerunning
 # with a keyword-free body stayed green — the exact false-negative this
 # body avoids).
+#
+# #6069: reworded off "Your input exceeds the context window" (matched
+# only via the now-removed general word "context") onto a surviving
+# PHRASE ("too large") — `_CONTEXT_OVERFLOW_KEYWORDS` no longer contains
+# any single-word general term, so the strip-falsify premise above needs
+# a phrase to still hold.
 _SSE_BODY = (
     'data: {"type": "response.created", '
     '"response": {"status": "in_progress", "output": []}}\n\n'
     'data: {"type": "response.in_progress", '
     '"response": {"status": "in_progress", "output": []}}\n\n'
     'data: {"type": "error", '
-    '"error": {"message": "Your input exceeds the context window"}}\n\n'
+    '"error": {"message": "Your input is too large for this model"}}\n\n'
 )
 
 

--- a/tests/runtime/test_5577_unify_overflow_classification_arms.py
+++ b/tests/runtime/test_5577_unify_overflow_classification_arms.py
@@ -13,8 +13,9 @@ ONLY quota (``is_quota_exhausted_error``) first; arm② excluded nothing at
 all. Neither excluded a FATAL exception (a plain ``AttributeError``/
 ``TypeError``/``KeyError`` in reyn's own glue code) or a RETRYABLE one
 (5xx/timeout/connection failure) whose ``str()`` happened to contain an
-overflow keyword ("context"/"token"/"length"/"limit"/"too long"/"too
-large") — both classes got misdiagnosed as overflow and entered the
+overflow keyword (at the time: "context"/"token"/"length"/"limit"/"too
+long"/"too large" — #6069 later removed the 4 general words, keeping
+only the phrases) — both classes got misdiagnosed as overflow and entered the
 shrink ladder, burning real LLM calls chasing a cause no amount of
 shrinking can fix (#3783's own owner ruling — the defect class #5543
 created ``classify_llm_failure`` to close, left open on these two arms).
@@ -71,10 +72,13 @@ from tests._support.events import collect_events, settle
 def test_arm1_fatal_exception_does_not_enter_shrink_ladder(monkeypatch) -> None:
     """Tier 2: #5577 accept — arm① (``_run_with_shrink``'s outer except).
 
-    A FATAL-shaped exception (``AttributeError`` whose message contains
-    "token" — the exact shape #5568's own incident produced) on the VERY
-    FIRST LLM call must not enter the shrink ladder: exactly one LLM call,
-    no ``router_context_overflow_detected`` event, the session survives.
+    A FATAL-shaped exception (``AttributeError`` whose message contains a
+    surviving ``_CONTEXT_OVERFLOW_KEYWORDS`` PHRASE — #6069 reworded this
+    off the general word "token", removed from that constant, onto "too
+    large" so the premise "even though the message WOULD otherwise match
+    the keyword fallback" still holds) on the VERY FIRST LLM call must not
+    enter the shrink ladder: exactly one LLM call, no
+    ``router_context_overflow_detected`` event, the session survives.
     """
     session = make_session(agent_name="arm1_fatal_test")
     collected = collect_events(session)
@@ -84,7 +88,7 @@ def test_arm1_fatal_exception_does_not_enter_shrink_ladder(monkeypatch) -> None:
     async def _fake_call_llm_tools(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        raise AttributeError("'NoneType' object has no attribute 'token'")
+        raise AttributeError("'NoneType' object has no attribute 'foo' (input too large)")
 
     monkeypatch.setattr(
         "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
@@ -102,7 +106,8 @@ def test_arm1_fatal_exception_does_not_enter_shrink_ladder(monkeypatch) -> None:
     kinds = [e.type for e in collected]
     assert "router_context_overflow_detected" not in kinds, (
         "a FATAL exception (AttributeError) must never be classified as "
-        "context overflow, even though its message contains 'token'"
+        "context overflow, even though its message contains a surviving "
+        "overflow phrase ('too large')"
     )
     terminated = [e for e in collected if e.type == "router_loop_terminated_by_exception"]
     assert terminated, "the exception must reach the generic catch-all's own P6 instrument"
@@ -118,7 +123,7 @@ def test_arm1_genuine_overflow_still_shrinks(monkeypatch) -> None:
     collected = collect_events(session)
 
     async def _fake_call_llm_tools(*args, **kwargs):
-        raise RuntimeError("maximum context length exceeded")
+        raise RuntimeError("the request is too large for this model's context")
 
     monkeypatch.setattr(
         "reyn.runtime.router_loop.call_llm_tools", _fake_call_llm_tools,
@@ -158,7 +163,7 @@ def test_arm2_fatal_exception_on_a_retry_stops_the_ladder(monkeypatch) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            raise RuntimeError("maximum context length exceeded")
+            raise RuntimeError("the request is too large for this model's context")
         raise AttributeError("'NoneType' object has no attribute 'token'")
 
     monkeypatch.setattr(

--- a/tests/runtime/test_5699_compaction_window_fold_parity.py
+++ b/tests/runtime/test_5699_compaction_window_fold_parity.py
@@ -254,14 +254,60 @@ def test_is_shrinkable_overflow_enters_the_ladder_for_a_code_only_signal():
     assert is_shrinkable_overflow(exc)
 
 
-def test_a_message_with_the_keyword_but_a_different_code_is_still_detected():
+def test_a_message_with_a_surviving_phrase_but_a_different_code_is_still_detected():
     """Tier 2: non-regression — the pre-existing keyword fallback must
     still work for a shape carrying no ``code`` at all (or a
     ``code`` this allowlist does not name), so the #5699 fix is additive,
-    not a replacement of the keyword path."""
+    not a replacement of the keyword path.
+
+    #6069 reworded this off "This model's maximum context length is
+    128000 tokens." (general words only, no phrase — see
+    ``test_6069_real_openai_style_overflow_message_without_a_phrase_is_
+    now_missed`` right below for what that ORIGINAL message now does)
+    onto a message carrying a surviving PHRASE."""
     exc = litellm.BadRequestError(
-        message="This model's maximum context length is 128000 tokens.",
+        message="This model's maximum context length is 128000 tokens; "
+        "the request is too large.",
         model="gpt-4", llm_provider="openai",
     )
     assert getattr(exc, "code", None) != "context_length_exceeded"
     assert is_context_overflow_error(exc)
+
+
+def test_6069_real_openai_style_overflow_message_without_a_phrase_is_now_missed():
+    """Tier 2: #6069's own required positive-control finding, pinned as a
+    test rather than only asserted in the PR body.
+
+    "This model's maximum context length is 128000 tokens." is the exact
+    pre-#6069 fixture this file's sibling test above used (see git
+    history) — modelled on OpenAI's own real API error text for a
+    context-length overflow, and the shape #5699's own incident
+    investigation built to confirm the gap that issue fixed. It carries
+    NEITHER "too long" NOR "too large" — it relied SOLELY on the two
+    general words #6069 removed ("context"/"length").
+
+    This is the literal case the issue's "positive control" step asked
+    to check BEFORE finalizing the word removal: verify real/historical
+    overflow text still classifies True. It does not. This is a genuine,
+    disclosed false-negative trade, not a bug introduced by accident —
+    see the PR body and ``_CONTEXT_OVERFLOW_KEYWORDS``'s own docstring
+    for why it is accepted anyway: a REAL, un-flattened provider response
+    for this exact message carries a structured ``error.code:
+    "context_length_exceeded"`` field (caught by the stage checked BEFORE
+    this one, #5699) — this keyword tuple is the fallback of last resort
+    for when BOTH the type AND the structured code have been stripped by
+    an intermediate proxy, a narrower situation than "any provider
+    message lacking a phrase"."""
+    exc = litellm.BadRequestError(
+        message="This model's maximum context length is 128000 tokens.",
+        model="gpt-4", llm_provider="openai",
+    )
+    assert getattr(exc, "code", None) != "context_length_exceeded", (
+        "test premise: no structured code field present"
+    )
+    assert not is_context_overflow_error(exc), (
+        "disclosed #6069 finding: this real-shaped message no longer "
+        "classifies as overflow once the general words are removed — "
+        "if this assertion ever flips back to True-required, re-read the "
+        "#6069 issue and PR body before 'fixing' it"
+    )

--- a/tests/runtime/test_5699_compaction_window_fold_parity.py
+++ b/tests/runtime/test_5699_compaction_window_fold_parity.py
@@ -274,30 +274,31 @@ def test_a_message_with_a_surviving_phrase_but_a_different_code_is_still_detecte
     assert is_context_overflow_error(exc)
 
 
-def test_6069_real_openai_style_overflow_message_without_a_phrase_is_now_missed():
-    """Tier 2: #6069's own required positive-control finding, pinned as a
-    test rather than only asserted in the PR body.
+def test_6069_real_openai_style_overflow_message_is_caught_via_phrase():
+    """Tier 2: #6069's own required positive-control, re-verified fixed
+    after the #6073 co-vet (architect + lead-coder) — not merely
+    disclosed.
 
     "This model's maximum context length is 128000 tokens." is the exact
-    pre-#6069 fixture this file's sibling test above used (see git
-    history) — modelled on OpenAI's own real API error text for a
-    context-length overflow, and the shape #5699's own incident
-    investigation built to confirm the gap that issue fixed. It carries
-    NEITHER "too long" NOR "too large" — it relied SOLELY on the two
-    general words #6069 removed ("context"/"length").
+    pre-#6069 fixture this file's sibling test above used (see the prior
+    revision of this file) — modelled on OpenAI's own real API error
+    text for a context-length overflow, and the shape #5699's own
+    incident investigation built to confirm the gap that issue fixed. It
+    carries NEITHER "too long" NOR "too large" — it relied SOLELY on
+    the two general words #6069 removed ("context"/"length").
 
-    This is the literal case the issue's "positive control" step asked
-    to check BEFORE finalizing the word removal: verify real/historical
-    overflow text still classifies True. It does not. This is a genuine,
-    disclosed false-negative trade, not a bug introduced by accident —
-    see the PR body and ``_CONTEXT_OVERFLOW_KEYWORDS``'s own docstring
-    for why it is accepted anyway: a REAL, un-flattened provider response
-    for this exact message carries a structured ``error.code:
-    "context_length_exceeded"`` field (caught by the stage checked BEFORE
-    this one, #5699) — this keyword tuple is the fallback of last resort
-    for when BOTH the type AND the structured code have been stripped by
-    an intermediate proxy, a narrower situation than "any provider
-    message lacking a phrase"."""
+    #6069's PR (#6073) first landed with this positive control going RED
+    (the message no longer classified as overflow at all) — a genuine
+    false negative, not an accepted trade: the co-vet ruled it must be
+    FIXED, since this is the exact OpenAI-proxy-flattened-overflow shape
+    the keyword fallback exists to catch. Fixed by adding 3 PHRASES
+    derived strictly from this one observed message --
+    ``"maximum context"``/``"context length"``/``"context window"`` (see
+    ``_CONTEXT_OVERFLOW_KEYWORDS``'s own docstring for the disclosed
+    "observed 1, not exhaustive" scope of that addition) — still
+    multi-word phrases, so the structural gate
+    (``test_context_overflow_keywords_contain_no_bare_words``) keeps
+    passing; this is not a re-add of a bare general word."""
     exc = litellm.BadRequestError(
         message="This model's maximum context length is 128000 tokens.",
         model="gpt-4", llm_provider="openai",
@@ -305,9 +306,9 @@ def test_6069_real_openai_style_overflow_message_without_a_phrase_is_now_missed(
     assert getattr(exc, "code", None) != "context_length_exceeded", (
         "test premise: no structured code field present"
     )
-    assert not is_context_overflow_error(exc), (
-        "disclosed #6069 finding: this real-shaped message no longer "
-        "classifies as overflow once the general words are removed — "
-        "if this assertion ever flips back to True-required, re-read the "
-        "#6069 issue and PR body before 'fixing' it"
+    assert is_context_overflow_error(exc), (
+        "#6073 fix: this real-shaped message must classify as overflow "
+        "again via the 'maximum context'/'context length' phrase — if "
+        "this assertion ever goes red, re-read #6069/#6073 before "
+        "re-removing the phrase"
     )

--- a/tests/runtime/test_retry_loop_chat_wiring_1125.py
+++ b/tests/runtime/test_retry_loop_chat_wiring_1125.py
@@ -470,7 +470,14 @@ def test_token_axis_fold_persist_policy_controls_compaction(
     class _AlwaysNonByteOverflowLoop:
         async def run(self, *, user_text: str, history: list) -> None:
             # No status_code — a plain context-length overflow, not a 413.
-            raise RuntimeError("context_length_exceeded: too many tokens")
+            # Real observed provider text (#6069's own positive-control
+            # fixture, itself modelled on OpenAI's actual API error copy) —
+            # this stub's only requirement is "a non-413, non-status_code
+            # overflow", which any textually-plausible overflow message
+            # satisfies; it does not need an invented spelling.
+            raise RuntimeError(
+                "This model's maximum context length is 128000 tokens."
+            )
 
     with pytest.raises(UnrecoveredError) as excinfo:
         asyncio.run(

--- a/tests/runtime/test_router_loop_pure_helpers.py
+++ b/tests/runtime/test_router_loop_pure_helpers.py
@@ -118,8 +118,18 @@ def test_is_context_overflow_error_bare_context_word_no_longer_matches() -> None
     containing "limit"). 'context'/'token'/'length'/'limit' fail the
     architect's own discriminator (the spelling can appear when the
     condition is NOT true) and were removed; only multi-word phrases
-    remain."""
-    assert is_context_overflow_error(Exception("context window exceeded")) is False
+    remain.
+
+    #6073 (positive-control follow-up): the fixture below is deliberately
+    "context exceeded", NOT "context window exceeded" — #6073's own fix
+    added the observed phrase "context window" back to
+    ``_CONTEXT_OVERFLOW_KEYWORDS`` (see that constant's own docstring),
+    so a fixture using that exact 2-word spelling would now match via the
+    PHRASE, not the bare word, and stop pinning what this test's name
+    claims. "context exceeded" carries neither "context window" nor
+    "context length" nor "maximum context" — still an isolated bare
+    word."""
+    assert is_context_overflow_error(Exception("context exceeded")) is False
 
 
 def test_is_context_overflow_error_bare_token_word_no_longer_matches() -> None:

--- a/tests/runtime/test_router_loop_pure_helpers.py
+++ b/tests/runtime/test_router_loop_pure_helpers.py
@@ -107,19 +107,29 @@ def test_overflow_ref_text_fallback_mime_type() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_is_context_overflow_error_context_keyword() -> None:
-    """Tier 2: exception message containing 'context' → True."""
-    assert is_context_overflow_error(Exception("context window exceeded")) is True
+def test_is_context_overflow_error_bare_context_word_no_longer_matches() -> None:
+    """Tier 2: #6069 — a message containing ONLY the general word
+    'context' (no surviving phrase, no typed/structured signal) → False.
+
+    This pins the DELIBERATE behaviour change: 'context' used to be in
+    ``_CONTEXT_OVERFLOW_KEYWORDS`` on its own and matched any message
+    containing it, including one with nothing to do with overflow (the
+    real false positive this issue started from: a fixture FILENAME
+    containing "limit"). 'context'/'token'/'length'/'limit' fail the
+    architect's own discriminator (the spelling can appear when the
+    condition is NOT true) and were removed; only multi-word phrases
+    remain."""
+    assert is_context_overflow_error(Exception("context window exceeded")) is False
 
 
-def test_is_context_overflow_error_token_keyword() -> None:
-    """Tier 2: exception message containing 'token' → True."""
-    assert is_context_overflow_error(Exception("too many tokens")) is True
+def test_is_context_overflow_error_bare_token_word_no_longer_matches() -> None:
+    """Tier 2: #6069 — same change as above, for 'token'."""
+    assert is_context_overflow_error(Exception("too many tokens")) is False
 
 
-def test_is_context_overflow_error_length_keyword() -> None:
-    """Tier 2: exception message containing 'length' → True."""
-    assert is_context_overflow_error(Exception("max length exceeded")) is True
+def test_is_context_overflow_error_bare_length_word_no_longer_matches() -> None:
+    """Tier 2: #6069 — same change as above, for 'length'."""
+    assert is_context_overflow_error(Exception("max length exceeded")) is False
 
 
 def test_is_context_overflow_error_too_long_keyword() -> None:
@@ -145,8 +155,13 @@ def test_is_context_overflow_error_unrelated_exception() -> None:
 
 
 def test_is_context_overflow_error_case_insensitive() -> None:
-    """Tier 2: keyword match is case-insensitive."""
-    assert is_context_overflow_error(Exception("CONTEXT_LENGTH_EXCEEDED")) is True
+    """Tier 2: keyword match is case-insensitive.
+
+    #6069: reworded off "CONTEXT_LENGTH_EXCEEDED" (general words only,
+    no surviving phrase — would now be False) onto a surviving PHRASE
+    ("too large"), upper-cased, so this still actually exercises case-
+    insensitivity rather than an artifact of the old general-word set."""
+    assert is_context_overflow_error(Exception("INPUT IS TOO LARGE")) is True
 
 
 def test_is_context_overflow_error_recognises_the_real_litellm_type() -> None:
@@ -193,9 +208,10 @@ def test_is_context_overflow_error_type_alone_recovers_when_message_has_no_keywo
             return "the request could not be completed"
 
     exc = _RewordedOverflow(message="irrelevant", model="m", llm_provider="p")
+    from reyn.services.compaction.engine import _CONTEXT_OVERFLOW_KEYWORDS
+
     assert not any(
-        kw in str(exc).lower()
-        for kw in ("context", "token", "length", "limit", "too long", "too large")
+        kw in str(exc).lower() for kw in _CONTEXT_OVERFLOW_KEYWORDS
     ), "test premise: the overridden __str__ must carry no overflow keyword"
     assert isinstance(exc, litellm.ContextWindowExceededError)  # sanity: real subclass
     assert is_context_overflow_error(exc) is True
@@ -215,8 +231,12 @@ def test_is_context_overflow_error_substring_still_catches_a_flattened_type() ->
     case, not dead code the type check already covers."""
     import litellm
 
+    # #6069: reworded onto a surviving PHRASE ("too large") — the
+    # original message ("the context length exceeds the model's limit")
+    # matched only via the now-removed general words "context"/"length"/
+    # "limit" and would no longer match at all.
     exc = litellm.BadRequestError(
-        message="the context length exceeds the model's limit",
+        message="the input is too large for the model's context window",
         model="m", llm_provider="p",
     )
     assert not isinstance(exc, litellm.ContextWindowExceededError), (


### PR DESCRIPTION
**[backlog-watcher]** — part of #6069: `_CONTEXT_OVERFLOW_KEYWORDS` no longer contains a general word, fallback decisions are now reported, and the constant has a structural gate.

## What changed (exactly the 3 things the settled design asked for)

1. **Removed the 4 general words** — `context`, `token`, `length`, `limit` — from `_CONTEXT_OVERFLOW_KEYWORDS` (`src/reyn/services/compaction/engine.py`). Every phrase (`too long`, `too large`) is untouched. This is the exact false positive #6069/#6070 started from: a CI `MissingFixture` whose message carried a fixture *filename* (`safety_limit_no_listener.jsonl`) matched `"limit"` by coincidence.
2. **Fallback decisions are now reported.** `is_context_overflow_error`'s keyword-fallback path now logs (`logger.info`) the matched spelling (or its absence) and the exception's type name, whichever way it decides — the exact "黙って分類しない" (don't silently classify) the issue asked for.
3. **A structural gate**, scoped to ONLY `_CONTEXT_OVERFLOW_KEYWORDS`: `tests/core/test_6069_overflow_keyword_general_words_removed.py::test_context_overflow_keywords_contain_no_bare_words` asserts every element contains whitespace. Structural (checks for whitespace), not a hand-maintained banned-word list — nobody can re-add a bare single word to this one constant, including a word nobody has thought of yet, without this test going red. Its own strip-falsify companion test confirms the check is sensitive to exactly this shape.

**Out of scope, deliberately untouched** (architect's own ruling): the other 5 family sites — 3× `"HTTP 404" in/not in str(exc)` (`core/op_runtime/mcp_install.py`, `core/registry/client.py`, `mcp/registry.py`), `"does not support parameter"` and `"encoding_format"` (both `runtime/router_loop.py`). These pass the architect's discriminator (the spelling can only appear when the condition is true) — touching them would create false rejects on sites that are currently correct. `test_out_of_scope_http_404_sites_are_unchanged` in the new test file reads each site's literal source text as a witness this PR did not sweep them in under the same family name.

## ⚠️ This gate raises the bar — it does not make collision impossible

Per lead-coder's explicit instruction, stating this plainly: a phrase like `"too large"` can still theoretically collide with an unrelated message (the architect's own example — a filename containing "context window"). The structural gate enforces "no bare single word", which is a materially narrower spelling than a general word, **not** a guarantee that no partial-string match can ever misfire. Do not read "the gate exists" as "collision-proof."

## Required positive control (done BEFORE finalizing, per lead-coder's explicit ask)

Searched git history (`git log -p` on the constant, back to its #3783 introduction) and the existing test suite for real/historical provider overflow message text this keyword set was written to catch.

**Found one corpus, and it does NOT fully survive the removal** — disclosing this rather than papering over it:

- The #5699 real-incident investigation's own test fixture uses `"This model's maximum context length is 128000 tokens."` — modelled on OpenAI's real API error text for a context-length overflow. It carries **neither** `"too long"` nor `"too large"` — it matched *only* via the now-removed general words `"context"`/`"length"`.
- Confirmed directly: this exact message, with no `status_code`, no structured `.code`, and not the typed `litellm.ContextWindowExceededError`, now classifies `False` via `is_context_overflow_error` — a genuine, disclosed false-negative trade. Pinned as its own test: `tests/runtime/test_5699_compaction_window_fold_parity.py::test_6069_real_openai_style_overflow_message_without_a_phrase_is_now_missed`.
- Why this is accepted anyway: a **real, un-flattened** provider response for this exact message carries a structured `error.code: "context_length_exceeded"` field (OpenAI's own SDK parses this off the response body), which is checked *before* the keyword fallback ever runs (#5699's own stage). The keyword tuple is the fallback of last resort *only* for the narrower case where an intermediate proxy has stripped **both** the typed exception class **and** the structured `code` field, keeping only free text. This narrower case is not proven to be non-empty — no positive, real-world example of a provider/proxy stripping both signals while preserving a phrase-free message was found (the module's own comment at #5699 documents a synthetic construction, not an observed-in-the-wild one).
- Every other real/recorded overflow-shaped fixture this repo's test suite already exercises (`"the prompt is too long"`, `"input is too large"`, 413-status-code shapes, `ContextWindowExceededError` instances, `error.code: context_length_exceeded`) still classifies `True` after the removal — verified by the full scoped test run below.

This is a genuine tension worth flagging for lead-coder's own judgment: the positive control did **not** come back clean 100%-of-the-time; one real message shape loses keyword-level coverage. I implemented the ruling as given (remove exactly the 4 words) since that is the settled design, and disclosed the gap rather than silently keeping a word back in or silently proceeding as if the check passed.

## Acceptance criteria

1. `MissingFixture(".../safety_limit_no_listener.jsonl...")` → `False` — ✅ `test_missing_fixture_filename_collision_is_no_longer_overflow`.
2. Present sibling (flattened 3rd-party error, no typed signal, message with a surviving phrase) → `True` — ✅ `test_present_sibling_flattened_third_party_phrase_is_still_overflow`.
3. Out-of-scope sites unchanged — ✅ `test_out_of_scope_http_404_sites_are_unchanged` (reads literal source text).
4. The 2 definitive non-keyword signal checks already in `is_context_overflow_error` (the `litellm.ContextWindowExceededError` type check, `status_code == 413`) still classify `True`, not vacuous — already covered by `tests/core/test_4381_stage1_overflow_classification.py` and `tests/runtime/test_router_loop_pure_helpers.py::test_is_context_overflow_error_recognises_the_real_litellm_type`. **Note**: this PR does *not* add a new `isinstance(exc, (ContextOverflowError, CompactionOverflowError))` check inside `is_context_overflow_error` itself — that was the architect's original (1st-comment) "stage 1" proposal, explicitly NOT listed in this PR's "what to implement" scope, and its own reachability through this predicate was left unconfirmed by the architect ("到達するかは追っていません"). Confirmed directly: today, a `ContextOverflowError`/`CompactionOverflowError` with no phrase in its message does **not** classify `True` through `is_context_overflow_error` — it relies on the caller's own `except (CompactionOverflowError, ContextOverflowError)` type-catch instead, which is how `retry_loop`'s existing except clause already handles it. Flagging this explicitly rather than silently assuming it's covered — if stage 1's explicit isinstance check is still wanted, it's a separate, follow-up change.
5. Fallback decisions reported — ✅ `test_fallback_match_is_reported_not_silent` / `test_fallback_no_match_is_also_reported_not_silent` (via the public `caplog` surface).
6. Strip-falsify: restoring the 4 words → the structural gate goes red (`test_context_overflow_keywords_gate_is_falsified_by_restoring_a_bare_word`), classification tests stay green either way (`test_strip_falsify_restoring_a_general_word_reclassifies_the_fixture_true` shows the ORIGINAL false positive reproduces with the word restored, on a local copy — never mutating the production constant).
7. False-negative positive control — reported above (found a corpus; it does not fully survive; disclosed, not papered over).

## Local gates (all green)

`ruff check .` / `python scripts/test_tier_audit.py --strict <changed test files>` / `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py` / `python scripts/mypy_ratchet.py` / `python scripts/flat_tests_ratchet.py` / `python scripts/check_tests_path_literal_reference.py` / the `tests/`-path gates (`check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`) / scoped `pytest` (195 passed across every touched + downstream-affected test file). CI will run the full suite in a clean checkout.

## Test plan

- [x] `ruff check .`
- [x] `python scripts/test_tier_audit.py --strict` on all changed test files
- [x] `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py`
- [x] `python scripts/mypy_ratchet.py`
- [x] `python scripts/flat_tests_ratchet.py`
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] `tests/`-path gates (bare-import, file-depth, subprocess-pin, no-core-dep-importorskip, suspected-time-dependence)
- [x] Scoped `pytest` — 195 passed, 0 failed, 0 skipped
- [x] (skipped — Visual, standing waiver 2026-08-08)

part of #6069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5
