### PR TITLE
fix(part of #6117): add 14 of 17 no-discovery-path gates to main-invariant-sweep.yml

### DIFF
--- a/.github/workflows/main-invariant-sweep.yml
+++ b/.github/workflows/main-invariant-sweep.yml
@@ -37,6 +37,28 @@ name: main invariant sweep
 # has no such artifact — running it would be an always-green check watching
 # nothing), the latter isn't `pull_request`/`push`-triggered at all.
 #
+# #6117: `litellm-proxy-patch-scaffold.yml` / `check-doc-drift-fixture.yml`
+# are NOT folded into the step list below either, though both CAN run
+# against `main` alone (neither needs a PR diff) — unlike the exclusions
+# above, this is a fit problem with THIS job, not a meaning problem with
+# them: `litellm-proxy-patch-scaffold` needs an ISOLATED Python 3.13 venv
+# carrying ONLY `litellm[proxy]==1.95.0` + pytest (owner ruling, #5620:
+# deliberately excludes reyn's own [dev]/[mcp]/[web] extras), which this
+# job's single shared Python-3.11-plus-`pip install -e .` environment
+# cannot host without breaking that isolation; `check-doc-drift-fixture`
+# needs `fetch-depth: 0` (full git history, for `git show <pinned-sha>:
+# <path>`) on ITS checkout, while this job's own checkout is shallow
+# (lead-coder ruling, #5298: paying full-clone cost on every hourly/every-
+# push run for 2 rarely-touched files was rejected there for the same
+# reason it would be rejected here). Both ALREADY have their own
+# `push: branches: [main]` leg (path-scoped to the same files their
+# `pull_request` trigger watches) — narrower than this sweep's
+# unconditional-every-push coverage, but real: a push to `main` that
+# touches either gate's own watched files re-runs it independently of
+# this file. Neither is a whole-tree gate over unrelated files the way the
+# 9+14 gates above are, so the composition-gap risk this workflow exists
+# to close is structurally small for both to begin with.
+#
 # Deliberately NOT a required status check (not referenced from branch
 # protection) — this runs on a schedule independent of any one PR, so
 # folding its result into a PR's merge gate would block merges on an
@@ -301,3 +323,84 @@ jobs:
       - name: remote-snapshot-placeholder-declared
         if: ${{ !cancelled() }}
         run: python scripts/check_remote_snapshot_placeholder_declared.py
+
+      # #6117 (lead-coder, split from #6113): 17 path-filtered, per-PR-only
+      # gates had NO discovery path for the SAME composition-gap class
+      # #4257 named above — a PR touching neither of two files that
+      # together violate one of these gates never triggers it, and (unlike
+      # the 9 gates above) nothing else re-checked them against `main`
+      # either. Measured runnable against `main` alone (no PR/diff context
+      # needed) and added here — 13 of the 14 below are stdlib-only; the
+      # 14th (bash-node-kind-count) needs the SAME `reyn` install already
+      # paid for above (#6014), so it costs nothing new. 2 of the 17 are
+      # NOT here — see this file's own exclusion note further down for
+      # why, and #6117's own comment for the third correction (`mypy
+      # (ratchet)` was miscounted into the 17 in #6113 — it already runs
+      # unconditionally on every PR via `test.yml`, no `paths:` filter, so
+      # it already had a discovery path and needs no entry here).
+      - name: audit-event-firing-condition
+        if: ${{ !cancelled() }}
+        run: python scripts/audit_event_firing_condition_gate.py
+
+      - name: bash-node-kind-count-ratchet
+        if: ${{ !cancelled() }}
+        run: python scripts/bash_node_kind_count_ratchet.py
+
+      - name: ci-role-declared
+        if: ${{ !cancelled() }}
+        run: python scripts/check_ci_role_declared.py
+
+      - name: faulthandler-timer-api-single-caller
+        if: ${{ !cancelled() }}
+        run: python scripts/check_faulthandler_timer_api_single_caller.py
+
+      - name: load-yaml-vocabulary
+        if: ${{ !cancelled() }}
+        run: python scripts/check_load_yaml_vocabulary.py
+
+      - name: media-store-unlink-single-caller
+        if: ${{ !cancelled() }}
+        run: python scripts/check_media_store_unlink_single_caller.py
+
+      - name: no-core-dep-importorskip
+        if: ${{ !cancelled() }}
+        run: python scripts/check_no_core_dep_importorskip.py
+
+      - name: silent-except-ratchet
+        if: ${{ !cancelled() }}
+        run: python scripts/silent_except_ratchet.py
+
+      - name: silent-except-return-reachability
+        if: ${{ !cancelled() }}
+        run: python scripts/check_silent_except_return_reachability.py
+
+      - name: suspected-time-dependence-ratchet
+        if: ${{ !cancelled() }}
+        run: python scripts/suspected_time_dependence_ratchet.py
+
+      # No `--check-growth` here (unlike this gate's own per-PR workflow,
+      # which passes `--check-growth "origin/${{ github.base_ref }}"`) —
+      # that flag needs a base ref to diff AGAINST, the same "no PR here to
+      # diff against" reason `tests-dir-names-gate` is excluded above. The
+      # bare form still checks the CURRENT measured counts against the
+      # committed baseline (the same skeleton `mypy_ratchet.py`'s own
+      # `--full`, argument-free invocation uses) — a real, narrower check,
+      # not a no-op: it still fails on a baseline the tree no longer
+      # matches, it just cannot ALSO catch a same-PR baseline edit gamed
+      # without a matching measured change (that half of the gate stays
+      # per-PR-only, same as it always was).
+      - name: tui-reactive-ratchet
+        if: ${{ !cancelled() }}
+        run: python scripts/check_tui_reactive_ratchet.py
+
+      - name: tui-widget-boundary
+        if: ${{ !cancelled() }}
+        run: python scripts/check_tui_widget_boundary.py
+
+      - name: unfiltered-caplog-consumption
+        if: ${{ !cancelled() }}
+        run: python scripts/check_unfiltered_caplog_consumption.py
+
+      - name: user-facing-lang
+        if: ${{ !cancelled() }}
+        run: python scripts/user_facing_lang_gate.py


### PR DESCRIPTION
**[tui-coder]** — `part of #6117`

Adds 14 of the 17 no-discovery-path gates (#6113) to `main-invariant-sweep.yml`'s step list — #4257 already applied the same fix to 9 other gates, for the same reason (a path-filtered, per-PR-only workflow cannot catch a break created by combining two independently-green PRs, and cannot become required either, since a PR that never touches the watched path would deadlock at `Expected — Waiting for status`).

## Measured, not assumed

Every one of the 17 was actually RUN against this tree (not just read) to confirm it needs no PR/diff context before adding it:

```
$ PYTHONPATH=src python3 scripts/audit_event_firing_condition_gate.py
audit-event firing-condition gate OK: 223 finding(s), all baselined (272 closed-vocabulary event kind(s) checked).
$ PYTHONPATH=src python3 scripts/bash_node_kind_count_ratchet.py
bash-node-kind-count ratchet OK: 236 node kind(s), matches baseline.
... (all 14 added here: rc=0, unmodified invocation)
```

## Breakdown (17 → 14 added / 2 excluded / 1 corrected out)

**14 added**, all confirmed runnable bare against `main`:
- 13 stdlib-only (no install needed): `audit-event-firing-condition-gate`, `ci-role-declared-gate`, `faulthandler-timer-api-single-caller-gate`, `load-yaml-vocabulary-gate`, `media-store-unlink-single-caller-gate`, `no-core-dep-importorskip-gate`, `silent-except-ratchet`, `silent-except-return-reachability`, `suspected-time-dependence-ratchet-gate`, `tui-widget-boundary-gate`, `unfiltered-caplog-consumption-gate`, `user-facing-lang-gate`, `tui-reactive-ratchet-gate` (bare form, no `--check-growth` — see the workflow's own new comment for what that drops and what it keeps).
- 1 needs `reyn` importable (`bash-node-kind-count-ratchet`) — costs nothing new: this sweep already gained a `pip install -e .` step in #6014.

**2 excluded, with a comment** (same shape as the file's existing 3 exclusions): `litellm-proxy-patch-scaffold` (owner ruling #5620: a deliberately ISOLATED Python 3.13 / `litellm[proxy]==1.95.0`-only venv — folding it in would break that isolation) and `check-doc-drift-fixture` (lead-coder ruling #5298: needs `fetch-depth: 0`, rejected from a shared shallow checkout for the same cost reason it's rejected here). Both already carry their OWN `push: branches: [main]` leg (path-scoped) — narrower than this sweep, but real, and neither is a whole-tree scan over unrelated files, so the composition-gap risk both exist to close is structurally small for them to begin with.

**1 corrected out** — `mypy (ratchet)` was miscounted into the 17 in my own #6113 census: `test.yml`'s `mypy-ratchet` job carries no `paths:` filter, so it already runs unconditionally on every PR (the same "no path filter" group as `sandbox-landlock-deny-gate`/`wheel-reachability` in #6113's own table) and already had a discovery path. No sweep entry needed; flagging the correction here since it was my own error.

## Not done here

- None of the 17 are made required (would deadlock a PR that never touches the path).
- The existing 3 exclusions (`tests-dir-names-gate`, `check-pr-closing-intent`, `dogfood-finding-triage`) are unchanged.
- `main sweep mirror verdict`'s required-status registration (#6113, pending the owner) is what turns a red from THESE 14 (and the existing 12) into an actual block on the next PR — this PR makes the red REAL, not yet BLOCKING. That's the owner's 1-line branch-protection edit, separate from this PR.

## Test plan

- [x] `ruff check .`
- [x] `mypy_ratchet.py` (no `.py` changed — n/a)
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] All 14 newly-added commands run against the real tree, rc=0, unmodified from their own per-PR invocation (shown above)
- [x] (skipped — Visual, standing waiver; n/a — no UI touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn

