### PR TITLE
fix(part of #6077): offload the router-cap wrap-up's own build_history() call

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -10516,7 +10516,15 @@ class Session:
 
         _wrapup_text: str | None = None
         _reason_unavailable = ""
-        history = self._history_buffer.build_history()
+        # #6077 (backlog-watcher finding, not that issue's own root cause --
+        # this call is reached ONLY on router-cap exhaustion, not on #6077's
+        # own steady-state symptom): build_history() re-serialises every
+        # watermark-surviving turn, a cost proportional to session length,
+        # and this was the ONE remaining call site still running it
+        # synchronously on the event loop -- every other build_history()
+        # call on the normal submit path is already offloaded (same idiom,
+        # router_loop_driver.py's own await asyncio.to_thread(...) call).
+        history = await asyncio.to_thread(self._history_buffer.build_history)
         messages: list[dict] = [
             *history,
             *(

--- a/tests/runtime/test_6077_router_cap_wrapup_build_history_offload.py
+++ b/tests/runtime/test_6077_router_cap_wrapup_build_history_offload.py
@@ -1,0 +1,82 @@
+"""Tier 2: #6077 (backlog-watcher finding, part of that issue -- NOT its
+own root cause) — ``Session._emit_router_cap_exhausted_user``'s own
+``build_history()`` call was the one remaining call site on the router-cap
+exhaustion path still running synchronously on the event loop; every other
+``build_history()`` call on the normal submit path is already offloaded
+via ``asyncio.to_thread`` (``router_loop_driver.py``'s own established
+idiom). This pins that offload as a STATE fact — which function
+``asyncio.to_thread`` was actually called with — never a measured
+duration (CLAUDE.md: "a test writes no duration, in EITHER direction").
+
+Real ``Session`` + a real, injectable wrapper around ``asyncio.to_thread``
+(never a Mock) that records what it was called with before delegating to
+the real implementation — the call genuinely still executes for real.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.config import LoopConfig, SafetyConfig
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.errors import RouterCapExceeded
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+from tests._support.router_loop import ScriptedLLM as _ScriptedLLM
+from tests._support.router_loop import text_result
+
+
+def _make_session(tmp_path: Path, cap: int = 3) -> Session:
+    safety = SafetyConfig(loop=LoopConfig(max_router_calls_per_turn=cap))
+    return make_session(
+        agent_name="test_cap_offload_agent",
+        budget_tracker=BudgetTracker(CostConfig()),
+        safety=safety,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_history_is_offloaded_via_asyncio_to_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """Tier 2: the load-bearing regression witness — ``build_history`` is
+    reached through ``asyncio.to_thread``, the SAME idiom
+    ``router_loop_driver.py``'s own submit-path call already uses, not a
+    direct synchronous call on the event loop.
+
+    Strip: change ``await asyncio.to_thread(self._history_buffer.
+    build_history)`` back to ``self._history_buffer.build_history()`` in
+    ``Session._emit_router_cap_exhausted_user`` -- this goes RED (the
+    wrapper below never sees ``build_history`` as a target, performed
+    during review)."""
+    session = _make_session(tmp_path)
+    calls: "list[object]" = []
+    real_to_thread = asyncio.to_thread
+
+    async def _recording_to_thread(func, /, *args, **kwargs):
+        calls.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", _recording_to_thread)
+
+    llm = _ScriptedLLM([text_result("wrap-up summary")])
+    exc = RouterCapExceeded(count=3, cap=3, last_reason="loop_reason")
+
+    await session._emit_router_cap_exhausted_user(
+        exc, chain_id="chain-cap-offload", _llm_caller=llm,
+    )
+
+    # Identify the target by its OWN introspectable identity (name +
+    # owning class), never by reaching through session._history_buffer at
+    # the assertion site — the wrapper above is the public witness; what
+    # it recorded is what this checks.
+    assert any(
+        getattr(fn, "__name__", None) == "build_history"
+        and type(getattr(fn, "__self__", None)).__name__ == "RouterHistoryBuffer"
+        for fn in calls
+    ), (
+        f"expected build_history (RouterHistoryBuffer's own) to be reached "
+        f"via asyncio.to_thread, got these targets instead: {calls!r}"
+    )

--- a/tests/runtime/test_6077_router_cap_wrapup_build_history_offload.py
+++ b/tests/runtime/test_6077_router_cap_wrapup_build_history_offload.py
@@ -11,6 +11,22 @@ duration (CLAUDE.md: "a test writes no duration, in EITHER direction").
 Real ``Session`` + a real, injectable wrapper around ``asyncio.to_thread``
 (never a Mock) that records what it was called with before delegating to
 the real implementation — the call genuinely still executes for real.
+
+lead-coder BLOCKING, PR #6099: this test's own ``monkeypatch.setattr(
+asyncio, "to_thread", ...)`` is a DELIBERATE departure from testing.md's
+"never fake a collaborator when a real instance is cheaply constructible"
+rule — named here, not left for the next reader to rediscover as "wasn't
+this forbidden?" (same shape as PR #6087's own precedent paragraph). ①
+The departure is intentional, not an oversight. ② It is not a fake: the
+wrapper WRAPS the real ``asyncio.to_thread`` and always delegates to it
+(``return await real_to_thread(func, *args, **kwargs)``) — the offload
+genuinely still happens, this only observes what target it was called
+with. ③ The only alternative external observation available here would
+be a measured DURATION (whether the call blocked the event loop for a
+detectable time) — and that is exactly what this SAME testing policy
+forbids in either direction (CLAUDE.md's own floor/ceiling ban). With no
+other externally-drivable STATE this call's own offload produces, this
+wrapper is the only undriven way to witness it.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**[e2e-coder]** — part of #6077, from backlog-watcher's own investigation comment (#6077#issuecomment-5619571734).

## ⚠️ This is NOT #6077's own root cause — the symptom remains

`Session._emit_router_cap_exhausted_user` (`session.py`) is reached ONLY when the per-turn router cap is exhausted — a narrow, cap-triggered path, not #6077's own steady-state symptom. Whether it matches the frequency of owner's own observed symptom is unconfirmed. **Fixing this does not close #6077.** Deliberately `part of #6077`, not `Closes`.

## What this fixes

`build_history()` re-serialises every watermark-surviving turn — a cost proportional to session length — and this was the ONE remaining call site on the router-cap-exhaustion wrap-up path still running it synchronously on the event loop. Every other `build_history()` call on the normal submit path is already offloaded via `asyncio.to_thread` (`router_loop_driver.py`'s own established idiom) — this uses the exact same idiom, no new mechanism.

## Why fix it despite being narrow and rarely-reached today

A cost proportional to session length running synchronously on the event loop is a defect in *shape*, independent of how often this specific call site is currently reached — "rarely reached today" is a measurement of today, not a property of the code.

## Test plan

- [x] Pins the fix as a **state** fact — which callable `asyncio.to_thread` was invoked with, verified via a real recording wrapper (never a Mock, never a measured duration in either direction, per CLAUDE.md's own testing policy)
- [x] Strip-falsified (confirmed RED, then restored)
- [x] Scoped pytest: 24 tests (new file + every router-cap-wrapup-adjacent regression suite) green
- [x] `ruff check .`, `mypy_ratchet.py`, `test_tier_audit.py --strict`, `verify_module_docstrings.py` green
- [x] `tests/` path-conditional gates (6 scripts) green
- [x] (skipped — Visual, standing waiver)

part of #6077

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S