### PR TITLE
fix(#6061): tool axis unwraps a wrapper's chain, not just argv[0]

### DIFF
--- a/src/reyn/security/exec_plan_policy.py
+++ b/src/reyn/security/exec_plan_policy.py
@@ -180,6 +180,48 @@ Recorded here (not filed as a separate follow-up — architect's own
 choice) for the future reader who reaches for "measured low enough"
 as a reason to add one anyway: that reason was never the load-bearing
 one, even before this PR: the SAME fact holds regardless of volume.
+
+## #6061 (lead-coder ruling, #6061 issue thread) — the tool axis now
+unwraps a WRAPPER binary (``env`` / ``xargs`` / ``sh -c`` / ``timeout`` /
+``nice`` / ``command`` — ``exec_wrappers.py``'s own curated table) rather
+than checking only ``argv[0]``. Before this: ``env ls`` checked ``env``
+against the tool-axis narrowing and never looked at ``ls`` — an operator
+who restricted ``ls`` read their own restriction as enforced when it was
+not (architect's own framing: "worse than no defence — without one,
+people take a different precaution; believing one is active, they do
+not"). :func:`_check_segment` now applies the SAME
+``tool_contextually_denied`` check to EVERY name in the chain (``env
+FOO=1 sh -c 'rm x'`` checks ``env``, ``sh``, AND ``rm``) — never strips
+the wrapper and checks only the inside, which would defeat an operator
+who denied the WRAPPER's own name.
+
+**Restriction-inert by construction, not by convention**: the whole walk
+is gated on a tool-axis restriction actually being configured
+(``contextual.tool_allow is not None or contextual.tool_deny`` — see
+:func:`_check_segment`'s own comment). An unrestricted session never
+enters the loop this adds, so ``resolve_real_executable`` is never called
+an extra time and no new denial path exists for the common (unrestricted)
+case — this is the "既定は変えません" ruling's own implementation, not
+merely its documentation.
+
+**Fails closed, never open, on the two ways a chain cannot be verified**:
+a wrapper whose own argv shape ``exec_wrappers.py`` cannot safely unwrap
+(some flag combination outside that module's own extraction rule), and a
+chain deeper than :data:`_MAX_UNWRAP_DEPTH` (8, matching OpenAI Codex's
+own limit for the identical recursion — architect's competitive
+research). Both raise :class:`PermissionError` and emit
+``exec_tool_axis_denied`` with the chain walked so far in
+``unwrap_chain`` — silently treating either as "nothing more to check"
+would approve exactly the class of command this PR exists to catch.
+
+**Threat scan and sandbox are UNCHANGED** — this PR's own scope, per
+architect's own charter-lens table (#6061 issue thread): the threat scan
+already sees a segment's FULL joined argv text (``env rm -rf /`` already
+matches a ``rm -rf`` pattern regardless of wrapper-awareness) and the
+sandbox already bounds effects rather than names. Only the tool axis's
+own promise — "these are the binaries that can run" — was narrower than
+its own wording implied; this PR brings the implementation up to that
+wording for the ONE axis it was ever false for.
 """
 from __future__ import annotations
 
@@ -187,6 +229,7 @@ import os
 from typing import TYPE_CHECKING
 
 from reyn.security.exec_plan import ExecRedirect, ExecSegment
+from reyn.security.exec_wrappers import extract_inner_argv, is_registered_wrapper
 from reyn.security.permissions.effective import (
     contextual_deny_message,
     gate_effective_tool_name,
@@ -198,10 +241,18 @@ if TYPE_CHECKING:
     from reyn.core.op_runtime.context import OpContext
     from reyn.security.exec_plan import ExecPlan
 
+# #6061: the max number of wrapper hops the tool axis will unwrap before
+# refusing outright (fail-closed) — matches OpenAI Codex's own depth limit
+# for the identical `sudo <cmd>`-style recursion (architect's competitive
+# research, #6061 issue thread). Only ever consulted when a tool-axis
+# restriction is actually active (see ``_check_segment``) — an unrestricted
+# session never reaches the loop this bounds at all.
+_MAX_UNWRAP_DEPTH = 8
+
 
 async def check_exec_plan_policy(
     plan: "ExecPlan", ctx: "OpContext", *, env_path: "str | None", cwd: "str | None"
-) -> "list[dict[str, str]]":
+) -> "list[dict[str, str | list[str]]]":
     """Apply 段3 policy to every item of *plan* — see this module's own
     docstring for exactly what each item type is checked against. Raises
     :class:`PermissionError` on the FIRST denial encountered, in plan
@@ -230,6 +281,17 @@ async def check_exec_plan_policy(
     ``ExecChainOp``/``ExecRedirect`` entries contribute nothing to this
     list (they have no argv[0] of their own).
 
+    #6061: an entry ALSO carries ``"unwrap_chain": [<name>, ...]`` when —
+    and ONLY when — a tool-axis restriction is active AND this segment's
+    own resolved binary is a registered wrapper (``exec_wrappers.py``)
+    that this policy walked through to reach the binary that actually
+    runs (``env ls`` records ``["env", "ls"]``). Absent entirely for an
+    unrestricted session or a segment that resolves to an ordinary,
+    non-wrapping binary — never an empty list, never a single-element
+    list duplicating ``resolved`` — so a caller reading this field for
+    the first time can tell "no chain was walked" from "a chain of
+    length 1" without a sentinel value.
+
     *env_path*/*cwd* are the ``PATH``/working-directory the eventual
     sandboxed run will actually see — BOTH REQUIRED, keyword-only, no
     internal fallback (#5991 BLOCKING ③, this module's own docstring):
@@ -244,11 +306,16 @@ async def check_exec_plan_policy(
     Never executes anything, never re-parses *plan* — a pure policy
     check over an already-parsed :data:`~reyn.security.exec_plan.
     ExecPlan`."""
-    resolved_argv0: "list[dict[str, str]]" = []
+    resolved_argv0: "list[dict[str, str | list[str]]]" = []
     for item in plan:
         if isinstance(item, ExecSegment):
-            resolved = await _check_segment(item, ctx, env_path=env_path, cwd=cwd)
-            resolved_argv0.append({"argv0": item.argv[0] if item.argv else "", "resolved": resolved})
+            resolved, unwrap_chain = await _check_segment(item, ctx, env_path=env_path, cwd=cwd)
+            entry: "dict[str, str | list[str]]" = {
+                "argv0": item.argv[0] if item.argv else "", "resolved": resolved,
+            }
+            if unwrap_chain is not None:
+                entry["unwrap_chain"] = unwrap_chain
+            resolved_argv0.append(entry)
         elif isinstance(item, ExecRedirect):
             await _check_redirect(item, ctx)
         # ExecChainOp carries no policy-relevant data of its own — the
@@ -258,19 +325,30 @@ async def check_exec_plan_policy(
 
 async def _check_segment(
     segment: "ExecSegment", ctx: "OpContext", *, env_path: "str | None", cwd: "str | None"
-) -> str:
+) -> "tuple[str, list[str] | None]":
     """Tool-axis + threat-scan check for one segment — see this module's
-    own docstring, "What gets checked", point 1/2. Returns the RESOLVED
+    own docstring, "What gets checked", point 1/2. Returns ``(resolved,
+    unwrap_chain)`` — ``resolved`` is the OUTER segment's own resolved
     ``argv[0]`` (#5838 段5 — see :func:`check_exec_plan_policy`'s own
     docstring for why this is returned rather than re-derived by a
-    caller)."""
+    caller), unchanged in shape from before #6061. ``unwrap_chain`` is
+    ``None`` unless a tool-axis restriction was active AND this segment's
+    own resolved binary was a registered wrapper — see :func:`check_exec_
+    plan_policy`'s own docstring for the exact contract.
+
+    #6061: a tool-axis restriction, when active, is applied to every name
+    in the wrapper chain (``env FOO=1 sh -c 'rm x'`` checks ``env``,
+    ``sh``, AND ``rm`` — never just ``env``), never the FIRST name alone
+    — see ``exec_wrappers.py``'s own module docstring for why a wrapper
+    is unwrapped rather than stripped (stripping would defeat an operator
+    who denied the wrapper NAME itself, e.g. ``env``)."""
     if not segment.argv:
         # Unreachable via parse_exec_plan (an empty segment is rejected at
         # parse time — exec_plan.py's own _flush_segment), kept as a
         # defensive no-op rather than an IndexError for any other future
         # ExecPlan producer. "" (not None) keeps the return type a plain
         # str, matching every reachable path.
-        return ""
+        return "", None
 
     # #2820 part A (the SAME resolution sandboxed_exec.py's own
     # argv0_resolved already performs): strip a version-manager shim
@@ -283,29 +361,114 @@ async def _check_segment(
     argv0_resolved = resolve_real_executable(segment.argv[0], env_path=env_path, cwd=cwd)
     resolved_name = os.path.basename(argv0_resolved)
 
-    effective = gate_effective_tool_name(resolved_name, None)
     contextual = getattr(ctx, "contextual_permission", None)
-    if effective is not None and tool_contextually_denied(contextual, effective):
-        message = contextual_deny_message("command", effective, contextual)
-        # #6016 ①: the SAME denial the threat axis already records
-        # (exec_threat_match/_blocked) but the tool axis never did — a
-        # reader had only `tool_failed.message`, an English sentence, to
-        # learn WHICH binary was denied. Fields, not prose: the denied
-        # binary is recoverable without parsing `message`. Deliberately
-        # does NOT have an "allowed" sibling event -- see this module's
-        # own docstring, "#6016 ①", for why (architect's structural
-        # reason, not merely "not measured yet"): the tool axis has no
-        # "did not run" state to distinguish (unlike threat_scan), and
-        # the allowed side is already recorded by 段5's own `plan` field.
-        ctx.events.emit(
-            "exec_tool_axis_denied",
-            argv0=segment.argv[0], resolved=argv0_resolved,
-            effective_name=effective, reason=message,
-        )
-        raise PermissionError(message)
+    # #6061: the wrapper-chain walk is a no-op, structurally, unless a
+    # tool-axis restriction is actually configured — `tool_allow`/
+    # `tool_deny` both at their unconfigured defaults means
+    # `tool_contextually_denied` already returns False for EVERY name, so
+    # walking further would only spend `resolve_real_executable` calls
+    # for a result that can never change. This is the "既定は変えません"
+    # guarantee's own implementation, not merely documented intent —
+    # `test_wrapper_chain_never_walked_when_no_restriction_is_configured`
+    # is the strip-falsify witness for this exact guard.
+    restriction_active = contextual is not None and (
+        contextual.tool_allow is not None or contextual.tool_deny
+    )
+
+    if not restriction_active:
+        await _run_threat_scan(ctx, " ".join(segment.argv), subject=list(segment.argv))
+        return argv0_resolved, None
+
+    chain_names = [resolved_name]
+    current_argv = segment.argv
+    current_resolved_name = resolved_name
+    current_argv0_resolved = argv0_resolved
+    depth = 0
+    while True:
+        effective = gate_effective_tool_name(current_resolved_name, None)
+        if effective is not None and tool_contextually_denied(contextual, effective):
+            message = contextual_deny_message("command", effective, contextual)
+            # #6016 ①: the SAME denial the threat axis already records
+            # (exec_threat_match/_blocked) but the tool axis never did — a
+            # reader had only `tool_failed.message`, an English sentence, to
+            # learn WHICH binary was denied. Fields, not prose: the denied
+            # binary is recoverable without parsing `message`. Deliberately
+            # does NOT have an "allowed" sibling event -- see this module's
+            # own docstring, "#6016 ①", for why (architect's structural
+            # reason, not merely "not measured yet"): the tool axis has no
+            # "did not run" state to distinguish (unlike threat_scan), and
+            # the allowed side is already recorded by 段5's own `plan` field.
+            #
+            # #6061: `unwrap_chain` names every name walked to reach this
+            # one (`["env", "ls"]` when `env ls` was denied on `ls`) — the
+            # audit-trail half of this PR's own charter Lens 7 obligation
+            # ("this check is the result of unwrapping N layers").
+            ctx.events.emit(
+                "exec_tool_axis_denied",
+                argv0=segment.argv[0], resolved=current_argv0_resolved,
+                effective_name=effective, reason=message,
+                unwrap_chain=list(chain_names),
+            )
+            raise PermissionError(message)
+
+        if not is_registered_wrapper(current_resolved_name):
+            break  # a terminal (non-wrapping) binary — nothing more to unwrap
+
+        depth += 1
+        if depth > _MAX_UNWRAP_DEPTH:
+            # #6061: fail CLOSED — a wrapper chain this deep cannot be
+            # verified within the bound this policy is willing to walk
+            # (matches Codex's own depth-8 limit, architect's competitive
+            # research). Only reachable when restriction_active, so an
+            # unrestricted session can never hit this.
+            reason = (
+                f"wrapper chain exceeded the {_MAX_UNWRAP_DEPTH}-hop unwrap "
+                f"limit starting from {chain_names[0]!r} — refusing rather "
+                "than approving a chain this policy could not fully verify"
+            )
+            ctx.events.emit(
+                "exec_tool_axis_denied",
+                argv0=segment.argv[0], resolved=current_argv0_resolved,
+                effective_name=current_resolved_name, reason=reason,
+                unwrap_chain=list(chain_names),
+            )
+            raise PermissionError(reason)
+
+        inner_argv = extract_inner_argv(current_resolved_name, current_argv)
+        if inner_argv is None:
+            # #6061: `current_resolved_name` IS a registered wrapper, but
+            # this invocation's own flag/arg shape is one
+            # `exec_wrappers.py`'s own extraction rule refuses (see that
+            # module's own docstring, "What 'cannot extract' means") — a
+            # restriction is active, so silently treating this as "nothing
+            # more to check" would let exactly the class of command this
+            # PR exists to catch through unexamined. Fail closed.
+            reason = (
+                f"{current_resolved_name!r} wraps its argument in a form "
+                "this policy cannot verify (see exec_wrappers.py's own "
+                f"{current_resolved_name!r} entry for the forms it does "
+                "and does not cover) — refusing rather than approving a "
+                "wrapper this policy could not see through"
+            )
+            ctx.events.emit(
+                "exec_tool_axis_denied",
+                argv0=segment.argv[0], resolved=current_argv0_resolved,
+                effective_name=current_resolved_name, reason=reason,
+                unwrap_chain=list(chain_names),
+            )
+            raise PermissionError(reason)
+
+        if not inner_argv:
+            break  # the wrapper consumed every argument — nothing left to check
+
+        current_argv = inner_argv
+        current_argv0_resolved = resolve_real_executable(inner_argv[0], env_path=env_path, cwd=cwd)
+        current_resolved_name = os.path.basename(current_argv0_resolved)
+        chain_names.append(current_resolved_name)
 
     await _run_threat_scan(ctx, " ".join(segment.argv), subject=list(segment.argv))
-    return argv0_resolved
+    unwrap_chain = chain_names if len(chain_names) > 1 else None
+    return argv0_resolved, unwrap_chain
 
 
 async def _run_threat_scan(ctx: "OpContext", text: str, *, subject: "list[str]") -> None:

--- a/src/reyn/security/exec_wrappers.py
+++ b/src/reyn/security/exec_wrappers.py
@@ -1,0 +1,357 @@
+"""#6061 — a hand-maintained table of exec "wrapper" binaries: binaries whose
+own ``argv[0]`` the tool axis checks, but which then run a DIFFERENT binary
+named in their OWN arguments (``env ls`` is checked as ``env``; what runs is
+``ls``). See ``exec_plan_policy.py``'s own docstring for how this table is
+consumed.
+
+## Why this table is CURATED, never derived (read before adding an entry)
+
+#6110 ruled "母集団は corpus から導出, never a hand-typed list" for
+``exec_plan.py``'s own node-kind allowlist — that ruling does NOT apply
+here, and conflating the two is the mistake this module's own issue thread
+(#6061) caught lead-coder making once already. The difference:
+
+- A grammar node KIND is a property of the GRAMMAR — parsing a corpus of
+  real shell one-liners enumerates it, because the population lives in the
+  grammar itself (``bash_node_kinds.py``).
+- Whether a binary named ``env`` treats its own arguments as "the next
+  program to run" is a property of THAT BINARY'S OWN SEMANTICS — world
+  knowledge no corpus in this repository contains. Parsing ``env`` a
+  thousand times never tells you ``env`` execs its argument; only reading
+  ``env``'s own manual does.
+
+There is no corpus to derive this table FROM. Architect's own competitive
+research (#6061 issue thread) found that Claude Code, OpenAI Codex, and
+Google Gemini CLI all ship the identical shape: a STATIC, hand-written table
+of wrapper names, none of them derived from any corpus, all shipped anyway
+— and each company's OWN table names a DIFFERENT set of wrappers (Codex
+checks ``env``; Claude Code does not). "There is no industry-standard
+table" was itself the finding — only industry-standard CHOICES exist, and
+each competitor documents what its own choice does not cover, in the same
+place the table lives. This module does the same: every entry below is
+required to carry both its own justification (why this binary belongs
+here) and, where its extraction rule is incomplete, an explicit note of the
+forms it does NOT handle — never a silent gap.
+
+## Scope of the initial table — deliberately narrow
+
+Six names, matching the exact 6 the #6061 issue thread measured against
+`origin/main` as of this table's creation (12 concrete command lines,
+collapsing to 6 wrapper binaries): ``env``, ``xargs``, ``sh`` (the ``-c``
+form only), ``timeout``, ``nice``, ``command``. ``sudo`` and ``find -exec``
+are DELIBERATELY not entered — their own option grammar was measured as
+"not yet measured for extraction difficulty" (#6061, architect) rather than
+silently dropped; see :data:`UNSUPPORTED_WRAPPERS` below, which names them
+and says why they are absent, rather than leaving a reader to wonder
+whether they were considered at all.
+
+## What "cannot extract" means, and why it is a SEPARATE outcome from
+"not a wrapper"
+
+:func:`extract_inner_argv` returns ``None`` in two structurally different
+cases a caller must NOT conflate:
+
+1. *name* is not a registered wrapper at all (see :func:`is_registered_
+   wrapper`) — an ordinary, non-wrapping binary. The correct caller
+   response is to STOP unwrapping; there is nothing more to look at.
+2. *name* IS a registered wrapper, but this specific invocation's flag/arg
+   shape is one this table's extraction rule does not cover (e.g. ``env
+   -u NAME cmd`` — ``-u`` takes a separate value argument this table does
+   not attempt to parse). The correct caller response, when a tool-axis
+   restriction is actually active, is to DENY — the alternative (silently
+   treating an unrecognised form as "nothing to unwrap") would let exactly
+   the class of command this table exists to catch through unexamined.
+
+:func:`is_registered_wrapper` is what tells these two apart; callers must
+check it BEFORE reading a ``None`` from :func:`extract_inner_argv` as
+"stop, nothing more to check" — see ``exec_plan_policy.py``'s own
+``_check_segment`` for the consuming shape.
+
+## What this table does NOT attempt
+
+- Full option-grammar parsing for any wrapper. Each entry's own docstring
+  says exactly which forms it extracts and which it refuses (returns
+  ``None`` for) rather than guessing.
+- Recursively re-parsing an ``sh -c``'s own command STRING through
+  ``exec_plan.py``'s grammar. Per architect's own ruling (#6061 issue
+  thread), the extraction for ``sh -c`` takes only the string's OWN first
+  whitespace-separated token as the next name to check — a conservative
+  approximation, not a second parse of an embedded shell command line.
+- Completeness. No wrapper table can be complete (this module's own
+  docstring, first section) — see :data:`UNSUPPORTED_WRAPPERS`.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+# A bare `KEY=VALUE` assignment token, e.g. `env`'s own argument-position
+# environment overrides (`env FOO=1 ls`). Matches POSIX environment-variable
+# name rules (leading letter/underscore, then alnum/underscore).
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# A plain, unsigned integer duration with an optional single-letter unit
+# suffix (GNU `timeout DURATION`, e.g. `5`, `5s`, `2m`) — the ONLY duration
+# shape #6061's own measurement exercised (`timeout 5 ls`).
+_DURATION_RE = re.compile(r"^[0-9]+(\.[0-9]+)?[smhd]?$")
+
+# An old-style `nice`/`renice` adjustment (`-N`, e.g. `-5`) — distinct from
+# a `-`-prefixed FLAG because it is digits-only after the sign.
+_NICE_OLD_STYLE_ADJUSTMENT_RE = re.compile(r"^-[0-9]+$")
+
+
+@dataclass(frozen=True)
+class WrapperSpec:
+    """One curated table entry. *name* is the resolved basename this entry
+    matches (``exec_plan_policy.py`` resolves ``argv[0]`` through the SAME
+    version-manager-shim resolution the rest of that module already uses,
+    then reduces to a basename, before ever consulting this table).
+
+    *rationale* is the 1-line "why does this binary belong in this table"
+    this module's own docstring requires of every entry — never omitted,
+    even for an obvious case ("this is genuinely obvious" is itself a
+    1-line rationale).
+
+    *unsupported_forms* names, in prose, the argv shapes THIS entry's own
+    :attr:`extract` will refuse (return ``None`` for) — required even when
+    short ("only the bare form"), so a reader of the table sees the limit
+    without having to read the extraction function's own source."""
+
+    name: str
+    rationale: str
+    unsupported_forms: str
+    extract: "Callable[[tuple[str, ...]], tuple[str, ...] | None]"
+
+
+def _extract_env(argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """``env [-i] [KEY=VALUE ...] COMMAND [ARG ...]``. Skips leading
+    ``KEY=VALUE`` assignment tokens and the bare, no-value ``-i``/
+    ``--ignore-environment`` flag; refuses (returns ``None``) at the first
+    OTHER ``-``-prefixed token — several real ``env`` flags (``-u NAME``,
+    ``-C DIR``, ``-S STRING``, ``--split-string=STRING``) take a SEPARATE
+    value argument this table does not attempt to parse, and guessing
+    wrong here would silently under-count the inner argv."""
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if _ASSIGNMENT_RE.match(tok):
+            i += 1
+            continue
+        if tok in ("-i", "--ignore-environment"):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            return None  # an env flag this table does not parse (may take a value)
+        break
+    return tuple(argv[i:])
+
+
+def _extract_xargs(argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """``xargs COMMAND [ARG ...]`` — ONLY the bare form (no flags at all),
+    matching Claude Code's own documented rule (competitive research,
+    #6061 issue thread, quoted verbatim there): "Stripping applies only
+    when xargs has no flags: an invocation like xargs -n1 grep pattern is
+    matched as an xargs command." Any ``-``-prefixed token anywhere in
+    ``argv[1:]`` refuses extraction — xargs' own flags change what runs
+    (``-I{}`` substitution, ``-0``/``-d`` delimiter, ``-P`` parallelism),
+    and a bare heuristic cannot safely re-derive that."""
+    if any(tok.startswith("-") for tok in argv[1:]):
+        return None
+    return tuple(argv[1:])
+
+
+def _extract_sh_c(argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """``sh -c 'COMMAND STRING' [ARG0 ...]`` — extracts only the FIRST
+    whitespace-separated token of the command STRING, never a full
+    re-parse of it (architect's own ruling, #6061 issue thread: "sh は
+    -c の次の1語"). Refuses unless argv is EXACTLY ``("sh", "-c",
+    <string>, ...)`` — any other flag before ``-c`` (``sh -e -c ...``) or
+    a missing ``-c`` (``sh script.sh``) is out of this entry's scope."""
+    if len(argv) < 3 or argv[1] != "-c":
+        return None
+    command_string = argv[2]
+    parts = command_string.split(None, 1)
+    if not parts:
+        return None
+    return (parts[0],)
+
+
+def _extract_timeout(argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """``timeout [OPTION] DURATION COMMAND [ARG ...]``. Skips a single
+    leading plain-duration token (``5``, ``5s``, ``2m`` — the only shape
+    #6061's own measurement exercised, ``timeout 5 ls``). Refuses at any
+    ``-``-prefixed token (``-s SIGNAL``, ``-k DURATION``, ``--foreground``
+    — several take a separate value this table does not parse) and at any
+    other non-duration, non-flag first token (malformed input to
+    ``timeout`` itself — not this table's job to validate)."""
+    if len(argv) < 2:
+        return None
+    first = argv[1]
+    if first.startswith("-"):
+        return None
+    if not _DURATION_RE.match(first):
+        return None
+    return tuple(argv[2:])
+
+
+def _extract_nice(argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """``nice [-n ADJUSTMENT | -ADJUSTMENT] COMMAND [ARG ...]``. Handles
+    the bare form (``nice ls``), ``-n ADJUSTMENT`` (``nice -n 5 ls``,
+    #6061's own measured form), and the old-style ``-ADJUSTMENT`` (``nice
+    -5 ls``). Refuses at any other ``-``-prefixed token."""
+    if len(argv) < 2:
+        return None
+    if not argv[1].startswith("-"):
+        return tuple(argv[1:])
+    if argv[1] == "-n":
+        if len(argv) < 4:
+            return None
+        return tuple(argv[3:])
+    if _NICE_OLD_STYLE_ADJUSTMENT_RE.match(argv[1]):
+        return tuple(argv[2:])
+    return None
+
+
+def _extract_command(argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """``command COMMAND [ARG ...]`` — ONLY the bare form (#6061's own
+    measured form, ``command ls``). Refuses at any ``-``-prefixed token
+    (``-p``/``-v``/``-V`` are real ``command`` flags this table does not
+    parse)."""
+    if len(argv) < 2 or argv[1].startswith("-"):
+        return None
+    return tuple(argv[1:])
+
+
+_WRAPPERS: "dict[str, WrapperSpec]" = {
+    "env": WrapperSpec(
+        name="env",
+        rationale=(
+            "env's whole documented purpose is to run its OWN argument as a "
+            "program, optionally under a modified environment -- #6061's own "
+            "lead-coder ruling picks this as the wrapper furthest from "
+            '"the binary that actually runs" (env FOO=1 CMD reads as `env` '
+            "to the tool axis while CMD is what executes)."
+        ),
+        unsupported_forms=(
+            "Any env flag that takes a separate value argument (-u NAME, "
+            "-C DIR, -S STRING, --split-string=STRING, ...) -- only -i / "
+            "--ignore-environment (bare, no value) and leading KEY=VALUE "
+            "assignments are handled."
+        ),
+        extract=_extract_env,
+    ),
+    "xargs": WrapperSpec(
+        name="xargs",
+        rationale=(
+            "xargs runs its own trailing argument as a command, appending "
+            "stdin-derived arguments -- Claude Code's own shipped behaviour "
+            "strips bare xargs for the identical reason (competitive "
+            "research, #6061 issue thread)."
+        ),
+        unsupported_forms=(
+            "Any invocation carrying ANY flag (-n, -I, -0, -P, ...) -- "
+            "matches Claude Code's own documented limit verbatim: bare "
+            "xargs only."
+        ),
+        extract=_extract_xargs,
+    ),
+    "sh": WrapperSpec(
+        name="sh",
+        rationale=(
+            "sh -c STRING execs STRING as a shell command line -- the "
+            "single most direct wrapper form measured (#6061 issue "
+            "thread's own `sh -c ls` example)."
+        ),
+        unsupported_forms=(
+            "Anything but exactly `sh -c STRING [ARG0 ...]` -- a script "
+            "path (`sh script.sh`), a flag before -c (`sh -e -c ...`), or "
+            "a missing -c. Extraction takes only STRING's first "
+            "whitespace-separated token, never a full re-parse of the "
+            "embedded command line."
+        ),
+        extract=_extract_sh_c,
+    ),
+    "timeout": WrapperSpec(
+        name="timeout",
+        rationale=(
+            "timeout DURATION COMMAND execs COMMAND once DURATION is "
+            "consumed -- #6061's own measurement (`timeout 5 rm -rf "
+            "/tmp/x`) is the example a naive argv[0]-only check misreads "
+            "as `timeout`."
+        ),
+        unsupported_forms=(
+            "Any timeout OPTION before the duration (-s SIGNAL, -k "
+            "DURATION, --foreground, ...) -- several take a separate "
+            "value argument this table does not parse. Only a single "
+            "leading plain-duration token is handled."
+        ),
+        extract=_extract_timeout,
+    ),
+    "nice": WrapperSpec(
+        name="nice",
+        rationale=(
+            "nice [ADJUSTMENT] COMMAND execs COMMAND at an adjusted "
+            "scheduling priority -- #6061's own measured forms (`nice "
+            "ls`, `nice -n 5 ls`)."
+        ),
+        unsupported_forms=(
+            "Any -flag other than `-n ADJUSTMENT` or the old-style "
+            "`-ADJUSTMENT` digits-only form."
+        ),
+        extract=_extract_nice,
+    ),
+    "command": WrapperSpec(
+        name="command",
+        rationale=(
+            "the `command` builtin execs its own argument directly, "
+            "bypassing shell function/alias lookup -- #6061's own "
+            "measured form (`command ls`)."
+        ),
+        unsupported_forms="Any -flag (-p / -v / -V) -- bare form only.",
+        extract=_extract_command,
+    ),
+}
+
+#: Named wrappers this table does NOT cover, with why — per #6061's own
+#: ruling: "取り出せない形が在るなら、それを entry 自身に書く" applied at
+#: the table's own edge, not just inside a covered entry. Written here so
+#: a reader of this module sees they were CONSIDERED, not forgotten.
+UNSUPPORTED_WRAPPERS: "dict[str, str]" = {
+    "sudo": (
+        "sudo execs its own trailing argument (optionally after option "
+        "flags: -u USER, -g GROUP, -E, ...); #6061's own architect ruling "
+        "left this table's initial version to the 6 forms actually "
+        "measured and named sudo's own option-parsing difficulty as "
+        "explicitly UNMEASURED, not merely deferred by oversight."
+    ),
+    "find": (
+        "find ... -exec COMMAND {} \\; (or the + terminator) execs "
+        "COMMAND once per matched path; the argv shape needs a scan for "
+        "the -exec token AND its own \\;/+ terminator, unmeasured for "
+        "extraction difficulty (#6061 issue thread, architect)."
+    ),
+}
+
+
+def is_registered_wrapper(name: str) -> bool:
+    """True iff *name* (a resolved basename, e.g. ``"env"``) has a table
+    entry — the FIRST check a caller must make; see this module's own
+    docstring, "What 'cannot extract' means"."""
+    return name in _WRAPPERS
+
+
+def extract_inner_argv(name: str, argv: "tuple[str, ...]") -> "tuple[str, ...] | None":
+    """The inner argv *name*'s own table entry extracts from *argv* (whose
+    ``argv[0]`` is *name*'s own invocation token), or ``None`` if this
+    entry's extraction rule does not cover *argv*'s specific shape (see
+    this module's own docstring — callers must have already confirmed
+    :func:`is_registered_wrapper` before treating a ``None`` return as
+    "cannot extract" rather than "not a wrapper").
+
+    Raises :class:`KeyError` if *name* has no table entry at all — callers
+    must check :func:`is_registered_wrapper` first; this is not a
+    graceful-degradation path, it is a programming-error guard (the two
+    ``None`` meanings this module's docstring distinguishes must never be
+    collapsed by a caller skipping the registration check)."""
+    return _WRAPPERS[name].extract(argv)

--- a/tests/security/test_6061_exec_wrapper_unwrap.py
+++ b/tests/security/test_6061_exec_wrapper_unwrap.py
@@ -1,0 +1,287 @@
+"""Tier 1/2: #6061 -- the exec tool axis unwraps a wrapper binary (``env``
+/ ``xargs`` / ``sh -c`` / ``timeout`` / ``nice`` / ``command``,
+``exec_wrappers.py``'s own curated table) rather than checking only
+``argv[0]``.
+
+Tier 1 (``exec_wrappers.py``'s own pure extraction functions): every one of
+the 12 concrete command lines #6061's own issue thread measured against
+``origin/main``, driven through the real production functions.
+
+Tier 2 (``exec_plan_policy.check_exec_plan_policy``, wired end to end): real
+``OpContext`` + real ``ContextualPermission`` throughout, no mocks -- same
+shape ``test_5838_stage3_exec_plan_policy.py`` already established.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.exec_plan import ExecSegment
+from reyn.security.exec_plan_policy import _MAX_UNWRAP_DEPTH, check_exec_plan_policy
+from reyn.security.exec_wrappers import (
+    UNSUPPORTED_WRAPPERS,
+    extract_inner_argv,
+    is_registered_wrapper,
+)
+from reyn.security.permissions.effective import ContextualPermission
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.events import collect_events, settle
+
+_REAL_PATH = os.environ.get("PATH")
+
+
+# ── Tier 1: exec_wrappers.py's own extraction, the 12 measured forms ────
+
+
+@pytest.mark.parametrize(
+    "name,argv,expected_inner",
+    [
+        ("env", ("env", "ls"), ("ls",)),
+        ("xargs", ("xargs", "ls"), ("ls",)),
+        ("sh", ("sh", "-c", "ls"), ("ls",)),
+        ("timeout", ("timeout", "5", "ls"), ("ls",)),
+        ("nice", ("nice", "ls"), ("ls",)),
+        ("command", ("command", "ls"), ("ls",)),
+        ("env", ("env", "FOO=1", "ls"), ("ls",)),
+        ("env", ("env", "-i", "ls"), ("ls",)),
+        ("nice", ("nice", "-n", "5", "ls"), ("ls",)),
+        (
+            "timeout",
+            ("timeout", "5", "rm", "-rf", "/tmp/x"),
+            ("rm", "-rf", "/tmp/x"),
+        ),
+    ],
+)
+def test_extracts_inner_argv_for_each_measured_form(name, argv, expected_inner):
+    """Tier 1: accept side -- 10 of #6061's own 12 measured command lines
+    (the other 2, ``eval ls`` and ``xargs -n 1 ls``, are the deny-side
+    witnesses below: ``eval`` is not a registered wrapper at all, and
+    ``xargs -n 1`` is the documented "cannot extract" form)."""
+    assert is_registered_wrapper(name)
+    assert extract_inner_argv(name, argv) == expected_inner
+
+
+def test_xargs_with_any_flag_refuses_extraction():
+    """Tier 1: deny -- #6061's own measured ``xargs -n 1 ls`` matches
+    Claude Code's own documented limit verbatim (competitive research,
+    #6061 issue thread): stripping applies to BARE xargs only."""
+    assert extract_inner_argv("xargs", ("xargs", "-n", "1", "ls")) is None
+
+
+def test_eval_is_not_a_registered_wrapper():
+    """Tier 1: deny -- ``eval`` resolves to no real binary (a shell
+    builtin, ``which`` returns None per #6061's own measurement) and is
+    deliberately absent from this table's initial version (the 6 names
+    that DO resolve to real binaries)."""
+    assert not is_registered_wrapper("eval")
+
+
+@pytest.mark.parametrize(
+    "name,argv",
+    [
+        ("env", ("env", "-u", "PATH", "ls")),  # -u takes a separate value
+        ("nice", ("nice", "-99", "ls")),  # not -n, not old-style digits-only shape recognised here... see below
+        ("command", ("command", "-v", "ls")),
+        ("sh", ("sh", "script.sh")),  # no -c at all
+        ("timeout", ("timeout", "-s", "KILL", "5", "ls")),  # -s takes a value
+    ],
+)
+def test_refuses_extraction_for_unsupported_flag_forms(name, argv):
+    """Tier 1: deny -- each of this table's own documented
+    ``unsupported_forms`` refuses rather than guesses. ``nice -99 ls`` IS
+    actually the old-style adjustment shape and DOES extract (kept in
+    this parametrize as a reminder it is covered, not a refusal case --
+    see the dedicated positive test above for ``-n``; this file does not
+    re-assert the old-style shape's own success here to avoid a
+    contradictory parametrize entry)."""
+    if name == "nice" and argv == ("nice", "-99", "ls"):
+        # Old-style `-ADJUSTMENT` IS handled -- positive control, not a
+        # refusal (kept in this list purely as documentation that this
+        # shape was deliberately considered, not overlooked).
+        assert extract_inner_argv(name, argv) == ("ls",)
+        return
+    assert extract_inner_argv(name, argv) is None
+
+
+def test_unsupported_wrappers_table_names_sudo_and_find_exec_explicitly():
+    """Tier 1: #6061's own architect ruling -- sudo/find -exec are NOT
+    silently absent from this module; they are named, with why, in
+    :data:`UNSUPPORTED_WRAPPERS`."""
+    assert "sudo" in UNSUPPORTED_WRAPPERS
+    assert "find" in UNSUPPORTED_WRAPPERS
+    assert UNSUPPORTED_WRAPPERS["sudo"] and UNSUPPORTED_WRAPPERS["find"]
+
+
+# ── Tier 2: check_exec_plan_policy, wired end to end ─────────────────────
+
+
+def _ctx(tmp_path: Path, *, contextual: "ContextualPermission | None" = None):
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    collected = collect_events(events)
+    workspace = Workspace(events=events, base_dir=project_root)
+    resolver = PermissionResolver(config_permissions={}, project_root=project_root, interactive=False)
+    ctx = OpContext(
+        workspace=workspace, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="test", contextual_permission=contextual,
+    )
+    return ctx, collected
+
+
+@pytest.mark.asyncio
+async def test_env_ls_is_denied_when_ls_itself_is_restricted(tmp_path: Path) -> None:
+    """Tier 2: accept -- THE #6061 defect, closed. Before this PR, a tool
+    axis restricting ``ls`` never saw ``ls`` at all in ``env ls`` (only
+    ``env`` was checked). Strip-falsify (performed during review, file
+    Edit only): reverting ``_check_segment`` to check only the outer
+    ``resolved_name`` (never unwrapping) makes this assertion fail --
+    ``env ls`` is silently approved."""
+    ctx, collected = _ctx(tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"ls"})))
+    plan = [ExecSegment(argv=("env", "ls"))]
+
+    with pytest.raises(PermissionError, match="ls"):
+        await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    await settle(ctx.events)
+    (denied,) = [e for e in collected if e.type == "exec_tool_axis_denied"]
+    assert denied.data["effective_name"] == "ls"
+    assert denied.data["unwrap_chain"] == ["env", "ls"]
+
+
+@pytest.mark.asyncio
+async def test_env_itself_denied_still_stops_the_chain_at_env(tmp_path: Path) -> None:
+    """Tier 2: accept -- an operator who denies the WRAPPER's own name
+    (``env``) still has that respected; the chain-walk denies at ``env``
+    before ever reaching ``ls`` (never silently unwrapped past a denial
+    on the wrapper name itself)."""
+    ctx, collected = _ctx(tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"env"})))
+    plan = [ExecSegment(argv=("env", "ls"))]
+
+    with pytest.raises(PermissionError, match="env"):
+        await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    await settle(ctx.events)
+    (denied,) = [e for e in collected if e.type == "exec_tool_axis_denied"]
+    assert denied.data["effective_name"] == "env"
+    assert denied.data["unwrap_chain"] == ["env"]
+
+
+@pytest.mark.asyncio
+async def test_deep_chain_denies_at_the_actual_binary_not_just_the_first_wrapper(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept -- a 2-layer chain (``env`` wrapping ``sh -c``
+    wrapping the real binary) is walked to its end; the SAME operator
+    restriction that would deny a bare ``rm`` also denies it 2 layers
+    deep."""
+    ctx, collected = _ctx(tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"rm"})))
+    plan = [ExecSegment(argv=("env", "FOO=1", "sh", "-c", "rm"))]
+
+    with pytest.raises(PermissionError, match="rm"):
+        await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    await settle(ctx.events)
+    (denied,) = [e for e in collected if e.type == "exec_tool_axis_denied"]
+    assert denied.data["unwrap_chain"] == ["env", "sh", "rm"]
+
+
+@pytest.mark.asyncio
+async def test_env_ls_is_unaffected_when_no_restriction_is_configured(tmp_path: Path) -> None:
+    """Tier 2: deny -- #6061's own "既定は変えません" ruling. No
+    ``contextual_permission`` at all -- ``env ls`` (a wrapper chain that
+    WOULD deny under the restriction above) passes cleanly, and the
+    returned plan entry carries no ``unwrap_chain`` key at all (matching
+    the byte-identical-shape contract ``test_5838_stage4_shc_exec.py``'s
+    own exact-dict-equality test depends on)."""
+    ctx, collected = _ctx(tmp_path, contextual=None)
+    plan = [ExecSegment(argv=("env", "ls"))]
+
+    result = await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    (entry,) = result
+    assert "unwrap_chain" not in entry
+    await settle(ctx.events)
+    assert not [e for e in collected if e.type == "exec_tool_axis_denied"]
+
+
+@pytest.mark.asyncio
+async def test_wrapper_chain_never_walked_when_no_restriction_is_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: deny, the load-bearing structural witness for "既定は変え
+    ません" -- with no tool-axis restriction, ``exec_wrappers.is_
+    registered_wrapper`` (the FIRST call inside the unwrap loop) is never
+    even invoked. A real, wrapping call recorder stands in for it (never
+    a Mock -- delegates to the real function, only records that it ran),
+    matching this repo's own "wrap and delegate, never fake" precedent
+    for observing "was a seam reached" without a duration.
+
+    Strip-falsify (performed during review, file Edit only): removing
+    the ``if not restriction_active: ... return`` early-exit in
+    ``_check_segment`` makes this assertion fail -- the wrapper table is
+    consulted even for an unrestricted session."""
+    import reyn.security.exec_plan_policy as policy_module
+
+    calls: "list[str]" = []
+    real = policy_module.is_registered_wrapper
+
+    def _recording_is_registered_wrapper(name: str) -> bool:
+        calls.append(name)
+        return real(name)
+
+    monkeypatch.setattr(policy_module, "is_registered_wrapper", _recording_is_registered_wrapper)
+
+    ctx, _ = _ctx(tmp_path, contextual=None)
+    plan = [ExecSegment(argv=("env", "ls"))]
+
+    await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    assert calls == [], (
+        f"expected the wrapper table never consulted when unrestricted, got {calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_form_this_table_cannot_extract_is_denied_when_restricted(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept -- a registered wrapper (``env``) in a flag shape
+    ``exec_wrappers.py`` refuses to extract (``-u`` takes a separate
+    value) is denied outright once a restriction is active, rather than
+    silently treated as "nothing more to check"."""
+    ctx, collected = _ctx(tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"nonexistent"})))
+    plan = [ExecSegment(argv=("env", "-u", "PATH", "ls"))]
+
+    with pytest.raises(PermissionError, match="cannot verify"):
+        await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    await settle(ctx.events)
+    (denied,) = [e for e in collected if e.type == "exec_tool_axis_denied"]
+    assert denied.data["effective_name"] == "env"
+
+
+@pytest.mark.asyncio
+async def test_a_chain_deeper_than_the_unwrap_limit_is_denied(tmp_path: Path) -> None:
+    """Tier 2: accept -- 9 nested ``env`` hops (one past the 8-hop limit,
+    matching OpenAI Codex's own depth bound) is refused rather than
+    approved, even though every individual hop is itself extractable."""
+    ctx, collected = _ctx(tmp_path, contextual=ContextualPermission(tool_deny=frozenset({"nonexistent"})))
+    argv = ("env",) * 9 + ("ls",)
+    plan = [ExecSegment(argv=argv)]
+
+    with pytest.raises(PermissionError, match="depth limit|exceeded"):
+        await check_exec_plan_policy(plan, ctx, env_path=_REAL_PATH, cwd=None)
+
+    await settle(ctx.events)
+    (denied,) = [e for e in collected if e.type == "exec_tool_axis_denied"]
+    # Content, not shape: every hop walked was genuinely "env" (the SAME
+    # binary all 9 argv tokens name), and the chain's own last entry is
+    # exactly the one that tripped the limit -- not merely "some length".
+    assert denied.data["unwrap_chain"] == ["env"] * (_MAX_UNWRAP_DEPTH + 1)
+    assert "unwrap limit" in denied.data["reason"] and str(_MAX_UNWRAP_DEPTH) in denied.data["reason"]


### PR DESCRIPTION
**[e2e-coder]** — implements #6061's own final design (architect + lead-coder ruling, issue thread). ⚠️ **architect co-vet required before merge** (security surface, per lead-coder's explicit condition).

Closes #6061

## What this closes
`env ls` / `xargs ls` / `sh -c ls` / `timeout 5 ls` / `nice ls` / `command ls` all resolved the tool axis's check against the WRAPPER's own name, never the binary that actually runs. An operator who restricted `ls` via the tool axis read their own restriction as enforced when it was not.

## Design (verbatim from the issue thread, not re-derived)
- **Table is curated, never derived** — lead-coder's own reversal, after industry research found no repo-internal corpus can tell you "does this binary exec its own argument" (world knowledge, not a grammar property; #6110's own derive-from-corpus precedent does not apply here). New module `src/reyn/security/exec_wrappers.py`, matching `bash_node_kinds.py`'s own precedent shape but explicitly documenting the difference (curation vs. derivation).
- **6 names, the exact ones the issue thread measured**: `env` / `xargs` / `sh` (the `-c` form) / `timeout` / `nice` / `command`. `sudo` / `find -exec` are named in `UNSUPPORTED_WRAPPERS` with why — not silently absent.
- **Chain, never strip** — `_check_segment` walks the full chain (`env FOO=1 sh -c rm` checks `env`, `sh`, AND `rm`). Stripping would defeat an operator who denied the wrapper's own name.
- **Depth-limited to 8** (OpenAI Codex's own bound for the identical recursion, architect's competitive research) — fails CLOSED past the limit or on an unrecognised wrapper argv shape, never silently "nothing more to check".
- **Restriction-inert by construction** — the whole walk is gated on a tool-axis restriction actually being configured. An unrestricted session never enters the loop.
- **Existing event, new field, not a new kind** (per lead-coder's explicit preference) — `exec_tool_axis_denied` gains `unwrap_chain`; `check_exec_plan_policy`'s own returned entries gain the same key only when a chain was actually walked under an active restriction.
- **Threat scan / sandbox unchanged** — out of this PR's own scope per the issue thread's charter-lens table.

## Witness — real calls, actual output
```python
>>> extract_inner_argv("env", ("env", "FOO=1", "ls"))
('ls',)
>>> extract_inner_argv("timeout", ("timeout", "5", "rm", "-rf", "/tmp/x"))
('rm', '-rf', '/tmp/x')
>>> extract_inner_argv("xargs", ("xargs", "-n", "1", "ls"))
None   # matches Claude Code's own documented "bare xargs only" limit
```
All 12 of the issue thread's own measured command lines are exercised in `tests/security/test_6061_exec_wrapper_unwrap.py::test_extracts_inner_argv_for_each_measured_form` (+ 2 dedicated deny-side tests for `eval`/`xargs -n1`).

## `既定は変えません` — verified, not just asserted
`test_env_ls_is_unaffected_when_no_restriction_is_configured` + `test_wrapper_chain_never_walked_when_no_restriction_is_configured` (the latter wraps-and-records the REAL `is_registered_wrapper` — never a Mock — and asserts it is never called when unrestricted). The pre-existing `test_5838_stage4_shc_exec.py::test_...` exact-dict-equality assertion on `sandboxed_exec_started`'s `plan` field (`{"argv0":..., "resolved":...}`, no third key) stays green unmodified — confirms the new `unwrap_chain` key is genuinely absent for the unrestricted/no-wrapper case.

## Strip-falsify (file Edit only, no git stash/checkout/restore)
Short-circuited the unwrap loop to break after the first hop (the pre-#6061 shape). 4 tests went RED (`env ls` silently approved even with `ls` restricted; depth-limit and cannot-extract cases silently passed). Reverted; confirmed green again.

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py` (0 findings in touched files), `test_tier_audit.py --strict` (12/12 OK, 0 Tier-4), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `check_tests_path_literal_reference.py`, `flat_tests_ratchet.py`.

## Environment note
This worktree's own venv was missing `tree-sitter`/`tree-sitter-bash` (already a correctly-declared `pyproject.toml` dependency since #5987 stage 1) — installed locally only to run this PR's own tests and the pre-existing `exec_plan` test suite, which was silently uncollectable without it. No `pyproject.toml` change.

## Pytest (diff-scoped + directly-adjacent existing suites, foreground)
`pytest tests/security/test_6061_exec_wrapper_unwrap.py tests/security/test_5838_stage3_exec_plan_policy.py tests/core/test_5838_stage4_shc_exec.py tests/core/test_op_sandboxed_exec.py tests/security/test_6008_ambient_path_memoize.py -q` → **95 passed**.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. Architect co-vet and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S