### PR TITLE
docs: part of #5989 -- stuck-forever residue in test_3300_p3_cancel_by_id.py, aligned to #6130

### DIFF
--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -421,7 +421,7 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
     matching ``inbox_cancel`` for ``m2`` carries ``seq <= _last_seq`` — is
     REAL: :meth:`apply_inbox_cancel`'s own ``WARNING`` branch in
     ``state.py`` exists to name exactly this condition (pre-existing on
-    ``main``, #5989 ③ — this PR did not add that branch), and it is the
+    ``main``, #5989 ③ — #6123 did not add that branch), and it is the
     condition behind the owner's own real #5989 symptom (a sent-queue item
     stuck for the life of this attached view, not "forever" — #6130:
     :meth:`apply_snapshot` REPLACES :attr:`items` wholesale rather than
@@ -453,7 +453,7 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
 
     Neither exclusion is a demonstrated path to the state under test —
     the server-side path that produces this state remains UNIDENTIFIED as
-    of this PR. Do not read the ``apply_snapshot`` call below as a claim
+    of #6123. Do not read the ``apply_snapshot`` call below as a claim
     that it is one, and do not supply a third unverified path in its
     place."""
     view = RemoteQueueView()

--- a/tests/interfaces/test_3300_p3_cancel_by_id.py
+++ b/tests/interfaces/test_3300_p3_cancel_by_id.py
@@ -423,8 +423,12 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
     ``state.py`` exists to name exactly this condition (pre-existing on
     ``main``, #5989 ③ — this PR did not add that branch), and it is the
     condition behind the owner's own real #5989 symptom (a sent-queue item
-    stuck forever). This test exercises the SAME predicate branch
-    :class:`RemoteQueueView` itself already treats as reachable.
+    stuck for the life of this attached view, not "forever" — #6130:
+    :meth:`apply_snapshot` REPLACES :attr:`items` wholesale rather than
+    merging into it, so a re-attach clears a stuck row; the row survives
+    exactly as long as this connection does). This test exercises the
+    SAME predicate branch :class:`RemoteQueueView` itself already treats
+    as reachable.
 
     ## The server-side path is explicitly UNIDENTIFIED — do not infer one
     Two proposed reproductions were each checked and separately excluded —
@@ -461,7 +465,7 @@ def test_remote_queue_view_apply_inbox_cancel_recovers_a_stuck_item():
     recovered = view.apply_inbox_cancel(msg_id="m2", seq=2)
 
     assert recovered is True, "m2's cancel must be applied, not dropped"
-    assert view.queue() == [], "m2 must not stay queued forever"
+    assert view.queue() == [], "m2 must not stay queued for the life of this attached view"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[tui-coder]** — part of #5989. Not closing #5989.

## What
`test_3300_p3_cancel_by_id.py` carried two copies of the "stuck forever" phrasing that #6130 corrects in `state.py` (`apply_snapshot` REPLACES `items` wholesale rather than merging into it, so a re-attach clears a stuck row — it survives exactly as long as the connection does, not "forever").

- The docstring's copy of the same sentence — aligned to #6130's correction (quoting `"forever"` as the retracted claim, matching #6130's own style).
- The assert message `"m2 must not stay queued forever"` — reworded to match, dropping the unbounded claim the assert itself never tested.

Docstring/message only. Assert content, test behavior, and the Tier line are unchanged.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (changed test file)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates: bare-import ref, file-depth ref, subprocess-reyn-pin, no-core-dep-importorskip, time-dependence ratchet
- [x] (skipped — Visual, standing waiver)

Diff-scoped pytest: `pytest tests/interfaces/test_3300_p3_cancel_by_id.py -q` → **16 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
