### PR TITLE
fix(part of #6084): widen user_facing_lang_gate's _SCOPE to src/reyn

### DIFF
--- a/.github/workflows/user-facing-lang-gate.yml
+++ b/.github/workflows/user-facing-lang-gate.yml
@@ -1,21 +1,24 @@
 name: user-facing-lang gate
 
 # #6084: ratchets a NEW undecided-language (Japanese) literal landing
-# directly at a confirmed user-facing-text sink call site under
-# src/reyn/interfaces/ -- see scripts/user_facing_lang_gate.py's own module
-# docstring for the exact sinks covered and lead-coder's ruling on scope
-# (sink-derivable range only, never full-population coverage; the ~89
-# already-existing kana-bearing strings this repo carries are a SEPARATE,
-# wider count -- this gate's own baseline, scripts/
-# user_facing_lang_gate_baseline.json, is narrower by design).
+# directly at a confirmed user-facing-text sink call site under src/reyn/
+# -- see scripts/user_facing_lang_gate.py's own module docstring for the
+# exact sinks covered and lead-coder's ruling on scope (sink-derivable
+# range only, never full-population coverage; the already-existing
+# kana-bearing strings this repo carries are a SEPARATE, wider count --
+# this gate's own baseline, scripts/user_facing_lang_gate_baseline.json,
+# is narrower by design).
 #
-# `paths: src/reyn/interfaces/**` matches this gate's own v1 scope exactly
-# -- same reasoning as silent-except-ratchet-gate.yml's identical path
-# scoping.
+# `paths: src/reyn/**` (widened from the gate's own v1 scope,
+# src/reyn/interfaces/**, per #6084 hole ⑶ -- #6104's CI caught a real
+# duplicate OUTSIDE the v1 scope, src/reyn/runtime/lifecycle_forwarder.py,
+# that this workflow's OLD paths: filter would never even have RUN
+# against). Matches the gate's own _SCOPE constant exactly -- same
+# reasoning as silent-except-ratchet-gate.yml's identical path scoping.
 on:
   pull_request:
     paths:
-      - "src/reyn/interfaces/**"
+      - "src/reyn/**"
       - "scripts/user_facing_lang_gate.py"
       - "scripts/user_facing_lang_gate_baseline.json"
 

--- a/scripts/user_facing_lang_gate.py
+++ b/scripts/user_facing_lang_gate.py
@@ -1,6 +1,24 @@
 #!/usr/bin/env python3
 """#6084 — a ratchet over user-facing-text sink call sites carrying an
-undecided (Japanese-literal) string, under `src/reyn/interfaces/`.
+undecided (Japanese-literal) string, under `src/reyn/`.
+
+## Scope widened from `src/reyn/interfaces/` to `src/reyn/` (hole ⑶)
+
+#6104's CI caught a real user-facing duplicate OUTSIDE the original
+`src/reyn/interfaces/` scope (`src/reyn/runtime/lifecycle_forwarder.py`,
+fixed by #6106/#6114) — this gate's own "0 findings" never saw it, because
+the file was never in `_iter_scan_files`'s population at all, not because
+its content had no kana. lead-coder's own #6084 hole ⑶ measurement
+(e2e-coder, `#6084` issue thread comment): the correct discriminator for
+this gate was ALWAYS "does a literal reach one of `_SINK_SPECS`'s sink
+calls", never "which directory is it in" — a `path`-only scope restriction
+was an accident of the gate's own first draft, not a deliberate boundary.
+Widening the scanned PATH to all of `src/reyn/` does not loosen the
+discriminator (`_SINK_SPECS` is unchanged) — it only lets that SAME
+discriminator see more of the tree. `scripts/`/`docs/`/`tests/` remain
+OUT of scope — `tests/` in particular carries this gate's own fixture
+files, which exist specifically to contain unflagged/flagged literals for
+the test suite and must never feed the real baseline.
 
 ## What this gate is, precisely — read lead-coder's ruling on #6084 first
 
@@ -122,7 +140,7 @@ from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
 _BASELINE_PATH = _ROOT / "scripts" / "user_facing_lang_gate_baseline.json"
-_SCOPE = "src/reyn/interfaces"
+_SCOPE = "src/reyn"
 
 # Kana (hiragana + katakana) only — see module docstring's "Detection
 # basis" section for why this deliberately does not widen to CJK
@@ -144,7 +162,7 @@ _SINK_SPECS: "dict[str, list[tuple[str, object]]]" = {
 
 
 def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
-    """Every tracked `.py` file under `src/reyn/interfaces/` — same
+    """Every tracked `.py` file under `_SCOPE` (`src/reyn/`) — same
     population source (`git ls-files`) `silent_except_ratchet.py` uses,
     for the same reason: no hand-maintained exclusion list."""
     proc = subprocess.run(


### PR DESCRIPTION
**[e2e-coder]** — lead-coder's裁定 on #6084 hole ⑶: https://github.com/tya5/reyn/issues/6084#issuecomment-5626744412

part of #6084

## What changed
`_SCOPE` widened from `src/reyn/interfaces` to `src/reyn`. `_SINK_SPECS` is **unchanged** — widening the scanned PATH does not loosen the discriminator (lead-coder's own framing: "path は *どこを見るか* を決めるだけで、*何を所見とするか* は sink が決める" — widening does not loosen the discriminator). `scripts/`, `docs/`, and `tests/` remain explicitly out of scope — `tests/` in particular carries this gate's own fixture files (kana literals that exist on purpose for the test suite), which must never feed the real baseline.

`.github/workflows/user-facing-lang-gate.yml`'s own `paths:` trigger widened to match (`src/reyn/interfaces/**` → `src/reyn/**`) — otherwise a PR touching a file like `lifecycle_forwarder.py` again would never even RUN this workflow, reproducing the exact gap #6104 exposed one layer up.

## No translation work included
Per the original #6084 ruling, this PR does not translate any existing findings (owner's own gate). None exist to translate here anyway — baseline is empty before AND after (0 findings both scopes), confirmed by `--write-baseline` producing a byte-identical `[]`, not assumed.

## Witness — sink calls scanned, before → after (this PR's own real gate runs)
```
before: user-facing-lang gate OK: scanned 506 sink call site(s) across 144 file(s) under src/reyn/interfaces/, 0 finding(s) (all baselined). ...
after:  user-facing-lang gate OK: scanned 538 sink call site(s) across 654 file(s) under src/reyn/, 0 finding(s) (all baselined). ...
```

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py` (no changed files relative to main outside this scope — nothing new to check), `check_ci_role_declared.py`.

## Pytest (diff-scoped, foreground)
`pytest tests/scripts/test_user_facing_lang_gate_6084.py -q` → 13 passed. (No full suite — per your brief.)

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. CI and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S