### PR TITLE
fix(part of #6084): close gate holes 1 and 2 (DrawerRow note=, chrome.py:1223/1225)

### DIFF
--- a/scripts/user_facing_lang_gate.py
+++ b/scripts/user_facing_lang_gate.py
@@ -31,8 +31,22 @@ site**:
   POSITIONAL argument
 - `argparse` `.add_argument(help=...)` and `.add_parser(..., help=...,
   description=...)`
-- `DrawerRow(label=...)` — the one confirmed custom-widget kwarg
-  (`src/reyn/interfaces/inline/textual_chat/chrome.py`)
+- `DrawerRow(label=..., note=..., state=...)` — the custom-widget kwargs
+  that reach the operator (`src/reyn/interfaces/inline/textual_chat/
+  chrome.py`). #6084 gate-hole ⑴ (lead-coder): the ORIGINAL sink spec here
+  registered only `label` — `note` (and `state`) were the same shape,
+  never registered, and a real kana literal (`chrome.py:1223/1225`) sat
+  unflagged from this gate's own first day. `_SINK_SPECS["DrawerRow"]`
+  now covers every kwarg :class:`~reyn.interfaces.inline.textual_chat.
+  chrome.DrawerRow`'s OWN `text` property (the class's single declared
+  "the row as the pane renders it" — chrome.py's own docstring) actually
+  reads via `self.<field>` — `command` is deliberately excluded (never
+  referenced there; it is a slash-command identifier the pane renders
+  elsewhere, not display prose). `tests/scripts/test_user_facing_lang_
+  gate_6084.py`'s own render-property cross-check is what keeps this from
+  silently falling behind DrawerRow's own future fields again: it derives
+  the "actually rendered" kwarg set from `text`'s AST and fails if this
+  spec and that derived set ever diverge, in EITHER direction.
 
 Anywhere else in `interfaces/` a user-facing string might originate — a
 different custom widget's kwarg not in this list, `App.notify(...)` (whose
@@ -125,7 +139,7 @@ _SINK_SPECS: "dict[str, list[tuple[str, object]]]" = {
     "reply_error": [("pos", 1)],
     "add_argument": [("kwarg", "help")],
     "add_parser": [("kwarg", "help"), ("kwarg", "description")],
-    "DrawerRow": [("kwarg", "label")],
+    "DrawerRow": [("kwarg", "label"), ("kwarg", "note"), ("kwarg", "state")],
 }
 
 

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -1220,9 +1220,9 @@ def task_pane_entries(
             bits.append(elapsed)
         cancellable = bool(task.get("cancellable"))
         if not cancellable:
-            note = "中断不可"
+            note = "not cancellable"
         elif task.get("cancel_requested_at"):
-            note = "中断要求済"
+            note = "cancel requested"
         else:
             note = None
         task_id = str(task.get("task_id") or "")

--- a/tests/interfaces/test_5654_task_pane.py
+++ b/tests/interfaces/test_5654_task_pane.py
@@ -140,7 +140,7 @@ def test_a_crash_recovered_task_is_not_cancellable_and_carries_no_command():
         {"tasks_reported": True, "tasks": [_task(cancellable=False)]}, now=_NOW,
     )
     text, command = entries[0]
-    assert "中断不可" in text
+    assert "not cancellable" in text
     assert command == ""
 
 
@@ -156,7 +156,7 @@ def test_a_cancel_already_requested_task_shows_the_note_but_keeps_its_command():
         now=_NOW,
     )
     text, command = entries[0]
-    assert "中断要求済" in text
+    assert "cancel requested" in text
     assert command == "/tasks cancel abc123"
 
 

--- a/tests/scripts/test_user_facing_lang_gate_6084.py
+++ b/tests/scripts/test_user_facing_lang_gate_6084.py
@@ -12,6 +12,7 @@ paired name, must still flag an unpaired sibling-less name).
 """
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -126,3 +127,84 @@ def test_a_new_uncommitted_finding_would_be_caught() -> None:
     measured_now = set(findings(_FIXTURES / "has_sink_literals.py"))
     assert new_findings(measured_now, set()) == measured_now
     assert measured_now, "expected at least one finding from this fixture, wiring is broken"
+
+
+# ── gate-hole ⑴ (lead-coder, #6084): DrawerRow's registered kwargs must ──
+# ── match what its OWN render property actually shows the operator ──────
+
+
+def _fields_rendered_by(cls: type, property_name: str) -> "set[str]":
+    """AST-derive every `self.<name>` attribute *cls*'s own *property_name*
+    property reads, by walking that property's real source — never a
+    second, hand-maintained guess at "which fields are text". This is the
+    SAME shape `_collect_i18n_pair_exempt_ids` already uses elsewhere in
+    this gate (a structural AST condition, not a name/file list): the
+    class's own rendering code is the single source of truth for "what
+    reaches the operator's screen" through it, since that is the literal
+    reason the property exists."""
+    import inspect
+    import textwrap
+
+    source = textwrap.dedent(inspect.getsource(cls))
+    class_node = ast.parse(source).body[0]
+    assert isinstance(class_node, ast.ClassDef)
+    (prop_node,) = [
+        n for n in class_node.body
+        if isinstance(n, ast.FunctionDef) and n.name == property_name
+    ]
+    fields: "set[str]" = set()
+    for node in ast.walk(prop_node):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        ):
+            fields.add(node.attr)
+    return fields
+
+
+def test_drawerrow_sink_spec_matches_its_own_render_property() -> None:
+    """Tier 2: the derivation gate for gate-hole ⑴ itself. `DrawerRow.text`
+    (`chrome.py`'s own docstring: "the row as the pane renders it") is the
+    class's single declared rendering path — every `self.<field>` it reads
+    is a field that can carry a kana literal all the way to the operator's
+    screen. `_SINK_SPECS["DrawerRow"]` must register EXACTLY that set, in
+    both directions: a field `text` reads but this spec does not register
+    is the gate-hole class this test exists to close (the ORIGINAL defect
+    — `note` was read by `text`, absent from the spec); a field registered
+    here that `text` does NOT read would be a stale/over-broad entry
+    (drift the other direction — question 4's own "would it stay green
+    having nothing to bite on" concern, applied to a spec instead of a
+    finding set).
+
+    STRIP-FALSIFY (verified by hand, file-internal Edit only, reverted):
+    removing `("kwarg", "note")` from `_SINK_SPECS["DrawerRow"]` turns
+    this red (`text`'s own AST still reads `self.note`, the spec no
+    longer does) — confirming this test genuinely depends on the spec
+    covering what the property renders, not just a fixed literal set."""
+    from reyn.interfaces.inline.textual_chat.chrome import DrawerRow
+    from scripts.user_facing_lang_gate import _SINK_SPECS
+
+    rendered = _fields_rendered_by(DrawerRow, "text")
+    assert rendered, "arrange: text's own AST must reference at least one field"
+    registered = {
+        key for kind, key in _SINK_SPECS["DrawerRow"] if kind == "kwarg"
+    }
+    assert registered == rendered, (
+        f"_SINK_SPECS['DrawerRow'] registers {registered!r} but "
+        f"DrawerRow.text actually reads {rendered!r} -- a mismatch either "
+        f"way means the gate is not watching (or is watching a stale set "
+        f"of) exactly what reaches the operator's screen"
+    )
+
+
+def test_drawerrow_command_is_correctly_excluded() -> None:
+    """Tier 2: deny side, named explicitly (question 1's own "who would
+    miss this test" answer: a future reader wondering why `command` isn't
+    in `_SINK_SPECS` needs this, not just the equality check above passing
+    silently) — `command` is a slash-command identifier, never referenced
+    by `DrawerRow.text`, so the render-derived set correctly excludes it
+    without this test needing a hand-written exemption list."""
+    from reyn.interfaces.inline.textual_chat.chrome import DrawerRow
+
+    assert "command" not in _fields_rendered_by(DrawerRow, "text")


### PR DESCRIPTION
**[tui-coder]** — `part of #6084`

Closes gate holes ⑴ and ⑵ (⑶ — extending `_SCOPE` beyond `src/reyn/interfaces` — is e2e-coder's, after #6106).

## ⑴ `_SINK_SPECS["DrawerRow"]` only registered `label=`

`note=` (and, found while deriving the fix mechanically: `state=`) were the same shape — both reach the operator through `DrawerRow`'s own `text` property — but were never registered, so a real kana literal (`chrome.py:1223/1225`) sat unflagged from this gate's own first day.

Per lead-coder's explicit instruction, this is not "add `note=` and stop": `_SINK_SPECS["DrawerRow"]` now covers **exactly** the kwarg set `DrawerRow`'s own `text` property (`chrome.py`'s own docstring: "the row as the pane renders it") reads via `self.<field>` — derived by AST-walking that property's real source, never hand-guessed. `command` is correctly excluded (never referenced by `text` — a slash-command identifier, not display prose).

`tests/scripts/test_user_facing_lang_gate_6084.py`: 2 new tests.
- `test_drawerrow_sink_spec_matches_its_own_render_property` is the derivation gate itself — fails if the registered kwarg set and the render-derived set ever diverge, in EITHER direction (a field `text` reads but the spec misses — the original defect; or a stale registered field `text` no longer reads).
- `test_drawerrow_command_is_correctly_excluded` names the deny side explicitly.

Strip-falsified by hand (file-internal Edit only, `git stash`/`checkout`/`restore` never used): removed `note=` from the spec, confirmed the derivation test goes RED, reverted, confirmed green again.

## ⑵ `chrome.py:1223/1225` — kanji-only, no kana, slipped both census and gate

`"中断不可"`/`"中断要求済"` → `"not cancellable"`/`"cancel requested"`. Translation only, no rewording (same tone as this file's own sibling notes — `"not honored"`, `"retrying…"`, `"not yet probed"`). `tests/interfaces/test_5654_task_pane.py`'s 2 assertions on the old Japanese text updated to the new English text.

**Witness** (`task_pane_entries` — a pure function, #6104's own shape — real output, not a diff quote):

```python
>>> task_pane_entries(snap, now=now)
[('prompt → peer-a  · not cancellable', ''),
 ('prompt → peer-b  · cancel requested', '/tasks cancel def456')]
```

Gate's own kana-only discriminator is **NOT** widened here — lead-coder's explicit ruling: 1 kanji-only instance is an exception, not yet a class; reopens only when a 2nd kanji-only user-facing literal is found (observer: lead-coder).

⚠️ **Width change is NOT verified here** — the English text has a different render width than the Japanese original; whether the drawer row still fits/reads well is the owner's own visual judgment on a real screen, not something this PR confirms.

## Remainder

`--write-baseline` was NOT needed — the baseline was already `[]` (0 findings) both before and after this PR: widening `_SINK_SPECS["DrawerRow"]` to `note=`/`state=` found no OTHER kana literal anywhere in scope (checked by hand across every `DrawerRow(...)` call site), so translating the one real instance brought the scanned findings back to 0 without any baseline edit.

## Test plan

- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (changed test files)
- [x] `verify_module_docstrings.py` (changed src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates (bare-tests-import, file-depth, subprocess-reyn-pin, no-core-dep-importorskip, suspected-time-dependence)
- [x] `src/reyn/interfaces/` touch: `silent_except_ratchet.py`
- [x] `user_facing_lang_gate.py` itself: 0 findings, all baselined
- [x] Diff-scoped pytest green, foreground (26 tests)
- [x] (skipped — Visual, standing waiver; also see the width-change note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
