### PR TITLE
fix(part of #6083): a session-locus slash command's could-not-run text no longer guesses no-session ahead of the real ControlOutcome

### DIFF
--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -223,14 +223,42 @@ async def maybe_dispatch_slash(
         # input loop is not a pump).
         if locus == "session":
             ran = await transport.run_slash_command(name, args)
+            if not ran:
+                # #6083: this branch's own ``ran`` comes back from a REAL
+                # control POST (`run_slash_command`), so ``False`` is NOT
+                # "this client has no session" — that claim was hardcoded
+                # here regardless of cause, and the owner's own real-machine
+                # report shows it firing on a compaction that had ALREADY
+                # SUCCEEDED server-side, with the actual cause (a 10s
+                # control-read timeout — #5894 ①-1) merely appended as a
+                # SUFFIX by ``_display``'s own ``with_control_failure`` call.
+                # A suffix does not fix a false prefix: a reader parses
+                # "could not run: <claim>. — <detail>" as the claim PLUS
+                # supporting detail, not the detail CORRECTING the claim.
+                # The typed ``ControlOutcome`` (delivered/refused/
+                # not_delivered — `transport.last_control_outcome()`,
+                # already recorded by this same call) already knows which
+                # of those three happened; this text no longer guesses
+                # ahead of it. ⚠️ This alone does not fix "a SUCCESS is
+                # reported as a failure" — see #6083's own PR body.
+                _display(
+                    transport, "error",
+                    f"/{name} could not run: the server did not confirm it ran.",
+                )
         else:
             ctx = SlashContext(transport=transport, session=None)
             ran = await execute_slash_command(ctx, name, args)
-        if not ran:
-            _display(
-                transport, "error",
-                f"/{name} could not run: this client has no session to run it on.",
-            )
+            if not ran:
+                # This branch's own ``ran`` comes back from a LOCAL,
+                # in-process call (`execute_slash_command`, no control POST
+                # at all — see the ``locus`` comment above) — `False` here
+                # genuinely does mean "this client has no session to run it
+                # on" (the client/connection-locus handler's own precondition
+                # check), unchanged from before #6083.
+                _display(
+                    transport, "error",
+                    f"/{name} could not run: this client has no session to run it on.",
+                )
 
     if runner is not None:
         runner(_run())

--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -225,26 +225,42 @@ async def maybe_dispatch_slash(
             ran = await transport.run_slash_command(name, args)
             if not ran:
                 # #6083: this branch's own ``ran`` comes back from a REAL
-                # control POST (`run_slash_command`), so ``False`` is NOT
-                # "this client has no session" — that claim was hardcoded
-                # here regardless of cause, and the owner's own real-machine
-                # report shows it firing on a compaction that had ALREADY
-                # SUCCEEDED server-side, with the actual cause (a 10s
-                # control-read timeout — #5894 ①-1) merely appended as a
-                # SUFFIX by ``_display``'s own ``with_control_failure`` call.
-                # A suffix does not fix a false prefix: a reader parses
-                # "could not run: <claim>. — <detail>" as the claim PLUS
-                # supporting detail, not the detail CORRECTING the claim.
-                # The typed ``ControlOutcome`` (delivered/refused/
-                # not_delivered — `transport.last_control_outcome()`,
-                # already recorded by this same call) already knows which
-                # of those three happened; this text no longer guesses
-                # ahead of it. ⚠️ This alone does not fix "a SUCCESS is
-                # reported as a failure" — see #6083's own PR body.
-                _display(
-                    transport, "error",
-                    f"/{name} could not run: the server did not confirm it ran.",
-                )
+                # control POST (`run_slash_command`), so ``False`` does NOT
+                # mean "this client has no session" — that claim was
+                # hardcoded here regardless of cause, and the owner's own
+                # real-machine report shows it firing on a compaction that
+                # had ALREADY SUCCEEDED server-side.
+                #
+                # lead-coder BLOCKING (PR #6094, self-caught in review): an
+                # earlier version of this fix still asserted "could not
+                # run" unconditionally, appending the real detail only as a
+                # SUFFIX — a reader reads left to right and classifies on
+                # the FIRST assertion, so "could not run: <claim>. —
+                # <detail>" still reads as the claim, the detail merely
+                # supporting it, never correcting it. ``ControlOutcome``'s
+                # own two failure kinds say DIFFERENT things and must not
+                # share a prefix: ``refused`` genuinely means the server
+                # said no — it did not run, and the text may say so.
+                # ``not_delivered`` means UNCONFIRMED, not unrun — #6083's
+                # own report is exactly this case (a control-read timeout
+                # on an operation that ran to completion regardless), so
+                # THIS prefix must not claim non-execution either.
+                from reyn.interfaces.transport.control_outcome import ControlOutcome
+
+                outcome = transport.last_control_outcome()
+                if isinstance(outcome, ControlOutcome) and outcome.kind == "refused":
+                    prefix = f"/{name} could not run"
+                else:
+                    # not_delivered, or no typed outcome recorded — neither
+                    # confirms non-execution, so this text does not claim
+                    # it. ⚠️ This alone does not fix "a SUCCESS is reported
+                    # as a failure" (the operation itself is not confirmed
+                    # either way here) — see #6083's own PR body for stage
+                    # 2 (an immediate accept + completion reported over the
+                    # existing SSE broadcast, the same channel compaction's
+                    # own lifecycle markers already use).
+                    prefix = f"/{name}: no confirmation received"
+                _display(transport, "error", prefix)
         else:
             ctx = SlashContext(transport=transport, session=None)
             ran = await execute_slash_command(ctx, name, args)

--- a/tests/interfaces/test_6083_slash_dispatch_control_outcome.py
+++ b/tests/interfaces/test_6083_slash_dispatch_control_outcome.py
@@ -1,0 +1,138 @@
+"""Tier 2: #6083 stage 1 — a session-locus slash command's own "could not
+run" line reflects the REAL typed ``ControlOutcome`` (delivered / refused /
+not_delivered), never a hardcoded "this client has no session" claim.
+
+owner-hit (reyn-self, real machine): a `/compact` that had ALREADY
+SUCCEEDED server-side (2,011 turns folded, window 48%) was reported as
+"could not run: this client has no session to run it on. — the server did
+not respond within 10s [ReadTimeout]" — the suffix (from
+``with_control_failure``) was already correct, but the hardcoded PREFIX was
+not: a reader parses "<claim>. — <detail>" as the claim plus supporting
+detail, not the detail correcting a false claim. #5907 ②'s own
+``ControlOutcome`` already distinguishes exactly this (delivered / refused /
+not_delivered); this fix stops a session-locus command's own text from
+guessing "no session" ahead of it.
+
+⚠️ This is stage 1 only — it stops the false CLAIM, it does not make a
+successful `/compact` stop taking longer than the control read timeout (see
+#6083's own PR body for stage 2).
+
+Real ``AgUiTransport`` throughout (the same "plain async `_send` callable"
+precedent ``test_3300_p3_cancel_by_id.py`` already established for this
+exact class) — no mock of the transport or of ``ControlOutcome``.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.slash import REGISTRY, SlashCommand
+from reyn.interfaces.slash.dispatch import maybe_dispatch_slash
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.control_outcome import ControlOutcome
+from reyn.runtime.outbox import OutboxMessage
+
+
+async def _empty_lines() -> "AsyncIterator[str]":
+    return
+    yield  # pragma: no cover
+
+
+async def _noop_handler(ctx, args: str) -> None:  # pragma: no cover - never called client-side
+    pass
+
+
+@pytest.fixture
+def _throwaway_session_command(monkeypatch):
+    """A registered, throwaway ``locus="session"`` command — its own
+    ``handler`` never runs client-side (session-locus dispatches via
+    ``transport.run_slash_command``, never ``cmd.handler`` directly; see
+    ``dispatch.py``'s own ``_run()``), so a no-op stand-in is enough."""
+    monkeypatch.setitem(
+        REGISTRY._commands, "__f6083test__",
+        SlashCommand(
+            name="__f6083test__", summary="test", handler=_noop_handler, locus="session",
+        ),
+    )
+    return "__f6083test__"
+
+
+@pytest.mark.asyncio
+async def test_a_control_read_timeout_does_not_claim_no_session(
+    _throwaway_session_command: str,
+) -> None:
+    """Tier 2: non-vacuity — ``not_delivered`` (the owner's own #6083 case,
+    a control read timeout) must not say "no session"."""
+    async def _send(payload: dict) -> "ControlOutcome":
+        return ControlOutcome.not_delivered("ReadTimeout", 10.0)
+
+    transport = AgUiTransport(_empty_lines(), _send)
+    captured: "list[OutboxMessage]" = []
+    transport.put_display = captured.append  # type: ignore[method-assign]
+
+    consumed = await maybe_dispatch_slash(transport, f"/{_throwaway_session_command}", echo=False)
+    assert consumed is True
+
+    error_lines = [m.text for m in captured if m.kind == "error"]
+    assert error_lines, "expected an error line for the failed session-locus command"
+    text = error_lines[-1]
+    assert "no session" not in text, (
+        f"a control-read-timeout was reported as 'no session' -- the exact "
+        f"#6083 owner-hit symptom, text was: {text!r}"
+    )
+    assert "did not respond" in text and "ReadTimeout" in text, (
+        f"expected the REAL typed outcome (not_delivered) in the text, got: {text!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_server_refusal_says_refused_not_no_session(
+    _throwaway_session_command: str,
+) -> None:
+    """Tier 2: the sibling typed outcome (``refused``) must also read as
+    what actually happened, not the same hardcoded guess."""
+    async def _send(payload: dict) -> "ControlOutcome":
+        return ControlOutcome.refused(403, "forbidden")
+
+    transport = AgUiTransport(_empty_lines(), _send)
+    captured: "list[OutboxMessage]" = []
+    transport.put_display = captured.append  # type: ignore[method-assign]
+
+    consumed = await maybe_dispatch_slash(transport, f"/{_throwaway_session_command}", echo=False)
+    assert consumed is True
+
+    error_lines = [m.text for m in captured if m.kind == "error"]
+    assert error_lines
+    text = error_lines[-1]
+    assert "no session" not in text
+    assert "refused" in text
+
+
+@pytest.mark.asyncio
+async def test_client_locus_never_touches_the_wire(monkeypatch) -> None:
+    """Tier 2: deny side, scope check — a CLIENT/CONNECTION-locus command
+    runs entirely in-process (``execute_slash_command``, no control POST —
+    the ``locus`` comment in ``dispatch.py``'s own ``_run()`` states this
+    directly) and its own "no session" wording is UNCHANGED by #6083 (that
+    branch's own ``ran`` never comes from a ``ControlOutcome`` at all, so
+    there is nothing to un-crush there). Proven by making the transport's
+    own send raise if ever called -- a client-locus dispatch that reached
+    the wire would fail this test, not merely mis-word its error."""
+    async def _handler(ctx, args: str) -> None:
+        pass
+
+    monkeypatch.setitem(
+        REGISTRY._commands, "__f6083client__",
+        SlashCommand(
+            name="__f6083client__", summary="test", handler=_handler, locus="client",
+        ),
+    )
+
+    async def _send(payload: dict) -> "ControlOutcome":
+        raise AssertionError("client-locus must never touch the wire")
+
+    transport = AgUiTransport(_empty_lines(), _send)
+
+    consumed = await maybe_dispatch_slash(transport, "/__f6083client__", echo=False)
+    assert consumed is True

--- a/tests/interfaces/test_6083_slash_dispatch_control_outcome.py
+++ b/tests/interfaces/test_6083_slash_dispatch_control_outcome.py
@@ -81,6 +81,12 @@ async def test_a_control_read_timeout_does_not_claim_no_session(
         f"a control-read-timeout was reported as 'no session' -- the exact "
         f"#6083 owner-hit symptom, text was: {text!r}"
     )
+    assert "could not run" not in text, (
+        f"lead-coder BLOCKING (PR #6094): 'not_delivered' means UNCONFIRMED, "
+        f"not unrun -- the owner's own /compact ran to completion despite "
+        f"this outcome, so this prefix must not assert non-execution either, "
+        f"text was: {text!r}"
+    )
     assert "did not respond" in text and "ReadTimeout" in text, (
         f"expected the REAL typed outcome (not_delivered) in the text, got: {text!r}"
     )
@@ -91,7 +97,10 @@ async def test_a_server_refusal_says_refused_not_no_session(
     _throwaway_session_command: str,
 ) -> None:
     """Tier 2: the sibling typed outcome (``refused``) must also read as
-    what actually happened, not the same hardcoded guess."""
+    what actually happened, not the same hardcoded guess. Unlike
+    ``not_delivered`` above, ``refused`` genuinely DOES mean the command
+    never ran -- the server said no -- so "could not run" is an accurate
+    claim here and is deliberately NOT forbidden by this test."""
     async def _send(payload: dict) -> "ControlOutcome":
         return ControlOutcome.refused(403, "forbidden")
 


### PR DESCRIPTION
**[tui-coder]** — fix(part of #6083 ⑴): a session-locus slash command's "could not run" text no longer guesses "no session" ahead of the real typed ControlOutcome

## What

owner-hit: a `/compact` that had ALREADY SUCCEEDED server-side (2,011 turns
folded, window 48%) was reported as "could not run: this client has no
session to run it on. — the server did not respond within 10s
[ReadTimeout]". The suffix (`with_control_failure`, #5907 ②) was already
correct — the hardcoded PREFIX was not. **Reproduced verbatim** in this PR's
own strip-falsified regression: reverting the fix reproduces the owner's
exact reported text, character for character.

**A precision on the issue's own stated mechanism**: "dispatch.py:227 skips
`with_control_failure`" does not describe the current tree exactly —
`_display` already calls it unconditionally for `kind="error"`, and
`run_slash_command`'s own control POST already records a typed
`ControlOutcome` (confirmed by reading `AgUiTransport`'s `_recording_send`
wrapper). The mechanism DOES already run and DOES append the real detail.
The actual gap, and the fix's direction, are unchanged: **a suffix does not
correct a false prefix** — a reader parses `"<claim>. — <detail>"` as the
claim plus supporting detail, not the detail correcting a false claim.

⚠️ **This is stage 1 of 2.** It stops the false CLAIM — it does **not** make
a successful, slow `/compact` stop exceeding the 10s control read timeout.
**Do not read #6083 as closed by this PR** — stage 2 (the read-timeout
population split + an immediate-accept channel) is tracked separately.

## Fix

`dispatch.py`'s `_run()` `if not ran:` branch now splits by `locus`. The
session-locus branch (a REAL control POST) no longer states a specific
cause — it defers entirely to the already-working `with_control_failure`
suffix (delivered/refused/not_delivered). The client/connection-locus
branch (`execute_slash_command`, no control POST at all) keeps its
original, genuinely-correct "no session" text.

## Test

3 new tests (real `AgUiTransport`, no mock — the `test_3300_p3_cancel_by_id.py`
precedent): a control-read-timeout no longer says "no session" and carries
the real detail; a server refusal reads as "refused"; the client-locus path
is unchanged (proven by making the transport's own `send` raise if ever
reached). Strip-falsified: reverting `dispatch.py` reproduces the owner's
own exact text.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict tests/interfaces/test_6083_slash_dispatch_control_outcome.py`
- [x] `verify_module_docstrings.py src/reyn/interfaces/slash/dispatch.py`
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` (tests/ touched)
- [x] `silent_except_ratchet.py` (`src/reyn/interfaces/` touched)
- [x] scoped pytest: new suite (3/3) + `test_5096_slash_dispatch_routes_attach_directly.py`, `test_slash_handler_crash_containment.py`, `test_slash_agent.py`, `test_5837_exec_slash_stage2_bang.py`, `test_slash_multi_line_dispatch.py` — 28/28 passed
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
