### PR TITLE
fix(part of #5987 stage 1): wire bash_node_kind_count_ratchet.py into CI

### DIFF
--- a/.github/workflows/bash-node-kind-count-ratchet.yml
+++ b/.github/workflows/bash-node-kind-count-ratchet.yml
@@ -1,0 +1,50 @@
+name: bash-node-kind-count ratchet
+
+# #5987 stage 1: ratchets the COUNT of tree-sitter-bash grammar node-kind
+# names scripts/bash_node_kind_count_ratchet.py derives from the INSTALLED
+# tree-sitter-bash package -- a red means either the dependency was bumped
+# (update the committed baseline, scripts/bash_node_kind_count_baseline.json,
+# in the SAME PR as the bump) or src/reyn/security/bash_node_kinds.py's own
+# derivation logic broke. See that script's own module docstring for the
+# full design. Landed (#6086) without ever being wired into a workflow --
+# scripts/check_ci_role_declared.py (#6014) caught the gap.
+#
+# `paths` matches everything that can move this gate's own inputs: the
+# dependency declaration, the derivation module, the script itself, and its
+# committed baseline.
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "src/reyn/security/bash_node_kinds.py"
+      - "scripts/bash_node_kind_count_ratchet.py"
+      - "scripts/bash_node_kind_count_baseline.json"
+
+permissions:
+  contents: read
+
+jobs:
+  bash-node-kind-count-ratchet:
+    name: bash-node-kind-count ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/bash_node_kind_count_ratchet.py imports
+      # reyn.security.bash_node_kinds, which needs the real installed
+      # tree-sitter/tree-sitter-bash packages (core deps) -- an editable
+      # install of the project itself is required, unlike most gate
+      # scripts here which are stdlib-only.
+      - name: Install reyn (core deps only)
+        run: pip install -e . -c ci-constraints.txt
+
+      - name: Check the bash-node-kind-count ratchet
+        run: |
+          python scripts/bash_node_kind_count_ratchet.py


### PR DESCRIPTION
**[backlog-watcher]** — main is currently red on `ci-role declared gate` (`scripts/check_ci_role_declared.py`): #6086 added `scripts/bash_node_kind_count_ratchet.py` declaring `CI: gate` but never wired it into any `.github/workflows/*.yml` — the exact #6014 class of defect that gate exists to catch. Surfaced by that check's own CI run on unrelated PR #6090 once #6086 merged.

Adds a dedicated per-PR workflow (`bash-node-kind-count-ratchet.yml`), path-scoped to what can move this gate's own inputs (`pyproject.toml`, the derivation module, the script, its committed baseline) — same shape as `silent-except-ratchet-gate.yml`.

Verified locally:
- `python scripts/check_ci_role_declared.py` → all 98 scripts satisfy their declared role.
- `python scripts/bash_node_kind_count_ratchet.py` → 236, matches baseline.

part of #5987

## Test plan
- [x] `check_ci_role_declared.py` green locally
- [x] `bash_node_kind_count_ratchet.py` green locally
- [x] (skipped — Visual: no UI surface, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5