### PR TITLE
docs(part of #4903): ADR-0043 Accepted (lead-coder ruling)

### DIFF
--- a/docs/deep-dives/decisions/0043-generic-secret-provider-seam.md
+++ b/docs/deep-dives/decisions/0043-generic-secret-provider-seam.md
@@ -1,6 +1,6 @@
 # ADR-0043: A generic `SecretProvider` seam — new consumers only, and the capability gate that already exists gets wired
 
-**Status**: Proposed (2026-08-19). Do not read `Proposed` as `Accepted`.
+**Status**: Accepted (2026-09-11, lead-coder ruling: https://github.com/tya5/reyn/issues/4903#issuecomment-5626833570). Proposed 2026-08-19.
 **Why this ADR exists**: M3 below — a capability gate that exists as code, is exercised 27 times by tests, and can deny nothing in production. That measurement is the whole basis; it stands on its own and depends on no one's interest.
 **Provenance, not motivation**: the review that produced this ADR (#4890) was started after an owner interest relayed via `reyn-reviewer` — **relayed, never confirmed by the owner to this ADR's author**. That relay is recorded here as history and is *not* a reason for any decision below. An attribution that might be wrong is worse than no attribution, so it is stated as what it is rather than removed.
 **Track**: Architecture — credential lookup, extending ADR-0030 (universal secret handling) and FP-0016 (OAuth lifecycle + scoped store).


### PR DESCRIPTION
**[architect]** — **lead-coder 裁定** → https://github.com/tya5/reyn/issues/4903#issuecomment-5626833570

## 変えたもの — **Status 行 1 行だけ**

```diff
- **Status**: Proposed (2026-08-19). Do not read `Proposed` as `Accepted`.
+ **Status**: Accepted (2026-09-11, lead-coder ruling: …#issuecomment-5626833570). Proposed 2026-08-19.
```

⭐ **本文は byte 単位で不変です**（**機械で確認: Status 行を元に戻すと file が完全一致**）。**diff は 1 行（+1/-1）。**
🔴 **`Provenance, not motivation` の段落も、M3 の再測註も そのまま**です — **accept した瞬間 immutable になるので、これが class 規則が許す最後の編集です**（`decisions/README.md`: **ADRs are immutable once accepted**）。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — OK
- [x] `python scripts/check_doc_anchors.py` — OK
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK
- [x] `ruff check .` — OK
- [x] (skipped — docs only, 1 行) `pytest` scoped to diff

## ⚠️ この PR には *入れていない* 発見

**`decisions/README.md` の一覧に、file が在るのに未掲載の ADR が 6 本 在ります**: **0021 / 0022 / 0023 / 0024 / 0025 / 0043。**
🔴 **0043 も その 1 つ** ∴ **Accepted になっても、一覧からは辿れません。**
⚠️ **発注は「Status 行だけ」なので入れていません。** ⭐ **単発ではなくクラス（6 本）なので、別途 裁定してください。**

part of #4903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow