### PR TITLE
fix(part of #6085 stage 1): compaction episode-marker absorption races an independently-polled settle

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -5621,12 +5621,38 @@ class TextualChatApp(App):
         # marker`` tag) absorb into the SAME single flowview entry the
         # episode's progress lives on, TUI-local — the source emission is
         # UNCHANGED (other surfaces with no episode-entry mechanism, e.g.
-        # AG-UI, still receive these frames exactly as before). Absorbed
-        # only while an entry is actually open; a marker arriving with no
-        # open entry (a REMOTE reconnect mid-episode, or the entry already
-        # settled) falls through and appends as its own row rather than
-        # being silently dropped.
-        if meta.get("compaction_episode_marker") and self._compaction_progress_entry is not None:
+        # AG-UI, still receive these frames exactly as before).
+        #
+        # #6085 stage 1: absorption is gated on ``compaction_episode_seq``
+        # IDENTITY, not merely "is some entry open" — the ROW's own settle
+        # (``_settle_compaction_progress``) and the MARKER frames arrive on
+        # two independent channels (a polled status snapshot vs. discrete
+        # display frames) with no ordering guarantee between them; a
+        # marker-tagged frame for the episode that JUST ended could
+        # therefore arrive AFTER the row already settled (reproduced live,
+        # #6085's own issue thread) — under the OLD "is not None" guard
+        # that late frame fell through and appeared as its own separate
+        # row (the reported "4 lines" symptom). Keeping the entry
+        # ADDRESSABLE past its own settle (see :meth:`_settle_compaction_
+        # progress`, which no longer clears the reference) and comparing
+        # STAMPED ids — never re-reading "what episode is current right
+        # now" at THIS decision point, which would just reproduce the same
+        # race one level up — closes that gap without any lock or wait.
+        #
+        # A MISMATCHED id (a genuinely new episode already started; or
+        # either side carries no id at all, e.g. an older producer/a
+        # forwarder built with no session context) falls through and
+        # appends as its own row — never silently absorbed into the wrong
+        # entry, and never silently dropped either (lead-coder ruling:
+        # "見えて間違う方が良い" — a stray extra row an operator can see and
+        # question beats a wrong fold nobody can see happened at all).
+        entry = self._compaction_progress_entry
+        if (
+            meta.get("compaction_episode_marker")
+            and entry is not None
+            and meta.get("compaction_episode_seq") is not None
+            and entry.item.meta.get("compaction_episode_seq") == meta.get("compaction_episode_seq")
+        ):
             return
         op_id = meta.get("op_id")
         if kind in ("tool_call_completed", "tool_call_failed") and op_id is not None:
@@ -7913,8 +7939,7 @@ class TextualChatApp(App):
         self._settle_compaction_progress(terminal_text=terminal_text, meta=meta)
 
     def _ensure_compaction_progress_entry(self, raw: dict) -> None:
-        """#5588: create the shrink-flow-episode row ONCE (idempotent — a
-        no-op while :attr:`_compaction_progress_entry` is already set) and
+        """#5588: create the shrink-flow-episode row ONCE per episode and
         start its spinner, mirroring :meth:`_begin_running_indicator`'s own
         two-step shape (stamp :data:`_RUNNING_SINCE_KEY`, register the
         per-entry ``animate_entry`` timer) rather than
@@ -7923,8 +7948,22 @@ class TextualChatApp(App):
         ``textual_flowview`` (confirmed: its own ``try``/``except`` swallows
         the ``AttributeError`` every time, so a pipeline run's row never
         actually spins today — a real, pre-existing, OUT-OF-SCOPE bug for
-        THIS issue, disclosed rather than silently copied into new code)."""
-        if self._compaction_progress_entry is not None:
+        THIS issue, disclosed rather than silently copied into new code).
+
+        #6085 stage 1: idempotency is now keyed on the entry's own
+        :attr:`~textual_flowview.Entry.state`, not merely "is a reference
+        held" — :meth:`_settle_compaction_progress` no longer clears
+        :attr:`_compaction_progress_entry` (kept addressable so a late
+        marker for the episode that just ended can still find it — see
+        that method's own docstring and ``_ingest_frame``'s absorption
+        check), so a bare ``is not None`` guard here would treat every
+        SETTLED prior episode's own row as "still open" and silently
+        block every later episode from ever getting its own row again. A
+        RUNNING entry blocks a new one (still genuinely the same, open
+        episode); a SUCCESS/ERROR entry does not (a new episode is
+        starting)."""
+        entry = self._compaction_progress_entry
+        if entry is not None and entry.state is EntryState.RUNNING:
             return
         from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
 
@@ -7935,32 +7974,52 @@ class TextualChatApp(App):
                 _COMPACTION_PROGRESS_KEY: True,
                 _RUNNING_SINCE_KEY: self._clock(),
                 "is_compacting": True,
+                # #6085 stage 1: this episode's own id, stamped ONCE at
+                # creation — read from the SAME snapshot dict the caller
+                # (_refresh_compaction_progress) already has in hand, never
+                # a second, separate "what's current now" read.
+                "compaction_episode_seq": raw.get("episode_seq"),
             },
         )
         try:
-            entry = self.conversation.append(item)
-            entry.set_state(EntryState.RUNNING)
-            self._flow.animate_entry(entry, 1.0 / self.RUNNING_BODY_FPS, lambda e: e.update())
+            new_entry = self.conversation.append(item)
+            new_entry.set_state(EntryState.RUNNING)
+            self._flow.animate_entry(new_entry, 1.0 / self.RUNNING_BODY_FPS, lambda e: e.update())
         except Exception:
             logger.exception("textual chat: could not start compaction progress row")
             return
-        self._compaction_progress_entry = entry
+        self._compaction_progress_entry = new_entry
         self._compaction_progress_terminal_baseline = raw.get("terminal_seq") or 0
 
     def _settle_compaction_progress(
         self, *, terminal_text: "str | None", meta: "dict | None" = None,
     ) -> None:
         """#5588 acceptance ③: stop the spinner and give the row a terminal
-        state EXACTLY ONCE — a no-op when no entry is open (already
-        settled, or never started), so a caller may call this
-        unconditionally every refresh cycle while ``is_compacting`` reads
-        False. *terminal_text* is ``None`` for a success settle (architect:
-        keep the EXISTING ``[↑ N turns compacted]`` marker as the success
-        text elsewhere — this row's own text never duplicates it, only its
-        gutter state flips to SUCCESS) or the resolved ``RetryLoopTerminal``
-        sentence for a genuine unrecovered failure."""
+        state EXACTLY ONCE — a no-op when no entry is open (never started)
+        OR the open entry has already been settled, so a caller may call
+        this unconditionally every refresh cycle while ``is_compacting``
+        reads False. *terminal_text* is ``None`` for a success settle
+        (architect: keep the EXISTING ``[↑ N turns compacted]`` marker as
+        the success text elsewhere — this row's own text never duplicates
+        it, only its gutter state flips to SUCCESS) or the resolved
+        ``RetryLoopTerminal`` sentence for a genuine unrecovered failure.
+
+        #6085 stage 1: the entry reference is deliberately NOT cleared at
+        the end any more (was ``self._compaction_progress_entry = None``)
+        — kept addressable so a marker-tagged display frame for THIS
+        episode that arrives late (reproduced live: the row's own settle
+        is driven by a POLLED status snapshot, a channel independent of
+        the discrete marker frames, with no ordering guarantee between
+        the two) can still find and fold into it via ``_ingest_frame``'s
+        own episode-id check, rather than falling through as its own
+        stray row. The "settled already" half of this no-op guard
+        (``entry.state is not RUNNING``) is what keeps this safe to call
+        every idle frame forever without redundant re-work — re-settling
+        an already-terminal entry on every subsequent False read would
+        otherwise bump its revision (and repaint it) once per frame,
+        unboundedly, for as long as the app stays idle."""
         entry = self._compaction_progress_entry
-        if entry is None:
+        if entry is None or entry.state is not EntryState.RUNNING:
             return
         try:
             self._flow.stop_entry_animation(entry)
@@ -7977,7 +8036,6 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: could not settle compaction progress row")
         entry.set_state(EntryState.ERROR if terminal_text is not None else EntryState.SUCCESS)
-        self._compaction_progress_entry = None
 
     def watch__destination(self, old_value: "_Destination", new_value: "_Destination") -> None:
         """#5131: the App is now showing a DIFFERENT agent (init or a real

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -21,7 +21,7 @@ own EventLog (#2570: a pipeline driver-session's live step progress).
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, Callable
 
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -50,9 +50,21 @@ class ChatLifecycleForwarder:
         outbox: asyncio.Queue,
         registry: "Any | None" = None,
         events: "Any | None" = None,
+        compaction_episode_seq: "Callable[[], int] | None" = None,
     ) -> None:
         self.outbox = outbox
         self._registry = registry
+        # #6085 stage 1: read-only access to the OWNING Session's compaction
+        # episode counter (`Session.compaction_episode_seq`) — a bound
+        # method, never a Session reference, so this forwarder stays
+        # decoupled from Session's own shape (same narrow-accessor idiom
+        # `_registry`/`_events` above already use). `None` (a caller with
+        # no session context, e.g. a test) means every marker this forwarder
+        # builds carries no episode id — the consumer's own absorption
+        # check (`app.py`) already treats a missing id as "does not match",
+        # never as "matches anything", so this degrades to always-append,
+        # never to a silent wrong-episode fold.
+        self._compaction_episode_seq = compaction_episode_seq
         # #2708 P3.1 Half-B: this forwarder's OWN session EventLog (the parent/caller
         # audit log). Used by the driver→parent bridge to re-emit a driver-session's
         # ``presented`` event onto the parent's log with ``bridged_from=<driver_sid>``,
@@ -181,6 +193,24 @@ class ChatLifecycleForwarder:
 
     # ── Compaction (issue #162) ──────────────────────────────────────────
 
+    def _compaction_marker_meta(self) -> "dict[str, Any]":
+        """#6085 stage 1: the marker meta every compaction-episode handler
+        below stamps its display frame with — carries the CURRENT episode's
+        own id (:meth:`Session.compaction_episode_seq`, read once, right
+        here, at the moment this frame is built — never re-read later by a
+        consumer deciding whether to fold it). ``None`` when this forwarder
+        was built with no accessor (a caller with no session context) —
+        app.py's own absorption check treats a missing id as "does not
+        match any open row", never as "matches anything", so a marker built
+        this way always lands as its own row rather than risking a silent
+        wrong-episode fold."""
+        return {
+            "compaction_episode_marker": True,
+            "compaction_episode_seq": (
+                self._compaction_episode_seq() if self._compaction_episode_seq else None
+            ),
+        }
+
     def on_compaction_started(self, data: dict) -> None:
         """Surface a ``[⟳ compacting N messages]`` marker when a real
         compaction pass begins (#5633 — owner: "縮小フロー開始開始通知みたいな
@@ -218,7 +248,7 @@ class ChatLifecycleForwarder:
         for BOTH producers, not different-but-each-correct. Degrades to a
         generic marker when absent, never a fabricated count."""
         count = data.get("new_message_count")
-        meta = {"compaction_episode_marker": True}
+        meta = self._compaction_marker_meta()
         if isinstance(count, int) and count > 0:
             self._enqueue(f"[⟳ compacting {count} message{'s' if count != 1 else ''}]", meta=meta)
         else:
@@ -266,7 +296,7 @@ class ChatLifecycleForwarder:
         """
         reason = str(data.get("error") or "unknown error")
         failure_class = data.get("failure_class")
-        meta = {"compaction_episode_marker": True}
+        meta = self._compaction_marker_meta()
         if failure_class == "overflow":
             self._enqueue(f"[⟳ compaction retry: shrinking input after {reason}]", meta=meta)
         else:
@@ -345,7 +375,7 @@ class ChatLifecycleForwarder:
         if data.get("outcome") != "persisted":
             return
         seq = data.get("covers_through_seq")
-        meta = {"compaction_episode_marker": True}
+        meta = self._compaction_marker_meta()
         if isinstance(seq, int) and seq > 0:
             self._enqueue(f"[↑ shrink flow recovered · folded through seq {seq}]", meta=meta)
         else:
@@ -400,7 +430,7 @@ class ChatLifecycleForwarder:
         # own shrink-retry ladder), so this must not scatter either, even
         # though its OWN text is architect's explicitly-unchanged success
         # format (still built exactly as before this PR).
-        self._enqueue(text, meta={"compaction_episode_marker": True})
+        self._enqueue(text, meta=self._compaction_marker_meta())
 
     # ── Router cap / iteration limit ─────────────────────────────────────
     # Two distinct ``limit_denied`` sources:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1769,6 +1769,34 @@ class Session:
         # as unknown when they disagree, so a finished episode's numbers never
         # get shown as the next one's progress.
         self._compaction_progress_episode: "int | None" = None
+        # #6085 stage 1: a general-purpose compaction-EPISODE identifier —
+        # NOT the same thing as ``_compaction_progress_episode`` above
+        # (that one is #5719's shrink-retry LADDER episode number,
+        # ``_recovery_episode()``, which reads ``None`` for a plain
+        # CONTROLLER-driven compaction — ``on_compaction_completed``'s own
+        # docstring, lifecycle_forwarder.py, states this explicitly: "a
+        # controller compaction ... runs in no episode"). The owner's own
+        # #6085 report (a plain ``/compact``) is exactly the controller
+        # case, so reusing the ladder-only number would silently NOT cover
+        # the case that was reported. ``is_compacting`` (below) is the ONE
+        # property that already unifies both paths (its own docstring: "the
+        # OR of TWO states"), so its own False->True transition is this
+        # counter's sole trigger.
+        #
+        # Single-increment-point discipline (lead-coder ruling, #6085): only
+        # :meth:`_advance_compaction_episode_seq` ever writes
+        # ``_compaction_episode_seq`` — nothing outside this class re-counts
+        # or re-derives it (the #5350-class hazard: two counters for one
+        # concept drift apart). Every OTHER layer (``lifecycle_forwarder.py``,
+        # ``app.py``) only CARRIES the value this method hands them via
+        # :meth:`compaction_episode_seq` — never re-reads "the current value"
+        # to decide anything at absorption time (that read-the-live-value-
+        # to-decide shape IS the race #6085 found: a marker-tagged frame and
+        # a snapshot-driven settle arrive on two independent channels with no
+        # ordering guarantee between them; a consumer polling "what's current
+        # now" at decision time reproduces exactly that race one level up).
+        self._compaction_episode_active: bool = False
+        self._compaction_episode_seq: int = 0
         self._audit_events.add_subscriber(self._on_compaction_progress_event)
         # #5939 PR-2: arms the memory ladder's own ①->③ escalation judge
         # (see `_compaction_seen_since_backpressure`'s own field
@@ -1806,7 +1834,12 @@ class Session:
         from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
         self._audit_events.add_subscriber(
             ChatLifecycleForwarder(
-                self.outbox, registry=self._registry, events=self._audit_events
+                self.outbox, registry=self._registry, events=self._audit_events,
+                # #6085 stage 1: a bound-method accessor, not `self` — the
+                # forwarder gets read access to ONE number, not this whole
+                # Session (same narrow-accessor idiom as
+                # `register_file_handler_path`/`find_file_handler_path`).
+                compaction_episode_seq=self.compaction_episode_seq,
             )
         )
         # Generic events-log subscriber converting op-emitted events to state_change history entries (#398 v4 emitter family, see session-construction.md#misc-lifecycle-wiring)
@@ -12273,7 +12306,42 @@ class Session:
         if episode is None or episode != self._compaction_progress_episode:
             for key in _IN_FLIGHT_PROGRESS_KEYS:
                 figures[key] = None
-        return {"is_compacting": self.is_compacting, **figures}
+        return {
+            "is_compacting": self.is_compacting,
+            # #6085 stage 1: read via the SAME accessor lifecycle_forwarder.py
+            # uses to stamp its own marker frames — one code path, one
+            # transition-detector, whichever caller happens to read first.
+            "episode_seq": self.compaction_episode_seq(),
+            **figures,
+        }
+
+    def compaction_episode_seq(self) -> int:
+        """#6085 stage 1: this compaction EPISODE's own identifier — see
+        :attr:`_compaction_episode_seq`'s own construction-site comment for
+        why it exists separately from :meth:`_recovery_episode`. Advances
+        (via :meth:`_advance_compaction_episode_seq`) on every call, so
+        BOTH :meth:`compaction_progress_raw` (the client's own snapshot
+        poll) and :class:`~reyn.runtime.lifecycle_forwarder.
+        ChatLifecycleForwarder` (stamping a marker frame at the moment it
+        is built) read the identical, already-current value from the ONE
+        place that increments it — neither one counts independently."""
+        self._advance_compaction_episode_seq()
+        return self._compaction_episode_seq
+
+    def _advance_compaction_episode_seq(self) -> None:
+        """#6085 stage 1: the ONLY place ``_compaction_episode_seq`` is
+        written. Detects a False->True transition of :attr:`is_compacting`
+        (idempotent: calling this any number of times while the SAME
+        episode is still active does nothing past the first call) and
+        bumps the counter exactly once per genuine episode start —
+        regardless of how many separate callers (the snapshot poll, a
+        lifecycle marker stamp) happen to trigger the check, since the
+        transition memory (:attr:`_compaction_episode_active`) lives on
+        this ONE Session instance, not per-caller."""
+        active = self.is_compacting
+        if active and not self._compaction_episode_active:
+            self._compaction_episode_seq += 1
+        self._compaction_episode_active = active
 
     async def _compact_now_for_op(self, *, selection: str = "shortfall") -> dict:
         """#272/#1128/#191: voluntary-compaction callback (compact op + /compact).

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1789,7 +1789,7 @@ class Session:
         # or re-derives it (the #5350-class hazard: two counters for one
         # concept drift apart). Every OTHER layer (``lifecycle_forwarder.py``,
         # ``app.py``) only CARRIES the value this method hands them via
-        # :meth:`compaction_episode_seq` — never re-reads "the current value"
+        # :meth:`_read_compaction_episode_seq` — never re-reads "the current value"
         # to decide anything at absorption time (that read-the-live-value-
         # to-decide shape IS the race #6085 found: a marker-tagged frame and
         # a snapshot-driven settle arrive on two independent channels with no
@@ -1839,7 +1839,7 @@ class Session:
                 # forwarder gets read access to ONE number, not this whole
                 # Session (same narrow-accessor idiom as
                 # `register_file_handler_path`/`find_file_handler_path`).
-                compaction_episode_seq=self.compaction_episode_seq,
+                compaction_episode_seq=self._read_compaction_episode_seq,
             )
         )
         # Generic events-log subscriber converting op-emitted events to state_change history entries (#398 v4 emitter family, see session-construction.md#misc-lifecycle-wiring)
@@ -12311,11 +12311,11 @@ class Session:
             # #6085 stage 1: read via the SAME accessor lifecycle_forwarder.py
             # uses to stamp its own marker frames — one code path, one
             # transition-detector, whichever caller happens to read first.
-            "episode_seq": self.compaction_episode_seq(),
+            "episode_seq": self._read_compaction_episode_seq(),
             **figures,
         }
 
-    def compaction_episode_seq(self) -> int:
+    def _read_compaction_episode_seq(self) -> int:
         """#6085 stage 1: this compaction EPISODE's own identifier — see
         :attr:`_compaction_episode_seq`'s own construction-site comment for
         why it exists separately from :meth:`_recovery_episode`. Advances
@@ -12324,7 +12324,16 @@ class Session:
         poll) and :class:`~reyn.runtime.lifecycle_forwarder.
         ChatLifecycleForwarder` (stamping a marker frame at the moment it
         is built) read the identical, already-current value from the ONE
-        place that increments it — neither one counts independently."""
+        place that increments it — neither one counts independently.
+
+        Private (lead-coder ruling, #6092 CI — Session's own #3595 S4
+        public-member ceiling): the ONE external caller
+        (``ChatLifecycleForwarder``) is handed a BOUND METHOD, not a name
+        — a receiver of a bound method needs no more access than this
+        already grants, so there was never a reason to publish it. Every
+        OTHER god-object-pressure ratchet in this codebase makes the same
+        point about a NEW public member that nobody calls by name from
+        outside; this one doesn't need to be the exception."""
         self._advance_compaction_episode_seq()
         return self._compaction_episode_seq
 

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -404,7 +404,7 @@ async def test_compaction_episode_marker_frame_absorbs_into_the_open_entry(
             kind="system", text="[⟳ compacting 3 turns]",
             meta={
                 "compaction_episode_marker": True,
-                "compaction_episode_seq": session.compaction_episode_seq(),
+                "compaction_episode_seq": session._read_compaction_episode_seq(),
             },
         ))
         after = list(app.conversation.entries)

--- a/tests/interfaces/test_5588_compaction_progress_chrome.py
+++ b/tests/interfaces/test_5588_compaction_progress_chrome.py
@@ -9,10 +9,19 @@ owner (real-machine, 2026-09-02/03): "スピナーになってないね"／"進�
 entry or group にして" — this file replaces its own prior generation
 (``CompactionProgressRow``, a standalone chrome ``Static`` sibling of
 ``MenuBar``, REMOVED by this same PR) with tests against the flowview entry
-that took its place: one ``Entry[OutboxMessage]``, created once, its
-``meta`` updated in place while running (never re-created), spinning via
-the SAME live-indicator convention a RUNNING tool-call row already uses,
-and settled to a terminal ``EntryState`` exactly once.
+that took its place: one ``Entry[OutboxMessage]`` PER EPISODE, its ``meta``
+updated in place while running (never re-created WHILE the SAME episode is
+still open), spinning via the SAME live-indicator convention a RUNNING
+tool-call row already uses, and settled to a terminal ``EntryState``
+exactly once per episode.
+
+#6085 stage 1: the entry is no longer discarded the instant it settles —
+kept addressable (see ``_settle_compaction_progress``'s own docstring) so
+a marker-tagged display frame for the SAME episode that arrives late can
+still fold into it, gated on ``compaction_episode_seq`` identity rather
+than "is some entry open" alone (a genuinely NEW episode's own entry
+creation is what actually retires the old reference — see
+``_ensure_compaction_progress_entry``'s own updated idempotency guard).
 
 Real ``Session``/``AgentRegistry``/``EventLog`` throughout. Driving via a
 direct ``session._audit_events.emit(...)`` call for
@@ -369,7 +378,15 @@ async def test_compaction_episode_marker_frame_absorbs_into_the_open_entry(
     """Tier 2: #5588 — a lifecycle_forwarder marker tagged
     ``compaction_episode_marker`` (on_compaction_started/completed/failed)
     is absorbed into the single open episode entry rather than appended
-    as its own conv-pane row, TUI-locally, while an entry is open."""
+    as its own conv-pane row, TUI-locally, while an entry is open.
+
+    #6085 stage 1: the marker now also carries ``compaction_episode_seq``
+    (read off the SAME real ``Session`` the open entry was itself stamped
+    from — the identical value ``lifecycle_forwarder.py``'s own
+    ``_compaction_marker_meta()`` would read at this same moment) —
+    absorption is gated on that id matching, not merely "some entry is
+    open" (see the sibling ``..._mismatched_episode_seq_does_not_absorb``
+    test for the deny side of THAT check)."""
     from reyn.runtime.outbox import OutboxMessage
 
     app, session, reg = await _make_app_with_real_session(tmp_path)
@@ -385,7 +402,10 @@ async def test_compaction_episode_marker_frame_absorbs_into_the_open_entry(
         before = list(app.conversation.entries)
         result = app._ingest_frame(OutboxMessage(
             kind="system", text="[⟳ compacting 3 turns]",
-            meta={"compaction_episode_marker": True},
+            meta={
+                "compaction_episode_marker": True,
+                "compaction_episode_seq": session.compaction_episode_seq(),
+            },
         ))
         after = list(app.conversation.entries)
 
@@ -421,3 +441,182 @@ async def test_compaction_episode_marker_frame_appends_normally_with_no_open_ent
 
         assert result is not None, "no open entry to absorb into -- must append"
         assert len(after) == len(before) + 1
+
+
+@pytest.mark.asyncio
+async def test_a_late_marker_still_absorbs_into_an_already_settled_entry(
+    tmp_path: Path,
+) -> None:
+    """Tier 2b: #6085 stage 1 — the strip-falsified regression.
+
+    Reproduces the race REPORTED in #6085 exactly: the row settles (its
+    OWN channel, a polled status snapshot going ``is_compacting=False``)
+    BEFORE a marker-tagged display frame for the SAME episode (a SEPARATE
+    channel) arrives. Under the OLD ``self._compaction_progress_entry is
+    not None`` guard the settle already popped the reference to ``None``,
+    so this exact sequence made the late marker fall through and appear
+    as its own stray row — the owner's own reported "4 independent
+    lines". Confirmed live before this fix landed (issue #6085's own
+    comment thread); strip-falsified again here by hand (reverting
+    ``_settle_compaction_progress``'s no-longer-nulling end and
+    ``_ingest_frame``'s episode-seq check both independently reproduce
+    the stray row)."""
+    from textual_flowview import EntryState
+
+    from reyn.runtime.outbox import OutboxMessage
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        entry = _open_compaction_entry(app)
+        assert entry is not None
+        episode_seq = entry.item.meta.get("compaction_episode_seq")
+
+        # The race: settle FIRST (is_compacting flips False on THIS
+        # session's own snapshot), THEN the marker frame for the SAME
+        # episode arrives.
+        session._compaction_controller._compacting = False
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        assert entry.state is not EntryState.RUNNING, "expected the row to have settled"
+
+        before = list(app.conversation.entries)
+        result = app._ingest_frame(OutboxMessage(
+            kind="system", text="[↑ 1746 messages compacted]",
+            meta={
+                "compaction_episode_marker": True,
+                "compaction_episode_seq": episode_seq,
+            },
+        ))
+        after = list(app.conversation.entries)
+
+        assert result is None, (
+            "the late marker was NOT absorbed -- it created a new entry, "
+            "reproducing the exact #6085 symptom this fix closes"
+        )
+        assert len(after) == len(before), (
+            f"expected the late marker to fold into the settled row (no new "
+            f"row) -- root count grew {len(before)} -> {len(after)}"
+        )
+        # Non-vacuity: absorption here means "prevented from becoming a
+        # second row" (the row's own body is meta-driven, per
+        # ``_ensure_compaction_progress_entry``'s own comment — a marker
+        # frame's TEXT was never folded into it even before #6085, only
+        # its EXISTENCE as a duplicate row was), so the real proof this
+        # assertion needs is the PAIRED deny-side test just below
+        # (``test_a_marker_for_a_different_episode_does_not_absorb``):
+        # the identical setup, a mismatched id, DOES append. Together the
+        # two prove the id check is load-bearing, not a green that would
+        # hold with no check at all.
+
+
+@pytest.mark.asyncio
+async def test_a_marker_for_a_different_episode_does_not_absorb(
+    tmp_path: Path,
+) -> None:
+    """Tier 2b: #6085 stage 1 deny side — lead-coder ruling: a MISMATCHED
+    episode id must fall through and append as its own row, never silently
+    fold into the wrong (already-settled) entry and never be dropped.
+    "見えて間違う方が良い" (a visible stray row an operator can question
+    beats a wrong fold nobody can see happened at all)."""
+    from reyn.runtime.outbox import OutboxMessage
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        entry = _open_compaction_entry(app)
+        assert entry is not None
+        real_seq = entry.item.meta.get("compaction_episode_seq")
+
+        session._compaction_controller._compacting = False
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+
+        before = list(app.conversation.entries)
+        result = app._ingest_frame(OutboxMessage(
+            kind="system", text="[✗ compaction failed: stale episode]",
+            meta={
+                "compaction_episode_marker": True,
+                # Deliberately NOT real_seq -- a stale/different episode's
+                # own id.
+                "compaction_episode_seq": (real_seq or 0) + 999,
+            },
+        ))
+        after = list(app.conversation.entries)
+
+        assert result is not None, (
+            "a mismatched episode id was absorbed -- silently folded into "
+            "the WRONG row, exactly the failure mode lead-coder's ruling "
+            "asked this NOT to have"
+        )
+        assert len(after) == len(before) + 1
+        assert result.item.text == "[✗ compaction failed: stale episode]", (
+            "the mismatched marker's own text should land on the NEW row "
+            "it appended as, not be lost"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_new_episode_after_settle_gets_its_own_fresh_entry(
+    tmp_path: Path,
+) -> None:
+    """Tier 2b: #6085 stage 1 — keeping the settled entry addressable (for
+    the late-marker fold above) must not also block a genuinely NEW
+    episode from getting its own row. ``_ensure_compaction_progress_
+    entry``'s own idempotency guard now keys on ``entry.state is RUNNING``,
+    not "is a reference held" -- a settled entry does not count."""
+    from textual_flowview import EntryState
+
+    app, session, reg = await _make_app_with_real_session(tmp_path)
+    session._compaction_controller._compacting = True
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        first = _open_compaction_entry(app)
+        assert first is not None
+        first_seq = first.item.meta.get("compaction_episode_seq")
+
+        session._compaction_controller._compacting = False
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+        assert first.state is not EntryState.RUNNING
+
+        # A second, genuinely new episode starts.
+        session._compaction_controller._compacting = True
+        app._read_model.snap = _snapshot_for_session(reg, session)
+        app._refresh_compaction_progress()
+        await pilot.pause()
+
+        from reyn.interfaces.inline.textual_chat._meta_keys import COMPACTION_PROGRESS_KEY
+
+        progress_entries = [
+            e for e in app.conversation.entries
+            if e.item.meta.get(COMPACTION_PROGRESS_KEY) is not None
+        ]
+        new_entries = [e for e in progress_entries if e is not first]
+        assert new_entries, (
+            "expected a fresh row for the new episode alongside the "
+            "settled old one, but no new progress entry was created"
+        )
+        assert first in progress_entries, (
+            "the old, settled entry must still be present, not replaced"
+        )
+        second = new_entries[0]
+        assert second.state is EntryState.RUNNING
+        assert second.item.meta.get("compaction_episode_seq") != first_seq

--- a/tests/runtime/test_5588_compaction_progress_session_wiring.py
+++ b/tests/runtime/test_5588_compaction_progress_session_wiring.py
@@ -28,14 +28,23 @@ def _make_session(tmp_path: Path):
 
 def test_raw_starts_with_every_field_none(tmp_path):
     """Tier 2: before any compaction_shrink_recovered/llm_request(_error)/
-    recovery_summary_persisted has fired, every cached field reads None —
-    never a fabricated 0. The closed-set comparison is what makes a future
-    FIFTH field a deliberate change rather than a silent drift (it already
-    caught #5578's own ``persisted_covers_through_seq`` being added)."""
+    recovery_summary_persisted has fired, every #5592 observability field
+    reads None — never a fabricated 0. The closed-set comparison is what
+    makes a future FIFTH field a deliberate change rather than a silent
+    drift (it already caught #5578's own ``persisted_covers_through_seq``
+    being added, and #6085's own ``episode_seq`` below).
+
+    ``episode_seq`` (#6085 stage 1) is DELIBERATELY not part of the
+    None-until-observed claim above — it is a monotonic counter, not an
+    observability cache, and ``0`` genuinely means "no episode has ever
+    started on this session", the correct answer here, not a fabrication
+    standing in for "unknown" (see ``Session.compaction_episode_seq``'s
+    own docstring)."""
     session = _make_session(tmp_path)
     raw = session.compaction_progress_raw()
     assert raw == {
         "is_compacting": False,
+        "episode_seq": 0,
         "raw_middle_remaining": None,
         "raw_middle_total": None,
         "upstream_recovery_call_count": None,


### PR DESCRIPTION
**[tui-coder]** — fix(part of #6085 stage 1): compaction episode-marker absorption races an independently-polled settle

## What

The shrink-flow-episode row's SETTLE (`Session._settle_compaction_progress`,
driven by `app.py`'s own `_refresh_compaction_progress` polling
`compaction_progress_raw()["is_compacting"]` on every frame) and the
`compaction_episode_marker`-tagged DISPLAY frames (`compaction_started`/
`_failed`/`_completed`, `recovery_summary_persisted` — `lifecycle_forwarder.py`)
travel on two independent channels with no ordering guarantee between them.
A marker for the episode that just ended could arrive AFTER the row had
already settled — under the OLD `is not None` absorption guard the settle
already popped the reference to `None`, so the late marker fell through and
appeared as its own stray row.

**Reproduced live** (real `TextualChatApp`, real frame pump — see #6085's own
comment thread): confirmed, not just a candidate — matches the owner's own
reported "4 independent lines" for one `/compact`.

## Fix (lead-coder ruling, #6085 — 2 conditions)

1. The episode-seq counter has exactly **ONE** increment point (`Session`);
   every other layer only **carries** the value it hands them.
2. The marker frame and the entry each carry their **own stamped seq**;
   absorption compares those two values — never re-reads "what's current
   now" (which would reproduce the same race one level up). A mismatch (or
   either side missing an id) falls through and appends as its own row —
   never silently absorbed into the wrong entry, never dropped.

- `session.py`: new `compaction_episode_seq()` — distinct from the EXISTING
  `_recovery_episode()` (#5719's ladder-only episode number, which reads
  `None` for a plain controller-driven `/compact` — exactly the owner's own
  reported case, so reusing it would not have covered the report at all).
  Increments on `is_compacting`'s own False→True transition.
- `lifecycle_forwarder.py`: `ChatLifecycleForwarder` takes an optional
  `compaction_episode_seq` accessor (a bound method, not a Session
  reference); a new `_compaction_marker_meta()` helper stamps it onto all 4
  marker-tagged handlers.
- `app.py`: `_ingest_frame`'s absorption check now compares episode-seq
  identity. `_settle_compaction_progress` no longer clears the entry
  reference (kept addressable for a late marker), guarded instead by
  `entry.state is not RUNNING` (no unbounded redundant re-work).
  `_ensure_compaction_progress_entry`'s idempotency guard changes from "is a
  reference held" to "is the held entry still RUNNING".

## Test

3 new tests in `test_5588_compaction_progress_chrome.py` (late-marker
absorption after settle — the strip-falsified regression; mismatched-seq
deny side; a new episode after settle still gets its own row) + 1 existing
test updated to stamp a real seq. `test_5588_compaction_progress_session_wiring.py`'s
closed-set dict-shape test updated for the new field.

⚠️ **Stage 2** (the 3 lines that still carry no episode marker at all — 2
`lifecycle_forwarder.py` handlers + the `/compact` slash-dispatch error line)
is tracked separately, not landed here.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (both modified test files, 21/21)
- [x] `verify_module_docstrings.py` (3 changed src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` (tests/ touched)
- [x] `silent_except_ratchet.py` (`src/reyn/interfaces/` touched)
- [x] scoped pytest: `test_5588_compaction_progress_chrome.py` (10/10), `test_5588_compaction_progress_session_wiring.py` (11/11), `test_5605_remote_compaction_progress.py`, `test_5885_remote_compaction_progress_wire.py`, `test_5588_compaction_progress_render.py`, `test_5618_recovery_episode_gate.py`, `test_4380_lifecycle_forwarder_new_markers.py`, `test_5828_compaction_failed_failure_class.py`, `test_5885_ladder_recovered_marker.py`, `test_chat_lifecycle_forwarder.py`, `test_4703_compaction_spend_visible.py`, `test_3792_pr2_session_injection.py`, `test_4496_pr2_event_backend.py` — all green
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
