### PR TITLE
fix: #6134 -- handleError no longer writes into the very stream that is failing

### DIFF
--- a/src/reyn/runtime/logging_failure_fallback.py
+++ b/src/reyn/runtime/logging_failure_fallback.py
@@ -128,12 +128,30 @@ class FailureFallbackRotatingFileHandler(logging.handlers.RotatingFileHandler):
     def handleError(self, record: logging.LogRecord) -> None:  # noqa: N802 - stdlib override name
         """#5989 ⑵: record this failure to the independent fallback
         destination, episode-gated (see module docstring), then defer to
-        the base class for the REST of stdlib's own behaviour (the
-        `sys.stderr` write #5989 PR1's own `capture_stray_output`
-        widening already keeps off the real terminal during a TUI
-        session — this method does not need to, and does not,
-        short-circuit that base behaviour; the two fixes are independent
-        layers, and neither assumes the other is present)."""
+        the base class for stdlib's own `sys.stderr` write — UNLESS
+        `sys.stderr` is currently `self.stream` (#6134): the SAME
+        redirect window `litellm_bootstrap.py` opens around the litellm
+        import (`redirect_stderr(handler.stream)`, to keep a chatty
+        import's own stray output off the real terminal — #5989 PR1's
+        `capture_stray_output` widening handles every OTHER window, but
+        cannot see this one, since inside it `sys.stderr` genuinely IS
+        the log stream, not a capture proxy) makes `self.stream` and
+        `sys.stderr` the SAME object precisely while THIS handler is
+        failing. Calling the base class's `handleError` there would write
+        `--- Logging error ---` + a traceback into the very file whose
+        `emit()` just failed — the exact shape this file's own module
+        docstring forbids ("must NOT depend on the very handler that is
+        failing"), and no less broken for going through `sys.stderr`
+        instead of `self` directly. The discriminator is observable, not
+        intentional: `is` identity between the two objects, checked
+        fresh on every failure (never cached — the redirect window opens
+        and closes around one import, so the identity is only true
+        inside it). The fallback write above has ALREADY happened by
+        this point regardless of which branch runs below, so skipping
+        the base call here loses nothing — three real destinations exist
+        (the real terminal, `capture_stray_output`'s capture buffer, and
+        this handler's own failing stream), and this guard is what keeps
+        the third from ever being written to."""
         try:
             self._record_fallback(record)
         except Exception:
@@ -142,7 +160,8 @@ class FailureFallbackRotatingFileHandler(logging.handlers.RotatingFileHandler):
             # matching every OTHER diagnostic writer in this codebase
             # (write_record, StallDumpArm's own callers).
             pass
-        super().handleError(record)
+        if sys.stderr is not self.stream:
+            super().handleError(record)
 
     def _record_fallback(self, record: logging.LogRecord) -> None:
         if not self._fallback_path:

--- a/tests/runtime/test_5989_handler_failure_fallback.py
+++ b/tests/runtime/test_5989_handler_failure_fallback.py
@@ -31,6 +31,7 @@ before ever reaching `write()` — passing for the wrong reason entirely
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 
 from reyn.runtime.logging_failure_fallback import (
@@ -210,3 +211,63 @@ def test_stays_a_real_file_handler_for_structural_readers(tmp_path: Path) -> Non
     — this subclass must still satisfy that, unchanged."""
     handler, _logger, _fallback_path = _make_handler(tmp_path)
     assert isinstance(handler, logging.FileHandler)
+
+
+def test_sys_stderr_pointed_at_the_failing_handlers_own_stream_leaves_the_log_byte_unchanged(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #6134 — inside `litellm_bootstrap.py`'s own
+    `redirect_stderr(handler.stream)` window (opened around the litellm
+    import, `capture_stray_output`'s widening does not cover this window
+    because `sys.stderr` genuinely IS the log stream there, not a capture
+    proxy), `sys.stderr` and this handler's OWN stream are the SAME
+    object. A record that fails to FORMAT (the stream itself stays open
+    and writable throughout — #6132's own UnicodeEncodeError shape, not a
+    broken stream) must not let `logging.Handler.handleError`'s base
+    `sys.stderr.write('--- Logging error ---\\n' + traceback)` leak
+    straight into `reyn.log`'s own bytes — the exact form this file's own
+    module docstring forbids ("must NOT depend on the very handler that
+    is failing").
+
+    `"%d" % "not-a-number"` (bad old-style formatting) is used rather than
+    `_break`'s read-only-reopen: that shape makes `.write()` itself raise
+    before touching the file, which would pass even without #6134's guard
+    for the WRONG reason (nothing ever reached the stream to begin with).
+    Here the stream stays genuinely writable the entire time — only
+    `record.getMessage()` fails — so a leaked banner would actually land
+    real bytes in the file if the guard were absent.
+
+    Strip-falsify (verified by hand, file-internal Edit only, reverted):
+    removing the `if sys.stderr is not self.stream:` guard in
+    `handleError` makes this test fail — the log file gains the
+    `--- Logging error ---` banner's own bytes."""
+    handler, logger, fallback_path = _make_handler(tmp_path)
+    assert not fallback_path.exists()
+
+    reyn_log = Path(handler.baseFilename)
+    logger.warning("a healthy line, written normally")
+    before = reyn_log.read_bytes()
+
+    real_stderr = sys.stderr
+    sys.stderr = handler.stream  # the exact litellm_bootstrap.py redirect window
+    try:
+        logger.warning("%d", "not-a-number")  # getMessage() raises TypeError; stream stays writable
+    finally:
+        sys.stderr = real_stderr
+    handler.stream.flush()  # a leaked write sits in the TextIOWrapper's own
+    # buffer until flushed -- production eventually flushes on any later
+    # successful emit() (StreamHandler.emit() always ends with self.flush()),
+    # so an unflushed leak here would still surface later; flushing now
+    # makes the assertion decisive without depending on a SECOND log call.
+
+    after = reyn_log.read_bytes()
+    assert after == before, (
+        "the failing handler's own log file gained bytes -- handleError's "
+        "base-class sys.stderr write leaked its traceback banner into the "
+        "very file it is supposed to protect"
+    )
+    assert fallback_path.exists(), (
+        "the fallback record must still fire even though the base "
+        "handleError call was skipped -- _record_fallback runs first, "
+        "unconditionally, regardless of the sys.stderr guard below it"
+    )


### PR DESCRIPTION
**[tui-coder]** — Closes #6134.

## Root cause (architect)
`litellm_bootstrap.py`'s `ensure_litellm_ready()` opens a `redirect_stdout`/`redirect_stderr` window around `import litellm`, pointed at `reyn.log`'s own `FileHandler` stream. Inside that window, `sys.stderr` genuinely IS this handler's own stream — not a capture proxy `#5989 PR1`'s `capture_stray_output` widening can see. A record that fails to emit during that window made stdlib's `logging.Handler.handleError` write `--- Logging error ---` + a traceback straight into `sys.stderr`, the SAME broken stream — exactly the shape this file's own module docstring already forbids ("must NOT depend on the very handler that is failing"), reached through `sys.stderr` instead of `self` directly.

## Fix
`if sys.stderr is not self.stream: super().handleError(record)` — an observable `is` identity check, checked fresh on every failure. The independent fallback record (`_record_fallback`) already runs before this guard, unconditionally, so skipping the base call loses nothing.

`handleError`'s own docstring corrected from "2 destinations" (real terminal, capture buffer) to 3 — the failing handler's own stream was the omitted third.

## Test
New test: a record whose `getMessage()` raises (the stream itself stays writable throughout — #6132's own `UnicodeEncodeError` shape, not a broken stream) with `sys.stderr` pointed at `handler.stream`, asserting `reyn.log`'s own bytes stay unchanged (flushed before comparison, since a leaked write sits in the `TextIOWrapper`'s own buffer until flushed).

Strip-falsified by hand (file-internal Edit, reverted): removing the guard made the new test fail with the exact leaked-banner shape.

## Out of scope (filed, not dropped)
C4 (third-party/C-extension fd-2 writes bypassing Python's own `sys.stderr`) is explicitly NOT closed by this PR, per the issue's own text — a separate, `src/`-invisible concern with its own reopen condition.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (changed test file)
- [x] `verify_module_docstrings.py` (changed src file)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates: bare-import ref, file-depth ref, subprocess-reyn-pin, no-core-dep-importorskip, time-dependence ratchet
- [x] (skipped — Visual, standing waiver)

Diff-scoped pytest: `pytest tests/runtime/test_5989_handler_failure_fallback.py -q` → **7 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
