### PR TITLE
feat(#6084 gate): AST ratchet over user-facing-text sink call sites

### DIFF
--- a/.github/workflows/user-facing-lang-gate.yml
+++ b/.github/workflows/user-facing-lang-gate.yml
@@ -1,0 +1,43 @@
+name: user-facing-lang gate
+
+# #6084: ratchets a NEW undecided-language (Japanese) literal landing
+# directly at a confirmed user-facing-text sink call site under
+# src/reyn/interfaces/ -- see scripts/user_facing_lang_gate.py's own module
+# docstring for the exact sinks covered and lead-coder's ruling on scope
+# (sink-derivable range only, never full-population coverage; the ~89
+# already-existing kana-bearing strings this repo carries are a SEPARATE,
+# wider count -- this gate's own baseline, scripts/
+# user_facing_lang_gate_baseline.json, is narrower by design).
+#
+# `paths: src/reyn/interfaces/**` matches this gate's own v1 scope exactly
+# -- same reasoning as silent-except-ratchet-gate.yml's identical path
+# scoping.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/interfaces/**"
+      - "scripts/user_facing_lang_gate.py"
+      - "scripts/user_facing_lang_gate_baseline.json"
+
+permissions:
+  contents: read
+
+jobs:
+  user-facing-lang-gate:
+    name: user-facing-lang gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/user_facing_lang_gate.py is stdlib-only (ast / json /
+      # pathlib). No pip install needed.
+      - name: Check no new undecided-language literal at a confirmed sink
+        run: |
+          python scripts/user_facing_lang_gate.py

--- a/scripts/claude_md_word_count_baseline.json
+++ b/scripts/claude_md_word_count_baseline.json
@@ -1,7 +1,7 @@
 {
-  "CLAUDE.md": 2657,
+  "CLAUDE.md": 2656,
   "src/reyn/core/events/CLAUDE.md": 74,
-  "src/reyn/interfaces/CLAUDE.md": 396,
+  "src/reyn/interfaces/CLAUDE.md": 428,
   "src/reyn/mcp/CLAUDE.md": 22,
   "src/reyn/schemas/CLAUDE.md": 34,
   "src/reyn/security/sandbox/CLAUDE.md": 31,

--- a/scripts/user_facing_lang_gate.py
+++ b/scripts/user_facing_lang_gate.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""#6084 — a ratchet over user-facing-text sink call sites carrying an
+undecided (Japanese-literal) string, under `src/reyn/interfaces/`.
+
+## What this gate is, precisely — read lead-coder's ruling on #6084 first
+
+lead-coder's #6084 ruling (quoted, not re-derived here): this gate's job is
+NOT "delete the existing ~89 findings" — it is "stop the NEXT one after the
+89th." A CONTRIBUTOR ADDING A NEW SINK CALL WRITES THE LITERAL AT THE CALL
+SITE, so the range this gate can see (a literal string argument, directly at
+a named sink's call site) IS the range where a new violation would land.
+
+## Scope: named sinks only — this is NOT full population coverage
+
+#6084's own investigation comment (file:line evidence, read it before
+touching this script) established that the population of "text a user sees"
+does NOT reduce to a single AST pattern: a literal can reach a sink through a
+dict lookup, another function's return value, or several hops of indirection
+(concrete examples: `compaction_progress.py:154158` — a dict-literal lookup
+several lines above the f-string that actually renders; `compaction_progress.
+py:258261` — a 3-hop dict-return through `compaction_failure_text()`;
+`voice.py:8391` — a same-shape indirection, in English, showing the pattern
+is language-neutral). None of those are IN SCOPE here. **This script gates
+ONLY these sinks, and only when the argument is a string literal (or an
+f-string whose literal segments are checked) written directly at the call
+site**:
+
+- `OutboxMessage(text=...)` — direct construction (keyword `text`)
+- `reply(ctx, text, ...)` / `reply_error(ctx, text)` — the slash-reply
+  helpers (`src/reyn/interfaces/slash/__init__.py`); `text` is their second
+  POSITIONAL argument
+- `argparse` `.add_argument(help=...)` and `.add_parser(..., help=...,
+  description=...)`
+- `DrawerRow(label=...)` — the one confirmed custom-widget kwarg
+  (`src/reyn/interfaces/inline/textual_chat/chrome.py`)
+
+Anywhere else in `interfaces/` a user-facing string might originate — a
+different custom widget's kwarg not in this list, `App.notify(...)` (whose
+argument is typically a function call, not a literal, per the investigation),
+`interfaces/repl/` renderers beyond the one `OutboxMessage(...)` call the
+investigation actually walked — is explicitly UNSCANNED. Extending the sink
+list is a deliberate, separate decision (add the name to `_SINK_SPECS` below
+and regenerate the baseline), never assumed by this docstring.
+
+**Never claim this "eventually catches everything."** It catches a NEW
+literal Japanese string landed directly at one of the five sink shapes
+above. Nothing else.
+
+## Detection basis: kana only, matching the investigation's own AST count
+
+The investigation's own from-scratch AST scanner (its own disclosed method,
+not this gate re-deriving it) used the kana range (`぀`-`ヿ`,
+hiragana + katakana) to reach its committed 89-finding/28-file number, and
+explicitly found that widening to CJK ideographs (`一`-`鿿`) added
+only comment/docstring hits, never a string-literal hit at one of these
+sinks. This gate matches that choice — kana only — so its own baseline count
+is comparable to the investigation's, rather than diverging on a range
+neither of us has re-justified.
+
+## Indirection at the ARGUMENT is out of scope, not the sink
+
+If the extracted argument node is not a plain string literal (`ast.Constant`
+str) or an f-string (`ast.JoinedStr`, checked only in its literal segments;
+a `{expr}` placeholder is not inspected) — e.g. a `Name`, `Attribute`,
+`Subscript`, or another `Call` — this script skips that call site entirely.
+It does NOT walk further to resolve what the name/lookup/call eventually
+returns. That is the exact indirection class ruling 1 puts out of scope.
+
+## Exception: a deliberate i18n pair, by STRUCTURE, never a name/file list
+
+`web/routers/web_data.py`'s `_COPY_EN`/`_COPY_JA` pair is a ALREADY-DECIDED
+i18n design (a locale-keyed `{"en": _COPY_EN, "ja": _COPY_JA}` table), not an
+instance of "no decision was made" — ruling 3 requires this be excluded by a
+MECHANICAL condition, never a hardcoded path or variable-name list (a list
+means the next new intentional-i18n pair silently isn't recognised until a
+human remembers to add it by hand).
+
+The condition implemented here: **a module-level assignment target whose
+name ends in `_EN` (or `_JA`) is exempt, together with everything nested
+inside its value expression, if — and only if — the SAME module also has a
+module-level assignment target with the identical prefix and the OTHER
+suffix** (`_EN`⟷`_JA`). This is checked purely from each file's own AST
+(`_collect_i18n_pair_names`) — no name is special-cased, no path is named;
+any future `_FOO_EN = {...}` / `_FOO_JA = {...}` pair in ANY file under
+scope is recognised the same way, automatically, the day it is written.
+
+## Baseline semantics — same contract as `silent_except_ratchet.py`
+
+The committed baseline is whatever THIS script's own AST logic measures
+against the tree TODAY — not a hand-transcription of the investigation's 89.
+The two are expected to be close (the investigation's own sink survey is
+what this script's `_SINK_SPECS` encodes) but not necessarily identical: the
+investigation's scanner and this one are independently written, and the
+investigation's own AST tool explicitly did not attempt to check for the
+i18n-pair exception at all (that exception was one of THIS gate's rulings).
+
+CI: gate
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_BASELINE_PATH = _ROOT / "scripts" / "user_facing_lang_gate_baseline.json"
+_SCOPE = "src/reyn/interfaces"
+
+# Kana (hiragana + katakana) only — see module docstring's "Detection
+# basis" section for why this deliberately does not widen to CJK
+# ideographs.
+_KANA_RE = re.compile(r"[぀-ヿ]")
+
+# Sink name -> list of ("kwarg", name) | ("pos", index) argument specs.
+# Each entry is a confirmed sink from #6084's investigation comment — see
+# module docstring's Scope section. Extending this is a deliberate,
+# separate decision (regenerate the baseline in the same PR).
+_SINK_SPECS: "dict[str, list[tuple[str, object]]]" = {
+    "OutboxMessage": [("kwarg", "text")],
+    "reply": [("pos", 1)],
+    "reply_error": [("pos", 1)],
+    "add_argument": [("kwarg", "help")],
+    "add_parser": [("kwarg", "help"), ("kwarg", "description")],
+    "DrawerRow": [("kwarg", "label")],
+}
+
+
+def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
+    """Every tracked `.py` file under `src/reyn/interfaces/` — same
+    population source (`git ls-files`) `silent_except_ratchet.py` uses,
+    for the same reason: no hand-maintained exclusion list."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _call_target_name(node: ast.Call) -> "str | None":
+    f = node.func
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    if isinstance(f, ast.Name):
+        return f.id
+    return None
+
+
+def _extract_arg(node: ast.Call, spec: "tuple[str, object]") -> "ast.expr | None":
+    kind, key = spec
+    if kind == "kwarg":
+        for kw in node.keywords:
+            if kw.arg == key:
+                return kw.value
+        return None
+    if kind == "pos":
+        idx = key
+        assert isinstance(idx, int)
+        if len(node.args) > idx:
+            return node.args[idx]
+        return None
+    return None
+
+
+def _literal_text(node: ast.expr) -> "str | None":
+    """The literal string content of *node*, or ``None`` if *node* is not a
+    plain string literal or an f-string with only-literal segments checked.
+    A `{expr}` placeholder inside an f-string is not inspected — only the
+    literal (`ast.Constant`) segments of the `ast.JoinedStr` are joined."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts = [v.value for v in node.values if isinstance(v, ast.Constant) and isinstance(v.value, str)]
+        return "".join(parts)
+    return None
+
+
+def _collect_i18n_pair_exempt_ids(tree: ast.Module) -> "set[int]":
+    """`id()` of every AST node nested inside a module-level assignment
+    whose target name ends in `_EN`/`_JA` AND has a same-prefix sibling
+    with the other suffix, also at module level. See module docstring's
+    "Exception" section — this is the structural condition, not a name or
+    file list."""
+    top_level_names: "set[str]" = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    top_level_names.add(tgt.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            top_level_names.add(node.target.id)
+
+    def has_sibling(name: str) -> bool:
+        if name.endswith("_EN"):
+            return (name[: -len("_EN")] + "_JA") in top_level_names
+        if name.endswith("_JA"):
+            return (name[: -len("_JA")] + "_EN") in top_level_names
+        return False
+
+    exempt_ids: "set[int]" = set()
+    for node in tree.body:
+        targets: "list[ast.expr]" = []
+        value: "ast.expr | None" = None
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target] if node.target else [], node.value
+        if value is None:
+            continue
+        for tgt in targets:
+            if isinstance(tgt, ast.Name) and has_sibling(tgt.id):
+                for descendant in ast.walk(value):
+                    exempt_ids.add(id(descendant))
+                break
+    return exempt_ids
+
+
+def findings(path: Path, display: "str | None" = None) -> "list[str]":
+    """`["display:lineno:sink_name", ...]` for every sink call site in
+    *path* whose extracted argument is a direct string literal (or
+    f-string literal segment) containing kana, and is not inside an
+    i18n-pair exemption. *display* is the path string used in the key
+    (defaults to `str(path)`) — `measured` passes the repo-relative form so
+    baseline keys stay portable across checkouts. Raises on a parse
+    failure — see `measured`'s fail-closed note; propagated the same way
+    `silent_except_ratchet.py` propagates one, for the same reason (a
+    silent under-count here would be the defect this gate exists to
+    catch, recurring one layer up)."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    exempt_ids = _collect_i18n_pair_exempt_ids(tree)
+    shown = display if display is not None else str(path)
+    out: "list[str]" = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_target_name(node)
+        if name is None or name not in _SINK_SPECS:
+            continue
+        for spec in _SINK_SPECS[name]:
+            arg = _extract_arg(node, spec)
+            if arg is None or id(arg) in exempt_ids:
+                continue
+            literal = _literal_text(arg)
+            if literal is None:
+                continue
+            if _KANA_RE.search(literal):
+                out.append(f"{shown}:{node.lineno}:{name}")
+    return out
+
+
+def measured(root: Path = _ROOT) -> "tuple[set[str], int]":
+    """`(finding_set, scanned_file_count)`. A file that fails to parse is
+    NOT caught here — it propagates to `main`, same fail-closed contract
+    `silent_except_ratchet.py` documents (this scan's own under-count would
+    be the exact defect this gate exists to prevent, one layer up)."""
+    files = _iter_scan_files(root)
+    all_findings: "set[str]" = set()
+    for path in files:
+        rel = str(path.relative_to(root))
+        all_findings.update(findings(path, display=rel))
+    return (all_findings, len(files))
+
+
+def load_baseline(path: Path = _BASELINE_PATH) -> "set[str]":
+    return set(json.loads(path.read_text(encoding="utf-8")))
+
+
+def write_baseline(finding_set: "set[str]", path: Path = _BASELINE_PATH) -> None:
+    path.write_text(json.dumps(sorted(finding_set), indent=2) + "\n", encoding="utf-8")
+
+
+def new_findings(measured_set: "set[str]", baseline_set: "set[str]") -> "set[str]":
+    """The ratchet check: a measured finding absent from baseline is new
+    debt. A baselined finding that disappears from `measured` (the file's
+    literal was fixed, or the call site removed) is silently allowed to
+    drop — the same silent-shrink contract every ratchet here shares."""
+    return measured_set - baseline_set
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help=(
+            "regenerate the baseline from the CURRENT measured findings "
+            "instead of checking against it. Use for initial adoption, a "
+            "real fix you want to lock in, or a deliberate reviewed new "
+            "sink-literal (say why in the PR body) — no comment-based "
+            "exception escape hatch exists."
+        ),
+    )
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        current, scanned = measured(_ROOT)
+    except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+        print(
+            f"user-facing-lang gate FAILED: could not scan the population "
+            f"({exc}). This gate fails CLOSED on a scan error rather than "
+            f"silently under-counting — fix the scan (or the file it "
+            f"choked on), do not treat this as a pass.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if scanned == 0:
+        print(
+            f"user-facing-lang gate FAILED: the scan found 0 files under "
+            f"{_SCOPE}/ — this is a scanner failure, not a clean "
+            "population; `git ls-files` returned nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.write_baseline:
+        write_baseline(current, _BASELINE_PATH)
+        print(
+            f"Wrote {len(current)} user-facing-lang finding(s) to "
+            f"{_BASELINE_PATH}, {scanned} file(s) scanned under {_SCOPE}/."
+        )
+        return 0
+
+    baseline = load_baseline(_BASELINE_PATH)
+    new = new_findings(current, baseline)
+
+    if new:
+        print("user-facing-lang gate FAILED:\n", file=sys.stderr)
+        print(
+            f"{len(new)} new sink call site(s) carry an undecided "
+            f"(kana-containing) literal, not in the baseline "
+            f"({_BASELINE_PATH.relative_to(_ROOT)}):",
+            file=sys.stderr,
+        )
+        for f in sorted(new):
+            print(f"  {f}", file=sys.stderr)
+        print(
+            "\nA literal string at one of this gate's confirmed sinks "
+            "(OutboxMessage(text=), reply()/reply_error(), argparse "
+            "help=/description=, DrawerRow(label=)) contains kana — see "
+            "scripts/user_facing_lang_gate.py's own module docstring for "
+            "exactly what this does and does not catch, and for the "
+            "existing ~89 grandfathered findings' baseline. This gate does "
+            "NOT enforce a target language; it only blocks a NEW site of "
+            "this specific shape from landing unreviewed. If this is a "
+            "deliberate, reviewed addition, say so in the PR body and run "
+            "--write-baseline.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"user-facing-lang gate OK: {len(current)} finding(s), all "
+        f"baselined ({scanned} file(s) scanned under {_SCOPE}/). Covers "
+        "only the confirmed sink list at a direct-literal call site — see "
+        "module docstring for scope."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/user_facing_lang_gate_baseline.json
+++ b/scripts/user_facing_lang_gate_baseline.json
@@ -1,0 +1,14 @@
+[
+  "src/reyn/interfaces/cli/commands/web.py:109:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:120:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:17:add_parser",
+  "src/reyn/interfaces/cli/commands/web.py:22:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:28:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:35:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:46:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:51:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:59:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:72:add_argument",
+  "src/reyn/interfaces/cli/commands/web.py:92:add_argument",
+  "src/reyn/interfaces/inline/textual_chat/chrome.py:1212:DrawerRow"
+]

--- a/src/reyn/interfaces/CLAUDE.md
+++ b/src/reyn/interfaces/CLAUDE.md
@@ -1,3 +1,9 @@
+## User-facing string language (#6084)
+
+`scripts/user_facing_lang_gate.py` blocks a NEW undecided-language literal
+at a confirmed sink call site — it does not cover the full population; see
+its own module docstring for scope.
+
 # TUI colour policy — rules for `src/reyn/interfaces/`
 
 Name the MEANING; the active Textual theme renders it. Never pick a colour

--- a/tests/scripts/fixtures/user_facing_lang_6084/has_sink_literals.py
+++ b/tests/scripts/fixtures/user_facing_lang_6084/has_sink_literals.py
@@ -1,0 +1,28 @@
+"""Fixture for user_facing_lang_gate.py's own test suite (#6084).
+
+Not a real module — never imported, never collected as a test.
+`tests/scripts/test_user_facing_lang_gate_6084.py` reads this file
+directly by path (parsed, never executed). Carries exactly THREE flagged
+sink call sites: an `OutboxMessage(text=...)` literal, a `reply(ctx, ...)`
+positional literal, and a `DrawerRow(label=...)` literal.
+"""
+from __future__ import annotations
+
+
+async def reply(ctx, text: str) -> None:  # stand-in for the real slash-reply helper
+    ...
+
+
+class DrawerRow:  # stand-in for the real custom widget
+    def __init__(self, *, label: str, command=None) -> None: ...
+
+
+async def emit(ctx) -> None:
+    from reyn.runtime.outbox import OutboxMessage
+
+    ctx.transport.put_display(OutboxMessage(kind="system", text="こんにちは"))
+    await reply(ctx, "ダメです")
+
+
+def rows():
+    return [DrawerRow(label="実行中の task はありません", command=None)]

--- a/tests/scripts/fixtures/user_facing_lang_6084/i18n_pair_exempt.py
+++ b/tests/scripts/fixtures/user_facing_lang_6084/i18n_pair_exempt.py
@@ -1,0 +1,21 @@
+"""Fixture for user_facing_lang_gate.py's own test suite (#6084).
+
+Not a real module — never imported, never collected as a test. Exercises
+ruling 3's structural i18n-pair exception: a module-level `_FOO_EN` /
+`_FOO_JA` pair (matching suffix, same prefix, both module-level) is exempt
+— together with everything nested inside its value expression — while a
+same-shaped `_BAR_JA` WITHOUT an `_BAR_EN` sibling is NOT exempt and must
+still be flagged. The exempt/non-exempt pair below share the exact same
+sink shape so the only variable between them is the sibling's presence.
+"""
+from __future__ import annotations
+
+from reyn.runtime.outbox import OutboxMessage
+
+# Exempt: `_FOO_EN` sibling exists below, same prefix, both module-level.
+_FOO_JA = OutboxMessage(kind="system", text="こんにちは")
+_FOO_EN = OutboxMessage(kind="system", text="hello")
+
+# NOT exempt: no `_BAR_EN` sibling anywhere in this module — same nesting
+# shape as `_FOO_JA` above, must still be flagged.
+_BAR_JA = OutboxMessage(kind="system", text="ダメです")

--- a/tests/scripts/fixtures/user_facing_lang_6084/indirect_not_flagged.py
+++ b/tests/scripts/fixtures/user_facing_lang_6084/indirect_not_flagged.py
@@ -1,0 +1,31 @@
+"""Fixture for user_facing_lang_gate.py's own test suite (#6084).
+
+Not a real module — never imported, never collected as a test. Every kana
+string here reaches a sink through indirection (dict lookup, another
+function's return value) — this IS the out-of-scope witness: ruling 1
+puts argument-side indirection out of scope, and this fixture's sink call
+sites must produce ZERO findings despite carrying kana strings nearby.
+"""
+from __future__ import annotations
+
+_LABELS = {"empty": "実行中の task はありません"}
+
+
+def unavailable_message() -> str:
+    return "ダメです"
+
+
+async def reply(ctx, text: str) -> None:  # stand-in for the real slash-reply helper
+    ...
+
+
+async def emit(ctx) -> None:
+    from reyn.runtime.outbox import OutboxMessage
+
+    # Sink literal argument is a dict lookup, not a literal at the call
+    # site — out of scope (same shape as compaction_progress.py:154/158
+    # from #6084's investigation comment).
+    ctx.transport.put_display(OutboxMessage(kind="system", text=_LABELS["empty"]))
+    # Sink literal argument is a function call's return value — out of
+    # scope (same shape as voice.py:83-91).
+    await reply(ctx, unavailable_message())

--- a/tests/scripts/test_user_facing_lang_gate_6084.py
+++ b/tests/scripts/test_user_facing_lang_gate_6084.py
@@ -1,0 +1,128 @@
+"""Tier 1: `user_facing_lang_gate.py`'s own detector logic (#6084).
+
+lead-coder's own ruling on #6084: the gate covers ONLY the sink-derivable
+range (a string literal directly at a named sink's call site), never the
+full population, and an i18n pair (`_FOO_EN`/`_FOO_JA`, matched by
+STRUCTURE not by name/file list) is exempt. The fixtures under
+`tests/scripts/fixtures/user_facing_lang_6084/` ARE that witness, permanently
+checked in (not a strip-and-revert scratch) — one for a direct sink literal
+(must flag), one for argument-side indirection (must NOT flag, out of
+scope per ruling 1), one for the i18n-pair exception (must exempt the
+paired name, must still flag an unpaired sibling-less name).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.user_facing_lang_gate import (
+    findings,
+    load_baseline,
+    new_findings,
+    write_baseline,
+)
+from tests._support.paths import REPO_ROOT
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "user_facing_lang_6084"
+
+
+def test_a_direct_sink_literal_is_flagged():
+    """Tier 1: the false-accept-side witness — a kana literal written
+    directly at one of the confirmed sinks (`OutboxMessage(text=)`,
+    `reply(ctx, ...)`, `DrawerRow(label=)`) is counted, one finding per
+    call site."""
+    fixture = _FIXTURES / "has_sink_literals.py"
+    found = set(findings(fixture))
+    expected_sinks = {"OutboxMessage", "reply", "DrawerRow"}
+    assert {f.rsplit(":", 1)[1] for f in found} == expected_sinks, (
+        "expected exactly one finding per confirmed sink in this fixture, "
+        "no more and no fewer"
+    )
+
+
+def test_argument_side_indirection_is_not_flagged():
+    """Tier 1: the false-reject-side witness, required alongside the test
+    above so a detector that flags every sink call unconditionally (which
+    would ALSO pass the direct-literal test) cannot pass this suite. Both
+    of this fixture's sink calls carry kana text NEARBY (a dict, a
+    function return) but never AS the literal argument at the call site —
+    ruling 1's explicit out-of-scope shape."""
+    assert findings(_FIXTURES / "indirect_not_flagged.py") == []
+
+
+def test_i18n_pair_is_exempt_by_structure_not_name():
+    """Tier 2: ruling 3's structural exception — `_FOO_JA` is exempt only
+    because a module-level `_FOO_EN` sibling exists in the SAME file; an
+    unpaired `_BAR_JA` with the identical nesting shape and no sibling is
+    still flagged. This is the discriminating pair: a detector that
+    exempted by matching the LITERAL `_JA`/`_EN` suffix alone (rather than
+    requiring the sibling) would pass a version of this test missing the
+    `_BAR_JA` half — both assertions are required."""
+    fixture = _FIXTURES / "i18n_pair_exempt.py"
+    found = findings(fixture)
+    lines = fixture.read_text(encoding="utf-8").splitlines()
+    bar_ja_lineno = next(i + 1 for i, line in enumerate(lines) if line.startswith("_BAR_JA ="))
+    assert found == [f"{fixture}:{bar_ja_lineno}:OutboxMessage"], (
+        "expected exactly one finding, at the unpaired _BAR_JA line — the "
+        "paired _FOO_JA line must be exempt"
+    )
+
+
+def test_new_findings_flags_a_finding_absent_from_baseline():
+    """Tier 2: the ratchet arithmetic itself (shared shape with
+    `silent_except_ratchet.py`'s own `grown_files`) — a measured finding
+    not in the baseline is new debt."""
+    assert new_findings({"a.py:1:OutboxMessage"}, set()) == {"a.py:1:OutboxMessage"}
+
+
+def test_new_findings_silently_allows_a_shrink():
+    """Tier 2: a baselined finding that disappears from `measured` (the
+    literal fixed, or the call site removed) is never reported — the
+    silent-shrink contract every ratchet here shares."""
+    assert new_findings(set(), {"a.py:1:OutboxMessage"}) == set()
+
+
+def test_write_baseline_then_load_baseline_round_trips(tmp_path: Path) -> None:
+    """Tier 2: the baseline format round-trips through write/load."""
+    path = tmp_path / "baseline.json"
+    write_baseline({"b.py:2:reply", "a.py:1:OutboxMessage"}, path)
+    assert load_baseline(path) == {"a.py:1:OutboxMessage", "b.py:2:reply"}
+
+
+def test_a_file_that_fails_to_parse_raises_rather_than_finding_nothing(tmp_path: Path) -> None:
+    """Tier 2: fail-closed on a scan error — a file this script cannot
+    parse must propagate the parse error, not silently contribute nothing
+    to the finding set (same contract `silent_except_ratchet.py` commits
+    to, for the same reason).
+
+    NON-VACUITY (strip-falsified locally, in-file Edit -> run -> Edit
+    back): reverting `findings` to a `try/except: return []` shape makes
+    this assertion fail — it would return `[]` instead of raising."""
+    broken = tmp_path / "broken.py"
+    broken.write_text("def f(:\n    pass\n", encoding="utf-8")
+    with pytest.raises(SyntaxError):
+        findings(broken)
+
+
+def test_the_real_scan_against_the_current_tree_matches_the_baseline() -> None:
+    """Tier 1: the load-bearing witness — running the real scan against
+    the real repo tree, right now, must find nothing beyond what's
+    baselined. Mirrors `silent_except_ratchet.py`'s own identically-shaped
+    test."""
+    from scripts.user_facing_lang_gate import _BASELINE_PATH, measured
+
+    baseline = load_baseline(_BASELINE_PATH)
+    current, scanned = measured(REPO_ROOT)
+    assert scanned > 0, "the scan found 0 files — a scanner failure, not a clean population"
+    assert new_findings(current, baseline) == set()
+
+
+def test_a_new_uncommitted_finding_would_be_caught() -> None:
+    """Tier 2: integration — planting the direct-sink-literal fixture's
+    own findings as a new "measured" set beyond an empty baseline is
+    reported as grown debt. Confirms the ratchet arithmetic is wired to
+    the real detector, not just unit-tested in isolation above."""
+    measured_now = set(findings(_FIXTURES / "has_sink_literals.py"))
+    assert new_findings(measured_now, set()) == measured_now
+    assert measured_now, "expected at least one finding from this fixture, wiring is broken"


### PR DESCRIPTION
**[backlog-watcher]** — part of #6084.

Implements lead-coder's #6084 ruling (quoted in full in the issue) exactly: rulings 1-4, no mass rewrite, no new language policy.

## What this does

`scripts/user_facing_lang_gate.py` — an AST-based gate over five confirmed sink shapes from #6084's investigation comment:

- `OutboxMessage(text=...)` — direct construction
- `reply(ctx, text, ...)` / `reply_error(ctx, text)` — the slash-reply helpers
- `argparse` `.add_argument(help=...)` and `.add_parser(..., help=..., description=...)`
- `DrawerRow(label=...)` — the one confirmed custom-widget kwarg

A call site is flagged only when the extracted argument is a **direct string literal** (or an f-string's literal segments) containing kana (`぀-ヿ`), matching the investigation's own detection basis. **Ruling 1 — scope, explicitly not full coverage**: when the argument is indirected (a dict lookup, another function's return value, multi-hop reference), that site is explicitly out of scope — the gate's own module docstring says so, with the investigation's own examples (`compaction_progress.py:154/158`, `:258-261`, `voice.py:83-91`).

## Baseline count: 12, not ~89 — why, explained

The investigation's 89 is a **file-wide** kana-literal AST count (docstrings 45, dict values 21, kwargs 13, f-string parts 4, etc. — the full population). This gate's own baseline is **12**, because ruling 1 narrows scope to only the five named sinks' *direct-literal call sites* — the overwhelming majority of the investigation's 89 (docstrings, dict-literal values not passed to a sink, indirected references) sit outside that range by design. The 12: all 11 in `src/reyn/interfaces/cli/commands/web.py` (`add_argument`/`add_parser` help/description text) plus 1 in `src/reyn/interfaces/inline/textual_chat/chrome.py:1212` (`DrawerRow(label=...)`). No `OutboxMessage(text=...)` or `reply()`/`reply_error()` call site in the current tree carries a kana literal *directly* at the call site (spot-checked with `git grep` — the Japanese text that does exist near those call sites lives in comments/docstrings or is built through an indirection, both out of this gate's scope).

## Ruling 2 — ratchet baseline, no mass rewrite

`scripts/user_facing_lang_gate_baseline.json` — committed, regenerated via `--write-baseline`, never hand-typed. Growth (a new finding not in the baseline) is red; the existing 12 are grandfathered. No Japanese string in the current tree was rewritten.

## Ruling 3 — exception is a CONDITION, never a list

`_collect_i18n_pair_exempt_ids` in the gate script: a module-level assignment target whose name ends `_EN` (or `_JA`) is exempt — together with everything nested inside its value expression — **only if** the same module also has a module-level assignment target with the identical prefix and the other suffix. No name or path is hardcoded; this recognizes `web_data.py`'s `_COPY_EN`/`_COPY_JA` (and any future `_FOO_EN`/`_FOO_JA` pair, anywhere in scope) automatically, purely from each file's own AST. Exercised by `tests/scripts/fixtures/user_facing_lang_6084/i18n_pair_exempt.py` (a paired `_FOO_JA`/`_FOO_EN` — exempt — next to an unpaired `_BAR_JA` — still flagged — sharing the identical nesting shape).

## Ruling 4 — one line in `src/reyn/interfaces/CLAUDE.md`

```
## User-facing string language (#6084)

`scripts/user_facing_lang_gate.py` blocks a NEW undecided-language literal
at a confirmed sink call site — it does not cover the full population; see
its own module docstring for scope.
```

`claude_md_word_count_ratchet.py` failed after this edit (the file already needed a baseline bump, not something this PR introduced beyond its own +32 words) — ran `--write-baseline` for this edit only; the updated `scripts/claude_md_word_count_baseline.json` is in this diff.

## What this explicitly does NOT do (per the ruling)

- No mass rewrite/translation of the existing 12 (or the investigation's ~89) Japanese user-facing strings.
- No new user-facing-string-language policy — this blocks growth of the CURRENT sink-detectable population; it does not enforce a target language.
- No new sinks/files beyond the confirmed list — `interfaces/repl/`, `interfaces/web/` (frontend), and any custom-widget kwarg not already confirmed remain unscanned, as the investigation explicitly disclosed.

## Gates run (all green)

- `ruff check .`
- `python scripts/test_tier_audit.py --strict tests/scripts/test_user_facing_lang_gate_6084.py`
- `python scripts/verify_module_docstrings.py scripts/user_facing_lang_gate.py`
- `python scripts/mypy_ratchet.py`
- `python scripts/flat_tests_ratchet.py`
- `python scripts/check_tests_path_literal_reference.py`
- `python scripts/claude_md_word_count_ratchet.py` (after `--write-baseline`, committed)
- `python scripts/check_bare_tests_import_reference.py`
- `python scripts/check_file_depth_reference.py`
- `python scripts/check_subprocess_reyn_pin.py`
- `python scripts/check_no_core_dep_importorskip.py`
- `python scripts/suspected_time_dependence_ratchet.py`
- `python scripts/silent_except_ratchet.py` (src/reyn/interfaces/ path touched, CLAUDE.md only)
- `pytest tests/scripts/test_user_facing_lang_gate_6084.py` — 9 passed

Note: this worktree's editable `reyn` install resolved to a different checkout on `sys.path` (a stale `.pth` from another project); worked around locally with an explicit `PYTHONPATH=<this worktree>/src` prefix per gate invocation rather than skipping any gate.

## Test plan

- [x] New Tier 1/2 tests in `tests/scripts/test_user_facing_lang_gate_6084.py` — false-accept witness (direct sink literal flagged), false-reject witness (argument-side indirection NOT flagged), i18n-pair-exception witness (paired name exempt, unpaired sibling-less name still flagged), ratchet arithmetic, baseline round-trip, fail-closed-on-parse-error, real-tree-matches-baseline, integration (new finding caught).
- [x] `python scripts/test_tier_audit.py --strict` on the new test file — 9/9 OK, no Tier 4 violations.
- [x] (skipped — Visual, standing waiver) no UI-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5