### PR TITLE
fix(part of #6085 stage 2): mark the 1 foldable line, document why 2 stay unmarked

### DIFF
--- a/src/reyn/interfaces/slash/dispatch.py
+++ b/src/reyn/interfaces/slash/dispatch.py
@@ -260,6 +260,23 @@ async def maybe_dispatch_slash(
                     # existing SSE broadcast, the same channel compaction's
                     # own lifecycle markers already use).
                     prefix = f"/{name}: no confirmation received"
+                # #6085 stage 2 (lead-coder ruling): this line deliberately
+                # carries NO ``compaction_episode_marker`` meta, even when
+                # ``name == "compact"`` — unlike this session's compaction
+                # markers do NOT run through the shared derivation
+                # mechanism, folding this into the same open flow entry.
+                # This code is entirely CLIENT-side (the #3595 S5 boundary:
+                # a client interprets, ``Session`` never interprets a
+                # string, so nothing here ever touches ``Session`` or its
+                # episode-seq counter) — a marker with no real seq would
+                # be inert under app.py's seq-equality absorption check,
+                # and threading the seq back across the control-response
+                # wire just to fold THIS one line was judged not worth
+                # crossing that boundary for. #6100 (⑵-b) is expected to
+                # make this branch fire far less often for `/compact`
+                # specifically, but that is not assumed here — this stays
+                # its own, unabsorbed line regardless of whether it still
+                # fires.
                 _display(transport, "error", prefix)
         else:
             ctx = SlashContext(transport=transport, session=None)

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -325,6 +325,24 @@ class ChatLifecycleForwarder:
         RUNTIME-layer, so importing it here would invert the dependency
         direction (same reasoning this module's own ``_compact_token_
         count`` docstring already gives for not importing ``gutter.py``).
+
+        ★ #6085 stage 2 (lead-coder ruling): this frame deliberately
+        carries NO ``compaction_episode_marker`` meta, unlike its 3
+        siblings above (``on_compaction_started``/``on_compaction_
+        failed``/``on_compaction_completed``) and ``on_recovery_summary_
+        persisted`` below. This is the ONE unrecoverable end-of-episode
+        signal — the shrink-retry ladder is exhausted, nothing else is
+        coming for this episode. Folding it into the same open flow entry
+        the way the other markers fold would make a genuine, terminal
+        failure disappear into a settled progress row instead of standing
+        on its own line — the repair (fewer separate lines) would destroy
+        the evidence (the ladder failed) it exists to report. Enforced by
+        ``test_router_context_overflow_unrecovered_without_terminal_
+        degrades_gracefully`` (tests/runtime/test_chat_lifecycle_
+        forwarder.py) — a DECIDING test (#6085's own original ask was to
+        mark all 3 remaining lines; this one line was found to be
+        deliberately exempt from #5588's original design, not an
+        oversight #5588 left behind).
         """
         terminal = data.get("terminal")
         text = {
@@ -349,7 +367,16 @@ class ChatLifecycleForwarder:
         compaction quality silently.
         """
         reason = str(data.get("error") or "unknown error")
-        self._enqueue(f"[✗ summary re-compress failed: {reason}]")
+        # #6085 stage 2: this fires DURING an active compaction episode (a
+        # T2 re-compression pass inside compact()'s own summarisation
+        # step) — same episode as on_compaction_started's own open row, so
+        # it belongs there rather than as a stray line. Previously
+        # unmarked: this was one of #6085's 2 markerless lifecycle_
+        # forwarder lines.
+        self._enqueue(
+            f"[✗ summary re-compress failed: {reason}]",
+            meta=self._compaction_marker_meta(),
+        )
 
     def on_recovery_summary_persisted(self, data: dict) -> None:
         """#5885 (architect ruling 3): the LADDER path's completion marker.

--- a/tests/runtime/test_chat_lifecycle_forwarder.py
+++ b/tests/runtime/test_chat_lifecycle_forwarder.py
@@ -687,7 +687,19 @@ def test_router_context_overflow_unrecovered_names_room_floor() -> None:
 def test_router_context_overflow_unrecovered_without_terminal_degrades_gracefully() -> None:
     """Tier 2: a plain ContextOverflowError (no ladder-terminal distinction
     at all — never fabricated) still emits a marker, generic rather than
-    naming an impossibility it was never told."""
+    naming an impossibility it was never told.
+
+    ★ #6085 stage 2 (lead-coder ruling, confirmed against #6085's own
+    original "mark every remaining markerless line" ask): this line stays
+    deliberately UNMARKED. It is the ONE unrecoverable end-of-episode
+    signal (the shrink-retry ladder is exhausted, nothing more is coming
+    for this episode) — folding it into the same open flow entry the
+    other compaction markers fold into would make a genuine, terminal
+    failure disappear into a settled progress row instead of standing on
+    its own line. See :meth:`ChatLifecycleForwarder.on_router_context_
+    overflow_unrecovered`'s own docstring for the full reasoning; this
+    assertion is what keeps that reasoning enforced, not just stated.
+    """
     q: asyncio.Queue = asyncio.Queue()
     fwd = ChatLifecycleForwarder(q)
     fwd(Event(


### PR DESCRIPTION
**[tui-coder]** — `part of #6085`

## Stage 2 — the 3 markerless lines, closed as designed (not as originally scoped)

Stage 1 (#6092, merged) fixed the confirmed race. This stage was
supposed to add `compaction_episode_marker` meta to the 3 lines
#6085's own investigation found with none. Attempting that surfaced
2 genuine conflicts with existing, deliberate design:

**① `on_summary_resummarize_failed` (lifecycle_forwarder.py) — marked.**
No conflicting design found; extends the existing `_compaction_marker_
meta()` derivation exactly as originally scoped.

**② `on_router_context_overflow_unrecovered` — left unmarked, reasoning documented.**
This is the ONE unrecoverable end-of-episode signal (the shrink-retry
ladder is exhausted). An existing #5588-era test already enforces that
this line is never absorbed (`test_router_context_overflow_
unrecovered_without_terminal_degrades_gracefully`, with its own
"Never absorbed — the ONE terminal signal" comment) — that was a
DECIDING test, not an unfinished implementation: folding a terminal
failure into a settled progress row would make it disappear instead
of standing on its own line. This PR adds the full reasoning to both
the production docstring (`ChatLifecycleForwarder.on_router_context_
overflow_unrecovered`) and the test's own docstring, so the next
person who wonders "why doesn't this fold" stops at the reason.

**③ `/compact`'s slash-dispatch error line (`dispatch.py`'s `_run()`) — left unmarked, reasoning documented.**
This code is entirely CLIENT-side (the #3595 S5 boundary: a client
interprets text, `Session` never interprets a string) — it structurally
has no access to `Session`'s episode-seq counter. A marker with no real
seq would be inert under `app.py`'s seq-equality absorption check
(#6092's own stage-1 fix), and threading the seq back across the
control-response wire just to fold this one line was judged not worth
crossing that boundary for. #6100 (⑵-b) is expected to make this
branch fire less often for `/compact` specifically, but that is not
assumed here — documented inline instead.

## Net result

Of the 4 originally-scoped lines, 2 already had markers (pre-existing),
1 gets one here, 2 are documented exemptions. Final visual judgment —
whether `/compact` reads as more legible now — is the owner's, over a
real TTY; will ask "does the next `/compact` look folded / more legible"
once this and #6100 both land.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (changed test file)
- [x] `verify_module_docstrings.py` (changed src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates (bare-tests-import, file-depth, subprocess-reyn-pin, no-core-dep-importorskip, suspected-time-dependence)
- [x] `src/reyn/interfaces/` touch: `silent_except_ratchet.py`
- [x] Diff-scoped pytest green (61 tests across the 3 affected files)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
