### PR TITLE
docs(pr-workflow): the gate reads a comment's FIRST line for BLOCKING

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -328,6 +328,20 @@ These rules then keep multi-session work coherent:
    carries that fact instead (`scripts/check_open_blocking_checkboxes.py`'s
    `_resolves_via_body`, #5919's census).
 
+   **Never write `BLOCKING` or `BLOCKING-CLEARED` in a comment's FIRST
+   non-empty line unless it IS the marker.** The gate reads that line and
+   only that line: a first line that names either word but does not parse
+   as the marker regex is RED (Condition C in
+   `scripts/check_open_blocking_checkboxes.py`, #5522 — a third failure
+   mode added after a real `**BLOCKING (head `9862413f0`)**` whose
+   backticks broke the regex and left the gate silent for 12 minutes).
+   Prose like "no blocking points here" trips it just as a malformed
+   marker does, and the script's own log still prints `OK` while the run
+   fails. **From the second line on, both words are free.** Two sessions
+   using this gate daily hit it without knowing the condition existed
+   (2026-08-29 lead-coder, 2026-09-11 architect), which is why it is
+   written here rather than left in the script.
+
    **A moved head lapses every live marker at once.** The gate asks each
    marker to name the PR's CURRENT head, so a `BLOCKING-CLEARED` or
    `TESTS-READ` posted against an earlier head silently stops counting —


### PR DESCRIPTION
**[architect]** — **lead-coder 依頼。** ⚠️ **今夜 私が踏んだので、その場で書いています。**

## 何が起きたか

**PR #6123 の required check `open-blocking-checkboxes` が failure。** 🔴 **script 自身のログは `OK — no open blocking checkbox` を出しています。**
**原因は私の review comment の *第 1 行***:

> `… ⚠️ **B​LOCKING は出しません。** …`

⭐ **Condition C は「第 1 非空行が その語を名指すが marker として parse できない」を RED にします。** 🔴 **散文でも、壊れた marker でも、同じ扱いです。**

## 足した 1 段落

**`docs/deep-dives/contributing/pr-workflow.md`**、**marker 規則の並びに**:
- 🔴 **第 1 非空行に その語を書かない（marker そのものである場合を除く）**
- ⭐ **2 行目以降は自由**
- ⚠️ **script のログが `OK` を出したまま run が落ちる**（**今夜の実物**）
- **根拠の 2 件**: **2026-08-29 lead-coder**（marker 内の backtick が regex を壊し 12 分 沈黙）／**2026-09-11 architect**（本件）

🔴 **2 session が この gate を毎日 使いながら条件を知りませんでした。** ⭐ **script に埋めたままにせず doc に出す理由が、それです。**

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — OK
- [x] `python scripts/check_doc_anchors.py` — OK
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK
- [x] `ruff check .` — OK
- [x] (skipped — docs only) `pytest` scoped to diff
- [x] **この PR 本文と comment の第 1 行に、その語を置いていないこと**（**自分で踏んだ罠を PR で再演しないため**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow