### PR TITLE
fix(#6042): a per-message durable-content byte cap at _append_history's own convergence point

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -2146,11 +2146,13 @@ Caps `Session.history`'s in-memory footprint (#4387 Phase B ③, applying #4431'
 ```yaml
 history_resident:
   max_bytes: 268435456   # 256 MiB — ceiling on Session.history's resident size
+  per_message_max_bytes: 10485760   # 10 MiB — ceiling on any ONE message's own content at durable write time
 ```
 
 | Field | Axis | Type | Default | Description |
 |---|---|---|---|---|
 | `max_bytes` | bounding | int | `268435456` (256 MiB) | Ceiling, in bytes, on `Session.history`'s in-memory footprint. Once exceeded, the oldest resident entries are evicted (never the just-appended newest one) until the cap is met again. A non-positive or non-numeric value falls back to the default. |
+| `per_message_max_bytes` | bounding | int | `10485760` (10 MiB) | #6042 — a SEPARATE axis from `max_bytes` above: bounds how big any ONE message's own content may be at DURABLE write time (`Session._append_history`, `history.jsonl`), never how many messages stay resident. Checked at `_append_history`'s own convergence point — every role funnels through it, so this catches an oversized message regardless of which path produced it. Over the cap: the content is spilled to a file (the same seam `MediaStore.save_tool_result` already uses for tool results, #5896) and the durable row keeps a short pointer text — never truncated when a media store is available. Only when no media store is configured (or the spill write itself fails) does it fall back to truncating, and even then a durable marker plus a preview of the first bytes survive (never a silent cut). An ESTIMATE, not a measurement: chosen to sit clearly above the tool-read inline caps (`read_cap.inline_bytes`) and clearly below the 13 MB / 462 MB single-entry sizes a real-machine incident (#6089) found slipping past the existing tool-result spill gate. A non-positive or non-numeric value falls back to the default. |
 
 Eviction is not information loss: `Session.history` is a cache, not the source of truth — `history.jsonl` (append-only, on disk) is, and every entry evicted from memory reloads on demand via the already-shipped backward-hydrate path (TUI scrollback paging, in-conversation search, and WAL rewind visibility all already page older entries back in as needed). This closes an unbounded-growth defect (`self.history` previously had no cap at all — see #4387) independent of any claim about what fraction of a given memory ceiling `history` itself accounts for, which this config does not measure or claim to fix.
 

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -97,6 +97,8 @@ file_read_media_denied
 file_read_media_write_unavailable
 force_close_triggered
 history_hydration_stopped_reading_early_unsafe
+history_oversized_content_spilled
+history_oversized_content_truncated
 hook_changed
 hook_drain_task_died
 hook_event_emitted
@@ -562,6 +564,8 @@ does not touch) — do not read the rows below as exhaustive coverage of
 | `chat_started`, `chat_stopped` | Chat session lifecycle | — |
 | `turn_cancelled` | A user turn was cancelled mid-router-loop (e.g. `/cancel` or a new submission supersedes the running turn). | `chain_id` |
 | `turn_stopped_memory` | #5851 PR-3 ③' — the turn-mid memory mini-ladder's own terminal step: `Session._check_turn_mid_memory_ladder`, polled at the SAME router-loop iteration boundary as the cancel checkpoint, found the process footprint still over `process_memory.max_bytes` after both ①' (an immediate compaction fold, excluding the in-flight turn's own messages) and ②' (PR-1's shared cache-release step) failed to bring it back under cap — so the turn ends at THIS boundary, never mid-tool-call. Deliberately a DIFFERENT kind from `turn_cancelled`: an operator's own cancel and this safety net must never be conflated (a reader needs to be able to tell "the user stopped it" from "the ladder stopped it"). The exit is otherwise shaped exactly like a cooperative cancel — history and WAL stay consistent, and the next turn starts normally. | `chain_id`, `footprint_bytes`, `cap_bytes` |
+| `history_oversized_content_spilled` | #6042 — `Session._enforce_per_message_content_cap`, checked at `_append_history`'s own convergence point ("every role funnels through" — its own docstring), found *msg.content* over `history_resident.per_message_max_bytes` and fully preserved it by spilling to a file via the SAME seam `MediaStore.save_tool_result` already uses for tool results (#5896) — the durable `history.jsonl` row's content becomes a short pointer text, never the original bytes. Real-machine grounding: #6089 (architect) measured a 462 MB single `role=tool` entry in a live `history.jsonl`, past the existing (non-airtight) tool-result spill gate. Role-agnostic by design (lead-coder ruling) — assistant-authored content is in scope too, even though `max_tokens` makes it unlikely to actually reach this cap in practice. | `role`, `seq`, `original_bytes`, `cap_bytes`, `path` |
+| `history_oversized_content_truncated` | #6042 — the FALLBACK sibling of `history_oversized_content_spilled`, fired when no `MediaStore` is configured (or the spill write itself failed): the content is truncated, but never silently — the durable row's own `meta` carries `content_truncated`/`content_truncated_original_bytes`, and `msg.content` itself becomes a preview of the first bytes (never a bare boolean marker with nothing else — lead-coder ruling: "何が失われたか" must stay at least partially readable). | `role`, `seq`, `original_bytes`, `cap_bytes`, `preview_bytes` |
 
 ## Session and turn lifecycle
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -938,6 +938,16 @@
 # -----------------------------------------------------------------------------
 # history_resident:
 #   max_bytes: 268435456   # 256 MiB — ceiling on Session.history's resident size
+#   # per_message_max_bytes (#6042): a SEPARATE axis from max_bytes above —
+#   # bounds how big any ONE message's own content may be at DURABLE write
+#   # time (Session._append_history, history.jsonl), never how many messages
+#   # stay resident. An ESTIMATE, not a measurement: chosen to sit clearly
+#   # above the tool-read inline caps (read_cap.inline_bytes) and clearly
+#   # below the 13 MB / 462 MB sizes a real-machine incident (#6089) found
+#   # slipping past the existing tool-result spill gate. Enabled by default
+#   # (unlike process_memory below, which shipped observe-only pending real
+#   # data) because this incident already happened on an unmodified config.
+#   per_message_max_bytes: 10485760   # 10 MiB — over this, content is spilled to a file (or truncated with a preview, if no media store is configured)
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -589,13 +589,36 @@ class HistoryResidentConfig:
     max_bytes: ResidentBytes = field(
         default=ResidentBytes(256 * 1024 * 1024), metadata={"axis": Axis.BOUNDING},
     )  # 256 MiB
+    # #6042: a THIRD, deliberately separate axis from max_bytes above and
+    # from the hydrate-window (this class's own docstring already warns
+    # against conflating those two — this is a different question again:
+    # how big may any ONE message's own content be at DURABLE write time
+    # (``Session._append_history``, ``history.jsonl``), independent of how
+    # many messages stay resident or how a window is read back). #6089
+    # (architect, real-machine): a single `role=tool` entry reached 462 MB
+    # in `.reyn/agents/default/state/sessions/6e13efdf/history.jsonl` — the
+    # existing tool-result spill gate (#5896/#5944) is real but NOT
+    # airtight (the SAME file had a 13 MB tool result sitting un-spilled
+    # next to a correctly-spilled one) — this is the backstop that catches
+    # whatever slips past upstream spill decisions, regardless of why they
+    # didn't fire, at the ONE point every role/path converges.
+    # 10 MiB default: no measured "typical large legitimate message" size
+    # to derive this from (disclosed, not fabricated precision) — chosen
+    # to sit clearly above ReadCapConfig.inline_bytes/MultimodalConfig's
+    # own much smaller inline thresholds (this is a LAST-RESORT bound, not
+    # the primary "keep inline" decision those make) and clearly below the
+    # 13 MB/462 MB real-machine sizes #6089 measured, so it would have
+    # caught both. Operator-overridable — see the field's own knob.
+    per_message_max_bytes: int = field(
+        default=10 * 1024 * 1024, metadata={"axis": Axis.BOUNDING},
+    )  # 10 MiB
 
 
 def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
-    """Parse the `history_resident:` section (#4387 Phase B ③).
+    """Parse the `history_resident:` section (#4387 Phase B ③, #6042).
 
-    Missing or malformed -> default (256 MiB). A non-numeric or non-positive
-    value falls back to the default — same discipline as
+    Missing or malformed -> default (256 MiB / 10 MiB). A non-numeric or
+    non-positive value falls back to the default — same discipline as
     ``_build_read_cap_config``: an operator typo must not silently disable
     the cap (zero/negative would evict everything or never fire)."""
     if not isinstance(raw, dict):
@@ -613,7 +636,21 @@ def _build_history_resident_config(raw: object) -> "HistoryResidentConfig":
             max_bytes, defaults.max_bytes,
         )
         max_bytes = defaults.max_bytes
-    return HistoryResidentConfig(max_bytes=ResidentBytes(max_bytes))
+    per_message_max_bytes = raw.get("per_message_max_bytes", defaults.per_message_max_bytes)
+    try:
+        per_message_max_bytes = int(per_message_max_bytes)
+        if per_message_max_bytes <= 0:
+            per_message_max_bytes = defaults.per_message_max_bytes
+    except (TypeError, ValueError):
+        import logging
+        logging.getLogger(__name__).warning(
+            "history_resident.per_message_max_bytes=%r is invalid (not an int); using %r",
+            per_message_max_bytes, defaults.per_message_max_bytes,
+        )
+        per_message_max_bytes = defaults.per_message_max_bytes
+    return HistoryResidentConfig(
+        max_bytes=ResidentBytes(max_bytes), per_message_max_bytes=per_message_max_bytes,
+    )
 
 
 @dataclass

--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -436,6 +436,23 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # Session._check_turn_mid_memory_ladder's own docstring for why an
     # operator's own cancel must never be conflated with this safety net.
     "turn_stopped_memory": frozenset({"footprint_bytes", "cap_bytes"}),
+    # history_oversized_content_spilled / _truncated (#6042): Session.
+    # _enforce_per_message_content_cap's own two outcomes -- a durable
+    # history.jsonl row whose content exceeded history_resident.
+    # per_message_max_bytes got either fully preserved off-row (spilled,
+    # PRIMARY path) or truncated with a preview (FALLBACK, no MediaStore
+    # configured or the spill write itself failed). Two distinct kinds,
+    # not one with an "outcome" field, because the required fields
+    # genuinely differ (spilled names the on-disk path; truncated names
+    # how much of the preview survived) -- same reasoning
+    # permission_approval_revoked/_granted already established for this
+    # file (#5065).
+    "history_oversized_content_spilled": frozenset(
+        {"role", "seq", "original_bytes", "cap_bytes", "path"}
+    ),
+    "history_oversized_content_truncated": frozenset(
+        {"role", "seq", "original_bytes", "cap_bytes", "preview_bytes"}
+    ),
 }
 
 
@@ -543,6 +560,8 @@ AUDIT_EVENT_KINDS: frozenset[str] = frozenset({
     "file_read_media_write_unavailable",
     "force_close_triggered",
     "history_hydration_stopped_reading_early_unsafe",
+    "history_oversized_content_spilled",
+    "history_oversized_content_truncated",
     "hook_changed",
     "hook_drain_task_died",
     "hook_event_emitted",

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4352,6 +4352,12 @@ class Session:
         # and skipped if already anchored (a re-append keeps its original anchor).
         if self._state_log is not None and "wal_seq" not in msg.meta:
             msg.meta["wal_seq"] = self._state_log.current_seq
+        # #6042: the per-message durable-content byte cap -- BEFORE the
+        # resident append and the disk write below, so neither ever
+        # transiently holds the oversized content (lead-coder ruling,
+        # #5851 issue thread: "durable な行が一度も過大な content を持たない
+        # ことを witness する"). Mutates msg.content/msg.meta in place.
+        self._enforce_per_message_content_cap(msg)
         self.history.append(msg)
         # #5896 (#5364 §1.1 "A"): the durable line is ``history_record``'s
         # form, not ``asdict`` — an un-spilled tool row's body stays on the
@@ -4362,6 +4368,104 @@ class Session:
             f.write(json.dumps(history_record(msg), ensure_ascii=False) + "\n")
         self._evict_oldest_resident_entries()
         self._update_untrusted_taint_on_append(msg)
+
+    def _enforce_per_message_content_cap(self, msg: ChatMessage) -> None:
+        """#6042 — the per-message durable-content byte cap, checked at
+        ``_append_history``'s own convergence point (its docstring already
+        establishes "every role funnels through" here). Design ruled on:
+        https://github.com/tya5/reyn/issues/6042 (lead-coder-approved,
+        2026-09-10).
+
+        Real-machine grounding (#6089, architect): a single ``role=tool``
+        entry reached 462 MB in a live ``history.jsonl`` — the existing
+        tool-result spill gate (#5896/#5944) is real but not airtight (the
+        SAME file had a 13 MB tool result sitting un-spilled next to a
+        correctly-spilled one). This is the backstop that catches whatever
+        slips past upstream spill decisions, regardless of why they didn't
+        fire — deliberately NOT another per-call-site check (this issue's
+        own premise: grep's own cap / #5896's tool-result file-backing /
+        ``enforce_new_msg_budget``'s pre-turn refusal each cover exactly
+        ONE path; adding a 4th would repeat the same shape).
+
+        Skips a message already carrying ``CONTENT_REF_META_KEY`` — that
+        row went through the EXISTING write-ahead externalization
+        (``RouterLoop.persist_feedback`` / #5364 §1.1 "A"): its real body
+        is already off this row (``history_record`` blanks it at write
+        time), so measuring ``msg.content`` here would double-count an
+        already-solved case.
+
+        Role-AGNOSTIC by design (lead-coder ruling): assistant-authored
+        content is in scope too, even though it is bounded by the model's
+        own ``max_tokens`` in practice and so is unlikely to actually
+        reach this cap — excluding it by role would undercut the very
+        argument for placing this check at the convergence point (adding
+        a role-based branch is the same "N+1th special case" shape this
+        design otherwise avoids).
+
+        PRIMARY path: spill to a file via the SAME seam ``MediaStore.
+        save_tool_result`` already uses for tool results (#5896), fully
+        preserving the content (never truncating it) — replaces
+        ``msg.content`` with a short, model-readable pointer text (same
+        shape ``router_loop.py``'s own ``_build_media_tail_preview``
+        already uses for an analogous over-budget-media case), and marks
+        the durable record so a reader can tell this was NOT originally a
+        ref (``meta["oversized_content_spilled"]``).
+
+        FALLBACK (no ``self._media_store`` configured, or the spill write
+        itself failed): truncate, but never silently — a durable marker
+        (``meta["content_truncated"]``, the original byte count) PLUS a
+        preview of the first bytes (lead-coder ruling: a bare boolean
+        marker is not enough — "何が失われたか" must be readable, at least
+        partially, without needing to reconstruct the original)."""
+        cap = self._history_resident_config.per_message_max_bytes
+        if cap is None or cap <= 0:
+            return
+        if msg.meta.get(CONTENT_REF_META_KEY):
+            return
+        content = msg.content
+        if isinstance(content, str):
+            content_str = content
+        else:
+            content_str = json.dumps(content, ensure_ascii=False)
+        content_bytes = len(content_str.encode("utf-8"))
+        if content_bytes <= cap:
+            return
+
+        if self._media_store is not None:
+            try:
+                saved = self._media_store.save_tool_result(
+                    content_str, mime_type="text/plain", tool=f"oversized_{msg.role}",
+                    chain_id=str(msg.meta.get("chain_id") or ""),
+                )
+            except Exception:
+                logger.exception(
+                    "#6042: spilling an oversized (%d bytes, cap %d) role=%s message's "
+                    "content failed -- falling back to truncate+preview",
+                    content_bytes, cap, msg.role,
+                )
+            else:
+                msg.content = (
+                    f"[content too large ({content_bytes} bytes, cap {cap}) -- spilled "
+                    f"to {saved['path']}; read via read_file(path={saved['path']!r})]"
+                )
+                msg.meta["oversized_content_spilled"] = True
+                msg.meta["oversized_content_original_bytes"] = content_bytes
+                self._audit_events.emit(
+                    "history_oversized_content_spilled",
+                    role=msg.role, seq=msg.seq, original_bytes=content_bytes, cap_bytes=cap,
+                    path=saved["path"],
+                )
+                return
+
+        preview = content_str[:2000]
+        msg.content = preview
+        msg.meta["content_truncated"] = True
+        msg.meta["content_truncated_original_bytes"] = content_bytes
+        self._audit_events.emit(
+            "history_oversized_content_truncated",
+            role=msg.role, seq=msg.seq, original_bytes=content_bytes, cap_bytes=cap,
+            preview_bytes=len(preview.encode("utf-8")),
+        )
 
     def _update_untrusted_taint_on_append(self, msg: ChatMessage) -> None:
         """#5276 (architect ruling): the single mutation-side update point

--- a/tests/runtime/test_6042_per_message_content_cap.py
+++ b/tests/runtime/test_6042_per_message_content_cap.py
@@ -1,0 +1,180 @@
+"""Tier 2: #6042 — the per-message durable-content byte cap
+(``Session._enforce_per_message_content_cap``, checked inside
+``_append_history``'s own convergence point).
+
+Real ``Session`` + real ``MediaStore`` (via ``multimodal_config=``) + real
+disk I/O throughout — never a Mock. Every "was it actually kept small"
+claim is verified by reading the ACTUAL bytes written to ``history.jsonl``
+on disk (lead-coder's own explicit condition: "durable な行が一度も過大な
+content を持たないことを witness する", not asserted from private state or
+claimed in prose).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reyn.config import MultimodalConfig
+from reyn.config.chat import HistoryResidentConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import CONTENT_REF_META_KEY, ChatMessage
+from tests._support.agent_session import make_session
+from tests._support.events import collect_events
+
+
+def _session_with_cap(
+    tmp_path: Path, *, per_message_max_bytes: int = 500, with_media: bool = True,
+):
+    return make_session(
+        agent_name="pr6042-agent",
+        state_log=StateLog(tmp_path / ".reyn" / "wal.jsonl"),
+        snapshot_path=tmp_path / "snap.json",
+        workspace_base_dir=tmp_path,
+        workspace_state_dir=tmp_path / "ws",
+        history_resident_config=HistoryResidentConfig(per_message_max_bytes=per_message_max_bytes),
+        multimodal_config=MultimodalConfig() if with_media else None,
+    )
+
+
+def _durable_line_bytes(s) -> "list[int]":
+    """The ACTUAL byte length of every line currently on disk in
+    ``history.jsonl`` — read fresh from the file, never from ``s.history``
+    (the resident cache) or any other in-memory state."""
+    return [
+        len(line.encode("utf-8"))
+        for line in s.history_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_oversized_content_is_spilled_and_the_durable_line_stays_small(tmp_path: Path):
+    """Tier 2: the PRIMARY path — a real MediaStore is configured, so the
+    oversized content is fully preserved off-row (never truncated), and
+    the durable history.jsonl line itself is small. Reads the ACTUAL file
+    bytes on disk, the load-bearing witness for lead-coder's own
+    ordering condition."""
+    s = _session_with_cap(tmp_path, per_message_max_bytes=500)
+    events = collect_events(s)
+    big_content = "X" * 50_000
+
+    s._append_history(ChatMessage(role="tool", content=big_content, ts="t1"))
+
+    line_bytes = _durable_line_bytes(s)
+    assert line_bytes, "sanity: a line was actually written"
+    assert max(line_bytes) < 5_000, (
+        f"the durable history.jsonl line must stay small (the oversized "
+        f"content must never reach disk as-is), got max line size "
+        f"{max(line_bytes)} bytes"
+    )
+    # The resident message was mutated too (byte-identical to what's durable).
+    msg = s.history[-1]
+    assert big_content not in msg.content
+    assert msg.meta["oversized_content_spilled"] is True
+    assert msg.meta["oversized_content_original_bytes"] == len(big_content.encode("utf-8"))
+
+    (spill_event,) = [e for e in events if e.type == "history_oversized_content_spilled"]
+    assert spill_event.data["role"] == "tool"
+    assert spill_event.data["original_bytes"] == len(big_content.encode("utf-8"))
+    assert spill_event.data["cap_bytes"] == 500
+    spilled_path = spill_event.data["path"]
+
+    # Round-trip: the FULL original content survives, off-row, on disk.
+    _, found = s._media_store.read_tool_result(spilled_path)
+    assert found is True
+
+
+def test_falls_back_to_truncate_with_a_preview_when_no_media_store(tmp_path: Path):
+    """Tier 2: the FALLBACK — no MediaStore configured. The content is
+    truncated, but never silently: a durable marker AND a preview of the
+    first bytes survive on the actual disk line (lead-coder ruling: a
+    bare boolean is not enough)."""
+    s = _session_with_cap(tmp_path, per_message_max_bytes=500, with_media=False)
+    events = collect_events(s)
+    big_content = "Y" * 50_000
+
+    s._append_history(ChatMessage(role="assistant", content=big_content, ts="t1"))
+
+    line_bytes = _durable_line_bytes(s)
+    assert max(line_bytes) < 5_000, "the truncated line must also stay small on disk"
+
+    raw_line = s.history_path.read_text(encoding="utf-8").splitlines()[-1]
+    record = json.loads(raw_line)
+    assert record["meta"]["content_truncated"] is True
+    assert record["meta"]["content_truncated_original_bytes"] == len(big_content.encode("utf-8"))
+    assert record["content"], "a preview must survive, not an empty string"
+    assert record["content"] == "Y" * 2000, "the preview must be the actual leading bytes"
+
+    (truncate_event,) = [e for e in events if e.type == "history_oversized_content_truncated"]
+    assert truncate_event.data["role"] == "assistant"
+    assert truncate_event.data["preview_bytes"] == 2000
+
+
+def test_content_already_externalized_via_content_ref_is_left_alone(tmp_path: Path):
+    """Tier 2: a row already carrying CONTENT_REF_META_KEY went through the
+    EXISTING write-ahead externalization (#5364 §1.1 "A") — this cap must
+    not re-measure or re-spill it (that content is a legitimate small
+    resident cache the write-ahead path already externalized; measuring it
+    here would be a double-count of an already-solved case)."""
+    s = _session_with_cap(tmp_path, per_message_max_bytes=500)
+    msg = ChatMessage(
+        role="tool", content="Z" * 50_000, ts="t1",
+        meta={CONTENT_REF_META_KEY: "some/ref/path.txt"},
+    )
+
+    s._append_history(msg)
+
+    assert msg.content == "Z" * 50_000, "content already handled by the write-ahead path must be untouched"
+    assert "oversized_content_spilled" not in msg.meta
+    assert "content_truncated" not in msg.meta
+
+
+def test_role_agnostic_assistant_content_is_also_capped(tmp_path: Path):
+    """Tier 2: lead-coder ruling — assistant-authored content is IN SCOPE,
+    not excluded by role (the convergence-point argument for this design
+    would be undercut by a role-based branch)."""
+    s = _session_with_cap(tmp_path, per_message_max_bytes=500)
+    events = collect_events(s)
+
+    s._append_history(ChatMessage(role="assistant", content="A" * 50_000, ts="t1"))
+
+    assert any(e.type == "history_oversized_content_spilled" for e in events)
+
+
+def test_content_under_cap_is_never_touched(tmp_path: Path):
+    """Tier 2: sanity — ordinary, small content is byte-identical after
+    ``_append_history``, no spill/truncate machinery runs at all."""
+    s = _session_with_cap(tmp_path, per_message_max_bytes=500)
+    events = collect_events(s)
+    msg = ChatMessage(role="user", content="hello", ts="t1")
+
+    s._append_history(msg)
+
+    assert msg.content == "hello"
+    assert "oversized_content_spilled" not in msg.meta
+    assert "content_truncated" not in msg.meta
+    assert not any(
+        e.type in ("history_oversized_content_spilled", "history_oversized_content_truncated")
+        for e in events
+    )
+
+
+def test_a_nonpositive_cap_is_inert(tmp_path: Path):
+    """Tier 2: the runtime guard for a directly-constructed non-positive
+    cap (the config BUILDER already falls back to the default for this —
+    see test_config_mirror_coverage_1056.py's own coverage of that — this
+    pins the runtime method's own independent defensive check).
+
+    Strip: remove the ``if cap is None or cap <= 0: return`` guard --
+    this goes RED (the oversized content gets spilled even with a
+    disabled cap, performed during review)."""
+    s = _session_with_cap(tmp_path, per_message_max_bytes=0)
+    events = collect_events(s)
+    msg = ChatMessage(role="tool", content="B" * 50_000, ts="t1")
+
+    s._append_history(msg)
+
+    assert msg.content == "B" * 50_000
+    assert not any(
+        e.type in ("history_oversized_content_spilled", "history_oversized_content_truncated")
+        for e in events
+    )


### PR DESCRIPTION
**[e2e-coder]** — fixes #6042. Design ruled on: #6042#issuecomment (lead-coder's approval + 3 rulings, 2026-09-10).

## Scope: this is about `history.jsonl` (durable), NOT "what's sent to the LLM"

`_append_history`'s own docstring already establishes it as the convergence point every role funnels through — this is where the cap lives, not a 4th per-call-site check (#5944's grep cap / #5896's tool-result file-backing / `enforce_new_msg_budget`'s pre-turn refusal each cover exactly ONE path; this issue's own premise is that pattern doesn't scale).

## Real-machine grounding (#6089, architect)

A single `role=tool` entry reached **462 MB** in a live `history.jsonl` (`default/state/sessions/6e13efdf`) — the existing tool-result spill gate is real but not airtight: the SAME file had a 13 MB tool result sitting un-spilled next to a correctly-spilled one.

## Design — 3 rulings from lead-coder, all implemented

1. **New knob**: `history_resident.per_message_max_bytes` (10 MiB default, disclosed as an **estimate**, not a measurement — sits between `read_cap.inline_bytes`'s much smaller inline threshold and the 13 MB/462 MB sizes #6089 measured). Deliberately **not** reusing `history_resident.max_bytes` — that measures the resident *total*, a different quantity (the same "cap watching the wrong quantity" shape #6047/#6050 already hit). **Enabled by default** — unlike `process_memory`'s own observe-only stage-a default (no data to derive from at the time), this incident already happened on an unmodified config.
2. **Ordering**: checked after seq assignment, before `history_record(msg)`/the line write — the durable row never transiently holds the oversized content. **Strip-falsified**: moving the call after the disk write reproduces a 50 KB line on disk, confirmed RED.
3. **Role-agnostic**: assistant-authored content is in scope too (docstring notes it's unlikely to actually reach this cap in practice due to `max_tokens`, per lead-coder's instruction so a future reader doesn't read the role-inclusiveness as dead code and remove it).

## Mechanism

- **Primary**: spill to a file via the SAME seam `MediaStore.save_tool_result` already uses for tool results (#5896) — fully preserves the content, never truncates; `msg.content` becomes a short pointer text; the row is marked (`meta["oversized_content_spilled"]`).
- **Fallback** (no `MediaStore` configured, or the spill write itself fails): truncate, but never silently — a durable marker (`meta["content_truncated"]` + original byte count) **plus** a preview of the first bytes (lead-coder ruling: a bare boolean isn't enough).
- Skips a row already carrying `CONTENT_REF_META_KEY` — that content already went through the existing write-ahead externalization (#5364 §1.1 "A"); measuring it here would double-count an already-solved case.

New audit-event kinds: `history_oversized_content_spilled` / `_truncated`.

## Test plan

- [x] Every "stays small on disk" claim verified by reading the **actual bytes** written to `history.jsonl` — never private state or prose claims (lead-coder's explicit condition)
- [x] Both the inert-guard (non-positive cap) and the ordering strip-falsified (confirmed RED, then restored)
- [x] Scoped pytest: 86 tests (new file + every history/media-store-adjacent regression suite) green
- [x] `ruff check .`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py` green
- [x] `tests/` path-conditional gates (6 scripts) green
- [x] `mkdocs build --strict` + `check_doc_anchors.py` + `check_retired_config_keys_denylist.py` green
- [x] (skipped — Visual, standing waiver)

Closes #6042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S