### PR TITLE
fix(#6076): pipeline flowview progress -- final step showed N+1/N ("5/4")

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -2038,6 +2038,22 @@ class PipelineExecutor:
             step = steps[i]
             kind = _step_kind(step)
             if events is not None:
+                # #6076: ``step_index`` on EVERY pipeline_step_* event (both
+                # kinds, and record_pipeline_state's own field below, and
+                # PipelineResult.step_index at the bottom of this method) is
+                # the SAME thing throughout this subsystem: the count of
+                # steps completed so far. Here, before step `i` has run,
+                # that count IS `i` (0-based: steps 0..i-1 are done) —
+                # emitted UN-ADJUSTED. A consumer wanting "how many are
+                # done" reads this value directly, for EITHER event kind
+                # (see pipeline_step_completed below for why its own value
+                # is already the done-count too, needing no adjustment
+                # there either) — a consumer-side "+1 for completed"
+                # double-counts against THAT event's own already-
+                # incremented value; that double-count is the exact #6076
+                # regression ("5/4" at the final step) presenter.py's own
+                # fix removed. See that fix's own docstring for the full
+                # account.
                 events.emit(
                     "pipeline_step_started",
                     run_id=run_id, step_index=i, step_kind=kind, total_steps=total_steps,
@@ -2089,6 +2105,15 @@ class PipelineExecutor:
                 durable=durable,
             )
             if events is not None:
+                # #6076: `step_index` here is `i + 1` (line above) — ALREADY
+                # the count of steps done, INCLUDING this one — the same
+                # "steps completed so far" meaning `pipeline_step_started`
+                # emits (see that call site's own comment). A consumer must
+                # read it as-is; adding another +1 "because this is the
+                # completed event" double-counts. At the FINAL step
+                # (i == total_steps - 1), step_index here == total_steps
+                # exactly — a further +1 is what produced the #6076 "5/4"
+                # regression.
                 events.emit(
                     "pipeline_step_completed",
                     run_id=run_id, step_index=step_index, step_kind=kind,

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -188,6 +188,25 @@ def _pipeline_row(meta: dict) -> "RenderableType":
     A run whose ``total_steps`` is unknown gets the step count with no bar,
     rather than a bar over a guessed denominator: a bar that is not measuring
     anything is worse than none.
+
+    #6076: ``step_index`` is READ DIRECTLY as the "steps completed so far"
+    count, for BOTH ``pipeline_step_started`` and ``pipeline_step_completed``
+    — never adjusted here based on ``step_event``. This is
+    ``core/pipeline/executor.py``'s own canonical meaning for the field
+    (see ``_run_from``'s own comment at its two ``events.emit`` call sites,
+    and matches ``PipelineResult.step_index`` / ``record_pipeline_state``'s
+    own resume-``start_index`` — the SAME name means the SAME thing
+    everywhere in the pipeline subsystem): ``i`` steps are done before step
+    ``i`` STARTS, and ``i + 1`` are done once step ``i`` COMPLETES —
+    executor.py emits exactly those two values already, un-adjusted. A
+    consumer that adds its own ``+1`` "for completed" double-counts: at the
+    FINAL step's completion, ``step_index`` already equals ``total_steps``,
+    so a further ``+1`` produced ``total_steps + 1`` — the owner-reported
+    ``"5/4"`` regression (#6076) this fix closes. See
+    ``lifecycle_forwarder._enqueue_pipeline_step``'s own comment for why
+    ITS "started" branch legitimately adds 1 anyway — a DIFFERENT, correct
+    convention (1-based CURRENT step ordinal for a text line, not a
+    done-count for a progress bar), not a copy of this bug.
     """
     from rich.progress_bar import ProgressBar
     from rich.table import Table
@@ -196,9 +215,7 @@ def _pipeline_row(meta: dict) -> "RenderableType":
     kind = str(meta.get("step_kind") or "?")
     index = meta.get("step_index")
     total = meta.get("total_steps")
-    done = (index or 0) + (
-        1 if meta.get("step_event") == "pipeline_step_completed" else 0
-    )
+    done = index or 0
 
     if not (isinstance(total, int) and total > 0):
         return Text.assemble((name, "bold"), (f"  step {done}  ", ""), (kind, _CC_DIM))

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -683,6 +683,23 @@ class ChatLifecycleForwarder:
         self._pipeline_subs[run_id] = (driver_events, _on_driver_event, tool)
 
     def _enqueue_pipeline_step(self, pipeline_name: str, event_type: str, data: dict) -> None:
+        # #6076: `data["step_index"]` is executor.py's own "steps completed
+        # so far" count (0 before step 0 starts, i before step i starts,
+        # i+1 once step i completes — see that emit site's own comment).
+        # `n` here is DELIBERATELY a different quantity from that raw
+        # count: the 1-based ORDINAL of the step this text line is ABOUT
+        # ("step 3 of 10 starting" / "step 3 of 10 done"), which for
+        # "started" is `step_index + 1` and for "completed" is
+        # `step_index` unmodified (step_index is already that step's own
+        # 1-based number once it has completed). Not the same "+1 for
+        # completed" bug presenter.py's own progress-bar `done` count fix
+        # closed (#6076) — that consumer wants steps-done as a fraction
+        # of total for a BAR, this one wants a step's own ordinal for a
+        # TEXT line, and the two conventions are not interchangeable.
+        # Neither ever exceeds total_steps: `step_index` ranges 0..
+        # total_steps-1 while "started", so `n = step_index + 1` ranges
+        # 1..total_steps; `step_index` ranges 1..total_steps while
+        # "completed", read unmodified.
         step_index = data.get("step_index")
         total_steps = data.get("total_steps")
         step_kind = data.get("step_kind", "?")

--- a/tests/interfaces/test_pipeline_single_flow_entry_3641.py
+++ b/tests/interfaces/test_pipeline_single_flow_entry_3641.py
@@ -32,10 +32,23 @@ def _plain(meta: dict) -> str:
 
 
 def _step_meta(index: int, *, total: "int | None" = 15, completed: bool = False) -> dict:
+    """*index* is the CONCEPTUAL 0-based step number ("step 6 of the run").
+
+    #6076: the ``step_index`` VALUE this puts in meta is NOT always
+    ``index`` — it matches whatever ``core/pipeline/executor.py``'s own
+    ``_run_from`` actually emits for that event kind (see that method's
+    own comment at its two ``events.emit`` call sites): ``index`` while
+    started (``i`` steps done before step ``i`` starts), ``index + 1``
+    while completed (``i + 1`` done once step ``i`` finishes). A fixture
+    that instead put ``index`` unmodified for the completed case (this
+    file's own pre-#6076 shape) was quietly out of step with the real
+    producer, and pinned presenter.py's OWN pre-#6076 bug (a redundant
+    consumer-side ``+1``) as if it were correct.
+    """
     return {
         PIPELINE_RUN_KEY: "run-1",
         "pipeline_name": "rag_ingest.ingest",
-        "step_index": index,
+        "step_index": index + 1 if completed else index,
         "total_steps": total,
         "step_kind": "transform",
         "step_event": (
@@ -91,3 +104,26 @@ def test_the_row_does_not_read_the_frame_text() -> None:
     row = _plain(_step_meta(2))
 
     assert "rag_ingest.ingest" in row  # rendered without any msg.text existing
+
+
+def test_the_final_steps_completion_shows_done_equal_to_total_not_over_it() -> None:
+    """Tier 2: #6076 regression — the owner-reported "5/4" (a completed
+    count exceeding its own total). The LAST step of an N-step run
+    completing carries ``step_index == total_steps`` already (the real
+    ``core/pipeline/executor.py`` shape — see ``_step_meta``'s own #6076
+    docstring); the row must show that value UN-ADJUSTED, never
+    ``total_steps + 1``.
+
+    NON-VACUITY (strip-falsified by hand, in-file Edit -> run -> Edit
+    back): restoring presenter.py's old ``done = (index or 0) + (1 if
+    ... == "pipeline_step_completed" else 0)`` line makes this assertion
+    fail with "5/4" for this exact fixture (index=3, total=4) — the
+    literal shape the owner reported.
+    """
+    row = _plain(_step_meta(3, total=4, completed=True))
+
+    assert "4/4" in row, (
+        f"expected the final step's completion to read 4/4, not an "
+        f"over-total count: {row!r}"
+    )
+    assert "5/4" not in row


### PR DESCRIPTION
**[tui-coder]** — part of #6076 (①「5/4」のみ — ②「終了後も張り付く」は束ねません、lead-coder明示指示 → https://github.com/tya5/reyn/issues/6076#issuecomment-5617797790).

## 根拠（lead-coder裁定）

`core/pipeline/executor.py`の`pipeline_step_completed`は既に`step_index = i + 1`（完了数そのもの、`pipeline_step_started`と同じ「ここまでに完了したstep数」という意味を、`PipelineResult.step_index`/`record_pipeline_state`のresume index規約とも一貫して共有）。`presenter.py`の`_pipeline_row`がcompletedの枝でさらに`+1`していたため、最終stepで`done = total_steps + 1` → owner報告の「5/4」。

## 修正

- **consumer側**（`presenter.py`）: `step_index`を両event種別ともそのまま`done`として読む。per-kind調整を削除。
- **「+1を消すだけで終えない」（lead-coder指示）**: 穴（`step_index`の意味がevent種別間で自明でない）をコードで閉じました:
  - `executor.py`の両`events.emit`呼び出しに、正準的な意味を明記するコメントを追加（次にeventを足す人がここを読めば同じ誤解をしない形）。
  - `lifecycle_forwarder.py`の`_enqueue_pipeline_step`は**別の、正しい**規約（doneカウントではなく1-basedの"現在のstep番号"、text行向け）を独自に採用していたことが判明 — こちらは壊れていない（overflowしない）ためロジックはそのままに、presenter側の規約と混同されないよう明記のコメントを追加。2つのconsumerが既に別々の解釈にdriftしていた事実自体が、契約を書き下す必要性の証拠です。
  - `test_pipeline_single_flow_entry_3641.py`の`_step_meta`フィクスチャ自体が実際のexecutor出力と不整合でした（completed時も生のindexをそのまま渡していた — presenterの旧バグをそのままpinしていた形）。実際のproducerと同じ計算に修正 — 既存assertionは全て変更なしで緑のままです（表示テキスト自体はたまたま正しかったため）。

## Tests

新規1本、owner報告と同じ形（4-stepの最終step完了）で"4/4"を、"5/4"ではないことを assert。strip-falsify済み（presenter旧コード復元で"5/4"を文字通り再現、既存testの1本も同時に壊れることを確認）。

## Gates

`ruff`、`test_tier_audit.py --strict`、`verify_module_docstrings.py`、`mypy_ratchet.py`、`flat_tests_ratchet.py`、`check_tests_path_literal_reference.py`、tests/-pathゲート、`silent_except_ratchet.py`、`check_silent_except_return_reachability.py` 全緑。関連sweep（test_5731_pipeline_flowview_entry.py / test_pipeline_tui_bridge_2570.py / test_pipeline_is6_attached.py）全緑。

## Test plan
- [x] `pytest tests/interfaces/test_pipeline_single_flow_entry_3641.py`（5/5、新規含む）
- [x] 上記gate + related sweep全緑
- [x] (skipped — Visual, standing waiver)

part of #6076 — ②「終了後も張り付く」（`_sweep_orphaned_running_tools`が`self._pipeline_runs`に触れない、別issue化候補）は本PRの対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
