### PR TITLE
docs(part of #5989): fix once-per-turn doc drift for turn_completed/turn_end

### DIFF
--- a/src/reyn/core/events/event_schema.py
+++ b/src/reyn/core/events/event_schema.py
@@ -315,14 +315,24 @@ EVENT_AUDIT_REQUIREMENTS: dict[str, frozenset[str]] = {
     # turn_completed: emitted in Session._run_router_loop() immediately after
     #   RouterLoopDriver.run_turn() returns — the router loop has reached a
     #   terminal condition (the turn's response is complete). One emit per
-    #   turn, independent of routing path. This is the hook point for
+    #   `_run_router_loop` CALL, independent of routing path — #5989: NOT
+    #   "once per user turn". `_run_router_loop` is the single seam every
+    #   turn KIND (user / hook / agent_request / pipeline_result, its own
+    #   docstring) funnels through, and it is re-entered once per such
+    #   kind's own arrival — a mid-turn hook injection, a settled peer
+    #   task delivering its reply, or an agent_request from another agent
+    #   each start a NEW call here, so what an operator experiences as
+    #   ONE exchange can legitimately reach this point, and dispatch the
+    #   turn_end hook below, more than once. This is the hook point for
     #   the turn_end lifecycle hook (slice 5b). chain_id matches the turn's
     #   chain_id for cross-agent tracing.
     "turn_completed": frozenset({"chain_id"}),
     # process_footprint (#5851 stage (a)): a live process-memory reading —
     # ``Session.load_history()``'s own finally (once, at startup, every
     # ``load_history()`` caller) and ``_run_router_loop``'s finally (once
-    # per turn, next to the turn_end dispatch). ``metric`` MUST ride with
+    # per `_run_router_loop` call — #5989, see ``turn_completed``'s own
+    # entry above for why this is not the same as "once per user turn" —
+    # next to the turn_end dispatch). ``metric`` MUST ride with
     # every ``bytes`` value (verification-hazards' own root: "an
     # observation does not name its own referent") — darwin's
     # ``phys_footprint`` and linux's ``rss`` are not comparable numbers.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -12857,10 +12857,14 @@ class Session:
                     )
                 finally:
                     # #5851 stage (a), observation point ④ ("turn 終端"): 1
-                    # emit per turn, unconditionally (#5248's own
-                    # nested-finally discipline — a turn_end hook that
-                    # raised still reaches this, same as it must not skip
-                    # the hot_reloader step right after it).
+                    # emit per `_run_router_loop` call, unconditionally
+                    # (#5248's own nested-finally discipline — a turn_end
+                    # hook that raised still reaches this, same as it must
+                    # not skip the hot_reloader step right after it). #5989:
+                    # NOT "once per user turn" — see event_schema.py's own
+                    # `turn_completed` entry for why a single operator
+                    # exchange can legitimately re-enter `_run_router_loop`,
+                    # and this finally with it, more than once.
                     _footprint = self._emit_process_footprint(chain_id=chain_id)
                     # #5939 PR-2: the steady-state memory ladder's own
                     # judge reads the SAME sample the emit above just


### PR DESCRIPTION
**[e2e-coder]** — verified each of the 3 `src/` locations individually before editing (did not trust `grep`'s hit count as "3 errors" — matches lead-coder's own self-correction earlier tonight: a grep hit is "the word is present", not "the claim is false").

part of #5989

## Verdicts, one per site

| Site | Verdict | Why |
|---|---|---|
| `event_schema.py:317` (`turn_completed`'s own comment) | 🔴 FALSE | "One emit per turn" reads as "once per operator exchange". `_run_router_loop` is the single seam every turn KIND (user / hook / agent_request / pipeline_result — its own docstring) funnels through, re-entered once per such kind's own arrival. |
| `event_schema.py:324` (`process_footprint`'s comment, re: `_run_router_loop`'s finally) | 🔴 FALSE | Same claim, same reason. |
| `session.py:12859` (the finally block itself, inside `_run_router_loop`) | 🔴 FALSE | Same claim, same reason. |

A mid-turn hook injection, a settled peer task delivering its reply, or an inbound `agent_request` from another agent each start a NEW `_run_router_loop` call — what an operator experiences as ONE exchange can legitimately reach `turn_completed`, and dispatch `turn_end`, more than once. This is the exact misreading behind the owner's own "turn_end fires repeatedly" report (#5989's own thread).

## Fix
All 3 → "per `_run_router_loop` call" — **never naming the number of call sites** (6, today) per architect's own ruling: a call-site count goes stale the day a 7th is added, and would just become tomorrow's drift.

## Before / after (verbatim)

**`event_schema.py:317`**
```
before: "One emit per turn, independent of routing path."
after:  "One emit per `_run_router_loop` CALL, independent of routing path —
         #5989: NOT "once per user turn". ... a mid-turn hook injection, a
         settled peer task delivering its reply, or an agent_request from
         another agent each start a NEW call here, so what an operator
         experiences as ONE exchange can legitimately reach this point ...
         more than once."
```

**`event_schema.py:324`**
```
before: "``_run_router_loop``'s finally (once per turn, next to the
         turn_end dispatch)."
after:  "``_run_router_loop``'s finally (once per `_run_router_loop` call
         — #5989, see ``turn_completed``'s own entry above for why this is
         not the same as "once per user turn" — next to the turn_end
         dispatch)."
```

**`session.py:12859`**
```
before: "1 emit per turn, unconditionally (#5248's own nested-finally
         discipline ...)."
after:  "1 emit per `_run_router_loop` call, unconditionally (#5248's own
         nested-finally discipline ...). #5989: NOT "once per user turn"
         — see event_schema.py's own `turn_completed` entry for why a
         single operator exchange can legitimately re-enter
         `_run_router_loop`, and this finally with it, more than once."
```

## Scope
`src/` comment/docstring only, per your explicit condition — `docs/` untouched (`events.md` is #6128's own scope; `hooks.md` already carries the correct wording, unmodified). No correct contrast ("not once per turn", `events.md:747`'s own phrasing) touched.

## Gates
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py` (183 findings, all baselined) — all pass.

## Pytest (diff-adjacent, foreground)
No test asserts on this comment's own wording (comment-only change). Ran `tests/runtime/test_5248_turn_finally.py` (the finally block's own existing test coverage) as a sanity check — `2 passed`, unaffected.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself (no `tests/` touched). CI and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
