### PR TITLE
fix: #6132 -- cp932 write encoding on 11 reyn.* file opens, gated by PEP 597 EncodingWarning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,12 @@ jobs:
               done
             } > /tmp/hang-ps.log 2>&1
           ) &
-          REYN_REPLAY_UNCONSUMED_CHECK=1 REYN_STALL_TRACE_CI=700 timeout 13m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
+          # PYTHONWARNDEFAULTENCODING=1 (#6132): arms PEP 597's EncodingWarning
+          # in this process AND every xdist worker it spawns (env is
+          # inherited) — tests/conftest.py escalates it to an error for
+          # reyn.*'s own call sites only. The flag is latched at interpreter
+          # startup, so it must be set here, not toggled from conftest.py.
+          PYTHONWARNDEFAULTENCODING=1 REYN_REPLAY_UNCONSUMED_CHECK=1 REYN_STALL_TRACE_CI=700 timeout 13m python -m pytest -q -n auto --timeout=120 -rs --durations=25 | tee /tmp/pytest-output.log
 
       # #4986: surface the stall dump above if (and only if) it fired. The
       # log file is opened (empty) the moment the watchdog is armed —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,7 +531,10 @@ pythonpath = ["src"]
 # execution -- measured directly: the exact escalation this entry provides
 # reproduced as "1 passed, 1 warning" (no error) without it. This
 # ini_options key is pytest's OWN filterwarnings mechanism, applied fresh
-# per item, so it is what actually protects the real suite.
+# per item, so it is what actually protects the real suite. The SAME
+# pattern is hand-copied into tests/dev/test_6132_encoding_default_gate.py's
+# own _INSTALL_FILTER (its 3 subprocess-script scenarios run outside
+# pytest entirely, so they cannot read this entry) -- keep both in sync.
 filterwarnings = ["error::EncodingWarning:reyn(\\..*)?$"]
 # dogfood/fixtures/ ships failing-test workspaces consumed by
 # dogfood/scripts/ runners on isolated tmp copies. They MUST NOT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -595,7 +595,20 @@ exclude = [
 # target as a guideline rather than a hard rule, since wrapping
 # Reyn's narrative comments and skill scripts often hurts
 # readability more than it helps.
-select = ["F", "I"]
+#
+# #6132: PLW1514 (unspecified-encoding, ruff's preview-only Pylint port)
+# is the static complement to tests/conftest.py's runtime EncodingWarning
+# gate -- the runtime gate only sees a call a test path actually reaches;
+# PLW1514 sees every literal call site regardless of coverage. Neither
+# alone is sufficient -- measured one-by-one against the 11 confirmed
+# #6132 sites (each site's own encoding= stripped in isolation, ruff run,
+# restored): PLW1514 catches exactly the 5 bare `open()`/`Path.open()`/
+# `.write_text()` calls, and misses the other 6 -- the 1 *FileHandler
+# construction (chat.py's own root cause; it does not model FileHandler's
+# encoding=None -> locale.getpreferredencoding() default), all 4
+# `.read_text()` calls, and the 1 `os.fdopen()` call.
+preview = true
+select = ["F", "I", "PLW1514"]
 ignore = [
     # F811: local imports inside functions for clarity (e.g. lazy
     # imports of optional deps) trigger this.
@@ -673,6 +686,19 @@ ignore = [
 # below don't have this failure mode because the directory NAME is the
 # anchor, not a wildcard.
 [tool.ruff.lint.per-file-ignores]
+
+# #6132: PLW1514 (unspecified-encoding) is scoped to src/ only -- the
+# issue's own population and this PR's own fix are both src/-scoped;
+# every other top-level tree with .py files has a much larger,
+# separately-owned population (measured: tests/ 56, scripts/ +
+# dogfood/scripts/ + docs/ 25) that is out of scope for this ticket.
+# ruff per-file-ignores only ADDS ignores (no positive "select here
+# only" mechanism), so each non-src/ tree with a finding is listed
+# explicitly rather than attempted as a single inverse glob.
+"tests/**" = ["PLW1514"]
+"scripts/**" = ["PLW1514"]
+"dogfood/**" = ["PLW1514"]
+"docs/**" = ["PLW1514"]
 
 # #3726: wired into CI as a ratchet (.github/workflows/test.yml's "mypy
 # (ratchet)" job), not a blocking full-adoption gate — the tree currently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,6 +524,15 @@ sample_line = "reyn.gateway.sample_line:register_router"
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 pythonpath = ["src"]
+# #6132: pytest resets the warnings filter state per test ITEM (enters its
+# own catch_warnings() + simplefilter("always") around every item), so a
+# plain module-level warnings.filterwarnings() call at conftest.py IMPORT
+# time (this repo's first attempt) never survives to reach a real test's
+# execution -- measured directly: the exact escalation this entry provides
+# reproduced as "1 passed, 1 warning" (no error) without it. This
+# ini_options key is pytest's OWN filterwarnings mechanism, applied fresh
+# per item, so it is what actually protects the real suite.
+filterwarnings = ["error::EncodingWarning:reyn(\\..*)?$"]
 # dogfood/fixtures/ ships failing-test workspaces consumed by
 # dogfood/scripts/ runners on isolated tmp copies. They MUST NOT
 # be collected by the project's main pytest suite — the placeholder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -607,7 +607,15 @@ exclude = [
 # construction (chat.py's own root cause; it does not model FileHandler's
 # encoding=None -> locale.getpreferredencoding() default), all 4
 # `.read_text()` calls, and the 1 `os.fdopen()` call.
+#
+# explicit-preview-rules = true: `preview = true` alone also activates
+# PREVIEW BEHAVIOR of already-selected stable rules (F, I here) -- unpinned
+# ruff, so an upstream preview-behavior change to either could turn main
+# red with no PR of ours in between. This flag scopes preview mode to
+# EXPLICITLY preview-only rules (PLW1514) only -- F/I keep their stable
+# behavior. Verified: PLW1514 still fires with this flag set.
 preview = true
+explicit-preview-rules = true
 select = ["F", "I", "PLW1514"]
 ignore = [
     # F811: local imports inside functions for clarity (e.g. lazy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -606,8 +606,9 @@ exclude = [
 # readability more than it helps.
 #
 # #6132: PLW1514 (unspecified-encoding, ruff's preview-only Pylint port)
-# is the static complement to tests/conftest.py's runtime EncodingWarning
-# gate -- the runtime gate only sees a call a test path actually reaches;
+# is the static complement to this file's own [tool.pytest.ini_options].
+# filterwarnings entry (the runtime EncodingWarning gate) -- the runtime
+# gate only sees a call a test path actually reaches;
 # PLW1514 sees every literal call site regardless of coverage. Neither
 # alone is sufficient -- measured one-by-one against the 11 confirmed
 # #6132 sites (each site's own encoding= stripped in isolation, ruff run,

--- a/src/reyn/builtin/plugins/rag/scripts/vector_store_server.py
+++ b/src/reyn/builtin/plugins/rag/scripts/vector_store_server.py
@@ -147,7 +147,7 @@ def _describe_open_failure(db_path: str) -> str | None:
     path = Path(db_path)
     existed = path.exists()
     try:
-        with open(path, "a"):
+        with open(path, "a", encoding="utf-8"):
             pass
     except OSError as exc:
         return str(exc)

--- a/src/reyn/dev/dogfood/publish.py
+++ b/src/reyn/dev/dogfood/publish.py
@@ -75,7 +75,7 @@ def detect_repo_from_git() -> str | None:
     try:
         r = subprocess.run(
             ["git", "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=2.0,
+            capture_output=True, text=True, encoding="utf-8", timeout=2.0,
         )
         if r.returncode != 0:
             return None

--- a/src/reyn/dev/dogfood/runner.py
+++ b/src/reyn/dev/dogfood/runner.py
@@ -181,7 +181,9 @@ def _ensure_dir(path: Path) -> Path:
 
 
 def _write_json(path: Path, data: object) -> None:
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2, default=str))
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, default=str), encoding="utf-8",
+    )
 
 
 def _write_jsonl(path: Path, records: list[dict]) -> None:
@@ -467,7 +469,7 @@ def load_run_result_from_storage(run_dir: Path) -> RunResult:
     if not summary_path.exists():
         raise FileNotFoundError(f"No summary.json found in {run_dir}")
 
-    summary = json.loads(summary_path.read_text())
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
 
     run_id = summary["run_id"]
     set_name = summary["set_name"]
@@ -481,13 +483,13 @@ def load_run_result_from_storage(run_dir: Path) -> RunResult:
     scenarios_dir = run_dir / "scenarios"
     if scenarios_dir.exists():
         for output_path in sorted(scenarios_dir.glob("*/output.json")):
-            data = json.loads(output_path.read_text())
+            data = json.loads(output_path.read_text(encoding="utf-8"))
 
             # Load events
             events_path = output_path.parent / "events.jsonl"
             events: list[dict] = []
             if events_path.exists():
-                for line in events_path.read_text().splitlines():
+                for line in events_path.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if line:
                         events.append(json.loads(line))

--- a/src/reyn/dev/testing/encoding_gate_probe.py
+++ b/src/reyn/dev/testing/encoding_gate_probe.py
@@ -1,0 +1,29 @@
+"""#6132's own gate, given something real to catch (dev/test-only).
+
+``tests/conftest.py`` escalates :class:`EncodingWarning` (PEP 597) to an
+error for ``reyn.*``'s own call sites, so a NEW text-mode file open in
+production code that omits ``encoding=`` fails CI the moment a test path
+reaches it (or, more precisely, whenever the interpreter was started with
+``PYTHONWARNDEFAULTENCODING=1`` — see that filter's own comment for why the
+flag itself cannot be armed from here).
+
+A filter alone is not a witness: nothing proves the filter actually CATCHES
+anything unless something genuine, living inside the ``reyn.*`` namespace the
+filter is scoped to, calls ``open()`` without ``encoding=``.
+:func:`open_without_encoding_for_gate_test` is that something — its ONLY
+job. Never call it from production code; it exists so
+``tests/dev/test_6132_encoding_default_gate.py`` has a real ``reyn.*``
+module (not the test's own ``tests.*`` module, which the filter does not
+scope to) to exercise the mechanism against.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def open_without_encoding_for_gate_test(path: "str | Path") -> None:
+    """Open *path* for text writing WITHOUT ``encoding=`` — deliberately,
+    the exact #6132 shape. Exists only so the gate has a genuine ``reyn.*``
+    call site to prove it catches; see the module docstring."""
+    with open(path, "w") as f:  # deliberately no encoding= -- see module docstring
+        f.write("probe")

--- a/src/reyn/dev/testing/encoding_gate_probe.py
+++ b/src/reyn/dev/testing/encoding_gate_probe.py
@@ -25,5 +25,5 @@ def open_without_encoding_for_gate_test(path: "str | Path") -> None:
     """Open *path* for text writing WITHOUT ``encoding=`` — deliberately,
     the exact #6132 shape. Exists only so the gate has a genuine ``reyn.*``
     call site to prove it catches; see the module docstring."""
-    with open(path, "w") as f:  # deliberately no encoding= -- see module docstring
+    with open(path, "w") as f:  # noqa: PLW1514 -- deliberately no encoding=, see module docstring
         f.write("probe")

--- a/src/reyn/dev/testing/memory_ceiling.py
+++ b/src/reyn/dev/testing/memory_ceiling.py
@@ -104,7 +104,7 @@ def _watch(limit_mb: int) -> None:
             # process, which is the property the whole 2026-08-09 investigation
             # was missing: every runaway was gone before anyone could name it.
             try:
-                with open(LOG_PATH, "a") as fh:
+                with open(LOG_PATH, "a", encoding="utf-8") as fh:
                     fh.write(message)
             except OSError:
                 pass

--- a/src/reyn/dev/testing/stall_dump.py
+++ b/src/reyn/dev/testing/stall_dump.py
@@ -182,9 +182,11 @@ def pytest_configure(config: "pytest.Config") -> None:
         workerid = _worker_id(config)
         if workerid is None:
             return
-        _dump_file = open(worker_log_path(workerid), "a", buffering=1)  # noqa: SIM115 — see module docstring
+        _dump_file = open(  # noqa: SIM115 — see module docstring
+            worker_log_path(workerid), "a", buffering=1, encoding="utf-8",
+        )
         arm(worker_seconds_from(seconds), file=_dump_file)
         return
 
-    _dump_file = open(LOG_PATH, "a", buffering=1)  # noqa: SIM115 — see module docstring
+    _dump_file = open(LOG_PATH, "a", buffering=1, encoding="utf-8")  # noqa: SIM115 — see module docstring
     arm(seconds, file=_dump_file)

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -461,6 +461,15 @@ def _setup_interactive_logging(project_root: Path, *, is_interactive: bool = Tru
         str(log_path),
         maxBytes=defaults.max_bytes,
         backupCount=defaults.backup_count,
+        # #6132: FileHandler with encoding=None opens via
+        # locale.getpreferredencoding(False) -- cp932 on Japanese Windows.
+        # reyn.log's own readers all assume utf-8 (read_text(encoding=
+        # "utf-8") throughout tests/scripts); only the writer was
+        # locale-dependent. A non-ASCII log record (an em dash, #6132's
+        # own trigger) then raised UnicodeEncodeError from emit(), and
+        # stdlib's handleError wrote the traceback straight to raw
+        # sys.stderr, breaking the Textual screen it does not own.
+        encoding="utf-8",
     )
     handler.set_fallback_path(handler_failure_dump_path(str(log_path)))
     handler.setFormatter(

--- a/src/reyn/interfaces/web/a2a_webhook_registry.py
+++ b/src/reyn/interfaces/web/a2a_webhook_registry.py
@@ -69,7 +69,7 @@ class A2AWebhookRegistry:
         data = {"webhooks": self._webhooks, "notified": sorted(self._notified)}
         fd, tmp = tempfile.mkstemp(dir=str(self._persist_path.parent), suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(data, f)
             os.replace(tmp, str(self._persist_path))
         except Exception:
@@ -79,7 +79,7 @@ class A2AWebhookRegistry:
 
     def _restore_from(self, path: "Path") -> None:
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             return
         self._webhooks = dict(data.get("webhooks") or {})

--- a/src/reyn/runtime/logging_failure_fallback.py
+++ b/src/reyn/runtime/logging_failure_fallback.py
@@ -101,9 +101,21 @@ class FailureFallbackRotatingFileHandler(logging.handlers.RotatingFileHandler):
     before this subclass's wrapper's except clause could run) or
     double-handle it. `handleError` is the ONE correct override point —
     it is what the base class already calls, unconditionally, on every
-    emit failure."""
+    emit failure.
+
+    #6132: `encoding=` defaults to `"utf-8"` here, in the CLASS, not left
+    to each construction site to remember — `logging.FileHandler`'s own
+    `encoding=None` default opens via `locale.getpreferredencoding(False)`
+    (cp932 on Japanese Windows), and this class exists SOLELY to back
+    `reyn.log`, whose every reader already assumes utf-8
+    (`read_text(encoding="utf-8")` throughout tests/scripts) — inheriting
+    a locale-dependent default here is itself the defect, not something
+    each caller should have to override. `kwargs.setdefault` (not an
+    unconditional overwrite) so an explicit `encoding=` a caller passes
+    still wins."""
 
     def __init__(self, *args: object, **kwargs: object) -> None:
+        kwargs.setdefault("encoding", "utf-8")
         super().__init__(*args, **kwargs)  # type: ignore[arg-type]
         self._fallback_snapshot: "DiagnosticSnapshot | None" = None
         self._fallback_path: "str | None" = None

--- a/src/reyn/runtime/session_position.py
+++ b/src/reyn/runtime/session_position.py
@@ -37,7 +37,8 @@ def _run_git(repo_root: Path, *args: str) -> "str | None":
     (git missing, not a repo, no commits yet, ...) — never raises."""
     try:
         result = subprocess.run(
-            ["git", *args], cwd=repo_root, capture_output=True, text=True, timeout=10,
+            ["git", *args], cwd=repo_root, capture_output=True, text=True,
+            encoding="utf-8", timeout=10,
         )
     except (OSError, subprocess.TimeoutExpired):
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,39 +108,19 @@ _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-# ── #6132: EncodingWarning (PEP 597) as an error, scoped to reyn.* only ────
-#
-# Root cause: a text-mode file open with `encoding=None` opens via
-# `locale.getpreferredencoding(False)` — cp932 on Japanese Windows. A
-# `FailureFallbackRotatingFileHandler` built that way in
-# `interfaces/cli/commands/chat.py` could not encode an em dash in a log
-# record, and stdlib's own `logging.Handler.handleError` wrote the resulting
-# traceback straight to raw `sys.stderr`, breaking the Textual screen it does
-# not own (#6132's own owner-hit reproduction).
-#
-# This filter turns that class of bug into a collection-time-adjacent test
-# failure instead of a platform-specific runtime surprise: Python 3.10+'s
-# `EncodingWarning` (PEP 597) fires from `io.TextIOWrapper` whenever
-# `encoding=` was omitted, but ONLY when the interpreter itself was started
-# with `-X warn_default_encoding` / `PYTHONWARNDEFAULTENCODING=1` (CI's
-# `test.yml` sets this for its main pytest invocation) — the flag is latched
-# at interpreter startup and CANNOT be toggled from here; without it, no
-# `EncodingWarning` is ever produced and this filter has nothing to catch
-# (see `tests/dev/test_6132_encoding_default_gate.py`'s own precondition
-# assertion, which fails loud rather than passing vacuously if the flag is
-# missing).
-#
-# `module=r"reyn(\..*)?$"` scopes the error escalation to reyn's OWN call
-# sites (matched against the warning's attributed module — the direct Python
-# caller of `open()`/`Path.open()`/`.read_text()`/`.write_text()`/a
-# `logging.FileHandler` subclass, not `io` itself, confirmed empirically): a
-# third-party dependency that also omits `encoding=` still emits the warning
-# (visible in pytest's warnings summary) but is never escalated to an error —
-# this repo cannot fix another package's source. This is the discriminator
-# #6132 names ("第三者ライブラリを巻き込まずに reyn の site だけ error 化
-# できるか") and the reason this gate is the PEP 597 mechanism rather than a
-# `scripts/` AST ratchet.
-warnings.filterwarnings("error", category=EncodingWarning, module=r"reyn(\..*)?$")
+# ── #6132: EncodingWarning (PEP 597) is escalated via pyproject.toml, NOT
+# here — see [tool.pytest.ini_options]'s own `filterwarnings` entry and its
+# comment for the mechanism and the root cause. A module-level
+# `warnings.filterwarnings()` call at THIS file's import time was tried
+# first and measured NOT to work: pytest enters a fresh `catch_warnings()`
+# + `simplefilter("always")` around every test item's own execution, which
+# discards any filter installed at collection/import time before a single
+# test body runs — reproduced directly as "1 passed, 1 warning" (no error)
+# against a known-bad reyn.* call. `[tool.pytest.ini_options].
+# filterwarnings` is pytest's OWN mechanism for this exact problem: it is
+# re-applied fresh per item, so it is what actually protects the real
+# suite (verified both directions: a reyn.* site fails, a third-party site
+# stays a non-fatal warning).
 
 # ── FP-0058 P2: A2A/MCP opt-in for pre-existing protocol tests ──────────────
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,40 @@ _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+# ── #6132: EncodingWarning (PEP 597) as an error, scoped to reyn.* only ────
+#
+# Root cause: a text-mode file open with `encoding=None` opens via
+# `locale.getpreferredencoding(False)` — cp932 on Japanese Windows. A
+# `FailureFallbackRotatingFileHandler` built that way in
+# `interfaces/cli/commands/chat.py` could not encode an em dash in a log
+# record, and stdlib's own `logging.Handler.handleError` wrote the resulting
+# traceback straight to raw `sys.stderr`, breaking the Textual screen it does
+# not own (#6132's own owner-hit reproduction).
+#
+# This filter turns that class of bug into a collection-time-adjacent test
+# failure instead of a platform-specific runtime surprise: Python 3.10+'s
+# `EncodingWarning` (PEP 597) fires from `io.TextIOWrapper` whenever
+# `encoding=` was omitted, but ONLY when the interpreter itself was started
+# with `-X warn_default_encoding` / `PYTHONWARNDEFAULTENCODING=1` (CI's
+# `test.yml` sets this for its main pytest invocation) — the flag is latched
+# at interpreter startup and CANNOT be toggled from here; without it, no
+# `EncodingWarning` is ever produced and this filter has nothing to catch
+# (see `tests/dev/test_6132_encoding_default_gate.py`'s own precondition
+# assertion, which fails loud rather than passing vacuously if the flag is
+# missing).
+#
+# `module=r"reyn(\..*)?$"` scopes the error escalation to reyn's OWN call
+# sites (matched against the warning's attributed module — the direct Python
+# caller of `open()`/`Path.open()`/`.read_text()`/`.write_text()`/a
+# `logging.FileHandler` subclass, not `io` itself, confirmed empirically): a
+# third-party dependency that also omits `encoding=` still emits the warning
+# (visible in pytest's warnings summary) but is never escalated to an error —
+# this repo cannot fix another package's source. This is the discriminator
+# #6132 names ("第三者ライブラリを巻き込まずに reyn の site だけ error 化
+# できるか") and the reason this gate is the PEP 597 mechanism rather than a
+# `scripts/` AST ratchet.
+warnings.filterwarnings("error", category=EncodingWarning, module=r"reyn(\..*)?$")
+
 # ── FP-0058 P2: A2A/MCP opt-in for pre-existing protocol tests ──────────────
 #
 # A2A and MCP are now secure-default OFF (``reyn.interfaces.web.surfaces`` —

--- a/tests/dev/test_6132_encoding_default_gate.py
+++ b/tests/dev/test_6132_encoding_default_gate.py
@@ -19,14 +19,27 @@ requires.
 
 ## Real subprocesses, not in-process
 
-``tests/conftest.py``'s filter (and the ``PYTHONWARNDEFAULTENCODING=1`` env
-CI's ``test.yml`` sets) already covers the real suite — but proving that
-combination CATCHES something needs a controlled, isolated process: the
-flag is latched at interpreter startup (cannot be armed from inside a
-running test), and this file needs to toggle it OFF for one scenario (to
-prove the flag itself is load-bearing, not merely the filter) — something
-only a fresh subprocess can do. ``out_of_process_reyn`` pins each spawn's
-``PYTHONPATH`` to the SAME checkout this test file itself imports (#5028).
+Two different claims need two different rigs:
+
+- The first three scenarios below exercise the raw mechanism (a bare
+  ``warnings.filterwarnings`` + ``PYTHONWARNDEFAULTENCODING``, in an
+  isolated ``sys.executable -c`` script) — proving the flag itself is
+  load-bearing needs toggling it OFF for one scenario, something only a
+  fresh interpreter can do. ``out_of_process_reyn`` pins each spawn's
+  ``PYTHONPATH`` to the SAME checkout this test file itself imports
+  (#5028).
+- The fourth, ``test_a_real_pytest_run_rejects_the_same_omission``, is the
+  one that actually matters operationally: a REAL ``sys.executable -m
+  pytest`` run, using THIS repo's own ``pyproject.toml``/rootdir, is what
+  CI actually runs. A bare ``warnings.filterwarnings()`` call at
+  ``tests/conftest.py`` IMPORT time was tried first and found NOT to
+  protect this path — pytest enters a fresh ``catch_warnings()`` +
+  ``simplefilter("always")`` around every test item's own execution,
+  discarding any filter installed at collection/import time before the
+  item's body runs (reproduced directly: "1 passed, 1 warning", no
+  error). ``[tool.pytest.ini_options].filterwarnings`` in
+  ``pyproject.toml`` is pytest's OWN mechanism for this — re-applied
+  fresh per item — and is what this scenario actually exercises.
 """
 from __future__ import annotations
 
@@ -129,3 +142,54 @@ def test_the_6132_fix_itself_is_clean_under_the_armed_gate(
     result = _run(out_of_process_reyn, script, warn_default_encoding=True)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
+
+
+_PROBE_TEST_SOURCE = (
+    "def test_probe():\n"
+    "    from reyn.dev.testing.encoding_gate_probe import "
+    "open_without_encoding_for_gate_test\n"
+    "    import tempfile, os\n"
+    "    open_without_encoding_for_gate_test("
+    "os.path.join(tempfile.mkdtemp(), 'p.txt'))\n"
+)
+
+
+def test_a_real_pytest_run_rejects_the_same_omission(
+    out_of_process_reyn: str,
+) -> None:
+    """Tier 2: the scenario that actually matters — a REAL ``sys.executable
+    -m pytest`` run, invoked from this repo's own root (so its
+    ``pyproject.toml`` — ``[tool.pytest.ini_options].filterwarnings`` — is
+    the one in effect, not a throwaway pytester tree), must FAIL a real
+    reyn.* omission, not merely warn about it.
+
+    This is the regression #6132's own BLOCKING review caught: the first
+    version of this gate (a bare ``warnings.filterwarnings()`` call at
+    ``tests/conftest.py`` import time) passed all three scenarios above
+    while doing NOTHING for the real suite — pytest's own per-item
+    ``catch_warnings()`` reset discarded it before any test body ran. This
+    scenario is what would have caught that: it spawns the actual command
+    CI runs, not a hand-rolled reproduction of the mechanism.
+
+    A throwaway single-test file is written under ``tests/dev/`` (not
+    ``tmp_path``, which pytest's rootdir discovery would not resolve back
+    to this repo's own ``pyproject.toml``) and removed in a ``finally``,
+    so nothing this test creates is ever left behind to commit."""
+    probe_path = Path(__file__).parent / "_tmp_6132_probe_for_gate_test.py"
+    probe_path.write_text(_PROBE_TEST_SOURCE, encoding="utf-8")
+    try:
+        env = {**os.environ, "PYTHONPATH": out_of_process_reyn, "PYTHONWARNDEFAULTENCODING": "1"}
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(probe_path), "-q"],
+            capture_output=True, text=True, env=env,
+            cwd=str(Path(out_of_process_reyn).parent),
+        )
+    finally:
+        probe_path.unlink(missing_ok=True)
+
+    assert result.returncode != 0, (
+        f"a real pytest run did not reject an unencoded reyn.* open; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "1 failed" in result.stdout, result.stdout
+    assert "EncodingWarning" in result.stdout, result.stdout

--- a/tests/dev/test_6132_encoding_default_gate.py
+++ b/tests/dev/test_6132_encoding_default_gate.py
@@ -1,0 +1,131 @@
+"""Tier 2: #6132's own gate — a reyn.* text-mode file open without
+``encoding=`` must fail CI, on ANY host locale, not only a non-utf-8 one.
+
+## Why this is platform-independent (the strip-falsify CLAUDE.md requires)
+
+The #6132 bug ("cp932 で reyn.log が書けず...") only manifests as a crash
+on a non-utf-8-locale host, because that is the one case where the OMITTED
+``encoding=`` actually fails to encode a real character. A test that writes
+an em dash and reads it back would pass on this repo's own utf-8 CI even
+with the bug PRESENT — vacuous, exactly what the issue warns against.
+
+:class:`EncodingWarning` (PEP 597) sidesteps this: it fires the moment
+``encoding=`` is omitted, regardless of what locale the process is running
+under or whether the write would actually succeed there. Reverting any of
+#6132's ``encoding="utf-8"`` additions in ``src/`` makes the corresponding
+scenario below fail on THIS machine's own locale (almost certainly utf-8),
+not only on a Windows/cp932 host — the platform-independence the issue
+requires.
+
+## Real subprocesses, not in-process
+
+``tests/conftest.py``'s filter (and the ``PYTHONWARNDEFAULTENCODING=1`` env
+CI's ``test.yml`` sets) already covers the real suite — but proving that
+combination CATCHES something needs a controlled, isolated process: the
+flag is latched at interpreter startup (cannot be armed from inside a
+running test), and this file needs to toggle it OFF for one scenario (to
+prove the flag itself is load-bearing, not merely the filter) — something
+only a fresh subprocess can do. ``out_of_process_reyn`` pins each spawn's
+``PYTHONPATH`` to the SAME checkout this test file itself imports (#5028).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _run(
+    src_root: str, script: str, *, warn_default_encoding: bool,
+) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": src_root}
+    if warn_default_encoding:
+        env["PYTHONWARNDEFAULTENCODING"] = "1"
+    else:
+        env.pop("PYTHONWARNDEFAULTENCODING", None)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+# The SAME filter tests/conftest.py installs (kept in sync by hand — the two
+# copies are documented at both ends: conftest.py's own comment names this
+# file, and this docstring below points back). One line, so interpolating it
+# into an indented triple-quoted script below never fights textwrap.dedent
+# over inconsistent per-line indentation.
+_INSTALL_FILTER = (
+    'import warnings; warnings.filterwarnings('
+    '"error", category=EncodingWarning, module=r"reyn(\\..*)?$")'
+)
+
+
+def test_a_reyn_open_without_encoding_raises_when_the_gate_is_armed(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
+    """Tier 2: the positive case — proves the filter+flag combination
+    actually CATCHES a real #6132-shaped omission. ``encoding_gate_probe``
+    (``reyn.dev.testing``) exists ONLY to give this test a genuine
+    ``reyn.*``-namespaced call site (the filter is scoped by the warning's
+    attributed module, not by this test file's own — see conftest.py's own
+    comment for why a call from this file would not be caught)."""
+    script = f"""
+        {_INSTALL_FILTER}
+        from reyn.dev.testing.encoding_gate_probe import open_without_encoding_for_gate_test
+        open_without_encoding_for_gate_test({str(tmp_path / "probe.txt")!r})
+        print("UNREACHABLE — the EncodingWarning above should have raised")
+        """
+    result = _run(out_of_process_reyn, script, warn_default_encoding=True)
+    assert result.returncode != 0, (
+        f"the gate did not catch an unencoded reyn.* open; stdout={result.stdout!r}"
+    )
+    assert "EncodingWarning" in result.stderr, result.stderr
+
+
+def test_the_same_open_is_silent_without_the_flag(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
+    """Tier 2: deny side — proves the flag itself is load-bearing, not just
+    the filter. Without ``PYTHONWARNDEFAULTENCODING=1``, CPython never
+    produces an ``EncodingWarning`` at all (the flag is latched at
+    interpreter startup, per conftest.py's own comment) — the SAME
+    unencoded open above must complete silently here. If this scenario
+    ever raised, the positive test above would be meaningless (every
+    process would fail regardless of the flag)."""
+    script = f"""
+        {_INSTALL_FILTER}
+        from reyn.dev.testing.encoding_gate_probe import open_without_encoding_for_gate_test
+        open_without_encoding_for_gate_test({str(tmp_path / "probe2.txt")!r})
+        print("OK — no EncodingWarning without the flag")
+        """
+    result = _run(out_of_process_reyn, script, warn_default_encoding=False)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_the_6132_fix_itself_is_clean_under_the_armed_gate(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
+    """Tier 2: the #6132 fix's own strip-falsify target. ``_setup_interactive_
+    logging`` (``interfaces/cli/commands/chat.py``) is the exact call path
+    #6132's owner-hit reproduction traced the bug to — it must run cleanly
+    under the SAME armed gate the two scenarios above use.
+
+    Strip-falsify (verified by hand, file-internal Edit only, reverted):
+    removing chat.py's ``encoding="utf-8"`` kwarg from the
+    ``FailureFallbackRotatingFileHandler`` construction makes this test fail
+    — on THIS machine's own (utf-8) locale, not only a cp932 one — because
+    the gate is a static-explicitness check, not a real encode failure."""
+    script = f"""
+        {_INSTALL_FILTER}
+        from pathlib import Path
+        from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+
+        _setup_interactive_logging(Path({str(tmp_path)!r}))
+        print("OK — the real #6132 call path raised no EncodingWarning")
+        """
+    result = _run(out_of_process_reyn, script, warn_default_encoding=True)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/tests/dev/test_6132_encoding_default_gate.py
+++ b/tests/dev/test_6132_encoding_default_gate.py
@@ -64,11 +64,12 @@ def _run(
     )
 
 
-# The SAME filter tests/conftest.py installs (kept in sync by hand — the two
-# copies are documented at both ends: conftest.py's own comment names this
-# file, and this docstring below points back). One line, so interpolating it
-# into an indented triple-quoted script below never fights textwrap.dedent
-# over inconsistent per-line indentation.
+# The SAME filter pyproject.toml's [tool.pytest.ini_options].filterwarnings
+# entry expresses for the real suite (kept in sync by hand -- both copies
+# are documented at each end: pyproject.toml's own comment names this
+# file, and this docstring below points back). One line, so interpolating
+# it into an indented triple-quoted script below never fights
+# textwrap.dedent over inconsistent per-line indentation.
 _INSTALL_FILTER = (
     'import warnings; warnings.filterwarnings('
     '"error", category=EncodingWarning, module=r"reyn(\\..*)?$")'
@@ -82,8 +83,9 @@ def test_a_reyn_open_without_encoding_raises_when_the_gate_is_armed(
     actually CATCHES a real #6132-shaped omission. ``encoding_gate_probe``
     (``reyn.dev.testing``) exists ONLY to give this test a genuine
     ``reyn.*``-namespaced call site (the filter is scoped by the warning's
-    attributed module, not by this test file's own — see conftest.py's own
-    comment for why a call from this file would not be caught)."""
+    attributed module, not by this test file's own — see pyproject.toml's
+    own `filterwarnings` comment for why a call from this file would not
+    be caught)."""
     script = f"""
         {_INSTALL_FILTER}
         from reyn.dev.testing.encoding_gate_probe import open_without_encoding_for_gate_test
@@ -103,7 +105,7 @@ def test_the_same_open_is_silent_without_the_flag(
     """Tier 2: deny side — proves the flag itself is load-bearing, not just
     the filter. Without ``PYTHONWARNDEFAULTENCODING=1``, CPython never
     produces an ``EncodingWarning`` at all (the flag is latched at
-    interpreter startup, per conftest.py's own comment) — the SAME
+    interpreter startup, per pyproject.toml's own comment) — the SAME
     unencoded open above must complete silently here. If this scenario
     ever raised, the positive test above would be meaningless (every
     process would fail regardless of the flag)."""


### PR DESCRIPTION
**[tui-coder]** — Closes #6132.

## Root cause
`interfaces/cli/commands/chat.py`'s `FailureFallbackRotatingFileHandler` had no `encoding=` kwarg, so `logging.FileHandler` opened `reyn.log` via `locale.getpreferredencoding(False)` — cp932 on Japanese Windows. A log record containing an em dash then raised `UnicodeEncodeError` from `emit()`, and stdlib's own `logging.Handler.handleError` wrote the traceback straight to raw `sys.stderr`, breaking the Textual screen it does not own.

## Fixed: 11 sites, not 45 — verified by hand, not assumed
The issue's own AST census (open/read_text/write_text/`*FileHandler`, binary excluded) reports 45. Reproducing that exact methodology with a naive scanner lands at 45 too — but each hit was individually read (not just pattern-matched), and three classes of false match account for the gap:

1. **`os.open()`/`os.fdopen()`** with a non-string-literal mode/flags arg (e.g. `os.O_RDONLY`) — `os.open` is fd-based, has no `encoding` param at all (passing one raises `TypeError`).
2. **Same-named, different-signature `.open()`** — `webbrowser.open()`, `PIL.Image.open()` (binary), a urllib `OpenerDirector.open()` (HTTP, not a file), an MCP subscription adapter's async `.open()`, two custom classmethods (`StallDumpArm.open`, `DiagnosticSnapshot.open`) whose own internal writes are already fd/bytes-based.
3. **A mode-extraction bug in my first scanner draft**: `Path.open(mode)` takes `mode` as its FIRST positional arg (method call), not the second like builtin `open(path, mode)` — conflating the two shapes misread **8 genuine `.open("rb")` BINARY reads** (`state_log.py` x2, `budget.py` x4, `history_tail_reader.py` x2, `session_api.py`, `approval_ledger.py`, `resolve.py`) as text-mode candidates.

The 11 real sites, all fixed: `chat.py`'s handler (root cause), `vector_store_server.py`, `dev/dogfood/runner.py` (x4), `dev/testing/memory_ceiling.py`, `dev/testing/stall_dump.py` (x2), `interfaces/web/a2a_webhook_registry.py` (x2).

## Gate: PEP 597 `EncodingWarning`, scoped to `reyn.*` (not an AST ratchet)
Verified empirically before choosing this over the AST-ratchet fallback: `warnings.filterwarnings("error", category=EncodingWarning, module=r"reyn(\.*)?$")` escalates only warnings attributed to a `reyn.*` module — a third-party dependency omitting `encoding=` still warns but never errors, satisfying #6132's own discriminator (third-party libraries not implicated). `tests/conftest.py` installs the filter; `.github/workflows/test.yml`'s main pytest invocation gets `PYTHONWARNDEFAULTENCODING=1` (the flag `EncodingWarning` production needs, latched at interpreter startup — cannot be armed from `conftest.py` itself).

`tests/dev/test_6132_encoding_default_gate.py` (new, 3 tests, real subprocesses):
1. a genuine `reyn.*` omission raises under the armed gate
2. the SAME omission is silent without the flag (proves the flag is load-bearing, not just the filter)
3. the fix's own call path (`_setup_interactive_logging`) runs clean under the armed gate

`reyn.dev.testing.encoding_gate_probe` (new, dev/test-only) exists solely to give test 1 a genuine `reyn.*`-namespaced call site — never call it from production code.

## Strip-falsify (platform-independent, per CLAUDE.md)
Reverting `chat.py`'s own `encoding="utf-8"` kwarg (file-internal Edit, hand-verified, reverted) makes test 3 fail on **this machine's own utf-8 locale**, not only a cp932 one — `EncodingWarning` fires on the missing argument itself, never on an actual encode failure, so the "write an em dash and read it back" vacuous shape the issue warns against does not apply here.

## Out of scope (filed, not dropped)
Item 5 in the issue (why `capture_stray_output` did not catch the resulting raw-stderr write) is explicitly out of scope per the issue's own text.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (new test file)
- [x] `verify_module_docstrings.py` (7 changed/new src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates: bare-import ref, file-depth ref, subprocess-reyn-pin, no-core-dep-importorskip, time-dependence ratchet
- [x] `silent_except_ratchet.py` (src/reyn/interfaces/ touched)
- [x] (skipped — Visual, standing waiver)

Diff-scoped pytest: `pytest tests/dev/test_6132_encoding_default_gate.py tests/runtime/test_5989_handler_failure_fallback.py tests/interfaces/test_inline_interactive_logging.py -q` → **22 passed**. Also spot-checked (with `PYTHONWARNDEFAULTENCODING=1` armed) `tests/llm/test_litellm_lazy_load.py` (11 passed), `tests/llm/test_budget_checkpoint_2945.py` + `tests/runtime/test_4676_history_tail_reader_toctou.py` + `tests/security/test_5153_approval_ledger.py` (35 passed) — none of the excluded false-positive/binary sites escalate under the armed gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
