### PR TITLE
fix(part of #6083 stage 2a): the control-POST read timeout applies by class, not uniformly

### DIFF
--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -50,16 +50,49 @@ def _env_float(name: str, default: float) -> float:
 # ``REYN_AGUI_HEARTBEAT_INTERVAL_S``; MUST stay below the server's timeout.
 _HEARTBEAT_INTERVAL = _env_float("REYN_AGUI_HEARTBEAT_INTERVAL_S", 25.0)
 
-#: #5894 (architect ruling ①-1): the read timeout for a CONTROL POST
-#: (submit / cancel / answer / heartbeat) — the one constant, the one place.
-#: The SSE stream keeps ``read=None`` (a live stream legitimately reads
-#: forever); a control request is a bounded round-trip and must not share
-#: the stream's policy. Owner-hit: the server was pinned by CPU-bound LLM
-#: request assembly, the client's control POSTs waited on the SAME
-#: unbounded-read client, and Ctrl-C hung forever. With this, the wait ends
-#: in a typed ``httpx.ReadTimeout`` that ``send`` turns into a
-#: non-delivery (``None``) the TUI can name.
+#: #5894 (architect ruling ①-1): the read timeout for a BOUNDED control
+#: POST (submit / cancel / answer / heartbeat, and every other payload
+#: type :data:`~reyn.interfaces.transport.agui.endpoint.BOUNDED_PAYLOAD_
+#: TYPES` names) — the one constant, the one place. The SSE stream keeps
+#: ``read=None`` (a live stream legitimately reads forever); a bounded
+#: control request must not share that policy. Owner-hit: the server was
+#: pinned by CPU-bound LLM request assembly, the client's control POSTs
+#: waited on the SAME unbounded-read client, and Ctrl-C hung forever. With
+#: this, the wait ends in a typed ``httpx.ReadTimeout`` that ``send``
+#: turns into a non-delivery (``None``) the TUI can name.
+#:
+#: #6083 ⑵-a: NOT every control POST is bounded, though — one class
+#: (:data:`~reyn.interfaces.transport.agui.endpoint.LONG_RUNNING_
+#: PAYLOAD_TYPES`, currently just ``attach_request``) has a server-side
+#: handler that awaits an operation with genuinely unbounded duration
+#: (a first-attach session load replaying its persisted WAL history).
+#: Applying THIS constant to those reproduces the exact #6083 symptom one
+#: level up — a slow-but-succeeding operation misread as a timed-out
+#: failure. :func:`_read_timeout_for` is the one place that decision is
+#: made; this constant itself is unchanged and still names the bounded
+#: default correctly.
 _CONTROL_TIMEOUT_S = _env_float("REYN_AGUI_CONTROL_TIMEOUT_S", 10.0)
+
+
+def _read_timeout_for(ptype: "object", *, override: "float | None" = None) -> "float | None":
+    """The read timeout :func:`post_control` should use for one payload
+    ``type`` — ``None`` (unbounded, matching the SSE stream's own policy)
+    for :data:`~reyn.interfaces.transport.agui.endpoint.LONG_RUNNING_
+    PAYLOAD_TYPES`; :data:`_CONTROL_TIMEOUT_S` (or ``override``, when a
+    caller supplies one — the same seam tests already use to inject T)
+    otherwise.
+
+    Split out as its OWN pure function (testing.md: a test writes no
+    duration; the DECISION is the thing to observe, not a live wait) — it
+    takes no client, opens no socket, and its whole body is one membership
+    check, so a test can assert its return value directly rather than
+    proving "did not time out" by watching a clock.
+    """
+    from reyn.interfaces.transport.agui.endpoint import LONG_RUNNING_PAYLOAD_TYPES
+
+    if ptype in LONG_RUNNING_PAYLOAD_TYPES:
+        return None
+    return _CONTROL_TIMEOUT_S if override is None else override
 
 
 async def post_control(
@@ -67,25 +100,29 @@ async def post_control(
     timeout_s: "float | None" = None,
 ) -> "ControlOutcome":
     """POST one client→server control message with the CONTROL timeout
-    policy (#5894 ①-1) and return the TYPED outcome (#5907 ②):
+    policy (#5894 ①-1, #6083 ⑵-a) and return the TYPED outcome (#5907 ②):
     :class:`ControlOutcome` — ``delivered(payload)`` on a 2xx, ``refused``
     on ≥300 (the server's own reason), ``not_delivered`` when the request
     raised (the control read timeout, a connect error …).
 
-    This is the whole policy in one place: ``timeout_s`` (default
-    :data:`_CONTROL_TIMEOUT_S`) bounds the read; the ``client`` passed in
-    keeps its OWN default (``read=None``, the SSE stream's) untouched — one
-    client, two request kinds, two policies. A 2xx whose body is empty /
-    not JSON is still delivered, with a truthy ``{"status": "ok"}`` payload,
-    so every ``if accepted:`` caller keeps the old bool contract — the
-    outcome itself is truthy iff delivered.
+    :func:`_read_timeout_for` decides the read timeout from ``payload``'s
+    own ``type`` (bounded by default, unbounded for the derived long-
+    running class); the ``client`` passed in keeps its OWN default
+    (``read=None``, the SSE stream's) untouched — one client, two request
+    kinds, at most two policies. A 2xx whose body is empty / not JSON is
+    still delivered, with a truthy ``{"status": "ok"}`` payload, so every
+    ``if accepted:`` caller keeps the old bool contract — the outcome
+    itself is truthy iff delivered.
 
-    ``timeout_s`` is a parameter so a test can supply T — it is the subject
-    there, never a wait the test sits out.
+    ``timeout_s`` is a parameter so a test can supply T for a BOUNDED
+    payload type — it is the subject there, never a wait the test sits
+    out; it has no effect on a long-running type, which is always
+    unbounded regardless of what a caller passes (there is no "T" to
+    inject for those — see :func:`_read_timeout_for`).
     """
     import httpx
 
-    read_timeout = _CONTROL_TIMEOUT_S if timeout_s is None else timeout_s
+    read_timeout = _read_timeout_for(payload.get("type"), override=timeout_s)
     try:
         resp = await client.post(
             url, params=params, json=payload,

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from typing import AsyncIterator
 
+from reyn.interfaces.transport.agui.protocol import LONG_RUNNING_PAYLOAD_TYPES
 from reyn.interfaces.transport.control_outcome import ControlOutcome
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,7 @@ _HEARTBEAT_INTERVAL = _env_float("REYN_AGUI_HEARTBEAT_INTERVAL_S", 25.0)
 
 #: #5894 (architect ruling ①-1): the read timeout for a BOUNDED control
 #: POST (submit / cancel / answer / heartbeat, and every other payload
-#: type :data:`~reyn.interfaces.transport.agui.endpoint.BOUNDED_PAYLOAD_
+#: type :data:`~reyn.interfaces.transport.agui.protocol.BOUNDED_PAYLOAD_
 #: TYPES` names) — the one constant, the one place. The SSE stream keeps
 #: ``read=None`` (a live stream legitimately reads forever); a bounded
 #: control request must not share that policy. Owner-hit: the server was
@@ -62,7 +63,7 @@ _HEARTBEAT_INTERVAL = _env_float("REYN_AGUI_HEARTBEAT_INTERVAL_S", 25.0)
 #: turns into a non-delivery (``None``) the TUI can name.
 #:
 #: #6083 ⑵-a: NOT every control POST is bounded, though — one class
-#: (:data:`~reyn.interfaces.transport.agui.endpoint.LONG_RUNNING_
+#: (:data:`~reyn.interfaces.transport.agui.protocol.LONG_RUNNING_
 #: PAYLOAD_TYPES`, currently just ``attach_request``) has a server-side
 #: handler that awaits an operation with genuinely unbounded duration
 #: (a first-attach session load replaying its persisted WAL history).
@@ -77,7 +78,7 @@ _CONTROL_TIMEOUT_S = _env_float("REYN_AGUI_CONTROL_TIMEOUT_S", 10.0)
 def _read_timeout_for(ptype: "object", *, override: "float | None" = None) -> "float | None":
     """The read timeout :func:`post_control` should use for one payload
     ``type`` — ``None`` (unbounded, matching the SSE stream's own policy)
-    for :data:`~reyn.interfaces.transport.agui.endpoint.LONG_RUNNING_
+    for :data:`~reyn.interfaces.transport.agui.protocol.LONG_RUNNING_
     PAYLOAD_TYPES`; :data:`_CONTROL_TIMEOUT_S` (or ``override``, when a
     caller supplies one — the same seam tests already use to inject T)
     otherwise.
@@ -87,9 +88,16 @@ def _read_timeout_for(ptype: "object", *, override: "float | None" = None) -> "f
     takes no client, opens no socket, and its whole body is one membership
     check, so a test can assert its return value directly rather than
     proving "did not time out" by watching a clock.
-    """
-    from reyn.interfaces.transport.agui.endpoint import LONG_RUNNING_PAYLOAD_TYPES
 
+    Reads the module-level ``LONG_RUNNING_PAYLOAD_TYPES`` name (a plain
+    global lookup, not a fresh re-import each call) — a Python function
+    body resolves a bare name against its OWN module's current globals at
+    CALL time, so reassigning ``remote_client.LONG_RUNNING_PAYLOAD_TYPES``
+    (this module's own bound copy of ``protocol.py``'s set — see the
+    import at the top of this file) is visible here immediately, the same
+    liveness the earlier per-call ``from ... import`` had, without paying
+    for a fresh import on every control POST.
+    """
     if ptype in LONG_RUNNING_PAYLOAD_TYPES:
         return None
     return _CONTROL_TIMEOUT_S if override is None else override

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1423,80 +1423,6 @@ async def agui_seize(request: Request):
     return JSONResponse({"seized": True})
 
 
-#: #6083 ⑵-a: the ``ptype`` values below whose branch, in :func:`agui_submit`,
-#: awaits an operation with genuinely UNBOUNDED duration — these are exempt
-#: from the client's bounded control-POST read timeout
-#: (``remote_client.py``'s own ``_CONTROL_TIMEOUT_S``, #5894 ①-1), which
-#: instead reads ``None`` (unbounded) for them, matching the SSE stream's
-#: own policy. Traced structurally into each branch's own awaited callee,
-#: not assumed — see the docstring on :data:`BOUNDED_PAYLOAD_TYPES` below
-#: for the ones that were traced and found bounded instead:
-#:
-#: - ``attach_request``: ``registry.attach()`` → ``get_or_load()`` (on a
-#:   first attach to a not-yet-loaded agent) → ``_construct_session()`` →
-#:   the session factory, which replays that agent's persisted WAL history
-#:   to rebuild in-memory state — a cost proportional to session length
-#:   (the SAME shape #6099's own ``build_history()`` finding named), with
-#:   no upper bound. The ONE unbounded operation found among all 10
-#:   ``ptype`` branches below.
-#:
-#: A ``ptype`` that reaches neither this set nor :data:`BOUNDED_PAYLOAD_
-#: TYPES` is a DERIVATION GAP — a new branch nobody has classified yet.
-#: ``test_6083_2a_long_running_control_timeout_class.py`` fails CI the
-#: moment one exists (walks :func:`agui_submit`'s own AST for every
-#: literal ``ptype ==`` comparison and asserts it is classified either
-#: side) — the population is DERIVED from the dispatch's own structure,
-#: never a name list someone has to remember to update by hand. An
-#: unclassified type is read as BOUNDED at runtime regardless (fail-closed,
-#: lead-coder ruling: the side the timeout still applies to — an unknown
-#: handler that turns out to hang is CUT, not awaited forever), but the
-#: test is what keeps that fallback from ever being silent.
-#:
-#: ⚠️ Cross-version limitation, deliberately NOT solved here: a
-#: ``--connect`` client and the server it talks to can run different reyn
-#: builds, and this set is read from the CLIENT's own installed copy of
-#: THIS module — accurate only for a same-install deployment. A client on
-#: an older build talking to a server whose newer ``agui_submit`` added a
-#: genuinely long-running branch would still apply the bounded timeout to
-#: it (the pre-#6100 symptom, one level up). Out of scope for this PR.
-LONG_RUNNING_PAYLOAD_TYPES = frozenset({"attach_request"})
-
-#: #6083 ⑵-a: the remaining ``ptype`` values :func:`agui_submit` handles —
-#: each one's own awaited callee was traced and confirmed BOUNDED (no
-#: external I/O whose duration scales with anything unbounded):
-#:
-#: - ``heartbeat``: no ``await`` at all — a pure in-memory timestamp write.
-#: - ``user_message``: ``session.submit_user_text()`` ENQUEUES the turn
-#:   (#3300's sent-queue) and returns once queued — it does not await the
-#:   turn's own LLM call. #5894's own original scope.
-#: - ``slash_command``: no longer awaits its own handler to completion at
-#:   all (#6100 ⑵-b) — hands off to the session's background-task funnel
-#:   and returns immediately.
-#: - ``cancel_inflight`` / ``cancel_queued``: signal-only (a flag flip / a
-#:   WAL-tombstone write + in-memory prune) — never await the turn they
-#:   target to actually finish. #5894's own original scope (cancel).
-#: - ``TOOL_CALL_RESULT`` (``_handle_answer``): records/delivers the
-#:   answer by id and returns — the TURN the answer unblocks resumes on
-#:   its OWN separately-running task, never awaited here. #5894's own
-#:   original scope (answer).
-#: - ``session_switch_request``: ``registry.attach_session()`` requires the
-#:   target session to be ALREADY loaded (a sync, in-memory
-#:   ``_peek_session()`` lookup) and raises rather than building one —
-#:   unlike ``attach_request`` above, this branch never constructs a
-#:   session or replays a WAL.
-#: - ``artifact_list_request`` / ``session_list_request`` /
-#:   ``load_older_backlog_request``: capped reads (a limited artifact-ref
-#:   list, an in-memory session-id roster, ONE backlog page — #5139 C's
-#:   own "one page per request" design) — bounded by construction, not by
-#:   how fast anything external answers.
-BOUNDED_PAYLOAD_TYPES = frozenset({
-    "heartbeat", "user_message", "slash_command", "cancel_inflight",
-    "cancel_queued", "TOOL_CALL_RESULT", "session_switch_request",
-    "artifact_list_request", "session_list_request",
-    "load_older_backlog_request",
-})
-
-
 @router.post("/agui/chat/{agent_name}")
 async def agui_submit(request: Request):
     """Client→server: turn submit, HITL answer, cancel, and heartbeat.
@@ -1544,6 +1470,13 @@ async def agui_submit(request: Request):
         return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
 
     ptype = payload.get("type")
+    # #6083 ⑵-a: each branch below has a declared control-POST timeout
+    # class (does its own await resolve in bounded time, or not) — the
+    # declaration itself lives in ``protocol.py``'s ``LONG_RUNNING_
+    # PAYLOAD_TYPES``/``BOUNDED_PAYLOAD_TYPES`` (a fact both ends of the
+    # wire need, not this module's own implementation detail), NOT here.
+    # A branch added below with no entry on either side there fails CI
+    # (that module's own derivation test AST-walks THIS function).
 
     # Heartbeat fast-path (liveness): a pure in-memory refresh of the surface's
     # keepalive timestamp, deliberately dispatched BEFORE ``registry.exists()``
@@ -1941,6 +1874,4 @@ __all__ = [
     "authenticate_request",
     "AGUI_OPERATOR_CHANNEL",
     "session_backlog_frames",
-    "LONG_RUNNING_PAYLOAD_TYPES",
-    "BOUNDED_PAYLOAD_TYPES",
 ]

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1423,6 +1423,80 @@ async def agui_seize(request: Request):
     return JSONResponse({"seized": True})
 
 
+#: #6083 ⑵-a: the ``ptype`` values below whose branch, in :func:`agui_submit`,
+#: awaits an operation with genuinely UNBOUNDED duration — these are exempt
+#: from the client's bounded control-POST read timeout
+#: (``remote_client.py``'s own ``_CONTROL_TIMEOUT_S``, #5894 ①-1), which
+#: instead reads ``None`` (unbounded) for them, matching the SSE stream's
+#: own policy. Traced structurally into each branch's own awaited callee,
+#: not assumed — see the docstring on :data:`BOUNDED_PAYLOAD_TYPES` below
+#: for the ones that were traced and found bounded instead:
+#:
+#: - ``attach_request``: ``registry.attach()`` → ``get_or_load()`` (on a
+#:   first attach to a not-yet-loaded agent) → ``_construct_session()`` →
+#:   the session factory, which replays that agent's persisted WAL history
+#:   to rebuild in-memory state — a cost proportional to session length
+#:   (the SAME shape #6099's own ``build_history()`` finding named), with
+#:   no upper bound. The ONE unbounded operation found among all 10
+#:   ``ptype`` branches below.
+#:
+#: A ``ptype`` that reaches neither this set nor :data:`BOUNDED_PAYLOAD_
+#: TYPES` is a DERIVATION GAP — a new branch nobody has classified yet.
+#: ``test_6083_2a_long_running_control_timeout_class.py`` fails CI the
+#: moment one exists (walks :func:`agui_submit`'s own AST for every
+#: literal ``ptype ==`` comparison and asserts it is classified either
+#: side) — the population is DERIVED from the dispatch's own structure,
+#: never a name list someone has to remember to update by hand. An
+#: unclassified type is read as BOUNDED at runtime regardless (fail-closed,
+#: lead-coder ruling: the side the timeout still applies to — an unknown
+#: handler that turns out to hang is CUT, not awaited forever), but the
+#: test is what keeps that fallback from ever being silent.
+#:
+#: ⚠️ Cross-version limitation, deliberately NOT solved here: a
+#: ``--connect`` client and the server it talks to can run different reyn
+#: builds, and this set is read from the CLIENT's own installed copy of
+#: THIS module — accurate only for a same-install deployment. A client on
+#: an older build talking to a server whose newer ``agui_submit`` added a
+#: genuinely long-running branch would still apply the bounded timeout to
+#: it (the pre-#6100 symptom, one level up). Out of scope for this PR.
+LONG_RUNNING_PAYLOAD_TYPES = frozenset({"attach_request"})
+
+#: #6083 ⑵-a: the remaining ``ptype`` values :func:`agui_submit` handles —
+#: each one's own awaited callee was traced and confirmed BOUNDED (no
+#: external I/O whose duration scales with anything unbounded):
+#:
+#: - ``heartbeat``: no ``await`` at all — a pure in-memory timestamp write.
+#: - ``user_message``: ``session.submit_user_text()`` ENQUEUES the turn
+#:   (#3300's sent-queue) and returns once queued — it does not await the
+#:   turn's own LLM call. #5894's own original scope.
+#: - ``slash_command``: no longer awaits its own handler to completion at
+#:   all (#6100 ⑵-b) — hands off to the session's background-task funnel
+#:   and returns immediately.
+#: - ``cancel_inflight`` / ``cancel_queued``: signal-only (a flag flip / a
+#:   WAL-tombstone write + in-memory prune) — never await the turn they
+#:   target to actually finish. #5894's own original scope (cancel).
+#: - ``TOOL_CALL_RESULT`` (``_handle_answer``): records/delivers the
+#:   answer by id and returns — the TURN the answer unblocks resumes on
+#:   its OWN separately-running task, never awaited here. #5894's own
+#:   original scope (answer).
+#: - ``session_switch_request``: ``registry.attach_session()`` requires the
+#:   target session to be ALREADY loaded (a sync, in-memory
+#:   ``_peek_session()`` lookup) and raises rather than building one —
+#:   unlike ``attach_request`` above, this branch never constructs a
+#:   session or replays a WAL.
+#: - ``artifact_list_request`` / ``session_list_request`` /
+#:   ``load_older_backlog_request``: capped reads (a limited artifact-ref
+#:   list, an in-memory session-id roster, ONE backlog page — #5139 C's
+#:   own "one page per request" design) — bounded by construction, not by
+#:   how fast anything external answers.
+BOUNDED_PAYLOAD_TYPES = frozenset({
+    "heartbeat", "user_message", "slash_command", "cancel_inflight",
+    "cancel_queued", "TOOL_CALL_RESULT", "session_switch_request",
+    "artifact_list_request", "session_list_request",
+    "load_older_backlog_request",
+})
+
+
 @router.post("/agui/chat/{agent_name}")
 async def agui_submit(request: Request):
     """Client→server: turn submit, HITL answer, cancel, and heartbeat.
@@ -1867,4 +1941,6 @@ __all__ = [
     "authenticate_request",
     "AGUI_OPERATOR_CHANNEL",
     "session_backlog_frames",
+    "LONG_RUNNING_PAYLOAD_TYPES",
+    "BOUNDED_PAYLOAD_TYPES",
 ]

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -157,6 +157,96 @@ CONTROL_FILTER_KINDS: "frozenset[str]" = frozenset({
     "__open_artifact__",
 })
 
+# #6083 ⑵-a: the control-POST TIMEOUT CLASS of each ``type`` a client→server
+# POST can carry (``endpoint.py``'s own ``agui_submit`` dispatch on the
+# server side; ``remote_client.py``'s ``_read_timeout_for`` on the client
+# side). Lives HERE, not in ``endpoint.py`` where it was first drafted —
+# architect co-vet (PR #6105): "その payload の POST がどれだけ掛かり得るか"
+# is a fact BOTH ends need, not one side's implementation detail, and this
+# module is already "the one place a Frame is turned into an AG-UI event and
+# back" for exactly that reason (this file's own module docstring) — the
+# ``__attach_request__`` vocabulary above already lived here for the same
+# reason before #4534 retired it. Declaring it here also means NEITHER end
+# needs to import the other's implementation module to read it (the prior
+# draft had ``remote_client.py`` import ``endpoint.py`` directly — a
+# client→server-implementation dependency neither previously had, and
+# architect's own concern was precedent, not correctness: the first such
+# import makes a second one look normal).
+#
+# ``LONG_RUNNING_PAYLOAD_TYPES``: a POST of this ``type`` awaits an operation
+# with genuinely UNBOUNDED duration server-side, so the client's bounded
+# control-POST read timeout (``remote_client.py``'s own ``_CONTROL_TIMEOUT_
+# S``, #5894 ①-1) does not apply — it reads ``None`` (unbounded) instead,
+# matching the SSE stream's own policy. Traced structurally into each
+# branch's own awaited callee, not assumed — see ``BOUNDED_PAYLOAD_TYPES``
+# below for the ones traced and found bounded instead:
+#
+# - ``attach_request``: ``registry.attach()`` -> ``get_or_load()`` (on a
+#   first attach to a not-yet-loaded agent) -> ``_construct_session()`` ->
+#   the session factory, which replays that agent's persisted WAL history to
+#   rebuild in-memory state — a cost proportional to session length (the
+#   SAME shape #6099's own ``build_history()`` finding named), with no upper
+#   bound. The ONE unbounded operation found among all 10 ``ptype`` branches
+#   ``agui_submit`` handles.
+#
+# A ``ptype`` in neither this set nor ``BOUNDED_PAYLOAD_TYPES`` is a
+# DERIVATION GAP — a new branch nobody has classified yet.
+# ``test_6083_2a_long_running_control_timeout_class.py`` fails CI the moment
+# one exists: it AST-walks ``endpoint.agui_submit``'s OWN source for every
+# ``ptype == "<literal>"`` comparison (see that test module's own docstring
+# for exactly what shape the walk does and does not see) and asserts each
+# one is classified on exactly one of the two sets HERE — the population is
+# derived from the dispatch's own structure; only the classification's
+# location moved, not the derivation. An unclassified type is read as
+# BOUNDED at runtime regardless (fail-closed, lead-coder ruling: the side
+# the timeout still applies to — an unknown handler that turns out to hang
+# is CUT, not awaited forever), but the test is what keeps that fallback
+# from ever being silent.
+#
+# ⚠️ Cross-version limitation, deliberately NOT solved here: a ``--connect``
+# client and the server it talks to can run different reyn builds, and this
+# set is read from the CLIENT's own installed copy of THIS module —
+# accurate only for a same-install deployment. A client on an older build
+# talking to a server whose newer ``agui_submit`` added a genuinely
+# long-running branch would still apply the bounded timeout to it (the
+# pre-#6100 symptom, one level up). Out of scope for this PR.
+LONG_RUNNING_PAYLOAD_TYPES: "frozenset[str]" = frozenset({"attach_request"})
+
+# #6083 ⑵-a: the remaining ``ptype`` values ``agui_submit`` handles — each
+# one's own awaited callee was traced and confirmed BOUNDED (no external I/O
+# whose duration scales with anything unbounded):
+#
+# - ``heartbeat``: no ``await`` at all — a pure in-memory timestamp write.
+# - ``user_message``: ``session.submit_user_text()`` ENQUEUES the turn
+#   (#3300's sent-queue) and returns once queued — it does not await the
+#   turn's own LLM call. #5894's own original scope.
+# - ``slash_command``: no longer awaits its own handler to completion at
+#   all (#6100 ⑵-b) — hands off to the session's background-task funnel and
+#   returns immediately.
+# - ``cancel_inflight`` / ``cancel_queued``: signal-only (a flag flip / a
+#   WAL-tombstone write + in-memory prune) — never await the turn they
+#   target to actually finish. #5894's own original scope (cancel).
+# - ``TOOL_CALL_RESULT`` (``_handle_answer``): records/delivers the answer
+#   by id and returns — the TURN the answer unblocks resumes on its OWN
+#   separately-running task, never awaited here. #5894's own original scope
+#   (answer).
+# - ``session_switch_request``: ``registry.attach_session()`` requires the
+#   target session to be ALREADY loaded (a sync, in-memory
+#   ``_peek_session()`` lookup) and raises rather than building one — unlike
+#   ``attach_request`` above, this branch never constructs a session or
+#   replays a WAL.
+# - ``artifact_list_request`` / ``session_list_request`` /
+#   ``load_older_backlog_request``: capped reads (a limited artifact-ref
+#   list, an in-memory session-id roster, ONE backlog page — #5139 C's own
+#   "one page per request" design) — bounded by construction, not by how
+#   fast anything external answers.
+BOUNDED_PAYLOAD_TYPES: "frozenset[str]" = frozenset({
+    "heartbeat", "user_message", "slash_command", "cancel_inflight",
+    "cancel_queued", "TOOL_CALL_RESULT", "session_switch_request",
+    "artifact_list_request", "session_list_request",
+    "load_older_backlog_request",
+})
+
 # Reserved frontend-tool namespace for the HITL round-trip (ADR-0039 P3, D6/R4).
 # An intervention rides the wire in TWO representations: the P2 ``DisplayFrame``
 # (kind ``intervention`` → the reyn client's NATIVE prompt UI) AND — added here —
@@ -762,6 +852,8 @@ __all__ = [
     "MESSAGES_SNAPSHOT",
     "CUSTOM",
     "CONTROL_FILTER_KINDS",
+    "LONG_RUNNING_PAYLOAD_TYPES",
+    "BOUNDED_PAYLOAD_TYPES",
     "encode_frame",
     "encode_frame_wire",
     "TextStreamTracker",

--- a/tests/interfaces/test_6083_2a_long_running_control_timeout_class.py
+++ b/tests/interfaces/test_6083_2a_long_running_control_timeout_class.py
@@ -4,17 +4,21 @@ an operation with genuinely unbounded duration is exempt (unbounded read,
 matching the SSE stream's own policy); every other one stays on the bounded
 10s default #5894 established.
 
-★ Population is DERIVED, never hand-listed. ``endpoint.py``'s own
+★ Population is DERIVED, never hand-listed. ``protocol.py``'s own
 ``LONG_RUNNING_PAYLOAD_TYPES`` / ``BOUNDED_PAYLOAD_TYPES`` are the single
-declared classification (co-located with ``agui_submit``'s own dispatch, by
-lead-coder's own ruling — the party that KNOWS whether a handler awaits to
-completion is the one who writes it, not the client that merely reads it).
-This module's own :func:`test_every_ptype_agui_submit_branches_on_is_classified`
-is what keeps that declaration from silently falling behind a NEW branch: it
-AST-walks ``agui_submit``'s real source for every literal ``ptype ==``
-comparison and asserts each one is classified on exactly one side. A new
-branch nobody classified is a DERIVATION GAP this test fails on, not a name
-someone forgot to add to a list they never look at again.
+declared classification — architect co-vet (PR #6105): this is a fact BOTH
+ends of the wire need (how long a payload's own POST can legitimately take),
+not one side's implementation detail, so it lives in the wire-protocol codec
+module both ends already import, not in ``endpoint.py`` (the server's own
+implementation) where it was first drafted. This module's own
+:func:`test_every_ptype_agui_submit_branches_on_is_classified` is what keeps
+that declaration from silently falling behind a NEW branch: it AST-walks
+``endpoint.agui_submit``'s real source (the population is still derived from
+the SERVER dispatch's own structure — only the classification's location
+moved) for every literal ``ptype ==`` comparison and asserts each one is
+classified on exactly one side. A new branch nobody classified is a
+DERIVATION GAP this test fails on, not a name someone forgot to add to a
+list they never look at again.
 
 The decision itself (:func:`reyn.interfaces.repl.remote_client._read_timeout_
 for`) is tested as a PURE FUNCTION — no live socket, no wait — per
@@ -32,12 +36,12 @@ import inspect
 
 import pytest
 
+from reyn.interfaces.repl import remote_client as remote_client_mod
 from reyn.interfaces.repl.remote_client import _CONTROL_TIMEOUT_S, _read_timeout_for
-from reyn.interfaces.transport.agui import endpoint as endpoint_mod
-from reyn.interfaces.transport.agui.endpoint import (
+from reyn.interfaces.transport.agui.endpoint import agui_submit
+from reyn.interfaces.transport.agui.protocol import (
     BOUNDED_PAYLOAD_TYPES,
     LONG_RUNNING_PAYLOAD_TYPES,
-    agui_submit,
 )
 
 
@@ -47,7 +51,24 @@ def _ptypes_agui_submit_branches_on() -> "set[str]":
     REAL population the classification below must fully cover. Never a
     hand-typed mirror of the branches: this walks the function's own
     current source, so a new branch is picked up automatically the next
-    time this runs."""
+    time this runs.
+
+    ⚠️ Scope (lead-coder BLOCKING, PR #6105): this walk recognizes exactly
+    ONE shape — an ``ast.Compare`` with a single ``Eq`` op, comparing a
+    bare ``ptype`` ``Name`` against a string ``Constant`` (either operand
+    order). It does NOT see ``ptype in (...)``, a ``match`` statement, or a
+    dict-dispatch table — a future branch written in one of those forms
+    would not be found here, so :func:`test_every_ptype_agui_submit_
+    branches_on_is_classified` would stay green while actually missing a
+    real, unclassified branch. This is a scope limit of THIS derivation,
+    not something the test's own vacuity guard
+    (:func:`test_the_ast_derivation_itself_is_not_vacuous`) catches —
+    that guard only floors on the two ``ptype``s already known to exist
+    today, so a new branch in one of the unrecognized forms would not
+    trip it either. Deliberately not widened: matching more shapes here
+    would mean guessing every form a future branch might take, which
+    would just replace the AST walk with a second hand-maintained list.
+    """
     source = inspect.getsource(agui_submit)
     tree = ast.parse(source)
     found: "set[str]" = set()
@@ -87,10 +108,10 @@ def test_every_ptype_agui_submit_branches_on_is_classified() -> None:
     unclassified = found - classified
     assert not unclassified, (
         f"agui_submit branches on {unclassified!r} with no timeout-class "
-        f"decision recorded in LONG_RUNNING_PAYLOAD_TYPES/BOUNDED_PAYLOAD_"
-        f"TYPES -- classify it on one side (endpoint.py, next to the "
-        f"branch, per lead-coder's own ruling: the party that knows "
-        f"whether the handler awaits to completion writes the decision)."
+        f"decision recorded in protocol.py's LONG_RUNNING_PAYLOAD_TYPES/"
+        f"BOUNDED_PAYLOAD_TYPES -- classify it on one side there (the "
+        f"fact both ends of the wire need: does this payload's own POST "
+        f"legitimately take a long time)."
     )
 
 
@@ -150,22 +171,24 @@ def test_an_override_bounds_a_bounded_type_but_not_a_long_running_one() -> None:
 
 def test_strip_falsify_removing_attach_request_from_the_set_changes_the_decision() -> None:
     """Tier 2: strip-falsify, in-process (no git stash/checkout/restore,
-    per lead-coder's own instruction) -- temporarily empty the REAL
-    ``LONG_RUNNING_PAYLOAD_TYPES`` set ``_read_timeout_for`` reads from
-    (via its own lazy import), confirm the decision flips to bounded, then
-    restore. Proves this test module is actually reading the production
-    set, not a copy that could silently drift from it.
+    per lead-coder's own instruction) -- temporarily empty
+    ``remote_client``'s own bound name for ``LONG_RUNNING_PAYLOAD_TYPES``
+    (its module-level import of ``protocol.py``'s set -- the exact
+    global ``_read_timeout_for`` resolves at call time, per that
+    function's own docstring), confirm the decision flips to bounded,
+    then restore. Proves this test module is actually exercising the
+    production coupling, not a copy that could silently drift from it.
     """
-    original = endpoint_mod.LONG_RUNNING_PAYLOAD_TYPES
+    original = remote_client_mod.LONG_RUNNING_PAYLOAD_TYPES
     assert "attach_request" in original, "arrange: the real set must start non-empty"
     try:
-        endpoint_mod.LONG_RUNNING_PAYLOAD_TYPES = frozenset()
+        remote_client_mod.LONG_RUNNING_PAYLOAD_TYPES = frozenset()
         assert _read_timeout_for("attach_request") == _CONTROL_TIMEOUT_S, (
-            "stripping attach_request out of the real set did not change "
+            "stripping attach_request out of the bound set did not change "
             "_read_timeout_for's own decision -- it is not actually reading "
-            "the production set"
+            "remote_client's own module-level name"
         )
     finally:
-        endpoint_mod.LONG_RUNNING_PAYLOAD_TYPES = original
+        remote_client_mod.LONG_RUNNING_PAYLOAD_TYPES = original
     # Restored: the ordinary (non-stripped) behavior returns.
     assert _read_timeout_for("attach_request") is None

--- a/tests/interfaces/test_6083_2a_long_running_control_timeout_class.py
+++ b/tests/interfaces/test_6083_2a_long_running_control_timeout_class.py
@@ -1,0 +1,171 @@
+"""Tier 2: #6083 ⑵-a — the control-POST read timeout applies by CLASS, not
+per-payload-type guesswork: a payload type whose server-side handler awaits
+an operation with genuinely unbounded duration is exempt (unbounded read,
+matching the SSE stream's own policy); every other one stays on the bounded
+10s default #5894 established.
+
+★ Population is DERIVED, never hand-listed. ``endpoint.py``'s own
+``LONG_RUNNING_PAYLOAD_TYPES`` / ``BOUNDED_PAYLOAD_TYPES`` are the single
+declared classification (co-located with ``agui_submit``'s own dispatch, by
+lead-coder's own ruling — the party that KNOWS whether a handler awaits to
+completion is the one who writes it, not the client that merely reads it).
+This module's own :func:`test_every_ptype_agui_submit_branches_on_is_classified`
+is what keeps that declaration from silently falling behind a NEW branch: it
+AST-walks ``agui_submit``'s real source for every literal ``ptype ==``
+comparison and asserts each one is classified on exactly one side. A new
+branch nobody classified is a DERIVATION GAP this test fails on, not a name
+someone forgot to add to a list they never look at again.
+
+The decision itself (:func:`reyn.interfaces.repl.remote_client._read_timeout_
+for`) is tested as a PURE FUNCTION — no live socket, no wait — per
+testing.md's own guidance: a duration is rarely the property under test, and
+splitting the decision out as a pure function is what removes the place a
+duration could be written into a test at all. The real socket-level mechanics
+(does ``httpx.Timeout(None, ...)`` genuinely never time out) are already
+proven by ``test_5894_control_timeout_and_coalesce.py``'s own real-listener
+tests; this module does not re-prove that.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from reyn.interfaces.repl.remote_client import _CONTROL_TIMEOUT_S, _read_timeout_for
+from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+from reyn.interfaces.transport.agui.endpoint import (
+    BOUNDED_PAYLOAD_TYPES,
+    LONG_RUNNING_PAYLOAD_TYPES,
+    agui_submit,
+)
+
+
+def _ptypes_agui_submit_branches_on() -> "set[str]":
+    """AST-derive every literal string ``agui_submit`` compares ``ptype``
+    against (``if``/``elif ptype == "..."``, either operand order) — the
+    REAL population the classification below must fully cover. Never a
+    hand-typed mirror of the branches: this walks the function's own
+    current source, so a new branch is picked up automatically the next
+    time this runs."""
+    source = inspect.getsource(agui_submit)
+    tree = ast.parse(source)
+    found: "set[str]" = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Compare) and len(node.ops) == 1
+                and isinstance(node.ops[0], ast.Eq)):
+            continue
+        left = node.left
+        right = node.comparators[0]
+        for name_side, other_side in ((left, right), (right, left)):
+            if (isinstance(name_side, ast.Name) and name_side.id == "ptype"
+                    and isinstance(other_side, ast.Constant)
+                    and isinstance(other_side.value, str)):
+                found.add(other_side.value)
+    return found
+
+
+def test_the_ast_derivation_itself_is_not_vacuous() -> None:
+    """Tier 2: question 4's own discipline — a derivation that silently
+    found zero branches would make every assertion below pass by having
+    nothing to check. Sanity floor: the two `ptype`s this module's own
+    docstring names by name must actually be found."""
+    found = _ptypes_agui_submit_branches_on()
+    assert {"heartbeat", "attach_request"} <= found, (
+        f"the AST walk found an implausibly small population -- it likely "
+        f"stopped matching agui_submit's real branch shape: {found!r}"
+    )
+
+
+def test_every_ptype_agui_submit_branches_on_is_classified() -> None:
+    """Tier 2: the derivation gate itself. A `ptype` `agui_submit` actually
+    branches on that is classified on NEITHER side is exactly the shape
+    lead-coder's own ruling forbids landing silently -- a future branch
+    nobody decided the timeout class for."""
+    found = _ptypes_agui_submit_branches_on()
+    classified = LONG_RUNNING_PAYLOAD_TYPES | BOUNDED_PAYLOAD_TYPES
+    unclassified = found - classified
+    assert not unclassified, (
+        f"agui_submit branches on {unclassified!r} with no timeout-class "
+        f"decision recorded in LONG_RUNNING_PAYLOAD_TYPES/BOUNDED_PAYLOAD_"
+        f"TYPES -- classify it on one side (endpoint.py, next to the "
+        f"branch, per lead-coder's own ruling: the party that knows "
+        f"whether the handler awaits to completion writes the decision)."
+    )
+
+
+def test_the_two_sets_do_not_overlap() -> None:
+    """Tier 2: deny side -- a `ptype` cannot be both bounded and
+    long-running; an overlap would make `_read_timeout_for`'s own
+    membership check ambiguous about which branch actually decided."""
+    overlap = LONG_RUNNING_PAYLOAD_TYPES & BOUNDED_PAYLOAD_TYPES
+    assert not overlap, f"classified on both sides: {overlap!r}"
+
+
+def test_no_classified_type_is_stale() -> None:
+    """Tier 2: the reverse direction of the derivation gate -- a classified
+    `ptype` that `agui_submit` no longer actually branches on (a removed or
+    renamed branch whose classification was left behind) is drift too,
+    just not the silently-dangerous kind the other test blocks on."""
+    found = _ptypes_agui_submit_branches_on()
+    classified = LONG_RUNNING_PAYLOAD_TYPES | BOUNDED_PAYLOAD_TYPES
+    stale = classified - found
+    assert not stale, (
+        f"classified but agui_submit no longer branches on it: {stale!r} "
+        f"-- likely a renamed/removed ptype branch"
+    )
+
+
+def test_attach_request_gets_no_read_timeout() -> None:
+    """Tier 1: attach_request is the one derived long-running type -- its
+    own computed read timeout is None (unbounded), matching the SSE
+    stream's own policy, never the bounded 10s control-POST default."""
+    assert _read_timeout_for("attach_request") is None
+
+
+@pytest.mark.parametrize("ptype", sorted(BOUNDED_PAYLOAD_TYPES))
+def test_every_bounded_type_keeps_the_control_timeout(ptype: str) -> None:
+    """Tier 1: non-vacuity's other half -- every OTHER classified type
+    still gets the bounded default, not accidentally exempted."""
+    assert _read_timeout_for(ptype) == _CONTROL_TIMEOUT_S
+
+
+def test_an_unclassified_type_defaults_to_bounded() -> None:
+    """Tier 1: fail-closed (lead-coder ruling, condition 2) -- a `ptype`
+    this function has never seen is read as bounded (the side the timeout
+    still applies to), never as long-running. The dangerous direction
+    (unbounded by accident) would let a broken handler hang the client
+    forever; this direction only ever cuts one short."""
+    assert _read_timeout_for("__no_such_ptype__") == _CONTROL_TIMEOUT_S
+
+
+def test_an_override_bounds_a_bounded_type_but_not_a_long_running_one() -> None:
+    """Tier 1: `override` (the existing seam tests already use to inject
+    T, #5894) still works for a bounded type; it has no effect on
+    attach_request, which stays unbounded regardless -- there is no T to
+    inject for a type this function has already decided has none."""
+    assert _read_timeout_for("heartbeat", override=5.0) == 5.0
+    assert _read_timeout_for("attach_request", override=5.0) is None
+
+
+def test_strip_falsify_removing_attach_request_from_the_set_changes_the_decision() -> None:
+    """Tier 2: strip-falsify, in-process (no git stash/checkout/restore,
+    per lead-coder's own instruction) -- temporarily empty the REAL
+    ``LONG_RUNNING_PAYLOAD_TYPES`` set ``_read_timeout_for`` reads from
+    (via its own lazy import), confirm the decision flips to bounded, then
+    restore. Proves this test module is actually reading the production
+    set, not a copy that could silently drift from it.
+    """
+    original = endpoint_mod.LONG_RUNNING_PAYLOAD_TYPES
+    assert "attach_request" in original, "arrange: the real set must start non-empty"
+    try:
+        endpoint_mod.LONG_RUNNING_PAYLOAD_TYPES = frozenset()
+        assert _read_timeout_for("attach_request") == _CONTROL_TIMEOUT_S, (
+            "stripping attach_request out of the real set did not change "
+            "_read_timeout_for's own decision -- it is not actually reading "
+            "the production set"
+        )
+    finally:
+        endpoint_mod.LONG_RUNNING_PAYLOAD_TYPES = original
+    # Restored: the ordinary (non-stripped) behavior returns.
+    assert _read_timeout_for("attach_request") is None


### PR DESCRIPTION
**[tui-coder]** — `part of #6083`

## ⑵-a: the read-timeout policy applies by CLASS, not uniformly

#6100 (⑵-b) fixed the ONE reported case (`slash_command`) by making the
server stop awaiting to completion. This PR closes the actual CLASS
lead-coder's own ruling named: "handler が完了まで await するか" — every
OTHER `ptype` `agui_submit` handles is traced the same way, so a future
long-running handler doesn't reproduce the exact #6083 symptom on a
different payload type.

## Population — traced into each callee, not guessed

- **`attach_request`** — LONG-RUNNING. `registry.attach()` →
  `get_or_load()` → `_construct_session()` replays a first-attach agent's
  persisted WAL history on construction — a cost proportional to session
  length (the same shape #6099's own `build_history()` finding named).
  The one unbounded operation found.
- **`session_switch_request`** — bounded. `attach_session()` requires the
  target session to be ALREADY loaded (`_peek_session`, sync, in-memory)
  and raises rather than building one — unlike `attach_request`, never
  constructs anything.
- **`artifact_list_request` / `session_list_request` /
  `load_older_backlog_request`** — bounded. Capped/in-memory reads (a
  limited artifact list, an in-memory session-id roster, one backlog
  page — #5139 C's own design).
- **`user_message` / `cancel_inflight` / `cancel_queued` /
  `TOOL_CALL_RESULT` / `heartbeat`** — #5894's own original bounded
  scope, unchanged.
- **`slash_command`** — bounded (post-#6100: no longer awaits its own
  handler to completion at all).

## Declaration lives server-side, client reads it (lead-coder correction)

My first draft proposed a client-side `send(..., long_running=True)`
kwarg (self-declared per `AgUiTransport` method). lead-coder corrected
the DIRECTION: the party that KNOWS whether a handler awaits to
completion is `endpoint.py`'s own `agui_submit`, not the client — a
future handler that starts awaiting something long would silently leave
a client-side declaration behind. `LONG_RUNNING_PAYLOAD_TYPES` /
`BOUNDED_PAYLOAD_TYPES` are declared in `endpoint.py`, right next to the
dispatch they classify; `remote_client.py`'s `_read_timeout_for` reads
the set (an import, not a widened callable contract) — no `send`/
`ClientTransport` signature changes, no test-stub blast radius.

## Population is DERIVED, not hand-listed

`test_every_ptype_agui_submit_branches_on_is_classified` AST-walks
`agui_submit`'s own real source for every literal `ptype ==` comparison
and asserts each one is classified on exactly one side — a NEW branch
nobody classified fails CI, rather than silently defaulting. The
reverse (a classified-but-no-longer-referenced type) is checked too.

## Fail-closed

An unclassified `ptype` reads as bounded (the side the timeout still
applies to) — the dangerous direction (unbounded by accident) would let
a broken handler hang the client forever; this direction only ever cuts
one short. `_CONTROL_TIMEOUT_S` itself is unchanged.

## Strip-falsified

`test_strip_falsify_removing_attach_request_from_the_set_changes_the_decision`
temporarily empties the REAL `LONG_RUNNING_PAYLOAD_TYPES` set at
runtime (save/restore, no `git stash`/`checkout`/`restore`) and
confirms the decision flips. Also verified by hand: edited
`endpoint.py`'s own `LONG_RUNNING_PAYLOAD_TYPES` to `frozenset()`
in-file, confirmed 4 tests go RED, reverted the edit, confirmed green
again.

## Documented, not solved

A `--connect` client reads its OWN installed copy of
`LONG_RUNNING_PAYLOAD_TYPES` — accurate only for a same-install
deployment against the server it talks to. Stated as a limitation in
both `endpoint.py`'s own docstring and `remote_client.py`'s, not solved
here.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (new test file)
- [x] `verify_module_docstrings.py` (changed src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates (bare-tests-import, file-depth, subprocess-reyn-pin, no-core-dep-importorskip, suspected-time-dependence)
- [x] `src/reyn/interfaces/` touch: `silent_except_ratchet.py`
- [x] Diff-scoped pytest green, foreground (28 tests across 4 files, incl. #5894/#5907/#3328's own existing suites — no regression)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
