### PR TITLE
part of #5989: recover stuck sent-queue items instead of silently rejecting

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -8,19 +8,23 @@ rewind picker / sent-queue / input — shared with the sibling #3299 arc, see
 ``app.py``'s :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.compose`).
 
 The "upward conveyor" lifecycle (the owner-ratified sent-queue exit contract,
-#3300 issue §6a) — this widget renders all THREE exits:
+#3300 issue §6a) — this widget renders ONE entrance and TWO exits (#5989 ④:
+a prior revision of this docstring read "THREE exits", which listed the
+entrance as if it were a third exit — that miscount let a reviewer read "the
+exits are sufficient" when a genuine gap existed; see :mod:`~reyn.interfaces.
+transport.agui.state`'s ``RemoteQueueView`` for the fix):
 
-- ``user_submitted`` → :meth:`show_item` — a submitted message first appears
-  HERE (dim, queued), not immediately as a flow entry. This REPLACES P1 C's
-  "render the echo directly as a flow entry": for an idle server the
-  promotion below follows almost instantly; for a busy/queued submission the
-  item stays visible here until dispatch.
-- ``turn_started`` → :meth:`remove_item` — the PROMOTE exit: the app removes
+- ``user_submitted`` → :meth:`show_item` — the ENTRANCE: a submitted message
+  first appears HERE (dim, queued), not immediately as a flow entry. This
+  REPLACES P1 C's "render the echo directly as a flow entry": for an idle
+  server the promotion below follows almost instantly; for a busy/queued
+  submission the item stays visible here until dispatch.
+- ``turn_started`` → :meth:`remove_item` — exit 1, the PROMOTE exit: the app removes
   the item from this widget and appends it as a flow entry (the user line) in
   the SAME step (see ``app.py``'s ``_pump_frames`` — the removal here and the
   flow-entry append are driven from one delta so there is never a frame where
   the item is both queued and already in the flow, or neither).
-- ``inbox_cancel`` → :meth:`remove_item` — the REMOVE exit (#3300 Y-client):
+- ``inbox_cancel`` → :meth:`remove_item` — exit 2, the REMOVE exit (#3300 Y-client):
   driven by the server-authoritative delta, never by a local "cancel
   succeeded" return value (``app.py``'s ``_handle_inbox_cancel_event``). The
   canceller ADDITIONALLY restores the text into the composer — that half is
@@ -31,8 +35,8 @@ seq-gated merge (the P2a order-race protocol, reused as-is — see the app
 module docstring); this widget is a pure renderer of whatever the app tells it
 to show/remove, keyed by ``msg_id``.
 
-**A fourth, LOCAL entry (#4409)**: before any of the three server-driven
-exits above can fire, ``app.py``'s ``on_composer_submitted`` calls
+**A second, LOCAL entrance (#4409)**: before the server-driven entrance/exits
+above can fire, ``app.py``'s ``on_composer_submitted`` calls
 :meth:`show_item` with ``sending=True`` and a LOCALLY-generated id,
 synchronously with clearing the composer — closing the gap the owner
 reported ("input box から消えると同時に... 消えること多い"): between a

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -439,10 +439,13 @@ class RemoteQueueView:
         ``Session._commit_mid_turn_injection``'s ``await self._journal.
         consume_inbox(msg_id=msg_id)`` is immediately followed by
         ``self._audit_events.emit("turn_started", ..., seq=self.
-        _bump_queue_seq())``; ``InboxArbiter.drain_to_wake``'s own
-        ``await self._journal.consume_inbox(msg_id=msg_id_nb)`` is
-        followed, with no await in between, by the caller's own
-        ``turn_started`` emit once ``drain_to_wake`` returns. Do not
+        _bump_queue_seq())``; both of ``InboxArbiter.drain_to_wake``'s own
+        prune sites — the common trigger path, ``_journal_and_filter``'s
+        ``await self._journal.consume_inbox(msg_id=msg_id)``, and the
+        non-blocking ride-along branch's ``await self._journal.
+        consume_inbox(msg_id=msg_id_nb)`` — are each followed, with no
+        await in between, by the caller's own ``turn_started`` emit once
+        ``drain_to_wake`` returns. Do not
         re-derive or re-assert the withdrawn scenario from this
         docstring).
 

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -331,6 +331,17 @@ class RemoteQueueView:
     delta stream: no duplicate (a replayed delta's ``seq`` was already
     applied), no resurrection-after-dispatch (the above), no loss (a delta
     whose ``seq`` IS new is always applied).
+
+    Two narrow, deliberate exceptions to "the gate discards a rejected
+    delta": :meth:`apply_user_submitted`'s ``is_own_pending`` (an identity-
+    confirmed echo for the caller's own still-pending submission) and
+    :meth:`apply_turn_started`/:meth:`apply_inbox_cancel`'s ``stuck``
+    (#5989 — a rejected delta whose matching item is STILL present in
+    :attr:`items`, proving it was never actually applied, and which has no
+    other delta that will ever arrive to apply it). Both apply the delta
+    (mutate :attr:`items`) without regressing :attr:`_last_seq` backward —
+    the ordering guarantee this docstring describes above is about OTHER
+    items, and stays intact for them either way.
     """
 
     items: dict = field(default_factory=dict)  # msg_id -> {msg_id, chain_id, text}
@@ -390,7 +401,7 @@ class RemoteQueueView:
     def apply_turn_started(self, *, chain_id: "str | None", seq: int) -> bool:
         """Apply a dispatch delta (removes the queued item matching
         ``chain_id``, if any); returns False (no-op) if the seq gate rejects
-        it as already reflected.
+        it AND no matching item is stuck (see the ``stuck`` exception below).
 
         #5989 ③ (lead-coder review, self-correction on the earlier "the log
         was empty so nothing failed" reading — this class had zero
@@ -401,27 +412,51 @@ class RemoteQueueView:
         here is EXPECTED (a genuine replay — this exact dispatch was
         already applied, and its matching queued item is already gone) when
         no item with this ``chain_id`` remains in :attr:`items` — logged at
-        ``DEBUG``. It is SUSPICIOUS (the item this delta would have
-        promoted/removed is still sitting here, un-promoted — exactly the
-        shape of a wrongly-rejected delta, not a correctly-rejected one)
-        when a matching item DOES remain — logged at ``WARNING``. No new
-        state: both branches only ever READ :attr:`items`, the same
-        collection the gate already owns."""
-        if seq <= self._last_seq:
-            stuck = [item for item in self.items.values() if item.get("chain_id") == chain_id]
-            log = logger.warning if stuck else logger.debug
-            log(
+        ``DEBUG``.
+
+        #5989 ④ (architect design, lead-coder ruling — the recovery half
+        ③ only observed): when a matching item DOES remain (``stuck``
+        non-empty), this is no longer merely SUSPICIOUS, it is the proven
+        defect ③ found and never closed — architect's own root cause:
+        :meth:`apply_snapshot` is the only ``_last_seq`` writer that
+        ASSIGNS rather than advances, so a ``turn_started`` generated
+        BEFORE a snapshot but delivered after it reads ``seq <=
+        self._last_seq`` and is rejected — and ``turn_started`` is a
+        once-per-turn edge the server never resends, so a rejected item
+        has no OTHER delta that will ever promote it; it would sit in
+        :attr:`items` forever. ``stuck`` non-empty is itself the proof
+        this delta was never actually applied (an already-applied item
+        would already be gone), so applying it here can never create a
+        double-promote — the SAME exception shape
+        :meth:`apply_user_submitted`'s own ``is_own_pending`` already
+        uses: apply the delta (remove the stuck item(s)), but do not
+        regress :attr:`_last_seq` backward — the ordering guarantee every
+        OTHER item's own gate relies on is untouched, because this delta
+        is being honored for IDENTITY (a specific stuck item), not for
+        ORDER. Still logged at ``WARNING`` — the rejection itself is still
+        the anomaly worth knowing about, only the outcome changed from
+        "logged and dropped" to "logged and recovered"."""
+        stuck = [item for item in self.items.values() if item.get("chain_id") == chain_id]
+        if seq <= self._last_seq and not stuck:
+            logger.debug(
                 "RemoteQueueView: seq-gate rejected turn_started (chain_id=%r, seq=%r, "
-                "baseline=%r) — %s",
+                "baseline=%r) — already reflected, no matching item remains",
                 chain_id, seq, self._last_seq,
-                "a matching queued item is STILL present (unpromoted)" if stuck
-                else "already reflected, no matching item remains",
             )
             return False
+        if seq <= self._last_seq:
+            logger.warning(
+                "RemoteQueueView: seq-gate rejected turn_started (chain_id=%r, seq=%r, "
+                "baseline=%r) — a matching queued item is STILL present (unpromoted); "
+                "applying it anyway (#5989 stuck-item exception) without advancing "
+                "the seq gate",
+                chain_id, seq, self._last_seq,
+            )
         for msg_id, item in list(self.items.items()):
             if item.get("chain_id") == chain_id:
                 del self.items[msg_id]
-        self._last_seq = seq
+        if seq > self._last_seq:
+            self._last_seq = seq
         return True
 
     def apply_inbox_cancel(self, *, msg_id: str, seq: int) -> bool:
@@ -429,31 +464,41 @@ class RemoteQueueView:
         queued item BY ITS OWN msg_id (unlike ``apply_turn_started``, which
         matches by ``chain_id``: a cancel targets one specific queued item,
         never a whole chain). Returns ``False`` (no-op) if the seq gate
-        rejects it as already reflected by a prior snapshot/delta — same
-        order-race protocol as ``apply_user_submitted``/``apply_turn_started``
-        (design-pass pin D): exclusive with a ``turn_started`` for the same
-        item (the server guarantees only one of the two ever fires,
-        issue #3300 owner addendum §6a), so no double-removal ambiguity.
+        rejects it AND the targeted item is not stuck (see :meth:`apply_
+        turn_started`'s own ``stuck`` exception, applied here the same way)
+        — same order-race protocol as ``apply_user_submitted``/
+        ``apply_turn_started`` (design-pass pin D): exclusive with a
+        ``turn_started`` for the same item (the server guarantees only one
+        of the two ever fires, issue #3300 owner addendum §6a), so no
+        double-removal ambiguity.
 
-        #5989 ③: same discriminator as :meth:`apply_turn_started` — EXPECTED
-        (``DEBUG``) when ``msg_id`` is already absent from :attr:`items`
-        (already removed, a genuine replay of a cancel already applied);
-        SUSPICIOUS (``WARNING``) when it is still present (the row this
-        cancel targets never left the queue — the operator who cancelled it
-        would see it sitting there regardless)."""
-        if seq <= self._last_seq:
-            stuck = msg_id in self.items
-            log = logger.warning if stuck else logger.debug
-            log(
+        #5989 ③/④: same discriminator and same recovery as :meth:`apply_
+        turn_started` — EXPECTED (``DEBUG``) when ``msg_id`` is already
+        absent from :attr:`items` (already removed, a genuine replay of a
+        cancel already applied); when it is still present (``stuck``), this
+        cancel is applied anyway (the item removed) without regressing
+        :attr:`_last_seq` — the same "``stuck`` non-empty proves this delta
+        was never actually applied" reasoning :meth:`apply_turn_started`'s
+        own docstring gives in full."""
+        stuck = msg_id in self.items
+        if seq <= self._last_seq and not stuck:
+            logger.debug(
                 "RemoteQueueView: seq-gate rejected inbox_cancel (msg_id=%r, seq=%r, "
-                "baseline=%r) — %s",
+                "baseline=%r) — already reflected, item already absent",
                 msg_id, seq, self._last_seq,
-                "the targeted item is STILL present (uncancelled)" if stuck
-                else "already reflected, item already absent",
             )
             return False
+        if seq <= self._last_seq:
+            logger.warning(
+                "RemoteQueueView: seq-gate rejected inbox_cancel (msg_id=%r, seq=%r, "
+                "baseline=%r) — the targeted item is STILL present (uncancelled); "
+                "applying it anyway (#5989 stuck-item exception) without advancing "
+                "the seq gate",
+                msg_id, seq, self._last_seq,
+            )
         self.items.pop(msg_id, None)
-        self._last_seq = seq
+        if seq > self._last_seq:
+            self._last_seq = seq
         return True
 
     def apply_turn_active(self, turn_active: bool) -> None:

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -421,7 +421,8 @@ class RemoteQueueView:
 
         This state — a queued item present in :attr:`items` while its own
         ``turn_started`` carries ``seq <= self._last_seq`` — is REAL: this
-        very ``WARNING`` branch exists to name it, and it matches the
+        very ``WARNING`` branch exists to name it (pre-existing on
+        ``main``, #5989 ③ — this PR did not add it), and it matches the
         owner's real #5989 symptom (a sent-queue item stuck forever, never
         promoted, since ``turn_started`` is a once-per-turn edge the
         server never resends — a rejected item would have no OTHER delta
@@ -430,10 +431,20 @@ class RemoteQueueView:
         this docstring named ``apply_snapshot``'s unconditional
         ``_last_seq`` assignment as the cause via a specific
         generated-before/delivered-after reconnect-snapshot scenario; that
-        scenario's ``apply_inbox_cancel`` counterpart was checked against
-        ``SnapshotJournal.cancel_inbox``'s prune-then-emit ordering during
-        PR #6123 review and withdrawn as unproducible by the server —
-        do not re-derive or re-assert it from this docstring).
+        scenario was withdrawn during PR #6123 review as unproducible by
+        the server — checked not only against its ``apply_inbox_cancel``
+        counterpart but against ``turn_started``'s OWN emission ordering:
+        both dispatch paths prune before stamping the delta's own seq, the
+        SAME prune-then-bump ordering ``SnapshotJournal.cancel_inbox`` has.
+        ``Session._commit_mid_turn_injection``'s ``await self._journal.
+        consume_inbox(msg_id=msg_id)`` is immediately followed by
+        ``self._audit_events.emit("turn_started", ..., seq=self.
+        _bump_queue_seq())``; ``InboxArbiter.drain_to_wake``'s own
+        ``await self._journal.consume_inbox(msg_id=msg_id_nb)`` is
+        followed, with no await in between, by the caller's own
+        ``turn_started`` emit once ``drain_to_wake`` returns. Do not
+        re-derive or re-assert the withdrawn scenario from this
+        docstring).
 
         ``stuck`` non-empty is itself the proof this delta was never
         actually applied (an already-applied item would already be gone),

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -417,25 +417,36 @@ class RemoteQueueView:
         #5989 ④ (architect design, lead-coder ruling — the recovery half
         ③ only observed): when a matching item DOES remain (``stuck``
         non-empty), this is no longer merely SUSPICIOUS, it is the proven
-        defect ③ found and never closed — architect's own root cause:
-        :meth:`apply_snapshot` is the only ``_last_seq`` writer that
-        ASSIGNS rather than advances, so a ``turn_started`` generated
-        BEFORE a snapshot but delivered after it reads ``seq <=
-        self._last_seq`` and is rejected — and ``turn_started`` is a
-        once-per-turn edge the server never resends, so a rejected item
-        has no OTHER delta that will ever promote it; it would sit in
-        :attr:`items` forever. ``stuck`` non-empty is itself the proof
-        this delta was never actually applied (an already-applied item
-        would already be gone), so applying it here can never create a
-        double-promote — the SAME exception shape
-        :meth:`apply_user_submitted`'s own ``is_own_pending`` already
-        uses: apply the delta (remove the stuck item(s)), but do not
-        regress :attr:`_last_seq` backward — the ordering guarantee every
-        OTHER item's own gate relies on is untouched, because this delta
-        is being honored for IDENTITY (a specific stuck item), not for
-        ORDER. Still logged at ``WARNING`` — the rejection itself is still
-        the anomaly worth knowing about, only the outcome changed from
-        "logged and dropped" to "logged and recovered"."""
+        defect ③ found and never closed.
+
+        This state — a queued item present in :attr:`items` while its own
+        ``turn_started`` carries ``seq <= self._last_seq`` — is REAL: this
+        very ``WARNING`` branch exists to name it, and it matches the
+        owner's real #5989 symptom (a sent-queue item stuck forever, never
+        promoted, since ``turn_started`` is a once-per-turn edge the
+        server never resends — a rejected item would have no OTHER delta
+        that will ever promote it). **The server-side PATH that produces
+        this state is UNIDENTIFIED as of this PR** (an earlier draft of
+        this docstring named ``apply_snapshot``'s unconditional
+        ``_last_seq`` assignment as the cause via a specific
+        generated-before/delivered-after reconnect-snapshot scenario; that
+        scenario's ``apply_inbox_cancel`` counterpart was checked against
+        ``SnapshotJournal.cancel_inbox``'s prune-then-emit ordering during
+        PR #6123 review and withdrawn as unproducible by the server —
+        do not re-derive or re-assert it from this docstring).
+
+        ``stuck`` non-empty is itself the proof this delta was never
+        actually applied (an already-applied item would already be gone),
+        so applying it here can never create a double-promote — the SAME
+        exception shape :meth:`apply_user_submitted`'s own
+        ``is_own_pending`` already uses: apply the delta (remove the stuck
+        item(s)), but do not regress :attr:`_last_seq` backward — the
+        ordering guarantee every OTHER item's own gate relies on is
+        untouched, because this delta is being honored for IDENTITY (a
+        specific stuck item), not for ORDER. Still logged at ``WARNING``
+        — the rejection itself is still the anomaly worth knowing about,
+        only the outcome changed from "logged and dropped" to "logged and
+        recovered"."""
         stuck = [item for item in self.items.values() if item.get("chain_id") == chain_id]
         if seq <= self._last_seq and not stuck:
             logger.debug(

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -428,17 +428,20 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
     ## The server-side path is explicitly UNIDENTIFIED — do not infer one
     Two proposed reproductions (an out-of-order pair of DELTAS, then an
     ``apply_snapshot(queue=[m2], queue_seq=3)`` "reconnect snapshot taken
-    after m2's own cancel was generated") were each checked against
-    ``SnapshotJournal.cancel_inbox`` (``snapshot_journal.py``) and both
-    conflict with it: ``cancel_inbox`` synchronously prunes the SAME
-    snapshot collection a subsequent snapshot's own ``queue``/``queue_seq``
-    are read from (``consume_inbox``'s sibling, same file, lines ~203-224),
-    so a snapshot can never simultaneously (a) still list ``m2`` in
-    ``queue`` and (b) carry a ``queue_seq`` already past ``m2``'s own
-    cancel — the two proposed shapes are mutually exclusive with the
-    server's own prune-then-snapshot ordering. The server-side path that
-    produces this state is UNIDENTIFIED as of this PR; do not read the
-    ``apply_snapshot`` call below as a claim that it is."""
+    after m2's own cancel was generated") were each checked against the
+    real ordering and both conflict with it. The correct exclusivity is:
+    ``Session.cancel_queued`` prunes via ``SnapshotJournal.cancel_inbox``
+    (``self._snapshot.inbox = [m for m in self._snapshot.inbox if
+    m.get("id") != msg_id]``) BEFORE it stamps the delta's own ``seq``
+    (``seq=self._bump_queue_seq()``) — prune always precedes the seq
+    bump for ``m2``'s own cancel, so no real snapshot can simultaneously
+    (a) still list ``m2`` in ``queue`` and (b) reflect a ``queue_seq``
+    that already accounts for ``m2``'s own cancel. This rules out BOTH
+    proposed shapes; it is an explanation of the EXCLUSIVITY, not a
+    demonstrated path to the state under test — the server-side path
+    that produces this state remains UNIDENTIFIED as of this PR. Do not
+    read the ``apply_snapshot`` call below as a claim that it is one,
+    and do not supply a third unverified path in its place."""
     view = RemoteQueueView()
     view.apply_snapshot(
         queue=[{"msg_id": "m2", "chain_id": "c2", "text": "bye"}],

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -440,11 +440,12 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
       (a) still list ``m2`` in ``queue`` and (b) reflect a ``queue_seq``
       that already accounts for ``m2``'s own cancel. This rules out the
       ``apply_snapshot`` shape.
-    - The out-of-order pair of DELTAS shape is excluded SEPARATELY — by
-      the monotonic single-counter emission order (a single session, one
-      event loop, one ``_queue_seq`` counter never actually emits two
-      DIFFERENT deltas racing out of order that way), not by the prune
-      ordering above.
+    - The out-of-order pair of DELTAS shape rests on a SEPARATE argument,
+      not on the prune ordering above: a single session with one event
+      loop and one ``_queue_seq`` counter EMITS deltas in seq order. That
+      covers EMISSION only — whether the transport can DELIVER two
+      deltas to a client out of that order was NOT verified during PR
+      #6123 review. Recorded here as unverified, not as established.
 
     Neither exclusion is a demonstrated path to the state under test —
     the server-side path that produces this state remains UNIDENTIFIED as

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -420,28 +420,37 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
     The state — ``m2`` present in :attr:`RemoteQueueView.items` while a
     matching ``inbox_cancel`` for ``m2`` carries ``seq <= _last_seq`` — is
     REAL: :meth:`apply_inbox_cancel`'s own ``WARNING`` branch in
-    ``state.py`` exists to name exactly this condition, and it is the
+    ``state.py`` exists to name exactly this condition (pre-existing on
+    ``main``, #5989 ③ — this PR did not add that branch), and it is the
     condition behind the owner's own real #5989 symptom (a sent-queue item
     stuck forever). This test exercises the SAME predicate branch
     :class:`RemoteQueueView` itself already treats as reachable.
 
     ## The server-side path is explicitly UNIDENTIFIED — do not infer one
-    Two proposed reproductions (an out-of-order pair of DELTAS, then an
-    ``apply_snapshot(queue=[m2], queue_seq=3)`` "reconnect snapshot taken
-    after m2's own cancel was generated") were each checked against the
-    real ordering and both conflict with it. The correct exclusivity is:
-    ``Session.cancel_queued`` prunes via ``SnapshotJournal.cancel_inbox``
-    (``self._snapshot.inbox = [m for m in self._snapshot.inbox if
-    m.get("id") != msg_id]``) BEFORE it stamps the delta's own ``seq``
-    (``seq=self._bump_queue_seq()``) — prune always precedes the seq
-    bump for ``m2``'s own cancel, so no real snapshot can simultaneously
-    (a) still list ``m2`` in ``queue`` and (b) reflect a ``queue_seq``
-    that already accounts for ``m2``'s own cancel. This rules out BOTH
-    proposed shapes; it is an explanation of the EXCLUSIVITY, not a
-    demonstrated path to the state under test — the server-side path
-    that produces this state remains UNIDENTIFIED as of this PR. Do not
-    read the ``apply_snapshot`` call below as a claim that it is one,
-    and do not supply a third unverified path in its place."""
+    Two proposed reproductions were each checked and separately excluded —
+    by TWO DIFFERENT arguments, not one:
+
+    - The ``apply_snapshot(queue=[m2], queue_seq=3)`` "reconnect snapshot
+      taken after m2's own cancel was generated" shape: ``Session.
+      cancel_queued`` prunes via ``SnapshotJournal.cancel_inbox``
+      (``self._snapshot.inbox = [m for m in self._snapshot.inbox if
+      m.get("id") != msg_id]``) BEFORE it stamps the delta's own ``seq``
+      (``seq=self._bump_queue_seq()``) — prune always precedes the seq
+      bump for ``m2``'s own cancel, so no real snapshot can simultaneously
+      (a) still list ``m2`` in ``queue`` and (b) reflect a ``queue_seq``
+      that already accounts for ``m2``'s own cancel. This rules out the
+      ``apply_snapshot`` shape.
+    - The out-of-order pair of DELTAS shape is excluded SEPARATELY — by
+      the monotonic single-counter emission order (a single session, one
+      event loop, one ``_queue_seq`` counter never actually emits two
+      DIFFERENT deltas racing out of order that way), not by the prune
+      ordering above.
+
+    Neither exclusion is a demonstrated path to the state under test —
+    the server-side path that produces this state remains UNIDENTIFIED as
+    of this PR. Do not read the ``apply_snapshot`` call below as a claim
+    that it is one, and do not supply a third unverified path in its
+    place."""
     view = RemoteQueueView()
     view.apply_snapshot(
         queue=[{"msg_id": "m2", "chain_id": "c2", "text": "bye"}],

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -409,27 +409,36 @@ def test_remote_queue_view_apply_inbox_cancel_removes_by_msg_id():
     assert [i["msg_id"] for i in view.queue()] == ["m2"]
 
 
-def test_remote_queue_view_apply_inbox_cancel_recovers_a_delta_delayed_past_a_snapshot():
-    """Tier 1: #5989 ④ (lead-coder review, BLOCKING on PR #6123, then
-    resolved with architect — https://github.com/tya5/reyn/issues/5989):
-    the OLD version of this test used ``m1``'s cancel (seq=3) to reach
-    ``_last_seq == 3`` and then replayed ``m2``'s OWN already-consumed
-    seq (2) against it, naming that a "stale/duplicate" that must no-op —
-    but a single monotonic seq counter, one event loop, same session,
-    never actually produces two DIFFERENT deltas racing out of order that
-    way; that arrangement was not a real protocol state.
+def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
+    """Tier 1: #5989 ④ (lead-coder review, BLOCKING on PR #6123 twice —
+    https://github.com/tya5/reyn/issues/5989, PR comments 5627521737 and
+    5627607454). This test DIRECTLY CONSTRUCTS the state below via
+    ``apply_snapshot`` — it is a state-construction tool here, not a claim
+    about how the state arises on the wire.
 
-    The REAL state this predicate answers for is reached only via a
-    ``snapshot`` whose own ``queue_seq`` already supersedes ``m2``'s own
-    (real, seq=2) cancel — e.g. a reconnect snapshot taken after some
-    LATER event (queue_seq=3), while ``m2``'s own cancel, generated
-    BEFORE that snapshot, is still in flight and arrives after it. Same
-    root cause :meth:`apply_turn_started`'s own ``stuck`` exception exists
-    for (#5989 ③/④): ``apply_snapshot`` is the only ``_last_seq`` writer
-    that ASSIGNS rather than advances, and ``inbox_cancel`` is a one-shot,
-    per-msg_id edge the server never resends — so a rejected cancel of
-    this shape has no OTHER delta that will ever remove ``m2``; it would
-    stay queued forever. The fix applies it instead."""
+    ## Why this state matters (the witness, not "because it's possible")
+    The state — ``m2`` present in :attr:`RemoteQueueView.items` while a
+    matching ``inbox_cancel`` for ``m2`` carries ``seq <= _last_seq`` — is
+    REAL: :meth:`apply_inbox_cancel`'s own ``WARNING`` branch in
+    ``state.py`` exists to name exactly this condition, and it is the
+    condition behind the owner's own real #5989 symptom (a sent-queue item
+    stuck forever). This test exercises the SAME predicate branch
+    :class:`RemoteQueueView` itself already treats as reachable.
+
+    ## The server-side path is explicitly UNIDENTIFIED — do not infer one
+    Two proposed reproductions (an out-of-order pair of DELTAS, then an
+    ``apply_snapshot(queue=[m2], queue_seq=3)`` "reconnect snapshot taken
+    after m2's own cancel was generated") were each checked against
+    ``SnapshotJournal.cancel_inbox`` (``snapshot_journal.py``) and both
+    conflict with it: ``cancel_inbox`` synchronously prunes the SAME
+    snapshot collection a subsequent snapshot's own ``queue``/``queue_seq``
+    are read from (``consume_inbox``'s sibling, same file, lines ~203-224),
+    so a snapshot can never simultaneously (a) still list ``m2`` in
+    ``queue`` and (b) carry a ``queue_seq`` already past ``m2``'s own
+    cancel — the two proposed shapes are mutually exclusive with the
+    server's own prune-then-snapshot ordering. The server-side path that
+    produces this state is UNIDENTIFIED as of this PR; do not read the
+    ``apply_snapshot`` call below as a claim that it is."""
     view = RemoteQueueView()
     view.apply_snapshot(
         queue=[{"msg_id": "m2", "chain_id": "c2", "text": "bye"}],
@@ -438,7 +447,7 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_delta_delayed_past_a_sn
 
     recovered = view.apply_inbox_cancel(msg_id="m2", seq=2)
 
-    assert recovered is True, "m2's own delayed cancel must be applied, not dropped"
+    assert recovered is True, "m2's cancel must be applied, not dropped"
     assert view.queue() == [], "m2 must not stay queued forever"
 
 

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -408,10 +408,38 @@ def test_remote_queue_view_apply_inbox_cancel_removes_by_msg_id():
     assert removed is True
     assert [i["msg_id"] for i in view.queue()] == ["m2"]
 
-    # stale/duplicate cancel delta (seq not strictly greater) is a no-op.
-    stale = view.apply_inbox_cancel(msg_id="m2", seq=2)
-    assert stale is False
-    assert [i["msg_id"] for i in view.queue()] == ["m2"]
+
+def test_remote_queue_view_apply_inbox_cancel_recovers_a_delta_delayed_past_a_snapshot():
+    """Tier 1: #5989 ④ (lead-coder review, BLOCKING on PR #6123, then
+    resolved with architect — https://github.com/tya5/reyn/issues/5989):
+    the OLD version of this test used ``m1``'s cancel (seq=3) to reach
+    ``_last_seq == 3`` and then replayed ``m2``'s OWN already-consumed
+    seq (2) against it, naming that a "stale/duplicate" that must no-op —
+    but a single monotonic seq counter, one event loop, same session,
+    never actually produces two DIFFERENT deltas racing out of order that
+    way; that arrangement was not a real protocol state.
+
+    The REAL state this predicate answers for is reached only via a
+    ``snapshot`` whose own ``queue_seq`` already supersedes ``m2``'s own
+    (real, seq=2) cancel — e.g. a reconnect snapshot taken after some
+    LATER event (queue_seq=3), while ``m2``'s own cancel, generated
+    BEFORE that snapshot, is still in flight and arrives after it. Same
+    root cause :meth:`apply_turn_started`'s own ``stuck`` exception exists
+    for (#5989 ③/④): ``apply_snapshot`` is the only ``_last_seq`` writer
+    that ASSIGNS rather than advances, and ``inbox_cancel`` is a one-shot,
+    per-msg_id edge the server never resends — so a rejected cancel of
+    this shape has no OTHER delta that will ever remove ``m2``; it would
+    stay queued forever. The fix applies it instead."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m2", "chain_id": "c2", "text": "bye"}],
+        turn_active=False, queue_seq=3,
+    )
+
+    recovered = view.apply_inbox_cancel(msg_id="m2", seq=2)
+
+    assert recovered is True, "m2's own delayed cancel must be applied, not dropped"
+    assert view.queue() == [], "m2 must not stay queued forever"
 
 
 @pytest.mark.asyncio

--- a/tests/interfaces/test_5989_3_queue_view_rejection_observability.py
+++ b/tests/interfaces/test_5989_3_queue_view_rejection_observability.py
@@ -23,6 +23,16 @@ NOT flood the operational log at WARNING.
 Real ``RemoteQueueView`` throughout, seeded via its own public
 ``apply_snapshot`` (never a private ``_last_seq`` poke) — no mocks, this
 class has no collaborator to fake.
+
+#5989 ④ (later, architect design + lead-coder ruling): observability alone
+did not close the defect — the WARNING-worthy case (``stuck`` non-empty)
+is now ALSO applied via a stuck-item exception (the same shape ``apply_
+user_submitted``'s own ``is_own_pending`` already uses), so the two
+"still queued" tests below assert ``applied is True`` / item REMOVED, not
+``False`` / still present, as they did before ④. See ``test_5989_4_queue_
+view_stuck_item_recovery.py`` for the recovery claim itself, framed as
+its own subject ("does not get stuck"), not as a side effect of a
+logging test.
 """
 from __future__ import annotations
 
@@ -47,7 +57,15 @@ def test_turn_started_rejection_of_a_still_queued_item_warns(
 ) -> None:
     """Tier 1: a ``turn_started`` delta rejected by the seq-gate while its
     own target item is STILL sitting in ``items``, unpromoted — the shape a
-    WRONG rejection leaves behind. Must warn.
+    WRONG rejection leaves behind. Must still warn (the rejection itself
+    stays worth knowing about).
+
+    #5989 ④ (lead-coder ruling, architect design): the WARNING is no
+    longer the end of the story — see ``test_5989_4_queue_view_stuck_item_
+    recovery.py`` for the recovery half (this delta is now APPLIED via the
+    ``stuck`` exception, so ``applied`` reads ``True`` and ``m1`` is
+    REMOVED here, not left behind — the opposite of what this test
+    asserted before ④ landed).
 
     Strip-falsifier (verified by hand: the ``stuck`` check replaced with a
     constant ``False``, so this branch is unconditionally logged at
@@ -61,8 +79,8 @@ def test_turn_started_rejection_of_a_still_queued_item_warns(
 
     applied = view.apply_turn_started(chain_id="c1", seq=3)  # stale: 3 <= 5
 
-    assert applied is False
-    assert "m1" in view.items, "the item must still be there — this IS the property under test"
+    assert applied is True, "#5989 ④: the stuck-item exception now applies this delta"
+    assert "m1" not in view.items, "#5989 ④: the stuck item is now recovered, not left behind"
     assert _levels(caplog) == ["WARNING"], (
         f"#5989 REGRESSION: a turn_started rejection whose target item is "
         f"still queued must warn — got {_levels(caplog)!r}"
@@ -115,8 +133,10 @@ def test_inbox_cancel_rejection_of_a_still_queued_item_warns(
 
     applied = view.apply_inbox_cancel(msg_id="m1", seq=3)  # stale: 3 <= 5
 
-    assert applied is False
-    assert "m1" in view.items
+    # #5989 ④: applied and removed via the stuck exception — see
+    # test_5989_4_queue_view_stuck_item_recovery.py for the recovery claim.
+    assert applied is True
+    assert "m1" not in view.items
     assert _levels(caplog) == ["WARNING"], (
         f"#5989 REGRESSION: an inbox_cancel rejection whose target item is "
         f"still queued must warn — got {_levels(caplog)!r}"

--- a/tests/interfaces/test_5989_4_queue_view_stuck_item_recovery.py
+++ b/tests/interfaces/test_5989_4_queue_view_stuck_item_recovery.py
@@ -1,0 +1,120 @@
+"""Tier 1: #5989 ④ (architect design, lead-coder ruling) — the recovery
+half of ③'s own observability. Subject: a queued sent-queue item does NOT
+get permanently stuck, never "a WARNING is logged".
+
+## Root cause (architect, verified against ``state.py`` directly)
+
+``RemoteQueueView._last_seq`` has 4 writers; only ``apply_snapshot``
+ASSIGNS it (``self._last_seq = queue_seq``, unconditional). A
+``turn_started`` for an item generated BEFORE that snapshot but delivered
+to the client AFTER it reads ``seq <= self._last_seq`` and is rejected by
+the seq-gate. ``turn_started`` is a once-per-turn edge the server never
+resends, and ``inbox_cancel`` only fires when the operator cancels — so a
+rejected delta of either kind has no OTHER chance to ever arrive. Before
+this fix, the item it would have promoted/removed stayed in
+:attr:`RemoteQueueView.items` (and, one layer up, in the TUI's own
+sent-queue widget) forever — the exact "stuck" shape.
+
+## Fix (same shape ``apply_user_submitted``'s own ``is_own_pending``
+already uses)
+
+``stuck`` (the matching item is still present) is itself the proof this
+delta was never actually applied — an already-applied item would already
+be gone — so applying it here can never create a double-promote/double-
+remove. The delta is applied (the item removed), but :attr:`_last_seq` is
+NOT regressed backward, so the ordering guarantee every OTHER item's own
+gate relies on is untouched.
+
+Real ``RemoteQueueView`` throughout — no mocks, this class has no
+collaborator to fake. Each reproduction is the MINIMAL shape architect's
+own root-cause account names: seed a snapshot whose ``queue_seq`` already
+supersedes an item's own dispatch/cancel ``seq`` (an out-of-order delivery,
+not a hand-picked coincidence — see each test's own setup for why this is
+the realistic case, not a contrived one).
+"""
+from __future__ import annotations
+
+from reyn.interfaces.transport.agui.state import RemoteQueueView
+
+
+def test_a_turn_started_generated_before_a_snapshot_still_promotes_its_item() -> None:
+    """Tier 1: the exact repro architect's own root-cause account gives —
+    a snapshot's ``queue_seq`` (5) already supersedes a ``turn_started``
+    (seq=3) generated for an item BEFORE that snapshot was taken. Before
+    ④, this delta was rejected and the item stayed in ``items`` forever
+    (``turn_started`` never resends). After ④: the item is promoted
+    (removed) anyway.
+
+    Strip-falsify (verified by hand, file-internal Edit only, reverted):
+    reverting ``apply_turn_started``'s ``stuck`` exception (the
+    ``if seq <= self._last_seq: ... return False`` shape, no application)
+    makes this test fail — ``m1`` stays in ``items`` and ``applied`` reads
+    ``False``."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m1", "chain_id": "c1", "text": "hi"}],
+        turn_active=False, queue_seq=5,
+    )
+
+    applied = view.apply_turn_started(chain_id="c1", seq=3)
+
+    assert applied is True, "the stuck item's own turn_started must be applied, not dropped"
+    assert "m1" not in view.items, "the item must not stay queued forever"
+
+
+def test_an_inbox_cancel_generated_before_a_snapshot_still_removes_its_item() -> None:
+    """Tier 1: the same shape as the turn_started test above, through
+    ``apply_inbox_cancel`` — an operator's own cancel, generated before a
+    snapshot that already supersedes it, must not leave the row sitting
+    in the queue looking un-cancelled."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m1", "chain_id": "c1", "text": "hi"}],
+        turn_active=False, queue_seq=5,
+    )
+
+    applied = view.apply_inbox_cancel(msg_id="m1", seq=3)
+
+    assert applied is True, "the stuck item's own cancel must be applied, not dropped"
+    assert "m1" not in view.items, "a cancelled item must not stay queued forever"
+
+
+def test_the_seq_gate_still_does_not_regress_for_other_items() -> None:
+    """Tier 1: deny side (architect's own safety claim, falsified directly)
+    — applying a stuck item's delta must NOT regress ``_last_seq``
+    backward. A genuinely stale delta for a DIFFERENT item, arriving
+    after the stuck-item recovery above, must still be rejected exactly
+    as before — the ordering guarantee the class's own seq-gate exists
+    for is untouched by the new exception."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m1", "chain_id": "c1", "text": "hi"}],
+        turn_active=False, queue_seq=5,
+    )
+    view.apply_turn_started(chain_id="c1", seq=3)  # the stuck-item recovery above
+    assert view.baseline_seq() == 5, "arrange: the recovery must not have moved the baseline"
+
+    # A genuinely stale delta for a DIFFERENT (never-queued) item, seq=4
+    # (still <= the baseline) — must still be rejected, same as always.
+    stale = view.apply_turn_started(chain_id="c-unrelated", seq=4)
+
+    assert stale is False, "a real stale delta for an unrelated item must still be rejected"
+
+
+def test_a_genuine_replay_after_recovery_is_still_a_quiet_no_op() -> None:
+    """Tier 1: deny side — once a stuck item is recovered, a REPLAY of the
+    SAME turn_started delta (the server occasionally redelivers over a
+    reconnect) must be a harmless no-op, not a second removal attempt
+    (there is nothing left to remove) and not a second WARNING (the item
+    is legitimately gone now — ``stuck`` correctly reads empty)."""
+    view = RemoteQueueView()
+    view.apply_snapshot(
+        queue=[{"msg_id": "m1", "chain_id": "c1", "text": "hi"}],
+        turn_active=False, queue_seq=5,
+    )
+    view.apply_turn_started(chain_id="c1", seq=3)  # recovers m1
+    assert "m1" not in view.items, "arrange: m1 must already be gone"
+
+    replay = view.apply_turn_started(chain_id="c1", seq=3)  # same delta again
+
+    assert replay is False, "a replay of an already-recovered delta is a genuine no-op"


### PR DESCRIPTION
**[tui-coder]** — part of #5989 (architect design, lead-coder ruling https://github.com/tya5/reyn/issues/5989#issuecomment-5627109153). #5989 stays open after this merges — item A remains.

## What
`RemoteQueueView.apply_turn_started`/`apply_inbox_cancel` gain a "stuck-item" exception mirroring `apply_user_submitted`'s existing `is_own_pending` pattern: when the seq-gate would reject a delta but the item it would have promoted/removed is STILL present, that presence is itself proof the delta was never applied, so it is applied anyway — without regressing `_last_seq` backward.

Root cause: `apply_snapshot` is the only `_last_seq` writer that ASSIGNS rather than advances, so a `turn_started`/`inbox_cancel` generated before a snapshot but delivered after it was rejected forever (both are once-per-item edges the server never resends) — the matching item stayed queued permanently. The code already observed this (a WARNING, #5989 ③) but had no recovery.

Also fixes `sent_queue.py`'s own "THREE exits" docstring miscount (`user_submitted → show_item` is the ENTRANCE, not a third exit) — the miscount is what let a prior review read "the exits are sufficient" past the actual gap.

## Tests
- `tests/interfaces/test_5989_4_queue_view_stuck_item_recovery.py` (new, 4 tests) — the recovery itself as its own subject.
- `tests/interfaces/test_5989_3_queue_view_rejection_observability.py` — 2 "still queued → warns" tests updated for the new `applied=True`/item-removed direction; WARNING assertion unchanged; the 2 "already resolved" tests untouched.
- Strip-falsified by hand (file-internal Edit, reverted): forcing `stuck` empty in each method reproduces the pre-fix rejection and the affected tests go red.

Diff-scoped pytest: `pytest tests/interfaces/test_5989_3_queue_view_rejection_observability.py tests/interfaces/test_5989_4_queue_view_stuck_item_recovery.py -q` → **8 passed**.

## Scope note (architect)
Server-side `queue_seq` issuance was not read for this fix — the claim is "overtaking is representable", not "observed in production". Owner improvement-confirmation requested post-fix.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (both test files)
- [x] `verify_module_docstrings.py` (both src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates: bare-import ref, file-depth ref, subprocess-reyn-pin, no-core-dep-importorskip, time-dependence ratchet
- [x] `silent_except_ratchet.py` (src/reyn/interfaces/ touched)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
