### PR TITLE
fix(#6084): translate web.py --help/description strings to English

### DIFF
--- a/scripts/user_facing_lang_gate_baseline.json
+++ b/scripts/user_facing_lang_gate_baseline.json
@@ -1,14 +1,3 @@
 [
-  "src/reyn/interfaces/cli/commands/web.py:109:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:120:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:17:add_parser",
-  "src/reyn/interfaces/cli/commands/web.py:22:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:28:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:35:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:46:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:51:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:59:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:72:add_argument",
-  "src/reyn/interfaces/cli/commands/web.py:92:add_argument",
   "src/reyn/interfaces/inline/textual_chat/chrome.py:1212:DrawerRow"
 ]

--- a/src/reyn/interfaces/cli/commands/web.py
+++ b/src/reyn/interfaces/cli/commands/web.py
@@ -16,21 +16,21 @@ from reyn.interfaces.cli.env_backend import build_environment_backend, register_
 def register(sub) -> None:
     p = sub.add_parser(
         "web",
-        help="Web UI ゲートウェイサーバを起動する",
-        description="FastAPI + AG-UI SSE ゲートウェイを uvicorn で起動します。",
+        help="Start the Web UI gateway server",
+        description="Start the FastAPI + AG-UI SSE gateway with uvicorn.",
     )
     p.add_argument(
         "--host",
         default="127.0.0.1",
         metavar="HOST",
-        help="バインドするホスト (デフォルト: 127.0.0.1)",
+        help="Host to bind to (default: 127.0.0.1)",
     )
     p.add_argument(
         "--port",
         type=int,
         default=8080,
         metavar="PORT",
-        help="バインドするポート番号 (デフォルト: 8080)",
+        help="Port number to bind to (default: 8080)",
     )
     p.add_argument(
         "--uds",
@@ -38,15 +38,15 @@ def register(sub) -> None:
         metavar="PATH",
         dest="uds",
         help=(
-            "UNIX ドメインソケットにバインドする (T2 same-machine; 指定時は "
-            "--host/--port を無視)。同一マシンの thin-client 接続向け — 認証は "
-            "OS の peer-credential (SO_PEERCRED / getpeereid)。"
+            "Bind to a UNIX domain socket (T2 same-machine; when given, "
+            "--host/--port are ignored). For same-machine thin-client "
+            "connections -- auth is the OS peer-credential (SO_PEERCRED / getpeereid)."
         ),
     )
     p.add_argument(
         "--reload",
         action="store_true",
-        help="コード変更時に自動リロードする (開発用)",
+        help="Auto-reload on code changes (for development)",
     )
     p.add_argument(
         "--log-level",
@@ -54,14 +54,14 @@ def register(sub) -> None:
         choices=["critical", "error", "warning", "info", "debug", "trace"],
         dest="log_level",
         metavar="LEVEL",
-        help="uvicorn のログレベル (デフォルト: info)",
+        help="uvicorn log level (default: info)",
     )
     p.add_argument(
         "--default-design",
         default=None,
         metavar="SLUG",
         dest="default_design",
-        help="デフォルトの design slug (env REYN_WEB_DEFAULT_DESIGN に設定)",
+        help="Default design slug (set via env REYN_WEB_DEFAULT_DESIGN)",
     )
     # Parity with `reyn chat --eager-embedding-build` (= B25-S5-1).
     # Builds the action-index synchronously on session start so
@@ -75,10 +75,10 @@ def register(sub) -> None:
         default=False,
         dest="eager_embedding_build",
         help=(
-            "action_embedding_index を session 起動時 sync で build "
-            "(env REYN_WEB_EAGER_EMBEDDING_BUILD=1 と同等)。"
-            " search_actions を 1 turn 目から見せたい dogfood / web "
-            "デプロイで有効化。"
+            "Build action_embedding_index synchronously at session start "
+            "(equivalent to env REYN_WEB_EAGER_EMBEDDING_BUILD=1). "
+            "Enable for dogfood / web deployments that want search_actions "
+            "visible from turn 1."
         ),
     )
     # #1401: scoped capabilities for the A2A server path — symmetric with
@@ -95,9 +95,9 @@ def register(sub) -> None:
         default=None,
         metavar="NAMES",
         help=(
-            "LLM の visible catalog から隠すツール名 (カンマ区切り、例 "
-            "web_search,web_fetch)。faithful eval の web-leak 抑止に "
-            "(`reyn chat --exclude-tools` と同等)。"
+            "Tool names to hide from the LLM's visible catalog (comma-separated, "
+            "e.g. web_search,web_fetch). For suppressing web-leak in faithful "
+            "eval (equivalent to `reyn chat --exclude-tools`)."
         ),
     )
     # FP-0058 P2: per-surface opt-in/opt-out mount toggles. Repeatable
@@ -113,8 +113,8 @@ def register(sub) -> None:
         default=None,
         metavar="SURFACE",
         help=(
-            "指定した surface を opt-in で有効化する (繰り返し指定可、例 "
-            "--enable a2a --enable mcp)。CLI > config > secure-default。"
+            "Opt in to enable the given surface (repeatable, e.g. "
+            "--enable a2a --enable mcp). Precedence: CLI > config > secure-default."
         ),
     )
     p.add_argument(
@@ -124,8 +124,8 @@ def register(sub) -> None:
         default=None,
         metavar="SURFACE",
         help=(
-            "指定した surface を無効化する (繰り返し指定可、例 --disable api)。"
-            "CLI > config > secure-default。"
+            "Disable the given surface (repeatable, e.g. --disable api). "
+            "Precedence: CLI > config > secure-default."
         ),
     )
     p.set_defaults(func=run)


### PR DESCRIPTION
**[e2e-coder]** — Narrow, granted exception to #6084's own "no mass translation" ruling (a bulk translation of the 89 grandfathered kana-literal findings is unverifiable until the owner sees it running on their own machine). This PR translates ONLY the argparse `help=`/`description=` strings in `src/reyn/interfaces/cli/commands/web.py` — static, argparse-rendered `--help` output, not TUI chrome, and directly verifiable by running `reyn web --help`.

part of #6084

## Scope
- Only `src/reyn/interfaces/cli/commands/web.py` touched (translation, not rewrite — meaning preserved exactly).
- Module docstring (lines 1-6) left as-is: it is not rendered by `--help`, so out of scope for this exception.
- `scripts/user_facing_lang_gate_baseline.json` regenerated via `python scripts/user_facing_lang_gate.py --write-baseline` (never hand-edited) — drops the 11 now-fixed `web.py` findings, leaves the 1 unrelated `chrome.py` finding untouched.

## Witness — real `reyn web --help` output (English, not "I translated the source")

```
usage: reyn web [-h] [--host HOST] [--port PORT] [--uds PATH] [--reload]
                [--log-level LEVEL] [--default-design SLUG]
                [--eager-embedding-build] [--env-backend {host,docker}]
                [--container NAME] [--repo-dir PATH] [--image IMAGE]
                [--mount host:container[:rw|ro]] [--keep-container]
                [--state-dir PATH] [--exclude-tools NAMES] [--enable SURFACE]
                [--disable SURFACE]

Start the FastAPI + AG-UI SSE gateway with uvicorn.

options:
  -h, --help            show this help message and exit
  --host HOST           Host to bind to (default: 127.0.0.1)
  --port PORT           Port number to bind to (default: 8080)
  --uds PATH            Bind to a UNIX domain socket (T2 same-machine; when
                        given, --host/--port are ignored). For same-machine
                        thin-client connections -- auth is the OS peer-
                        credential (SO_PEERCRED / getpeereid).
  --reload              Auto-reload on code changes (for development)
  --log-level LEVEL     uvicorn log level (default: info)
  --default-design SLUG
                        Default design slug (set via env
                        REYN_WEB_DEFAULT_DESIGN)
  --eager-embedding-build
                        Build action_embedding_index synchronously at session
                        start (equivalent to env
                        REYN_WEB_EAGER_EMBEDDING_BUILD=1). Enable for dogfood
                        / web deployments that want search_actions visible
                        from turn 1.
  --env-backend {host,docker}
                        Where the repo filesystem and commands execute: 'host'
                        (default, no isolation change) or 'docker'. For
                        docker, either attach to a running container
                        (--container/--repo-dir) or, if --container is
                        omitted, reyn LAUNCHES a mount-mode container
                        (workspace bind-mounted, security-hardened).
  --container NAME      Running container name/id to ATTACH to (--env-
                        backend=docker). Omit to have reyn launch a new mount-
                        mode container instead.
  --repo-dir PATH       In-container absolute path of the repo working tree
                        (e.g. /repo) for --env-backend=docker ATTACH mode.
                        Relative paths resolve against this; commands run with
                        it as cwd.
  --image IMAGE         Container image for --env-backend=docker LAUNCH mode
                        (when --container is omitted). Defaults to a sensible
                        generic base; override per task.
  --mount host:container[:rw|ro]
                        Additional bind mount for docker LAUNCH mode
                        (repeatable). The workspace root is always mounted at
                        /workspace.
  --keep-container      Do not tear down a reyn-launched container after the
                        run (persistent reuse). Default: launched containers
                        are removed.
  --state-dir PATH      Host-side directory for OS state/artifacts (events,
                        offload, artifact handles), kept off the routed repo
                        FS. Recommended with --env-backend=docker so state
                        stays on the host.
  --exclude-tools NAMES
                        Tool names to hide from the LLM's visible catalog
                        (comma-separated, e.g. web_search,web_fetch). For
                        suppressing web-leak in faithful eval (equivalent to
                        `reyn chat --exclude-tools`).
  --enable SURFACE      Opt in to enable the given surface (repeatable, e.g.
                        --enable a2a --enable mcp). Precedence: CLI > config >
                        secure-default.
  --disable SURFACE     Disable the given surface (repeatable, e.g. --disable
                        api). Precedence: CLI > config > secure-default.
```

(`--env-backend`/`--container`/`--repo-dir`/`--image`/`--mount`/`--keep-container`/`--state-dir` are wired via `register_env_backend_args` in a separate module, already English — not touched here.)

## Local gates (all green)
- `ruff check src/reyn/interfaces/cli/commands/web.py` — pass
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/web.py` — OK
- `python scripts/mypy_ratchet.py` — OK (changed-files)
- `python scripts/silent_except_ratchet.py` — OK (baselined, unchanged)
- `python scripts/user_facing_lang_gate.py` — OK against the regenerated baseline

No tests touched (no `tests/` path-conditional gates apply).

## Test plan
- [x] Ran `reyn web --help` for real, pasted the literal English output above.
- [x] (skipped — Visual, standing waiver) no TUI/visual surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S