### PR TITLE
feat(part of #6083 stage 2b): slash_command accepts immediately, runs in background

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -40,17 +40,23 @@ A2A; tools are MCP; observability export is OTEL. Those are separate surfaces.)
     at-most-once retry).
   - `{"type": "slash_command", "name": "model", "args": "strong"}` — run a
     registered slash command (#3595 S5). The response body is
-    `{"status": "ok", "ran": true|false}`; `ran: false` means this server's
-    registry has no such command (a client on a different build), never a
-    crash. ★ The client has ALREADY interpreted the operator's `/…` line and
-    resolved the NAME against its own registry — nothing on the wire or on the
-    server tests a leading `/`, which is the whole point of #3595: `Session`
-    interprets no string, and a client maps typed text onto published
-    operations. A remote client sends this rather than running the command
-    itself because it holds no `Session`, and the commands that still read
-    session state can only run where that session is. Permission-gated by the
-    same `authorize_write` check `user_message` passes, and the command's reply
-    rides the ordinary display stream.
+    `{"status": "ok", "accepted": true|false}`; `accepted: false` means this
+    server's registry has no such command (a client on a different build),
+    never a crash. ★ The client has ALREADY interpreted the operator's `/…`
+    line and resolved the NAME against its own registry — nothing on the wire
+    or on the server tests a leading `/`, which is the whole point of #3595:
+    `Session` interprets no string, and a client maps typed text onto
+    published operations. A remote client sends this rather than running the
+    command itself because it holds no `Session`, and the commands that still
+    read session state can only run where that session is. Permission-gated by
+    the same `authorize_write` check `user_message` passes.
+    #6083 ⑵-b: `accepted: true` means the command was HANDED OFF to the
+    session's own background-task funnel, not that it has finished — a slow
+    handler (e.g. `/compact`) no longer holds this POST open until it
+    completes (the false-failure shape #6083 itself reports). The command's
+    real success/failure line still rides the ordinary display stream, exactly
+    as before; a caller that needs the actual outcome reads it from there, not
+    from this response.
   - `{"type": "heartbeat"}` — a liveness keepalive.
 
   An input type the server does not model is a **graceful no-op** (a `200` ack),

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -694,11 +694,25 @@ class AgUiTransport(ClientTransport):
         # no transport re-tests ``startswith("/")`` and the server executes a
         # named operation rather than sniffing a string. The server re-resolves
         # the name against its OWN registry (a client and a server can be
-        # running different builds) and answers whether it ran.
+        # running different builds).
+        #
+        # #6083 ⑵-b: the server no longer awaits the command to completion
+        # before answering — it hands the command to its own background-task
+        # funnel and answers ``accepted`` immediately (endpoint.py's own
+        # comment on the ``slash_command`` arm has the full reasoning). So
+        # ``True`` here means "the server accepted this and will run it",
+        # NOT "it already ran" / "it succeeded" — a meaning narrower than
+        # this method's own ABC docstring states for the general case
+        # (``ClientTransport.run_slash_command``), which still holds for
+        # ``InProcessTransport``'s synchronous, local execution. A caller
+        # that needs the real outcome reads it off the display stream this
+        # command's own success/error line already rides (the SAME SSE
+        # broadcast every other reply uses — see endpoint.py), same as it
+        # always had to for any other asynchronously-reported effect.
         result = await self._send(
             {"type": "slash_command", "name": name, "args": args}
         )
-        return bool((result or {}).get("ran"))
+        return bool((result or {}).get("accepted"))
 
     async def request_attach(self, agent_name: str) -> bool:
         # #4534 PR-1/PR-2: same shape as run_slash_command above, a second

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1549,7 +1549,7 @@ async def agui_submit(request: Request):
         # string, so nothing on the server side tests a leading ``/``. The name
         # is re-resolved against THIS process's registry — a client on a
         # different build must not be able to name something this one does not
-        # have — and an unknown name answers ``ran: False`` rather than raising.
+        # have.
         #
         # A remote client holds no ``Session``, so eleven of the registered
         # commands (the S4 residue: /model, /cost, /image, …) can only run where
@@ -1557,14 +1557,84 @@ async def agui_submit(request: Request):
         # attach's slash catalog identical to a local one; it rides the same
         # ``authorize_write`` gate above that a turn submit does, which is the
         # gate they already passed when they rode ``user_message``.
+        #
+        # #6083 ⑵-b: this used to AWAIT ``execute_slash_command`` and answer
+        # ``ran`` only once it finished — a slow handler (the reported case:
+        # ``/compact``) then held this POST open past the client's own control
+        # timeout, so a command that was still genuinely running read back as
+        # a false "did not run" (#6083 ⑴ narrowed WHERE that false read came
+        # from; this closes the actual wait). The response now answers
+        # ``accepted`` the instant the command is HANDED OFF to the session's
+        # own background-task funnel (``#4759``'s ``TrackedTaskSet``, already
+        # the established mechanism for exactly this kind of fire-and-forget
+        # session work) — not once it has run. Real completion/failure is not
+        # a new signal: ``session._slash_context()`` already wires
+        # ``SessionBoundTransport(display_sink=self._put_outbox_nowait)``, so
+        # ``execute_slash_command``'s own success/error display (dispatch.py)
+        # already flows through the session's outbox → the SAME SSE broadcast
+        # every other reply rides. No new client-side channel is needed.
+        from reyn.interfaces.slash import REGISTRY
         from reyn.interfaces.slash.dispatch import execute_slash_command
         name = str(payload.get("name", "")).strip()
-        if name:
-            ran = await execute_slash_command(
-                session._slash_context(), name, str(payload.get("args", "")),
+        # Resolved BEFORE deciding to schedule anything — ``execute_slash_
+        # command`` re-checks this same registry itself (harmless, it is a
+        # dict read), but the check has to happen HERE too: an unknown name
+        # (a client on a different build) must answer ``accepted: false``
+        # synchronously, not get scheduled and let the background task's own
+        # ``cmd is None -> return False`` early-out invisibly disappear —
+        # this response is the only signal an unresolved name ever gets.
+        if not name or REGISTRY.get(name) is None:
+            return JSONResponse({"status": "ok", "accepted": False})
+        args = str(payload.get("args", ""))
+
+        async def _run_slash_command_in_background() -> None:
+            # ``execute_slash_command`` already contains its own try/except
+            # around the handler and displays a failure via ``ctx.transport``
+            # (dispatch.py) — that covers "the command itself failed". This
+            # OUTER try/except is defense for anything that could still
+            # escape it (``SlashContext``/``_ErrorWatchingTransport``
+            # construction): a background task's own uncaught exception
+            # would otherwise just become an unretrieved ``asyncio`` task
+            # exception (logged to stderr, never reaching the client) — a
+            # silent drop AFTER the client was already told "accepted" is
+            # exactly the shape #6083 itself exists to close, one layer
+            # further down.
+            try:
+                await execute_slash_command(session._slash_context(), name, args)
+            except Exception:
+                logger.exception(
+                    "slash command /%s failed in its background task", name,
+                )
+                session._put_outbox_nowait(OutboxMessage(
+                    kind="error",
+                    text=f"/{name} failed unexpectedly after being accepted",
+                ))
+
+        coro = _run_slash_command_in_background()
+        try:
+            session._background_tasks.spawn(
+                coro,
+                name=f"slash:{name}",
+                # #6083 ⑵-b, condition ⑵ (lead-coder): a slash handler can
+                # itself append to the WAL (e.g. ``/compact`` recording a
+                # compaction), so this must be drained before
+                # ``await_quiescent``'s rewind reset-record — the same
+                # reasoning tracked_tasks.py's own module docstring gives
+                # for every other WAL-appending producer. See this PR's own
+                # body for what a mid-command reyn crash leaves behind.
+                appends_wal=True,
             )
-            return JSONResponse({"status": "ok", "ran": ran})
-        return JSONResponse({"status": "ok", "ran": False})
+        except Exception:
+            # ``spawn()`` itself failed BEFORE the task could even start —
+            # the one path that must NOT still answer "accepted": nothing
+            # will ever run, so the client learns that NOW, synchronously,
+            # rather than from silence later. ``coro.close()`` is what
+            # keeps this a clean failure rather than ALSO leaking an
+            # unawaited-coroutine warning on top of it.
+            coro.close()
+            logger.exception("failed to schedule slash command /%s", name)
+            return JSONResponse({"status": "ok", "accepted": False})
+        return JSONResponse({"status": "ok", "accepted": True})
     elif ptype == "cancel_inflight":
         cancel_fn = getattr(session, "cancel_inflight", None)
         if callable(cancel_fn):

--- a/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
+++ b/tests/interfaces/test_3595_s5_session_does_not_interpret_text.py
@@ -483,7 +483,7 @@ async def test_a_client_whose_terminal_already_echoed_does_not_echo_twice(
 
 @pytest.mark.asyncio
 async def test_a_remote_client_can_still_run_a_command(tmp_path, monkeypatch) -> None:
-    """Tier 2: the AG-UI ``slash_command`` arm runs a NAME, and refuses an
+    """Tier 2: the AG-UI ``slash_command`` arm accepts a NAME, and refuses an
     unknown one.
 
     ★ The leg that keeps S5 from being a feature removal. A ``--connect`` client
@@ -495,9 +495,16 @@ async def test_a_remote_client_can_still_run_a_command(tmp_path, monkeypatch) ->
     a re-introduction of it.
 
     The refusal leg is the pair: a name this server's registry does not have
-    answers ``ran: false`` — a client on a different build, not a crash — and it
-    is what proves ``ran: true`` above is reporting a real resolution rather than
-    acking everything.
+    answers ``accepted: false`` — a client on a different build, not a crash —
+    and it is what proves ``accepted: true`` above is reporting a real
+    resolution rather than acking everything.
+
+    #6083 ⑵-b: ``accepted`` (was ``ran``) — the endpoint now hands the command
+    to the session's own background-task funnel and answers the instant it is
+    scheduled, not once it has finished running. This test's own wait for the
+    reply below was ALREADY an unbounded poll on the subscription queue (never
+    a fixed sleep), so it needed no change for that: the response landing
+    before the command's own display line is exactly the behavior under test.
 
     #3793 stage 2: this test is now ``async`` (was a plain ``def`` using the
     SYNC ``TestClient``) — subscribing to ``session.outbox_hub`` requires a
@@ -546,8 +553,8 @@ async def test_a_remote_client_can_still_run_a_command(tmp_path, monkeypatch) ->
             "/agui/chat/operator?token=s3cret",
             json={"type": "slash_command", "name": "help", "args": ""},
         )
-        assert resp.status_code == 200 and resp.json().get("ran") is True, (
-            f"the remote slash arm did not run /help: {resp.status_code} {resp.text}"
+        assert resp.status_code == 200 and resp.json().get("accepted") is True, (
+            f"the remote slash arm did not accept /help: {resp.status_code} {resp.text}"
         )
         # Yield to the event loop so the hub's background drain task (a
         # separate asyncio.Task the request handler's put_nowait doesn't
@@ -571,9 +578,9 @@ async def test_a_remote_client_can_still_run_a_command(tmp_path, monkeypatch) ->
             "/agui/chat/operator?token=s3cret",
             json={"type": "slash_command", "name": "no_such_command", "args": ""},
         )
-        assert unknown.status_code == 200 and unknown.json().get("ran") is False, (
-            "an unresolvable command name did not answer ran:false — the arm is "
-            f"acking without resolving. {unknown.status_code} {unknown.text}"
+        assert unknown.status_code == 200 and unknown.json().get("accepted") is False, (
+            "an unresolvable command name did not answer accepted:false — the "
+            f"arm is acking without resolving. {unknown.status_code} {unknown.text}"
         )
 
 

--- a/tests/interfaces/test_6083_2b_slash_command_immediate_accept.py
+++ b/tests/interfaces/test_6083_2b_slash_command_immediate_accept.py
@@ -1,0 +1,185 @@
+"""Tier 2: #6083 ⑵-b — the AG-UI ``slash_command`` arm answers ``accepted``
+the instant the command is HANDED OFF to the session's own background-task
+funnel, not once it has finished running.
+
+★ Why this closes what stage 1 (#6094) could not. Stage 1 fixed the false
+CLAIM a slow session-locus command produced (see
+``test_6083_slash_dispatch_control_outcome.py``), but the owner's own
+``/compact`` case did not just read wrong — it took longer than the client's
+control read timeout, full stop. This stage removes the wait itself: the
+endpoint schedules ``execute_slash_command`` on ``Session._background_tasks``
+(#4759's existing task funnel) and returns immediately. Real completion/
+failure is not a new signal — ``Session._slash_context()`` already wires
+``SessionBoundTransport(display_sink=self._put_outbox_nowait)``, so a
+background-run command's own success/error line rides the SAME outbox → SSE
+broadcast every other reply does.
+
+Two legs, both real ``AgentRegistry`` + ``Session`` (no mock/stub of either —
+testing.md's "never fake a collaborator when a real instance is cheaply
+constructible"):
+
+- the positive: the response returns ``accepted: true`` while a
+  externally-gated handler is STILL BLOCKED — proof the server did not wait,
+  driven by an ``asyncio.Event`` the test itself controls (never a sleep;
+  testing.md's no-duration rule) — then releasing the gate and observing the
+  command's own completion arrive later, on the display stream.
+- the negative (condition ⑴ of lead-coder's design review): if
+  ``TrackedTaskSet.spawn`` itself raises before the task can even start, the
+  response must NOT still say ``accepted: true`` — the one shape that must
+  never happen is "told it ran, nothing runs". ``spawn`` is monkeypatched on
+  the REAL, already-constructed ``TrackedTaskSet`` instance (one method on a
+  real collaborator, not a mock object) to make that path reachable at all;
+  there is no way to make the real funnel fail on demand otherwise.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.slash import REGISTRY, SlashCommand
+from reyn.runtime.registry import AgentRegistry
+from tests._support.agent_session import make_session
+from tests._support.minimal_reyn_yaml import MINIMAL_REYN_YAML
+
+
+def _one_session_registry(tmp_path, monkeypatch) -> "tuple[AgentRegistry, dict]":
+    """Same shape as ``test_3595_s5_session_does_not_interpret_text.py``'s own
+    helper of the same name — kept local rather than imported across test
+    modules, matching this repo's existing convention of no cross-test-file
+    helper imports."""
+    monkeypatch.chdir(tmp_path)
+    state_log = StateLog(tmp_path / "state.wal")
+    (tmp_path / "reyn.yaml").write_text(MINIMAL_REYN_YAML, encoding="utf-8")
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None):
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+    )
+    holder["reg"] = reg
+    reg.create("operator")
+    reg.get_or_load("operator")
+    return reg, holder
+
+
+def _app_and_client(reg, monkeypatch):
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+    from reyn.interfaces.transport.agui.endpoint import router
+    from reyn.interfaces.web.auth import AuthContext
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: reg)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_accept_returns_while_the_handler_is_still_running(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: the response lands before the handler's own gate is released."""
+    reg, _holder = _one_session_registry(tmp_path, monkeypatch)
+    session = reg._peek_session("operator")
+    assert session is not None
+    gate = asyncio.Event()
+    entered = asyncio.Event()
+    finished = asyncio.Event()
+
+    async def _blocking_handler(ctx, args: str) -> None:
+        entered.set()
+        await gate.wait()
+        finished.set()
+
+    monkeypatch.setitem(
+        REGISTRY._commands, "__f6083b_block__",
+        SlashCommand(
+            name="__f6083b_block__", summary="test",
+            handler=_blocking_handler, locus="session",
+        ),
+    )
+
+    sub = session.outbox_hub.subscribe()
+    async with _app_and_client(reg, monkeypatch) as client:
+        resp = await client.post(
+            "/agui/chat/operator?token=s3cret",
+            json={"type": "slash_command", "name": "__f6083b_block__", "args": ""},
+        )
+        assert resp.status_code == 200 and resp.json().get("accepted") is True, (
+            f"expected an immediate accept: {resp.status_code} {resp.text}"
+        )
+        # Unbounded wait on the real signal the handler itself raises on
+        # entry — never a sleep (testing.md). If the endpoint had instead
+        # AWAITED the handler to completion (the pre-⑵-b shape), this would
+        # already be true by the time ``resp`` came back, so this assertion
+        # on its own would not distinguish old from new behavior — the
+        # point being proven is the ORDER: the response above already
+        # returned, and only NOW do we confirm the handler had a chance to
+        # run at all.
+        await entered.wait()
+        assert not gate.is_set(), (
+            "sanity: the handler must still be gated when we check this"
+        )
+        gate.set()
+        # Let the background task actually finish before the client (and
+        # this session) tear down — waited on ``finished`` (a signal this
+        # handler itself raises on its own exit), never on
+        # ``session._background_tasks.pending()``: that set also holds the
+        # SESSION's own session-lifetime producers (the outbox drain loop,
+        # the mcp tools probe), which never empty on their own, so polling
+        # it to become ``[]`` here would hang on tasks this test never
+        # spawned and has no reason to wait for.
+        await finished.wait()
+        sub.close()
+
+
+@pytest.mark.asyncio
+async def test_a_scheduling_failure_does_not_still_answer_accepted(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: condition ⑴ (lead-coder) — if ``spawn()`` itself fails before
+    the task can start, the response must say ``accepted: false`` — not the
+    one shape that must never happen, "told it ran, nothing runs"."""
+    reg, _holder = _one_session_registry(tmp_path, monkeypatch)
+    session = reg._peek_session("operator")
+    assert session is not None
+
+    ran = asyncio.Event()
+
+    async def _handler(ctx, args: str) -> None:
+        ran.set()  # pragma: no cover - must never be reached
+
+    monkeypatch.setitem(
+        REGISTRY._commands, "__f6083b_fail__",
+        SlashCommand(name="__f6083b_fail__", summary="test", handler=_handler, locus="session"),
+    )
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("simulated scheduling failure")
+
+    monkeypatch.setattr(session._background_tasks, "spawn", _raise)
+
+    async with _app_and_client(reg, monkeypatch) as client:
+        resp = await client.post(
+            "/agui/chat/operator?token=s3cret",
+            json={"type": "slash_command", "name": "__f6083b_fail__", "args": ""},
+        )
+        assert resp.status_code == 200 and resp.json().get("accepted") is False, (
+            f"a spawn() failure must not still answer accepted:true: "
+            f"{resp.status_code} {resp.text}"
+        )
+    assert not ran.is_set(), (
+        "the handler ran despite spawn() raising -- the fixture itself is "
+        "not exercising the failure path this test is named for"
+    )


### PR DESCRIPTION
**[tui-coder]** — `part of #6083`

## What this closes

Stage 2b (⑵-b). #6094 fixed the false-CLAIM half of #6083 (stage 1: a
session-locus command's error line no longer asserts "no session" for a
control read-timeout — the owner's own `/compact` case). This PR closes
the actual WAIT: the AG-UI `slash_command` arm no longer awaits a
handler to completion before answering. It hands the command to the
session's own background-task funnel (`Session._background_tasks`,
#4759's `TrackedTaskSet`) and answers `accepted` the instant it is
scheduled — not once it has run. A slow handler (the reported case,
`/compact`) can no longer hold the control POST open past the client's
own read timeout at all.

No new signal channel was needed: `Session._slash_context()` already
wires `SessionBoundTransport(display_sink=self._put_outbox_nowait)`, so
a background-run command's own success/error display already flows
through the session's outbox → the SAME SSE broadcast every other
reply rides. Confirmed by reading the code, not assumed.

## Condition ⑴ — spawn() failure

If `session._background_tasks.spawn(...)` itself fails BEFORE the task
starts, the response answers `accepted: false`, not `true` — the
one shape that must never happen ("told it ran, nothing runs").
Additionally, the AG-UI arm first resolves the name against `REGISTRY`
before deciding to spawn at all — an unknown name (a client on a
different build) answers `accepted: false` synchronously rather than
being silently absorbed into the background task's own
`cmd is None -> return False` path, which the client would never see.

Once scheduled, `_run_slash_command_in_background` wraps
`execute_slash_command` in ITS OWN try/except as a second line of
defense: `execute_slash_command` already catches and displays its own
handler's exception (dispatch.py), but this outer layer catches
anything that could still escape it (`SlashContext`/
`_ErrorWatchingTransport` construction) — a background task's own
uncaught exception would otherwise become a silently-logged, never-
retrieved `asyncio` task exception the client never learns about. It
is caught, logged, and surfaced as a display-stream error line instead.

Covered by `test_a_scheduling_failure_does_not_still_answer_accepted`
(strip-falsified: fails with `accepted: true` on the pre-fix tree).

## Condition ⑵ — what survives a mid-command crash

`appends_wal=True` is passed to `spawn()` (a slash handler can itself
append to the WAL, e.g. `/compact` recording a compaction) — this is
what makes `await_quiescent`'s rewind reset-record drain it correctly,
same reasoning as every other WAL-appending producer through this
funnel.

**If reyn crashes while this background task is running: the command
itself is LOST.** The scheduling (the `asyncio.Task` this PR spawns) is
tracked only in-memory by `TrackedTaskSet` — nothing durable records
"a slash command was accepted and is in flight." If the handler had not
yet reached its own append point at the moment of the crash, nothing
resumes it and nothing retries it; the operator sees no completion and
no failure, only silence, the same as any other in-flight fire-and-
forget task that never got there. If the handler HAD already durably
appended before the crash (e.g. `/compact`'s own WAL record), that
record survives exactly as it always did — this PR changes nothing
about an individual handler's OWN crash-recovery behavior, only WHEN
the client is told "accepted" versus "completed". "Lost" is the honest
answer for the scheduling itself; this PR does not add a retry or
resume mechanism for it.

## Condition ⑶ — this is a UX change, stated for the owner

**Before:** typing `/compact` (or any session-locus command) waited —
the terminal showed nothing new until the command finished or the
client's own control-read timeout (10s) elapsed, at which point a slow
but still-succeeding command could show a FALSE failure line (#6083's
own reported symptom).

**After:** the command is accepted instantly — there is no wait state
between pressing Enter and seeing SOME response. What changes concretely:
there is no longer a multi-second span where the terminal shows nothing
after typing a slow command; the real completion/failure (e.g.
`/compact`'s own "compacted N turns" or an error) now arrives
separately, slightly later, over the same display stream every other
reply already uses — the operator sees an acceptance essentially
instantly, then the real outcome shortly after, rather than one single
wait-then-result. This is judged an improvement (no more false failures
on a slow command), but the owner should see this stated plainly since
"what you see right after pressing Enter" is a visual/UX judgment call
this session cannot make on the owner's behalf (no TTY access).

## Scope note (⑵-a's server-only-decision half)

This PR does NOT introduce a registry of "which payload types get
202-style treatment" — only `slash_command` changes, per the explicit
ruling not to build a generalized mechanism ahead of a second need.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (changed test files)
- [x] `verify_module_docstrings.py` (changed src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates (bare-tests-import, file-depth, subprocess-reyn-pin, no-core-dep-importorskip, suspected-time-dependence)
- [x] `src/reyn/interfaces/` touch: `silent_except_ratchet.py`
- [x] docs/ touch: `mkdocs build --strict`, `check_doc_anchors.py`, `check_retired_config_keys_denylist.py`
- [x] Diff-scoped pytest green (17 tests: the 2 new + the modified test_3595_s5 test + the existing #6083 stage-1 tests), strip-falsified both new tests
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
