### PR TITLE
fix(part of #5989): a broken logging handler leaves a durable failure record, independent of the handler that broke

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -428,10 +428,12 @@ def _setup_interactive_logging(project_root: Path, *, is_interactive: bool = Tru
     (``isinstance(handler, logging.FileHandler)`` — ``litellm_bootstrap.py``,
     ``stall_trace.py``) are unaffected either way.
     """
-    from logging.handlers import RotatingFileHandler
-
     from reyn.config.chat import LogsConfig
     from reyn.runtime import early_log_buffer, stall_trace
+    from reyn.runtime.logging_failure_fallback import (
+        FailureFallbackRotatingFileHandler,
+        handler_failure_dump_path,
+    )
 
     # #5989 symptom 3: grab the early buffer BEFORE force=True below wipes
     # it off the root logger — the module-level singleton survives being
@@ -446,11 +448,21 @@ def _setup_interactive_logging(project_root: Path, *, is_interactive: bool = Tru
     log_dir = project_root / ".reyn" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / "reyn.log"
-    handler = RotatingFileHandler(
+    # #5989 ⑵: a drop-in RotatingFileHandler subclass whose handleError
+    # ALSO records the failure to an INDEPENDENT destination (never THIS
+    # handler's own, broken one) -- see logging_failure_fallback.py's
+    # own module docstring for why re-logging through the failing
+    # handler itself (or through `logging` at all, risking the SAME
+    # handler via propagation) cannot durably record its own failure.
+    # Every existing structural reader (isinstance(handler, logging.
+    # FileHandler) in litellm_bootstrap.py/stall_trace.py) is unaffected
+    # -- this class still IS one.
+    handler = FailureFallbackRotatingFileHandler(
         str(log_path),
         maxBytes=defaults.max_bytes,
         backupCount=defaults.backup_count,
     )
+    handler.set_fallback_path(handler_failure_dump_path(str(log_path)))
     handler.setFormatter(
         logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
     )

--- a/src/reyn/runtime/logging_failure_fallback.py
+++ b/src/reyn/runtime/logging_failure_fallback.py
@@ -1,0 +1,168 @@
+"""A durable record of a `logging.Handler`'s own `emit()` failure, that does
+NOT depend on the handler that just failed (#5989 ⑵).
+
+#5989 PR1 (`run_textual_chat`'s widened `capture_stray_output` window)
+closes the "goes to the operator's raw terminal" half of this issue -- but
+closing that alone opens a NEW gap the owner's own three-question checklist
+(CLAUDE.md, "does the repair destroy the evidence?") names directly:
+`logging.Handler.handleError`'s own default behaviour, left alone, still
+prints `--- Logging error ---` + a traceback to `sys.stderr` -- if PR1's
+capture swallows that (as designed) and NOTHING else records it, the
+handler's failure now vanishes with no trace at all, which is worse than
+the original symptom (a garbled screen at least told the operator
+SOMETHING broke).
+
+The one thing this file's own destination must NOT depend on is the very
+handler that is failing: reyn.log's own `RotatingFileHandler` re-logging
+through itself (or through `logging` at all, which risks landing on that
+SAME handler via propagation) proves nothing when THAT handler is what's
+broken -- re-verified empirically in #5989's own comment thread (a strip
+script: the underlying stream stays broken through a whole reentrant
+retry, and the "durable" record ends up empty).
+
+Reuses :class:`~reyn.runtime.diagnostic_snapshot.DiagnosticSnapshot` (the
+SAME single-fd, always-overwritten, boundedness-by-SHAPE primitive
+:class:`~reyn.runtime.loop_tripwire.StallDumpArm` already uses for the
+stall dump -- #5978 ①'s own "this module's first caller" invitation to
+reuse it) rather than inventing a second file-lifecycle mechanism. Same
+pid-suffixed naming as :func:`~reyn.runtime.loop_tripwire.stall_dump_path`,
+for the identical reason: N reyn processes sharing one `.reyn/logs/`
+directory must not silently overwrite or interleave each other's records
+(#5992's own finding, re-applied here rather than re-derived).
+
+**Episode gating (#5989 ⑶, lead-coder ruling: "the same failure needs
+recording only once per episode")**: the smallest shape that still answers
+the question -- a plain "was the LAST recorded failure's own text
+identical to this one" comparison. A REPEATING identical failure (the
+common case: the same broken handler raising the same exception on every
+subsequent record) collapses to one write per distinct occurrence rather
+than one per record; a NEW, different failure (a different exception, or
+the same handler recovering then breaking again with new content) is
+still recorded -- `reset()`'d first, per :class:`DiagnosticSnapshot`'s own
+truncate-timing rule (truncate for the NEXT write, never pre-emptively).
+No cross-process/cross-restart state: a fresh process starts with no
+prior "last recorded" text, so its first genuine failure is always
+recorded regardless of what an earlier process (or an earlier run) last
+saw -- this module holds no persisted state of its own, matching
+`LoopTripwire`'s own per-instance (not per-file) episode memory.
+"""
+from __future__ import annotations
+
+import logging.handlers
+import os
+import sys
+import time
+import traceback
+
+from reyn.runtime.diagnostic_snapshot import DiagnosticSnapshot, diagnostic_snapshot
+
+
+def handler_failure_dump_path(reyn_log_path: "str | None") -> "str | None":
+    """The single-file destination for THIS PROCESS's handler-failure
+    record — same directory `reyn.log` lives in, same pid-suffixed naming
+    as :func:`~reyn.runtime.loop_tripwire.stall_dump_path` (see that
+    function's own docstring for why the pid suffix is load-bearing, not
+    decorative: N reyn processes attached to one workspace must not share
+    one destination). `None` when there is no `reyn.log` path to sit
+    beside, matching :meth:`DiagnosticSnapshot.open`'s own "no genuinely
+    stable destination, no attempt" posture."""
+    if reyn_log_path is None:
+        return None
+    from pathlib import Path
+
+    return str(Path(reyn_log_path).with_name(f"handler_failure.{os.getpid()}.log"))
+
+
+class FailureFallbackRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """A `RotatingFileHandler` whose `handleError` ALSO records the
+    failure to an independent destination (see module docstring) — a
+    drop-in replacement for the plain `RotatingFileHandler`
+    `_setup_interactive_logging` (`interfaces/cli/commands/chat.py`)
+    already constructs; nothing else about this class's behaviour
+    differs from the base.
+
+    :meth:`set_fallback_path` must be called once, right after
+    construction, by the installer — the same "declare the path
+    directly" idiom :func:`~reyn.runtime.stall_trace.
+    register_file_handler_path` already established, rather than making
+    this class re-derive its own destination from `self.baseFilename`
+    (which would couple this class to that attribute's own private
+    shape). Uninstalled (`set_fallback_path` never called, or called with
+    `None`) means this class behaves BYTE-IDENTICALLY to the plain base
+    — every existing structural reader (`isinstance(handler, logging.
+    FileHandler)` in `litellm_bootstrap.py`/`stall_trace.py`) still sees
+    a `FileHandler`, since this class still IS one.
+
+    Deliberately does NOT override `emit()` — `StreamHandler.emit()`
+    already wraps its own body in `try/except Exception: self.handleError
+    (record)` internally (stdlib, unchanged since first release); a
+    subclass re-wrapping `emit()` itself would either never see the
+    exception (the base class's OWN try/except already swallowed it
+    before this subclass's wrapper's except clause could run) or
+    double-handle it. `handleError` is the ONE correct override point —
+    it is what the base class already calls, unconditionally, on every
+    emit failure."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._fallback_snapshot: "DiagnosticSnapshot | None" = None
+        self._fallback_path: "str | None" = None
+        self._fallback_last_text: "str | None" = None
+
+    def set_fallback_path(self, path: "str | None") -> None:
+        self._fallback_path = path
+        self._fallback_snapshot = None  # opened lazily, on first real failure
+
+    def handleError(self, record: logging.LogRecord) -> None:  # noqa: N802 - stdlib override name
+        """#5989 ⑵: record this failure to the independent fallback
+        destination, episode-gated (see module docstring), then defer to
+        the base class for the REST of stdlib's own behaviour (the
+        `sys.stderr` write #5989 PR1's own `capture_stray_output`
+        widening already keeps off the real terminal during a TUI
+        session — this method does not need to, and does not,
+        short-circuit that base behaviour; the two fixes are independent
+        layers, and neither assumes the other is present)."""
+        try:
+            self._record_fallback(record)
+        except Exception:
+            # A failure recording a failure must never mask the original
+            # one, nor crash the logging call site — best-effort only,
+            # matching every OTHER diagnostic writer in this codebase
+            # (write_record, StallDumpArm's own callers).
+            pass
+        super().handleError(record)
+
+    def _record_fallback(self, record: logging.LogRecord) -> None:
+        if not self._fallback_path:
+            return
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        if exc_type is None:
+            return  # handleError() was called outside an active exception -- nothing to record
+        try:
+            message = record.getMessage()
+        except Exception as exc:  # the SAME "message vs args" failure class handleError itself guards
+            message = f"<could not format: {type(exc).__name__}: {exc}>"
+        text = (
+            f"logger={record.name!r} level={record.levelname} "
+            f"handler={type(self).__name__}\n"
+            f"message={message!r}\n"
+            + "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+        )
+        if text == self._fallback_last_text:
+            return  # #5989 ⑶: same episode, already recorded -- collapse, don't re-write
+        if self._fallback_snapshot is None:
+            self._fallback_snapshot = diagnostic_snapshot(self._fallback_path)
+            if self._fallback_snapshot is None:
+                return  # no genuinely stable destination -- never attempt, matches StallDumpArm
+        else:
+            self._fallback_snapshot.reset()  # truncate for THIS new episode's own write
+        if not self._fallback_snapshot.usable:
+            return
+        fd = self._fallback_snapshot.fd
+        assert fd is not None  # `usable` already confirmed this (DiagnosticSnapshot's own contract)
+        payload = f"{time.strftime('%Y-%m-%dT%H:%M:%S')} #5989 handler failure\n{text}"
+        try:
+            os.write(fd, payload.encode("utf-8", errors="replace"))
+        except OSError:
+            return
+        self._fallback_last_text = text

--- a/tests/runtime/test_5989_handler_failure_fallback.py
+++ b/tests/runtime/test_5989_handler_failure_fallback.py
@@ -1,0 +1,207 @@
+"""Tier 2: a logging handler's own emit() failure is durably recorded to an
+INDEPENDENT destination — never re-logged through the SAME (possibly
+broken) handler (#5989 ⑵, PR2).
+
+#5989 PR1 widened run_textual_chat's capture_stray_output window so a
+logging.Handler.handleError firing during a live TUI session no longer
+writes its `--- Logging error ---` banner + traceback straight to the
+operator's real terminal. Capturing it and going nowhere else would just
+move the failure from "visible but garbled" to "invisible" -- worse, not
+better (CLAUDE.md's own "does the repair destroy the evidence?" question).
+This is the other half: FailureFallbackRotatingFileHandler's own
+handleError records the failure to a SEPARATE file, independent of
+whichever handler (possibly this very instance) just broke.
+
+A real logging.Logger + a real FailureFallbackRotatingFileHandler
+throughout -- no MagicMock. The "broken handler" is produced by swapping
+the handler's own `.stream` for a real, write-raising file-like object
+(not a mock of the handler itself) -- the SAME technique #5989's own
+strip-falsified issue-thread reproduction used, mirroring CPython's actual
+StreamHandler.emit() -> handleError() call sequence rather than
+monkeypatching emit() itself (which would bypass handleError entirely and
+prove nothing about it).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from reyn.runtime.logging_failure_fallback import (
+    FailureFallbackRotatingFileHandler,
+    handler_failure_dump_path,
+)
+
+
+class _BreakableStream:
+    """A real, minimal file-like object whose `write` raises on demand —
+    not a mock of the handler under test, just its underlying stream."""
+
+    def __init__(self) -> None:
+        self.broken = False
+        self.written: "list[str]" = []
+
+    def write(self, s: str) -> int:
+        if self.broken:
+            raise OSError("simulated stream failure")
+        self.written.append(s)
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    def tell(self) -> int:
+        # RotatingFileHandler.shouldRollover() calls this BEFORE emit()'s
+        # own write -- a real stream always answers it; only write() is
+        # what this test wants to fail.
+        return 0
+
+
+def _make_handler(tmp_path: Path) -> "tuple[FailureFallbackRotatingFileHandler, logging.Logger, Path]":
+    reyn_log = tmp_path / "reyn.log"
+    handler = FailureFallbackRotatingFileHandler(str(reyn_log), maxBytes=10_000, backupCount=1)
+    fallback_path = handler_failure_dump_path(str(reyn_log))
+    assert fallback_path is not None
+    handler.set_fallback_path(fallback_path)
+    logger = logging.getLogger(f"test-5989-{id(handler)}")
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.propagate = False
+    logger.setLevel(logging.WARNING)
+    return handler, logger, Path(fallback_path)
+
+
+def test_a_broken_handler_still_leaves_a_durable_failure_record(tmp_path: Path) -> None:
+    """Tier 2: non-vacuity — the fallback file is EMPTY/absent before the
+    failure, and holds the failure's own content after it, even though
+    the handler that failed is this SAME instance's own destination."""
+    handler, logger, fallback_path = _make_handler(tmp_path)
+    assert not fallback_path.exists()
+
+    stream = _BreakableStream()
+    handler.stream = stream
+    stream.broken = True
+    logger.warning("first failure: %s", "payload-one")
+
+    assert fallback_path.exists(), (
+        "the fallback file was never written — a broken handler's own "
+        "failure left no durable record anywhere"
+    )
+    content = fallback_path.read_text()
+    assert "payload-one" in content
+    assert "OSError" in content
+
+
+def test_no_false_kill_a_healthy_handler_writes_no_fallback(tmp_path: Path) -> None:
+    """Tier 2: a handler that is NOT broken must not spuriously create the
+    fallback file — its absence, not an empty file, is the healthy
+    signal (an operator finding the file at all means something failed)."""
+    _handler, logger, fallback_path = _make_handler(tmp_path)
+    logger.warning("a perfectly normal warning")
+    assert not fallback_path.exists()
+
+
+def test_repeated_identical_failure_collapses_to_one_episode(tmp_path: Path) -> None:
+    """Tier 2b: #5989 ⑶ — the SAME failure repeating (the common case: a
+    persistently broken handler raising the identical exception on every
+    subsequent record) writes the fallback file's content once, not once
+    per occurrence. Proven via the internal reset()-call count rather
+    than a private-state read of the content alone, since content alone
+    cannot distinguish "written once" from "overwritten with the same
+    bytes twice" — a real accumulation-bounding claim needs the write
+    COUNT, not just the end state."""
+    handler, logger, fallback_path = _make_handler(tmp_path)
+    stream = _BreakableStream()
+    handler.stream = stream
+    stream.broken = True
+
+    reset_calls = {"count": 0}
+    orig_reset = None
+
+    logger.warning("repeating failure")
+    assert fallback_path.exists()
+    snapshot = handler._fallback_snapshot
+    assert snapshot is not None
+    orig_reset = snapshot.reset
+
+    def _counting_reset() -> None:
+        reset_calls["count"] += 1
+        orig_reset()
+
+    snapshot.reset = _counting_reset  # type: ignore[method-assign]
+
+    logger.warning("repeating failure")
+    logger.warning("repeating failure")
+
+    assert reset_calls["count"] == 0, (
+        "an IDENTICAL repeating failure re-truncated+rewrote the fallback "
+        "file — #5989 ⑶ asked for one record per distinct episode, not "
+        "one per occurrence"
+    )
+
+
+def test_a_genuinely_new_failure_after_a_repeat_is_still_recorded(tmp_path: Path) -> None:
+    """Tier 2b: the episode gate must not become a permanent mute — a
+    DIFFERENT failure (new exception content) after an identical-repeat
+    streak is still written."""
+    handler, logger, fallback_path = _make_handler(tmp_path)
+    stream = _BreakableStream()
+    handler.stream = stream
+    stream.broken = True
+
+    logger.warning("failure A")
+    logger.warning("failure A")  # collapsed, per the test above
+    logger.warning("failure B, different payload")
+
+    content = fallback_path.read_text()
+    assert "failure B" in content
+    assert "failure A" not in content, (
+        "the fallback file is an always-overwritten SNAPSHOT (mirrors "
+        "stall_dump_path's own shape) — the latest distinct episode "
+        "replaces the prior one, it does not accumulate"
+    )
+
+
+def test_recovery_then_a_new_failure_is_recorded_as_a_fresh_episode(tmp_path: Path) -> None:
+    """Tier 2b: once the underlying stream is healthy again (a normal
+    record succeeds), a LATER failure — even with byte-identical text to
+    an earlier, already-recorded one — must still produce a fresh
+    record, matching LoopTripwire's own "episode ends at recovery, not
+    at session end" rule."""
+    handler, logger, fallback_path = _make_handler(tmp_path)
+    stream = _BreakableStream()
+    handler.stream = stream
+
+    stream.broken = True
+    logger.warning("same text")
+    first_mtime = fallback_path.stat().st_mtime_ns
+
+    stream.broken = False
+    logger.warning("a healthy record in between")
+
+    stream.broken = True
+    logger.warning("same text")
+
+    # The handler's own last-recorded-text memory is reset only by a
+    # DIFFERENT text arriving, per this class's own (simple, documented)
+    # gate -- a byte-identical failure after a recovery is therefore
+    # still collapsed by this shape, which is the disclosed limit this
+    # test pins rather than hides: the gate keys on TEXT identity, not
+    # on episode boundaries the handler cannot itself observe (recovery
+    # is invisible to handleError, which is only ever called on failure).
+    assert fallback_path.stat().st_mtime_ns == first_mtime, (
+        "disclosed limit: this handler's episode gate keys on failure-text "
+        "identity only, not on a genuine recovery boundary — a byte-"
+        "identical failure recurring after a healthy interval still "
+        "collapses. A true LoopTripwire-style recovery-aware gate would "
+        "need this handler to also observe successful emits, which "
+        "StreamHandler.emit()'s own control flow (this class deliberately "
+        "does not override) does not hand back to handleError."
+    )
+
+
+def test_stays_a_real_file_handler_for_structural_readers(tmp_path: Path) -> None:
+    """Tier 1: litellm_bootstrap.py / stall_trace.py both discover the
+    interactive-path handler via isinstance(handler, logging.FileHandler)
+    — this subclass must still satisfy that, unchanged."""
+    handler, _logger, _fallback_path = _make_handler(tmp_path)
+    assert isinstance(handler, logging.FileHandler)

--- a/tests/runtime/test_5989_handler_failure_fallback.py
+++ b/tests/runtime/test_5989_handler_failure_fallback.py
@@ -13,13 +13,20 @@ handleError records the failure to a SEPARATE file, independent of
 whichever handler (possibly this very instance) just broke.
 
 A real logging.Logger + a real FailureFallbackRotatingFileHandler
-throughout -- no MagicMock. The "broken handler" is produced by swapping
-the handler's own `.stream` for a real, write-raising file-like object
-(not a mock of the handler itself) -- the SAME technique #5989's own
-strip-falsified issue-thread reproduction used, mirroring CPython's actual
-StreamHandler.emit() -> handleError() call sequence rather than
-monkeypatching emit() itself (which would bypass handleError entirely and
-prove nothing about it).
+throughout -- no MagicMock, no hand-rolled stream stand-in either
+(CLAUDE.md: "never fake a collaborator when a real instance is cheaply
+constructible" — a real broken file IS cheap here). "Broken" is produced
+by re-opening the handler's OWN real log file in READ mode and swapping
+that in as `.stream` — a genuinely unwritable real file object, not a
+mock of one. Verified directly (both interpreters this repo's own CI runs,
+3.11.15 and 3.12.7) that this raises `io.UnsupportedOperation` — a real
+`OSError` subclass — from `StreamHandler.emit()`'s own `stream.write(...)`
+call, landing in `handleError` exactly like production would; a v1 of
+this file used a hand-rolled stub instead, which on 3.11's
+`RotatingFileHandler` path raised `AttributeError` (missing `.seek`)
+before ever reaching `write()` — passing for the wrong reason entirely
+(lead-coder BLOCKING, PR #6088: "test は『実装が OSError を捕まえた』では
+なく『stub に属性が無かった』を記録しています").
 """
 from __future__ import annotations
 
@@ -32,28 +39,28 @@ from reyn.runtime.logging_failure_fallback import (
 )
 
 
-class _BreakableStream:
-    """A real, minimal file-like object whose `write` raises on demand —
-    not a mock of the handler under test, just its underlying stream."""
-
-    def __init__(self) -> None:
-        self.broken = False
-        self.written: "list[str]" = []
-
-    def write(self, s: str) -> int:
-        if self.broken:
-            raise OSError("simulated stream failure")
-        self.written.append(s)
-        return len(s)
-
-    def flush(self) -> None:
+def _break(handler: FailureFallbackRotatingFileHandler) -> None:
+    """Swap the handler's `.stream` for the SAME file, reopened read-only —
+    a real, genuinely unwritable file object. `write()` on it raises
+    `io.UnsupportedOperation` (confirmed an `OSError` subclass, and
+    confirmed identical on 3.11/3.12 — see module docstring)."""
+    try:
+        handler.stream.close()
+    except Exception:
         pass
+    handler.stream = open(handler.baseFilename, "r")
 
-    def tell(self) -> int:
-        # RotatingFileHandler.shouldRollover() calls this BEFORE emit()'s
-        # own write -- a real stream always answers it; only write() is
-        # what this test wants to fail.
-        return 0
+
+def _heal(handler: FailureFallbackRotatingFileHandler) -> None:
+    """Reopen the SAME file in append mode — a real, writable stream
+    again, mirroring the handler's own normal `_open()` shape (append,
+    not truncate: a healed handler must not silently lose what a prior
+    healthy write already wrote)."""
+    try:
+        handler.stream.close()
+    except Exception:
+        pass
+    handler.stream = open(handler.baseFilename, "a")
 
 
 def _make_handler(tmp_path: Path) -> "tuple[FailureFallbackRotatingFileHandler, logging.Logger, Path]":
@@ -77,9 +84,7 @@ def test_a_broken_handler_still_leaves_a_durable_failure_record(tmp_path: Path) 
     handler, logger, fallback_path = _make_handler(tmp_path)
     assert not fallback_path.exists()
 
-    stream = _BreakableStream()
-    handler.stream = stream
-    stream.broken = True
+    _break(handler)
     logger.warning("first failure: %s", "payload-one")
 
     assert fallback_path.exists(), (
@@ -88,7 +93,7 @@ def test_a_broken_handler_still_leaves_a_durable_failure_record(tmp_path: Path) 
     )
     content = fallback_path.read_text()
     assert "payload-one" in content
-    assert "OSError" in content
+    assert "UnsupportedOperation" in content
 
 
 def test_no_false_kill_a_healthy_handler_writes_no_fallback(tmp_path: Path) -> None:
@@ -110,9 +115,7 @@ def test_repeated_identical_failure_collapses_to_one_episode(tmp_path: Path) -> 
     bytes twice" — a real accumulation-bounding claim needs the write
     COUNT, not just the end state."""
     handler, logger, fallback_path = _make_handler(tmp_path)
-    stream = _BreakableStream()
-    handler.stream = stream
-    stream.broken = True
+    _break(handler)
 
     reset_calls = {"count": 0}
     orig_reset = None
@@ -144,9 +147,7 @@ def test_a_genuinely_new_failure_after_a_repeat_is_still_recorded(tmp_path: Path
     DIFFERENT failure (new exception content) after an identical-repeat
     streak is still written."""
     handler, logger, fallback_path = _make_handler(tmp_path)
-    stream = _BreakableStream()
-    handler.stream = stream
-    stream.broken = True
+    _break(handler)
 
     logger.warning("failure A")
     logger.warning("failure A")  # collapsed, per the test above
@@ -168,17 +169,16 @@ def test_recovery_then_a_new_failure_is_recorded_as_a_fresh_episode(tmp_path: Pa
     record, matching LoopTripwire's own "episode ends at recovery, not
     at session end" rule."""
     handler, logger, fallback_path = _make_handler(tmp_path)
-    stream = _BreakableStream()
-    handler.stream = stream
 
-    stream.broken = True
+    _break(handler)
     logger.warning("same text")
-    first_mtime = fallback_path.stat().st_mtime_ns
+    first_content = fallback_path.read_text()
+    assert "same text" in first_content
 
-    stream.broken = False
+    _heal(handler)
     logger.warning("a healthy record in between")
 
-    stream.broken = True
+    _break(handler)
     logger.warning("same text")
 
     # The handler's own last-recorded-text memory is reset only by a
@@ -188,7 +188,12 @@ def test_recovery_then_a_new_failure_is_recorded_as_a_fresh_episode(tmp_path: Pa
     # test pins rather than hides: the gate keys on TEXT identity, not
     # on episode boundaries the handler cannot itself observe (recovery
     # is invisible to handleError, which is only ever called on failure).
-    assert fallback_path.stat().st_mtime_ns == first_mtime, (
+    # Observed via CONTENT, not mtime (lead-coder BLOCKING, PR #6088: an
+    # mtime identity pin records the TEST'S OWN filesystem-timestamp
+    # resolution, an environment property, not reyn's own behaviour --
+    # the CONTENT staying byte-identical is what "no re-write happened"
+    # actually means).
+    assert fallback_path.read_text() == first_content, (
         "disclosed limit: this handler's episode gate keys on failure-text "
         "identity only, not on a genuine recovery boundary — a byte-"
         "identical failure recurring after a healthy interval still "


### PR DESCRIPTION
**[tui-coder]** — fix(part of #5989 ⑵): a broken logging handler leaves a durable failure record, independent of the handler that broke

## What

PR1 (#6087) widened `run_textual_chat`'s `capture_stray_output` window so a
`logging.Handler.handleError` firing during a live TUI session no longer
writes its `--- Logging error ---` banner + traceback straight to the
operator's real terminal. Capturing it and going nowhere else would just
move the failure from "visible but garbled" to "invisible" — worse, not
better (CLAUDE.md's own "does the repair destroy the evidence?" question,
lead-coder's #5989 ⑵ ruling). This is that other half.

⚠️ Together with PR1 this closes both halves of #5989's ⑴/⑵ requirement, but
**#5989 itself stays open** per lead-coder's own ruling until the owner
confirms on their real machine.

## Fix

- `src/reyn/runtime/logging_failure_fallback.py` (new):
  `FailureFallbackRotatingFileHandler`, a drop-in `RotatingFileHandler`
  subclass whose `handleError()` ALSO records the failure to an
  **independent** destination — reuses `DiagnosticSnapshot` (the same
  single-fd, always-overwritten, bounded-by-shape primitive `StallDumpArm`
  already uses for the stall dump), never re-logs through the SAME
  (possibly broken) handler or through `logging` at all. Episode-gated
  (#5989 ⑶, lead-coder ruling: "same failure needs recording only once per
  episode") — a plain "identical to the last recorded failure" text
  comparison, mirroring `LoopTripwire`'s own episode-memory shape at the
  smallest scope that still answers the question.
- `src/reyn/interfaces/cli/commands/chat.py`: `_setup_interactive_logging`
  now constructs `FailureFallbackRotatingFileHandler` instead of the plain
  `RotatingFileHandler`, wired via `handler_failure_dump_path()`. Every
  existing structural reader (`isinstance(handler, logging.FileHandler)` in
  `litellm_bootstrap.py`/`stall_trace.py`) is unaffected — this class still
  IS one.

## Test

`tests/runtime/test_5989_handler_failure_fallback.py` (new, 6 tests): a
broken handler still leaves a durable record (non-vacuity); a healthy
handler writes no fallback file at all (no-false-kill); a repeating
identical failure collapses to one write; a genuinely new failure after a
repeat is still recorded; a disclosed limit around recovery-then-repeat
(the gate keys on failure-TEXT identity, since `handleError` has no
visibility into a successful emit to reset against — documented in the
test's own docstring, not hidden); structural `isinstance(FileHandler)`
compatibility. Real `logging.Logger` + real handler throughout, no
`MagicMock`. Strip-falsified by hand: disabling the fallback-record call
reproduces 4/6 failing assertions.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/runtime/test_5989_handler_failure_fallback.py`
- [x] `verify_module_docstrings.py` (both changed src files)
- [x] `mypy_ratchet.py` (one real finding fixed directly, not baselined)
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` (tests/ touched)
- [x] `silent_except_ratchet.py` (`src/reyn/interfaces/` touched)
- [x] scoped pytest: new suite (6/6) + `test_isolate_root_logging_handlers_main_red.py`, `test_3671_stall_trace_startup_wiring.py`, `test_config_warning_chrome_4194.py`, `test_inline_interactive_logging.py`, `test_loop_probe_3539.py`, `test_litellm_lazy_load.py` — 84/84 passed
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
