### PR TITLE
fix(part of #6084): gate output names the scope's sink-call count (hole 4)

### DIFF
--- a/scripts/user_facing_lang_gate.py
+++ b/scripts/user_facing_lang_gate.py
@@ -266,17 +266,43 @@ def findings(path: Path, display: "str | None" = None) -> "list[str]":
     return out
 
 
-def measured(root: Path = _ROOT) -> "tuple[set[str], int]":
-    """`(finding_set, scanned_file_count)`. A file that fails to parse is
-    NOT caught here — it propagates to `main`, same fail-closed contract
-    `silent_except_ratchet.py` documents (this scan's own under-count would
-    be the exact defect this gate exists to prevent, one layer up)."""
+def sink_call_count(path: Path) -> int:
+    """Count of ``(sink call, registered arg position)`` matches in *path*
+    whose argument is PRESENT — regardless of whether it turns out to be a
+    literal, or contains kana. #6084 hole ⑷ (lead-coder): a gate that
+    prints only "0 findings" lets a reader believe no user-facing sink
+    exists anywhere in scope — the true claim is narrower ("no sink CALL
+    this gate can see carries kana"). This count names how many sink
+    calls the scan actually looked at, so the output can say which."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_target_name(node)
+        if name is None or name not in _SINK_SPECS:
+            continue
+        for spec in _SINK_SPECS[name]:
+            if _extract_arg(node, spec) is not None:
+                count += 1
+    return count
+
+
+def measured(root: Path = _ROOT) -> "tuple[set[str], int, int]":
+    """`(finding_set, scanned_file_count, sink_call_count)`. A file that
+    fails to parse is NOT caught here — it propagates to `main`, same
+    fail-closed contract `silent_except_ratchet.py` documents (this scan's
+    own under-count would be the exact defect this gate exists to
+    prevent, one layer up)."""
     files = _iter_scan_files(root)
     all_findings: "set[str]" = set()
+    total_sink_calls = 0
     for path in files:
         rel = str(path.relative_to(root))
         all_findings.update(findings(path, display=rel))
-    return (all_findings, len(files))
+        total_sink_calls += sink_call_count(path)
+    return (all_findings, len(files), total_sink_calls)
 
 
 def load_baseline(path: Path = _BASELINE_PATH) -> "set[str]":
@@ -315,7 +341,7 @@ def main(argv: "list[str] | None" = None) -> int:
     args = build_parser().parse_args(argv)
 
     try:
-        current, scanned = measured(_ROOT)
+        current, scanned, sink_calls = measured(_ROOT)
     except (OSError, UnicodeDecodeError, SyntaxError) as exc:
         print(
             f"user-facing-lang gate FAILED: could not scan the population "
@@ -339,7 +365,8 @@ def main(argv: "list[str] | None" = None) -> int:
         write_baseline(current, _BASELINE_PATH)
         print(
             f"Wrote {len(current)} user-facing-lang finding(s) to "
-            f"{_BASELINE_PATH}, {scanned} file(s) scanned under {_SCOPE}/."
+            f"{_BASELINE_PATH} — scanned {scanned} file(s) under {_SCOPE}/, "
+            f"{sink_calls} sink call site(s)."
         )
         return 0
 
@@ -372,10 +399,12 @@ def main(argv: "list[str] | None" = None) -> int:
         return 1
 
     print(
-        f"user-facing-lang gate OK: {len(current)} finding(s), all "
-        f"baselined ({scanned} file(s) scanned under {_SCOPE}/). Covers "
-        "only the confirmed sink list at a direct-literal call site — see "
-        "module docstring for scope."
+        f"user-facing-lang gate OK: scanned {sink_calls} sink call site(s) "
+        f"across {scanned} file(s) under {_SCOPE}/, {len(current)} "
+        f"finding(s) (all baselined). This is NOT \"no user-facing kana "
+        f"anywhere\" — it is \"none of the {sink_calls} sink calls this "
+        "gate can see, in this scope, carry one\"; see module docstring "
+        "for exactly which sinks/scope that is."
     )
     return 0
 

--- a/tests/scripts/test_user_facing_lang_gate_6084.py
+++ b/tests/scripts/test_user_facing_lang_gate_6084.py
@@ -21,6 +21,7 @@ from scripts.user_facing_lang_gate import (
     findings,
     load_baseline,
     new_findings,
+    sink_call_count,
     write_baseline,
 )
 from tests._support.paths import REPO_ROOT
@@ -114,9 +115,32 @@ def test_the_real_scan_against_the_current_tree_matches_the_baseline() -> None:
     from scripts.user_facing_lang_gate import _BASELINE_PATH, measured
 
     baseline = load_baseline(_BASELINE_PATH)
-    current, scanned = measured(REPO_ROOT)
+    current, scanned, sink_calls = measured(REPO_ROOT)
     assert scanned > 0, "the scan found 0 files — a scanner failure, not a clean population"
+    assert sink_calls > 0, "the scan found 0 sink calls — a scanner failure, not a clean population"
     assert new_findings(current, baseline) == set()
+
+
+def test_sink_call_count_counts_calls_seen_not_just_findings() -> None:
+    """Tier 1: #6084 hole ⑷ — `sink_call_count` must count a sink call it
+    LOOKED AT even when the argument turns out to be indirection (never a
+    literal, so it produces zero findings) — this is what lets the gate's
+    own output distinguish "scanned N sink calls, 0 carry kana" from "0
+    sink calls exist in scope", the exact conflation hole ⑷ closes.
+    `indirect_not_flagged.py` has 2 sink calls (`OutboxMessage`, `reply`),
+    both argument-present, neither literal — 0 findings, but the count
+    here must still be 2, not 0."""
+    fixture = _FIXTURES / "indirect_not_flagged.py"
+    assert findings(fixture) == [], "sanity: this fixture must still produce 0 findings"
+    assert sink_call_count(fixture) == 2
+
+
+def test_sink_call_count_matches_the_direct_literal_fixtures_own_3_sinks() -> None:
+    """Tier 1: accept side — `has_sink_literals.py`'s own docstring claims
+    exactly 3 flagged sink call sites; `sink_call_count` must agree
+    (every one of them is also an argument-present sink call)."""
+    fixture = _FIXTURES / "has_sink_literals.py"
+    assert sink_call_count(fixture) == len(findings(fixture)) == 3
 
 
 def test_a_new_uncommitted_finding_would_be_caught() -> None:


### PR DESCRIPTION
**[e2e-coder]** — Hole ⑷ (gate output wording) only. Hole ⑶ (`_SCOPE` widening measurement) is NOT a code change per lead-coder's instruction ("広げないでください — 数だけ") — reported as a comment on #6084 instead: https://github.com/tya5/reyn/issues/6084

part of #6084

## Hole ⑷ — gate output now names the scope's sink-call count

The gate's own "0 findings" output let a reader believe no user-facing kana exists ANYWHERE; the true claim is narrower — "none of the sink calls this gate can see, in `src/reyn/interfaces`, carry one". `measured()` now also returns the number of sink CALL SITES actually examined (present-argument matches against `_SINK_SPECS`, regardless of whether the argument turns out literal or contains kana), printed in both `--write-baseline` and the OK-path output, with the narrower claim spelled out explicitly.

**Real output** (this PR's own gate run):
```
user-facing-lang gate OK: scanned 506 sink call site(s) across 144 file(s) under src/reyn/interfaces/, 0 finding(s) (all baselined). This is NOT "no user-facing kana anywhere" — it is "none of the 506 sink calls this gate can see, in this scope, carry one"; see module docstring for exactly which sinks/scope that is.
```

2 new tests for `sink_call_count`: one confirms it counts an indirection-only sink call (0 findings) as still-counted; one confirms it agrees with the existing 3-literal fixture's own finding count.

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py`, `test_tier_audit.py --strict` (13/13 OK), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `check_tests_path_literal_reference.py`, `flat_tests_ratchet.py`.

## Pytest (diff-scoped, foreground)
`pytest tests/scripts/test_user_facing_lang_gate_6084.py -q` → 13 passed. (No full suite — per your corrected brief.)

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. CI and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S