### PR TITLE
docs(pr-workflow): the rule was written down and still not pulled

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -337,10 +337,15 @@ These rules then keep multi-session work coherent:
    backticks broke the regex and left the gate silent for 12 minutes).
    Prose like "no blocking points here" trips it just as a malformed
    marker does, and the script's own log still prints `OK` while the run
-   fails. **From the second line on, both words are free.** Two sessions
-   using this gate daily hit it without knowing the condition existed
-   (2026-08-29 lead-coder, 2026-09-11 architect), which is why it is
-   written here rather than left in the script.
+   fails. **From the second line on, both words are free.** The reason
+   this is written here and not left in the script is not that nobody
+   knew: one of the two sessions that hit it (2026-08-29 lead-coder,
+   2026-09-11 architect) already carried the rule in their own standing
+   checklist, with an instance (#5713) attached, and did not pull it —
+   a checklist read when DISPATCHING work is not reached while
+   DIAGNOSING a red gate. A rule only helps at the moment its reader is
+   already in. This page is read before opening or reviewing a PR, which
+   is where both instances happened.
 
    **A moved head lapses every live marker at once.** The gate asks each
    marker to name the PR's CURRENT head, so a `BLOCKING-CLEARED` or


### PR DESCRIPTION
**[architect]** — **#6125 の根拠 1 文の訂正**（lead-coder 申告、本人の checklist に既記載と判明）。

## 何が偽だったか

**#6125 で私はこう書きました**（lead-coder の申告をそのまま使いました）:
> **Two sessions using this gate daily hit it without knowing the condition existed**

🔴 **2 人のうち 1 人については偽です。** ⭐ **lead-coder の恒久 checklist に、実例（#5713）つきで *既に* 書かれていました。** ⚠️ **障害の診断中に、それが引かれませんでした。**

## なぜ直す価値が在るか

⭐ **「知らなかった」は「書けば足りる」と読めます。** 🔴 **実際に起きたのは もっと狭く、もっと有用です**:
**規則は *発注の直前に読む* checklist に在り、必要になったのは *赤い gate を診断している* ときでした。** ⭐ **同じ知識が、違う文脈では引き出されません。**

🔴 **∴ この page に書く理由は「事実が欠けていたから」では在りません。** ⭐ **この page は PR を開く／review する直前に読まれ、2 件ともその文脈で起きたから** — **参照点を移すのが直しで、事実をもう 1 度 記録することは直しでは在りませんでした。**

⚠️ **rule 自体は #6125 のまま正しく、変えていません。** **根拠の 1 段落だけです。**

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — OK
- [x] `python scripts/check_doc_anchors.py` — OK
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK
- [x] `ruff check .` — OK
- [x] (skipped — docs only) `pytest` scoped to diff
- [x] **この PR 本文と comment の第 1 行に、当の語を置いていないこと**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow