### PR TITLE
fix(#6106): typed-marker path through _enqueue, move RetryLoopTerminal

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -21,6 +21,7 @@ own EventLog (#2570: a pipeline driver-session's live step progress).
 from __future__ import annotations
 
 import asyncio
+from enum import Enum
 from typing import Any, Callable
 
 from reyn.runtime.outbox import OutboxMessage
@@ -319,12 +320,24 @@ class ChatLifecycleForwarder:
         ladder-terminal distinction at all) carries no ``terminal`` field
         (never fabricated) and degrades to a generic marker.
 
-        The 2-line mapping is a SMALL, deliberate duplicate of
-        ``compaction_progress.py``'s own ``compaction_failure_text`` —
-        that module is INTERFACES-layer (imports ``textual``); this one is
-        RUNTIME-layer, so importing it here would invert the dependency
-        direction (same reasoning this module's own ``_compact_token_
-        count`` docstring already gives for not importing ``gutter.py``).
+        ★ #6106 stage 1 (architect/lead-coder ruling): this handler used
+        to carry its OWN small English-sentence table for
+        ``RetryLoopTerminal``, a literal duplicate of ``compaction_
+        progress.py``'s own ``compaction_failure_text`` — #6104's CI
+        caught the two drifting (one side translated, the other not).
+        Fixed structurally, not by re-syncing the duplicate: this handler
+        now passes ``_enqueue(marker=(...))`` — see that method's own
+        docstring — so the fallback text here is the member's own
+        ``.name`` (a structural identifier), never a hand-authored
+        sentence. The polished sentence lives in EXACTLY one place
+        (``compaction_progress.compaction_failure_text``), reached by
+        ``app.py`` independently (reading the same ``terminal`` value off
+        the cached ``compaction_progress_raw()`` snapshot to build the
+        flowview entry's own row) — not through this forwarder at all.
+        ``str(terminal)`` + ``.get()`` (silently ``None`` on an unmapped
+        value) is also gone: a value that does not resolve to a real
+        ``RetryLoopTerminal`` member degrades to the generic marker
+        instead of ever half-matching.
 
         ★ #6085 stage 2 (lead-coder ruling): this frame deliberately
         carries NO ``compaction_episode_marker`` meta, unlike its 3
@@ -345,12 +358,15 @@ class ChatLifecycleForwarder:
         oversight #5588 left behind).
         """
         terminal = data.get("terminal")
-        text = {
-            "mid_floor": "A single exchange is too large on its own",
-            "room_floor": "The most recent messages alone don't fit in the window",
-        }.get(str(terminal))
-        if text is not None:
-            self._enqueue(f"[✗ shrink flow failed: {text}]")
+        member = None
+        if terminal is not None:
+            from reyn.services.compaction.engine import RetryLoopTerminal as _RLT
+            try:
+                member = _RLT(terminal)
+            except ValueError:
+                member = None
+        if member is not None:
+            self._enqueue(marker=("shrink flow failed", member))
         else:
             self._enqueue("[✗ shrink flow failed]")
 
@@ -587,7 +603,13 @@ class ChatLifecycleForwarder:
         kind = str(data.get("kind") or "?")
         self._enqueue(f"[✗ intervention denied: {kind}]")
 
-    def _enqueue(self, text: str, *, meta: "dict | None" = None) -> None:
+    def _enqueue(
+        self,
+        text: "str | None" = None,
+        *,
+        meta: "dict | None" = None,
+        marker: "tuple[str, Enum] | None" = None,
+    ) -> None:
         # Fire-and-forget: lifecycle markers are advisory, never block the
         # session loop. Uses ``kind="system"`` so the conv pane's
         # ``_render_system_message`` path styles it as a dim marker line.
@@ -605,6 +627,43 @@ class ChatLifecycleForwarder:
         # a doc/comment goes stale the moment the mechanism it describes
         # changes; fixed here in the same PR that found it, per that rule —
         # the writer itself is untouched).
+        #
+        # *marker* (#6106 stage 1) — ``(label, member)``, the TYPED
+        # alternative to a hand-authored *text* string. Pass this when a
+        # handler is naming WHICH closed-vocabulary outcome fired, not
+        # authoring English prose about it. This is the ONE new path
+        # stage 1 moves onto (:meth:`on_router_context_overflow_
+        # unrecovered`'s ``RetryLoopTerminal``); the other 24 ``_enqueue``
+        # call sites in this module are untouched — #6106 architect
+        # ruling: this module IS a runtime-layer renderer (25 call
+        # sites), and stage 1 closes only the ONE duplicated table, not
+        # the module's whole contract.
+        #
+        # The fallback text built here is *member.name* — the enum's own
+        # structural identifier (``"MID_FLOOR"``), never a hand-authored
+        # sentence: this runtime layer names WHAT happened, an
+        # interfaces-layer subscriber reading the SAME source audit-event
+        # (``app.py``'s own ``compaction_failure_text(RetryLoopTerminal(
+        # terminal))`` call, building the flowview entry's row, #5588)
+        # renders the polished sentence independently — importing
+        # ``interfaces`` here would invert the layer (#6106 architect
+        # ruling). A surface with no such richer mechanism (AG-UI generic
+        # client, plain CUI) shows this mechanical fallback as-is — the
+        # same "a surface without that mechanism shows the line as-is"
+        # contract :meth:`on_recovery_summary_persisted`'s own docstring
+        # already names for the (unrelated) ``compaction_episode_marker``
+        # fold. Also stamps ``meta[label + "_terminal"] = member.value``
+        # (the raw wire value, e.g. ``"mid_floor"``) — nothing reads it
+        # yet; kept for a future consumer, same as ``lifecycle_bundle_
+        # key`` above started inert too.
+        #
+        # *text* and *marker* are mutually exclusive.
+        if marker is not None:
+            assert text is None, "_enqueue: pass text OR marker, never both"
+            label, member = marker
+            text = f"[✗ {label}: {member.name}]"
+            meta = {**(meta or {}), f"{label.replace(' ', '_')}_terminal": member.value}
+        assert text is not None, "_enqueue requires text or marker"
         try:
             self.outbox.put_nowait(OutboxMessage(kind="system", text=text, meta=meta or {}))
         except asyncio.QueueFull:

--- a/tests/interfaces/test_5588_compaction_progress_render.py
+++ b/tests/interfaces/test_5588_compaction_progress_render.py
@@ -156,6 +156,28 @@ def test_failure_text_mid_floor_and_room_floor_are_distinct():
     )
 
 
+def test_failure_text_covers_every_retry_loop_terminal_member():
+    """Tier 1: #6106 stage 1 exhaustiveness witness — every REAL
+    ``RetryLoopTerminal`` member (never a hand-maintained list of the 2
+    known today) must resolve to a real sentence through the actual
+    production function; a member with no entry must raise loud
+    (``compaction_failure_text``'s own dict-keyed-by-member lookup
+    already does this — a plain ``[terminal]`` index, never ``.get()``),
+    not silently degrade.
+
+    Strip-falsify (performed during review, per #6106's own architect
+    ruling — witness is "add a member, leave the mapping untouched, go
+    RED"): add a 3rd member to ``RetryLoopTerminal`` in
+    ``reyn/services/compaction/engine.py`` without adding it to
+    ``compaction_failure_text``'s own table — this test goes RED with a
+    ``KeyError`` on the new member. Reverted after confirming."""
+    for member in RetryLoopTerminal:
+        text = compaction_failure_text(member)
+        assert isinstance(text, str) and text, (
+            f"{member!r} did not resolve to a non-empty sentence"
+        )
+
+
 # ── the Ctx pane's ``folded`` row (#5578's persisted watermark) ─────────
 #
 # Three states that must stay distinct: two of them arrive as ``None`` at

--- a/tests/runtime/test_chat_lifecycle_forwarder.py
+++ b/tests/runtime/test_chat_lifecycle_forwarder.py
@@ -658,7 +658,17 @@ def test_compaction_failed_carries_the_episode_marker_meta() -> None:
 def test_router_context_overflow_unrecovered_names_mid_floor() -> None:
     """Tier 2: #5588 architect ruling — the true end-of-ladder failure is
     named via the RetryLoopTerminal member itself, never a parse of
-    error's own repr() text."""
+    error's own repr() text.
+
+    #6106 stage 1: the fallback text here is the member's own ``.name``
+    (``"MID_FLOOR"``), never a hand-authored English sentence — this
+    runtime layer names WHAT happened; the polished sentence
+    (``compaction_failure_text``) lives in exactly one place,
+    ``interfaces``, reached independently by ``app.py`` for the flowview
+    entry's own row (see ``test_entry_settles_error_with_the_real_
+    retry_loop_terminal_text`` in ``tests/interfaces/test_5588_
+    compaction_progress_chrome.py`` — that assertion is unaffected by
+    this change, a different code path entirely)."""
     q: asyncio.Queue = asyncio.Queue()
     fwd = ChatLifecycleForwarder(q)
     fwd(Event(
@@ -667,8 +677,8 @@ def test_router_context_overflow_unrecovered_names_mid_floor() -> None:
     ))
     (only,) = _drain(q)
     assert only.kind == "system"
-    assert "A single exchange is too large on its own" in only.text
-    assert "shrink flow failed" in only.text
+    assert only.text == "[✗ shrink flow failed: MID_FLOOR]"
+    assert only.meta.get("shrink_flow_failed_terminal") == "mid_floor"
 
 
 def test_router_context_overflow_unrecovered_names_room_floor() -> None:
@@ -681,7 +691,23 @@ def test_router_context_overflow_unrecovered_names_room_floor() -> None:
         data={"error": "ContextOverflowError(...)", "terminal": "room_floor"},
     ))
     (only,) = _drain(q)
-    assert "The most recent messages alone don't fit in the window" in only.text
+    assert only.text == "[✗ shrink flow failed: ROOM_FLOOR]"
+    assert only.meta.get("shrink_flow_failed_terminal") == "room_floor"
+
+
+def test_router_context_overflow_unrecovered_names_mid_floor_and_room_floor_distinctly() -> None:
+    """Tier 2: #6106 stage 1 deny — an unrecognised terminal VALUE (not a
+    real RetryLoopTerminal member) must degrade to the generic marker,
+    never half-match or raise; the mid/room floor markers above must stay
+    distinct from each other and from this generic one."""
+    q: asyncio.Queue = asyncio.Queue()
+    fwd = ChatLifecycleForwarder(q)
+    fwd(Event(
+        type="router_context_overflow_unrecovered",
+        data={"error": "UnrecoveredError(...)", "terminal": "not_a_real_terminal"},
+    ))
+    (only,) = _drain(q)
+    assert only.text == "[✗ shrink flow failed]"
 
 
 def test_router_context_overflow_unrecovered_without_terminal_degrades_gracefully() -> None:


### PR DESCRIPTION
**[e2e-coder]** — Stage 1 of architect's design (#6106 issue thread). Closes #6106.

Closes #6106

## What changed
`lifecycle_forwarder.py` is a runtime-layer **renderer** (25 `_enqueue` call sites carrying user-facing text), not an accidental duplicate — architect's own measurement. The 2-line `RetryLoopTerminal → text` table WAS a real duplicate of `compaction_progress.compaction_failure_text` though (#6104's CI caught the two drifting when only one side got translated). Re-syncing the table again would just repeat the same defect at the next translation drift, so this fixes it structurally: runtime stops authoring wording for this ONE case.

- `_enqueue` gains an optional `marker: tuple[str, Enum]` path — the existing `text` path is untouched. This stage moves **only** `RetryLoopTerminal` onto it; the other 24 call sites are unaffected (a wider migration is a separate, future issue per architect's own staging — this issue closes on stage 1 alone).
- When given a marker, `_enqueue` builds its fallback text from the member's own `.name` (a structural identifier, e.g. `"MID_FLOOR"`) — never a hand-authored sentence — and stamps the raw wire value into `meta`.
- The polished English sentence continues to live in **exactly one place**, `compaction_progress.compaction_failure_text` (interfaces layer), reached independently by `app.py` for the flowview entry's own row (pre-existing code, unrelated to this forwarder) — so runtime never imports interfaces and the layer is not inverted.
- `str(terminal)` + a string-keyed `.get()` (silently `None` on an unmapped value) is gone: `on_router_context_overflow_unrecovered` now reconstructs the real `RetryLoopTerminal` member via its own `Enum` constructor and degrades to the generic marker on anything that doesn't resolve — never a silent half-match.

## The "default fallback placement" architect flagged as undecided
Decided: the fallback lives right where the marker is built (`_enqueue` itself), rendering the member's raw `.name` — no new interfaces-side consumer needed, because a richer, INDEPENDENT rendering path already exists (`app.py:7935-7936`, reading the same `terminal` value off the cached snapshot to build the flowview entry's row, calling `compaction_failure_text` directly). A surface with no such mechanism (AG-UI generic client, plain CUI) shows the mechanical fallback as-is — the same "as-is" contract `on_recovery_summary_persisted`'s own docstring already names for the (unrelated) `compaction_episode_marker` fold.

## Exhaustiveness witness (architect's ③)
Added `test_failure_text_covers_every_retry_loop_terminal_member` — loops over the REAL `RetryLoopTerminal` membership and calls the real `compaction_failure_text` for each (its own dict-keyed-by-member lookup already raises `KeyError` on a miss, never `.get()`).

**Strip-falsify performed** (file-Edit only, no `git stash`/`checkout`/`restore`): added a 3rd member to `RetryLoopTerminal` in `engine.py` without touching `compaction_failure_text`'s table → test went RED with a real `KeyError`. Reverted via file Edit; `git diff --stat` on `engine.py` confirmed clean (empty) after revert.

## Witness — real path through `lifecycle_forwarder`, actual output
```
'[✗ shrink flow failed: MID_FLOOR]' {'shrink_flow_failed_terminal': 'mid_floor'}
'[✗ shrink flow failed: ROOM_FLOOR]' {'shrink_flow_failed_terminal': 'room_floor'}
'[✗ shrink flow failed]' {}
```
`grep` confirms zero occurrences of the old translated sentences (or the raw `mid_floor`/`room_floor` string keys) anywhere in `lifecycle_forwarder.py` outside one docstring example.

## Tests updated
- `tests/runtime/test_chat_lifecycle_forwarder.py`: the 2 mid_floor/room_floor tests updated for the new fallback shape; added a deny test for an unrecognised terminal value degrading to the generic marker.
- `tests/interfaces/test_5588_compaction_progress_chrome.py`: **unchanged** — its `terminal_text` assertion exercises `app.py`'s own independent path, never `lifecycle_forwarder`.

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `test_tier_audit.py --strict` (66/66 OK), `user_facing_lang_gate.py` (0 findings, unaffected — file is outside its `_SCOPE`, as architect measured), `check_tests_path_literal_reference.py`, `suspected_time_dependence_ratchet.py`, `flat_tests_ratchet.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`.

## Full pytest (foreground, one Bash call, `timeout: 600000`, committed locally first)
`14478 passed, 54 skipped, 14 failed` in ~32 min. The 14 failures are in `tests/builtin/test_3009_*`, `tests/core/test_5838_stage4_shc_exec.py`, `tests/interfaces/test_inline_interactive_logging.py`, `tests/security/test_6008_*`, `tests/tools/test_5838_stage6_*` — **none reference `lifecycle_forwarder`/`compaction_progress`/`RetryLoopTerminal`** (`grep` confirmed), and 4 unrelated `test_5838_*`/`test_5987_*` files failed even at COLLECTION time with `ModuleNotFoundError: No module named 'tree_sitter'` (excluded via `--ignore` to let collection proceed) — this venv is missing `tree_sitter`, a pre-existing environment gap unrelated to this PR's diff.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. CI and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S