### PR TITLE
docs(#5989): "stuck forever" overstated it — the stuck row lives exactly as long as the attached view

### DIFF
--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -422,12 +422,21 @@ class RemoteQueueView:
         This state — a queued item present in :attr:`items` while its own
         ``turn_started`` carries ``seq <= self._last_seq`` — is REAL: this
         very ``WARNING`` branch exists to name it (pre-existing on
-        ``main``, #5989 ③ — this PR did not add it), and it matches the
-        owner's real #5989 symptom (a sent-queue item stuck forever, never
-        promoted, since ``turn_started`` is a once-per-turn edge the
-        server never resends — a rejected item would have no OTHER delta
-        that will ever promote it). **The server-side PATH that produces
-        this state is UNIDENTIFIED as of this PR** (an earlier draft of
+        ``main``, #5989 ③ — #6123 did not add it), and it matches the
+        owner's real #5989 symptom (a sent-queue item stuck for the life
+        of this attached view, never promoted, since ``turn_started`` is a
+        per-DISPATCH edge the server never re-sends — a rejected item has
+        no OTHER delta that will ever promote it. Not "forever": a
+        re-attach clears it, because :meth:`apply_snapshot` REPLACES
+        :attr:`items` wholesale rather than merging into it, so the stuck
+        row survives exactly as long as this connection does. And
+        "per-dispatch" is not "per operator turn" — a mid-turn injection
+        fires its own ``turn_started``
+        (``Session._commit_mid_turn_injection``, which "rides inside the
+        ALREADY-running turn's lifecycle"); what this branch relies on is
+        only that no SECOND one ever arrives for the same rejected
+        dispatch). **The server-side PATH that produces this state is
+        UNIDENTIFIED as of #6123** (an earlier draft of
         this docstring named ``apply_snapshot``'s unconditional
         ``_last_seq`` assignment as the cause via a specific
         generated-before/delivered-after reconnect-snapshot scenario; that


### PR DESCRIPTION
**[architect]** — **`apply_inbox_cancel` / `apply_turn_started` の docstring が「stuck forever」と書いていましたが、⭐ 滞留は *この attach の間だけ* です。** `part of #5989`

**docstring のみ。挙動・test は 1 行も変えていません。**

## ⚠️ 先に 1 点 — **依頼された文は main に 在りませんでした**

🔴 **私が直すはずだった文（`it would sit in :attr:`items` forever`）は、#6123 の docstring 全面書き換えで *既に消えています*。**
```
$ git grep -nE "sit in|would sit" origin/main -- src/reyn/interfaces/transport/agui/state.py
（no match）
```
⭐ **残っていたのは 隣の別の文**で、**同じ誤りを 弱い形で持っていました** ∴ **そちらを直しました。** ⚠️ **「依頼された文字列が無い」を「やることが無い」と読まないように、経緯を書いておきます。**

## ⑴ `forever` — **何が偽か**

**`apply_snapshot` は `items` を *総入れ替え* します**（**自身の docstring 逐語: 「Seed the view from a ``STATE_SNAPSHOT`` — replaces the queue wholesale」**、実体も `self.items = {…}` の再代入）。
🔴 **∴ 再 attach で 滞留は消えます。** ⭐ **`forever` が真なのは *この接続が続く間* だけ。**

⚠️ **ここは言葉の綾ではありません** ―― **operator にとって「再接続すれば消える」は *回避策* です。** 🔴 **`forever` はその回避策を隠していました。**

## ⑵ 同じ文に もう 1 つ — **`turn_started` は once-per-turn では在りません**

**元の文**: 「since ``turn_started`` is a **once-per-turn** edge the server never resends」

🔴 **偽です。** **mid-turn injection が *自分の* `turn_started` を出します** ―― **`Session._commit_mid_turn_injection` の docstring 逐語:**
> Reuses the **SAME ``turn_started`` audit-event shape** the ordinary turn-boundary promote uses … does not care whether this is the FIRST ``turn_started`` for that chain_id or **an extra one fired mid-turn** … **a mid-turn injection rides inside the ALREADY-running turn's lifecycle, it does not start a new one**

⚠️ **`events.md` も同じことを言っています**（`skipped_over` は「#5647 — **MID-TURN injections only**, absent on an ordinary turn-boundary `turn_started`」）。

⭐ **ただし この分岐が *必要としている* 性質は もっと狭く、今も真です** ―― **「同じ rejected な dispatch に対して 2 本目が来ない」。** 🔴 **そこだけを言う形に直しました**（**`per-DISPATCH edge … no SECOND one ever arrives for the same rejected dispatch`**）。

⚠️ **これは #6128 と同じ族です**（**`turn_end` を「once per turn」と書いていた件**）。⭐ **こちらは `turn_started` 側で、別の主語です。**

## ⑶ ついでに 2 語 — **`this PR` を `#6123` に**

**同じ段落に `this PR` が 2 箇所 在りました**（「#5989 ③ — **this PR** did not add it」／「UNIDENTIFIED as of **this PR**」）。
🔴 **#6123 が merge された今、`this PR` は読者が辿れる何も指しません。** ⭐ **番号に固定しました**（**書いた時点を入れれば腐りません**）。

## 🔴 私の面の外（**別便が要ります**）

**`tests/interfaces/test_3300_p3_cancel_by_id.py` に 同じ文言が 2 箇所 生きています。** ⚠️ **私は test を書かないので触れません:**

| 行 | 逐語 |
|---|---|
| **426** | `stuck forever). This test exercises the SAME predicate branch` ―― ⭐ **上の ⑴ と同じ文の写し** |
| **464** | `assert view.queue() == [], "m2 must not stay queued forever"` ―― ⚠️ **assert message。test 自身が構築した状態についてなので誤りとまでは言いませんが、⑴ の後だと不揃いです** |

## Test plan

- [x] `ruff check .` — All checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/transport/agui/state.py` — OK
- [x] `python scripts/silent_except_ratchet.py`（`src/reyn/interfaces/` を触るため）— OK、baseline 変化なし
- [x] **diff が docstring のみであることを確認** — ⭐ **code 行の増減 0**（`git diff` 全体が 1 つの docstring の中）
- [x] (skipped — `pytest`: **挙動も test も変えていない** ∴ 差分に対応する test が在りません)
- [x] (skipped — `mypy_ratchet.py`: **owner 恒久指示により local 実行しません。CI が判定します**)
- [x] (skipped — Visual なし: docstring のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow
