### PR TITLE
fix(part of #5989): widen run_textual_chat's stray-output capture to outlive app.run_async()'s own return

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -8475,25 +8475,51 @@ async def run_textual_chat(
     _stall_seconds = stall_trace_seconds_from_env()
     if _stall_seconds is not None:
         _arm_stall_trace(_stall_seconds)
-    try:
-        mark_app_constructed()
-        with stage("tui-boot:construct"):
-            app = TextualChatApp(
-                transport=transport,
-                read_model=read_model,
-                agent_name=agent_name,
-                config=config,
-                initial_history_messages=_initial_history_messages,
-            )
-        # #5168: sys.stdout/sys.stderr are the RENDERER's own from here until
-        # run_async returns — anything else writing to them (a third-party
-        # print(file=sys.stderr), a warnings.warn) corrupts the live region.
-        # See stray_output.py's own module docstring for the full rationale;
-        # __exit__ restores BOTH streams unconditionally, including a crash
-        # inside run_async, so the operator's terminal is never left mid-swap.
-        with capture_stray_output(app) as stray_output_stats:
-            app._stray_output_stats = stray_output_stats
+    mark_app_constructed()
+    with stage("tui-boot:construct"):
+        app = TextualChatApp(
+            transport=transport,
+            read_model=read_model,
+            agent_name=agent_name,
+            config=config,
+            initial_history_messages=_initial_history_messages,
+        )
+    # #5168/#5989 stage 1: sys.stdout/sys.stderr are the RENDERER's own from
+    # here until THIS WHOLE FUNCTION returns or raises — not merely
+    # `app.run_async()`'s own await span (#5168's original, narrower scope).
+    # See stray_output.py's own module docstring for the base rationale;
+    # __exit__ restores BOTH streams unconditionally, including a crash
+    # inside run_async, so the operator's terminal is never left mid-swap.
+    #
+    # #5989: widened on purpose. `_setup_interactive_logging`'s own
+    # background daemon threads (e.g. `_litellm_warm_worker`) are NEVER
+    # joined (lead-coder ruling, #5989: joining would add a wait that
+    # collides with #6077's own "loop must not block" concern) — one of
+    # them can still
+    # call `logging` after `app.run_async()` has already returned but
+    # before this function's own remaining teardown (`_disarm_stall_trace`)
+    # has finished, and a `logging.Handler.handleError` firing at that
+    # exact moment used to write straight past this capture (the OLD,
+    # narrower `with` exited the instant `run_async()` returned, before
+    # that teardown ran) — see the strip-falsified reproduction in
+    # `test_5989_capture_window_outlives_run_async.py`.
+    #
+    # Deliberately still NOT process-lifetime: a `try`/`finally` scope, so
+    # a genuinely FATAL exception unwinding OUT of this whole function
+    # exits this `with` (restoring the real streams) via `finally` BEFORE
+    # Python's own top-level unhandled-exception printer ever runs — a
+    # real crash still reaches the operator's actual terminal, not
+    # reyn.log where nobody would think to look for "why did reyn die".
+    # The residual gap this does NOT close: a daemon thread that outlives
+    # this ENTIRE function's own return (not just `run_async()`'s) can
+    # still write past capture in the instant after it exits — closing
+    # that needs joining the thread, which this fix deliberately does not
+    # do (see the acknowledged-gap test's own docstring, and #5989's own
+    # PR body).
+    with capture_stray_output(app) as stray_output_stats:
+        app._stray_output_stats = stray_output_stats
+        try:
             await app.run_async(inline=inline)
-    finally:
-        if _stall_seconds is not None:
-            _disarm_stall_trace()
+        finally:
+            if _stall_seconds is not None:
+                _disarm_stall_trace()

--- a/tests/interfaces/test_5989_capture_window_outlives_run_async.py
+++ b/tests/interfaces/test_5989_capture_window_outlives_run_async.py
@@ -1,0 +1,132 @@
+"""Tier 2: run_textual_chat's stray-output capture window outlives
+app.run_async()'s own return, not just its await span (#5989 PR1).
+
+The OLD scope (`with capture_stray_output(app): await app.run_async(...)`)
+restored the real sys.stdout/sys.stderr the INSTANT run_async() returned.
+A daemon thread `_setup_interactive_logging` starts (e.g.
+`_litellm_warm_worker`) is never joined (lead-coder ruling, #5989: joining
+would add a wait that collides with #6077's own "loop must not block"
+concern), so it can call `logging` at ANY later moment with no lifetime tie
+to run_async() at all -- and a `logging.Handler.handleError` firing in that
+gap used to write straight past capture, to the real terminal (the owner's
+own reported `_logger.warning(`/`--- Logging error ---` symptom).
+
+This does not close that gap for good (a daemon thread that outlives
+run_textual_chat's own RETURN, not merely run_async()'s, is still
+unaddressed -- closing that needs a thread join, which #5989's own ruling
+explicitly declines to add). What it DOES close: the specific, narrower gap
+between run_async() returning and run_textual_chat's own remaining
+teardown finishing -- proven here by observing capture is STILL active at
+that exact point.
+
+No timing/race between the daemon thread's own fire and the capture
+window (CLAUDE.md: no floor/ceiling duration) -- the boundary is read as a
+STATE at two fixed control-flow points instead: right when
+run_textual_chat's own post-run_async teardown (`_disarm_stall_trace`)
+runs, and right after run_textual_chat itself has fully returned. Neither
+waits.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp, run_textual_chat
+from reyn.interfaces.transport.client_transport import ClientTransportStub
+from reyn.runtime import stall_trace
+
+
+class _NullTransport(ClientTransportStub):
+    """A transport that never has anything to say -- ``run_async`` is
+    faked out below (this test is about ``run_textual_chat``'s own control
+    flow, not a real Textual boot), so ``frames()`` is never actually
+    driven."""
+
+    async def frames(self) -> "AsyncIterator[object]":
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    def start(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: object) -> None:  # pragma: no cover
+        pass
+
+    async def submit_user_text(self, text: str, *, client_ref: "str | None" = None) -> str:  # pragma: no cover
+        return ""
+
+    async def answer_intervention_text(
+        self, text: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(
+        self, choice_id: str, *, intervention_id: "str | None" = None
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def cancel_inflight(self) -> str:  # pragma: no cover
+        return ""
+
+    async def shutdown(self) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_capture_is_still_active_when_post_run_async_teardown_runs(
+    monkeypatch,
+) -> None:
+    """Tier 2b: the strip-falsified regression. Forces the SAME
+    ``_disarm_stall_trace()`` teardown ``run_textual_chat`` already calls
+    (no new probe hook invented) to fire, and reads which ``sys.stderr``
+    was live at that exact instant."""
+    observed: "dict[str, object]" = {}
+
+    async def _fake_run_async(self, *, inline: bool = False) -> None:
+        # Stands in for a real Textual boot -- returns immediately, no
+        # pump loop needed. What matters here is everything run_textual_
+        # chat does AROUND this call, not Textual's own internals.
+        return None
+
+    def _probe_disarm() -> None:
+        import sys
+
+        observed["stderr_at_disarm"] = sys.stderr
+
+    monkeypatch.setattr(TextualChatApp, "run_async", _fake_run_async)
+    monkeypatch.setattr(stall_trace, "stall_trace_seconds_from_env", lambda: 5.0)
+    monkeypatch.setattr(stall_trace, "arm", lambda *a, **kw: None)
+    monkeypatch.setattr(stall_trace, "disarm", _probe_disarm)
+
+    import sys
+
+    real_stderr_before = sys.stderr
+
+    await run_textual_chat(transport=_NullTransport(), agent_name="probe-agent")
+
+    assert "stderr_at_disarm" in observed, (
+        "the fake stall_trace.disarm() was never called -- run_textual_chat's "
+        "own post-run_async teardown did not run, so this test proved nothing"
+    )
+    assert observed["stderr_at_disarm"] is not real_stderr_before, (
+        "capture had ALREADY been torn down by the time post-run_async "
+        "teardown ran -- this is the OLD, narrow-scope bug: a daemon "
+        "thread emitting in this exact gap would write straight to the "
+        "real terminal"
+    )
+    assert sys.stderr is real_stderr_before, (
+        "capture must be fully restored once run_textual_chat itself has "
+        "returned -- it must not stay swapped past this function's own "
+        "scope (that would risk swallowing a genuinely fatal, unrelated "
+        "crash the operator needs to see)"
+    )

--- a/tests/interfaces/test_5989_capture_window_outlives_run_async.py
+++ b/tests/interfaces/test_5989_capture_window_outlives_run_async.py
@@ -25,6 +25,26 @@ STATE at two fixed control-flow points instead: right when
 run_textual_chat's own post-run_async teardown (`_disarm_stall_trace`)
 runs, and right after run_textual_chat itself has fully returned. Neither
 waits.
+
+lead-coder BLOCKING, PR #6087: this test's `monkeypatch.setattr(...)` on
+`TextualChatApp.run_async` and on `reyn.runtime.stall_trace`'s own
+functions is a DELIBERATE departure from testing.md's "never fake a
+collaborator when a real instance is cheaply constructible" rule -- named
+here, not left for the next reader to rediscover as "wasn't this
+forbidden?" ① the departure is intentional, not an oversight; ② it rests
+on the SAME policy's own carve-out, "cheap to construct is not the same
+as drivable": a real `TextualChatApp` IS cheap to construct, but a real
+Textual boot through `run_async()` does not RETURN control back to this
+test on any signal this test can drive -- it runs the app's own event
+loop until something inside that loop (a `/quit`, a crash) ends it, and
+nothing external can reach in and end it deterministically without a
+timing-dependent hack (the exact CLAUDE.md floor/ceiling ban this file's
+own paragraph above already invokes for a different reason); ③ with no
+externally-drivable "return now" signal, there is no undriven way to
+observe run_textual_chat's own control flow AROUND a real boot at all --
+patching the ONE seam (`run_async` itself) that both IS the boundary
+under test and has no other drive mechanism is the seam this test needs,
+not a shortcut around a drivable one.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[tui-coder]** — fix(part of #5989 ⑴): widen run_textual_chat's stray-output capture past app.run_async()'s own return

## What

`_setup_interactive_logging`'s own daemon threads (e.g. `_litellm_warm_worker`,
`llm/litellm_bootstrap.py`) are never joined (lead-coder ruling, #5989: joining
would add a wait that collides with #6077's own "loop must not block" concern).
One of them can call `logging` at any later moment with no lifetime tie to
`run_async()` at all, and a `logging.Handler.handleError` firing in the gap
between `run_async()` returning and the OLD, narrower `capture_stray_output`
window tearing down used to write straight past capture, to the real terminal
— matching the owner's own reported `_logger.warning(`/`--- Logging error ---`
symptom.

Root-caused via a strip-falsified repro in #5989's own comment thread: a
minimal reproduction of the real `logging.Handler.handleError` sequence shows
the narrow window leaks and the widened window does not — demonstrated, not
assumed.

**⚠️ This is stage 1 of 2.** PR2 (#5989's own ⑵) is the independent
durable-record fallback for when the FAILING handler is reyn.log's own —
tracked separately, **not landed here**. This PR alone makes the terminal
quieter but does **not** make a handler failure durably recorded in that
case. **#5989 stays open until PR2 also lands.**

## Fix

`run_textual_chat`'s `with capture_stray_output(app):` now wraps the
function's own full remaining scope (`app.run_async()` + its existing
post-run `finally` teardown), not just the await span. Still a `try`/`finally`
scope, deliberately not process-lifetime: a genuinely fatal exception
unwinding out of this function still exits the `with` (restoring the real
streams) before Python's own top-level unhandled-exception printer runs, so a
real crash still reaches the operator's actual terminal.

**Acknowledged, not closed** (see the new test's own docstring): a daemon
thread that outlives `run_textual_chat` itself (not just `run_async()`) can
still write past capture in the instant after this widened window exits —
closing that needs a thread join, explicitly out of scope per the ruling
above.

## Test

`tests/interfaces/test_5989_capture_window_outlives_run_async.py` (new) — a
state-based (no timing/race, per CLAUDE.md's no-floor/no-ceiling rule)
regression: forces `run_textual_chat`'s own existing `stall_trace.disarm()`
teardown to fire and asserts capture is still active at that instant (the OLD
failure mode), then asserts capture is fully restored once `run_textual_chat`
itself has returned. Strip-falsified by hand: reverting the `app.py` change
reproduces the exact failing assertion.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/interfaces/test_5989_capture_window_outlives_run_async.py`
- [x] `verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` (tests/ touched)
- [x] `silent_except_ratchet.py` (`src/reyn/interfaces/` touched)
- [x] scoped pytest: new test (1/1) + `test_3671_stall_trace_startup_wiring.py`, `test_4983_mount_hydrate_off_loop.py`, `test_5168_tui_stdio_capture.py` — 26/26 passed
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
