### PR TITLE
fix(part of #6061): widen sandboxed_exec.py's plan_field annotation

### DIFF
--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -172,8 +172,11 @@ async def run_sandboxed_exec(
     # `check_exec_plan_policy`'s own RETURN VALUE in cmd-mode, never by
     # calling `resolve_real_executable` a second time here -- see that
     # function's own docstring for why a second resolution is the exact
-    # bug class this closes.
-    plan_field: "list[dict[str, str]] | None" = None
+    # bug class this closes. #6061: each entry may ALSO carry an
+    # `unwrap_chain` (a `list[str]`) alongside the existing `argv0`/
+    # `resolved` `str` values -- see `check_exec_plan_policy`'s own
+    # docstring for exactly when.
+    plan_field: "list[dict[str, str | list[str]]] | None" = None
 
     if cmd_text is not None:
         from reyn.security.exec_plan import ExecPlanRejected, parse_exec_plan


### PR DESCRIPTION
**[e2e-coder]** — main's `mypy (ratchet)` CI check went red after #6124 merged. Fixing the mismatch, not widening the baseline.

part of #6061

## Why this happened, and why local `mypy_ratchet.py` (changed-files) didn't catch it
#6124 widened `check_exec_plan_policy`'s own return type from `list[dict[str, str]]` to `list[dict[str, str | list[str]]]` (the new `unwrap_chain` field). #6124 itself only touched `exec_plan_policy.py`/`exec_wrappers.py`/its own test — `sandboxed_exec.py`, the ONE consumer of that return value, was never touched by #6124's own diff, so `scripts/mypy_ratchet.py`'s own default changed-files mode never even looked at it. Its `plan_field` annotation (unchanged, still `list[dict[str, str]] | None`) went stale the moment #6124's return type widened one file over. CI's `--full` run caught it on main.

## Fix
Widened `sandboxed_exec.py`'s `plan_field` annotation to match: `list[dict[str, str | list[str]]] | None`. Per `scripts/mypy_ratchet.py`'s own docstring instruction, did **not** regenerate the whole baseline with `--write-baseline` to silence this — fixed the actual type mismatch.

## Witness
```
mypy ratchet OK (--full): 187 findings, all baselined (208 declared).
```
(the `--full` mode CI actually runs, not the changed-files default that could never have seen this)

## Gates
`ruff`, `verify_module_docstrings.py` — pass.

## Pytest (diff-scoped + directly-adjacent, foreground)
`pytest tests/core/test_op_sandboxed_exec.py tests/core/test_5838_stage4_shc_exec.py tests/security/test_5838_stage3_exec_plan_policy.py tests/security/test_6061_exec_wrapper_unwrap.py -q` → **90 passed**.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. CI and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S