### PR TITLE
fix(part of #6076): pipeline row stuck open forever when the turn ends before its completion frame

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -5949,7 +5949,13 @@ class TextualChatApp(App):
         don't-fabricate-a-failure lesson). Every step is guarded so one orphan's
         settle failure never kills the pump or leaves the others un-swept; the
         dict is cleared unconditionally at the end so no turn's leftovers bleed
-        into the next."""
+        into the next.
+
+        Also sweeps :attr:`_pipeline_runs` (#6076 ②) via
+        :meth:`_sweep_orphaned_pipeline_runs` at the end — a SEPARATE dict
+        this method never touched before, so a ``run_pipeline`` row whose
+        own completion frame never arrived stayed RUNNING forever even
+        though every tool-row orphan above it settled correctly."""
         for entry in list(self._running_tools.values()):
             try:
                 self._flow.stop_entry_animation(entry)
@@ -6008,6 +6014,47 @@ class TextualChatApp(App):
                     logger.exception(
                         "textual chat: could not settle an orphaned call-parent"
                     )
+        self._sweep_orphaned_pipeline_runs()
+
+    def _sweep_orphaned_pipeline_runs(self) -> None:
+        """Force-settle any pipeline row still open in :attr:`_pipeline_runs`
+        at a TURN BOUNDARY (#6076 ②).
+
+        The SAME orphan class :meth:`_sweep_orphaned_running_tools` above
+        closes for a tool row — a ``run_pipeline`` call's own completion
+        frame never arrives (the turn ends first: a cancel, a reconnect, an
+        unrelated failure elsewhere in the turn) — but that sweep only ever
+        touched :attr:`_running_tools`; :attr:`_pipeline_runs` is a
+        SEPARATE dict (keyed by ``run_id``, not ``op_id``) that nothing else
+        in this class clears at a turn boundary. Before this fix, a pipeline
+        row orphaned this way stayed open FOREVER — the exact
+        "終わってるはずなのに表示が上の方に張り付いてたり" (stuck after
+        completion) shape #6076 reported, independent of #6076 ①'s own
+        off-by-one (that fix is presenter.py-only and does not touch
+        lifecycle at all).
+
+        Same #72/#3296 discipline as the tool-row sweep: CANCELLED, never
+        SUCCESS (would claim it finished) or ERROR (would claim it failed)
+        — the run's own report simply never arrived, which is neither. Every
+        step guarded so one orphan's settle failure never leaves the rest
+        un-swept; the dict is cleared unconditionally at the end so no
+        turn's leftovers bleed into the next (mirrors
+        :meth:`_sweep_orphaned_running_tools`'s own ``_running_tools.clear()``
+        for the identical reason)."""
+        for entry in list(self._pipeline_runs.values()):
+            try:
+                self._flow.stop_entry_animation(entry)
+            except Exception:
+                logger.exception(
+                    "textual chat: could not stop orphaned-pipeline animation"
+                )
+            try:
+                entry.set_state(EntryState.CANCELLED)
+            except Exception:
+                logger.exception(
+                    "textual chat: could not settle an orphaned pipeline row"
+                )
+        self._pipeline_runs.clear()
 
     def _settle_turn_parent(self) -> None:
         """#4691 arc item ① — give the CURRENT turn's own parent (the user

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -5951,11 +5951,12 @@ class TextualChatApp(App):
         dict is cleared unconditionally at the end so no turn's leftovers bleed
         into the next.
 
-        Also sweeps :attr:`_pipeline_runs` (#6076 ②) via
-        :meth:`_sweep_orphaned_pipeline_runs` at the end — a SEPARATE dict
-        this method never touched before, so a ``run_pipeline`` row whose
-        own completion frame never arrived stayed RUNNING forever even
-        though every tool-row orphan above it settled correctly."""
+        Does NOT also sweep :attr:`_pipeline_runs` (#6076 ②) — that dict's
+        orphan class is a SEPARATE sibling, :meth:`_sweep_orphaned_pipeline_runs`,
+        called from its own guarded site at the same turn-boundary trigger
+        (next to this method's own call and :meth:`_sweep_orphaned_streaming_replies`'s),
+        not nested here — a failure partway through THIS method's own loops
+        must not also skip that one."""
         for entry in list(self._running_tools.values()):
             try:
                 self._flow.stop_entry_animation(entry)
@@ -6014,11 +6015,17 @@ class TextualChatApp(App):
                     logger.exception(
                         "textual chat: could not settle an orphaned call-parent"
                     )
-        self._sweep_orphaned_pipeline_runs()
 
     def _sweep_orphaned_pipeline_runs(self) -> None:
         """Force-settle any pipeline row still open in :attr:`_pipeline_runs`
         at a TURN BOUNDARY (#6076 ②).
+
+        Called from :meth:`_pump_frames`'s own ``_TURN_END_EVENT_TYPES`` leg,
+        in its OWN guarded ``try``/``except`` sibling to
+        :meth:`_sweep_orphaned_running_tools`'s and
+        :meth:`_sweep_orphaned_streaming_replies`'s calls there — deliberately
+        NOT nested inside either of those methods, so a failure partway
+        through one dict's own sweep loop can never skip this one.
 
         The SAME orphan class :meth:`_sweep_orphaned_running_tools` above
         closes for a tool row — a ``run_pipeline`` call's own completion
@@ -7565,6 +7572,18 @@ class TextualChatApp(App):
                             except Exception:
                                 logger.exception(
                                     "textual chat: orphaned-stream sweep failed"
+                                )
+                            try:
+                                # #6076 ②: its own sibling try/except, NOT
+                                # nested at the tail of the tool sweep above —
+                                # a mid-sweep failure in THAT dict's loop must
+                                # not also skip this one; each dict's orphan
+                                # class is swept independently, same as the
+                                # tool/stream pair already is.
+                                self._sweep_orphaned_pipeline_runs()
+                            except Exception:
+                                logger.exception(
+                                    "textual chat: orphaned-pipeline sweep failed"
                                 )
                             try:
                                 # #4691 arc item ①: settle the turn's own parent

--- a/tests/interfaces/test_6076_orphan_pipeline_sweep.py
+++ b/tests/interfaces/test_6076_orphan_pipeline_sweep.py
@@ -1,0 +1,207 @@
+"""Force-settle an orphaned pipeline row at the turn boundary (#6076 ②).
+
+:meth:`_sweep_orphaned_running_tools` (#72) already force-settles an orphaned
+TOOL row at a turn boundary — but it only ever walked ``_running_tools``.
+``_pipeline_runs`` is a SEPARATE dict (keyed by ``run_id``, populated by a
+``run_pipeline`` tool call's own progress frames), and nothing cleared it when
+a turn ended before the run's completion frame arrived: the reported symptom
+("終わってるはずなのに表示が上の方に張り付いてたり" — a row stuck as if
+still running, after the turn is long over). This is independent of #6076 ①
+(a display-only off-by-one in the SAME row's ``done/total`` text, fixed in
+presenter.py; that fix does not touch lifecycle at all).
+
+Same #72/#3296 discipline reused here: the row goes CANCELLED, never
+SUCCESS/ERROR — the run's own report simply never arrived, which is neither
+success nor failure.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat._meta_keys import RUNNING_SINCE_KEY
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+class QueueTransport(ClientTransportStub):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue — display OR event frames — so a test can push a pipeline-started
+    frame, inspect its live RUNNING row, THEN push a turn-end event and
+    inspect the sweep, with the stream staying open throughout. Mirrors
+    ``test_textual_chat_orphan_sweep_72.py``'s own ``QueueTransport``."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def push_event(self, event_type: str) -> None:
+        await self._queue.put(EventFrame(Event(type=event_type)))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _pipeline_started(run_id: str, index: int = 0) -> OutboxMessage:
+    return OutboxMessage(
+        kind="status",
+        text="[pipeline step]",
+        meta={
+            "source": "pipeline",
+            "run_id": run_id,
+            "pipeline_name": "probe",
+            "step_index": index,
+            "total_steps": 4,
+            "step_kind": "transform",
+            "step_event": "pipeline_step_started",
+        },
+    )
+
+
+def _entries(app: TextualChatApp):
+    return app.query_one(FlowView).entries
+
+
+@pytest.mark.asyncio
+async def test_orphaned_pipeline_run_settles_cancelled_on_turn_settled() -> None:
+    """Tier 2b: a pipeline row still open (live-animated, per
+    :data:`RUNNING_SINCE_KEY`) when the turn settles is force-closed
+    CANCELLED — never left spinning, and popped from ``_pipeline_runs``
+    (verified separately below)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_pipeline_started("run-orphan"))
+        await pilot.pause()
+        entry = next(
+            e for e in _entries(app) if e.item.meta.get("run_id") == "run-orphan"
+        )
+        assert (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is not None
+
+        await transport.push_event("turn_settled")
+        await pilot.pause()
+
+        assert entry.state is EntryState.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_without_the_sweep_the_pipeline_row_would_stay_running() -> None:
+    """Tier 2b: non-vacuity witness — with NO turn-end event delivered, the
+    orphaned pipeline row stays open (still live-animated, never CANCELLED),
+    proving the sweep (not some other mechanism) is what closes the gap in
+    the paired test above."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_pipeline_started("run-still-open"))
+        await pilot.pause()
+        await pilot.pause()
+        entry = next(
+            e for e in _entries(app) if e.item.meta.get("run_id") == "run-still-open"
+        )
+        assert (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is not None
+        assert entry.state is not EntryState.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_a_new_run_after_the_sweep_gets_its_own_fresh_row() -> None:
+    """Tier 2b: the swept run is popped from ``_pipeline_runs`` (not just
+    settled in place) — observed via the PUBLIC surface: a later frame
+    reusing the same ``run_id`` (the dict-not-cleared failure mode) creates a
+    SECOND, freshly-RUNNING entry rather than reanimating the CANCELLED one
+    in place. Mirrors ``_running_tools.clear()`` in the #72 sweep."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_pipeline_started("run-reused-id"))
+        await pilot.pause()
+        await transport.push_event("turn_settled")
+        await pilot.pause()
+        before = [
+            e for e in _entries(app) if e.item.meta.get("run_id") == "run-reused-id"
+        ]
+        settled = before[0]
+        assert settled.state is EntryState.CANCELLED
+
+        await transport.push_display(_pipeline_started("run-reused-id"))
+        await pilot.pause()
+
+        after = [
+            e for e in _entries(app) if e.item.meta.get("run_id") == "run-reused-id"
+        ]
+        fresh = [e for e in after if e not in before]
+        assert fresh, (
+            "a cleared _pipeline_runs must not reanimate the settled row in "
+            "place — it has no live handle to it any more, so a same-id "
+            "frame appends fresh instead"
+        )
+        assert settled.state is EntryState.CANCELLED, (
+            "the settled row itself must stay untouched by the new frame"
+        )
+        assert (fresh[0].item.meta or {}).get(RUNNING_SINCE_KEY) is not None
+
+
+@pytest.mark.asyncio
+async def test_turn_completed_and_turn_cancelled_also_sweep_pipeline_runs() -> None:
+    """Tier 2b: the belt-and-suspenders turn-end events (``turn_completed`` /
+    ``turn_cancelled``) trigger the same pipeline sweep as ``turn_settled``."""
+    for event_type in ("turn_completed", "turn_cancelled"):
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await transport.push_display(_pipeline_started(f"run-{event_type}"))
+            await pilot.pause()
+            entry = next(
+                e
+                for e in _entries(app)
+                if e.item.meta.get("run_id") == f"run-{event_type}"
+            )
+            assert (entry.item.meta or {}).get(RUNNING_SINCE_KEY) is not None
+
+            await transport.push_event(event_type)
+            await pilot.pause()
+
+            assert entry.state is EntryState.CANCELLED, event_type


### PR DESCRIPTION
**[tui-coder]** — fix(part of #6076 ②): a pipeline row left open when the turn ends stays visually stuck forever

## What

`_sweep_orphaned_running_tools` (#72) force-settles an orphaned TOOL row at a
turn boundary, but it only ever walked `_running_tools`. `_pipeline_runs` is a
separate dict (keyed by `run_id`), and nothing cleared it when a turn ended
before the run's own completion frame arrived — the reported symptom
("終わってるはずなのに表示が上の方に張り付いてたり"): a pipeline progress
row left visually stuck, never settled, forever.

Independent of #6076 ① (#6079, a display-only off-by-one in the same row's
`done/total` text — presenter.py-only, no lifecycle change).

## Fix

- `app.py`: new `_sweep_orphaned_pipeline_runs`, called at the end of
  `_sweep_orphaned_running_tools` (same turn-boundary trigger). Settles each
  remaining `_pipeline_runs` entry to `EntryState.CANCELLED` — never
  `SUCCESS`/`ERROR` (#3296 don't-fabricate-a-failure lesson, matching
  `_settle_pipeline_run`'s own discipline on the normal completion path) —
  stops its animation, and clears the dict. Every step individually guarded,
  mirroring the existing `_running_tools`/`_call_parents` loops exactly.
- `tests/interfaces/test_6076_orphan_pipeline_sweep.py` (new, 4 tests): open
  row → CANCELLED on `turn_settled`/`turn_completed`/`turn_cancelled`;
  non-vacuity witness (no turn-end event → stays open); the freed dict slot,
  observed via the public surface (a same-`run_id` frame after settling
  appends a fresh row rather than reanimating the CANCELLED one in place).

## Out of scope

The `_coalesce_tool_result` "settle ALL open pipeline runs on any
`run_pipeline` completion" gap is filed as #6080 (separate, has its own
reachability precondition).

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/interfaces/test_6076_orphan_pipeline_sweep.py`
- [x] `verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` (tests/ touched)
- [x] `silent_except_ratchet.py` (`src/reyn/interfaces/` touched)
- [x] scoped pytest: new file (4/4) + `test_textual_chat_orphan_sweep_72.py`, `test_pipeline_single_flow_entry_3641.py`, `test_5731_pipeline_flowview_entry.py` — 13/13 passed
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
