### PR TITLE
docs: 7 ADRs had no row in decisions/README.md — index them, and gate the class

### DIFF
--- a/docs/deep-dives/contributing/pr-workflow.md
+++ b/docs/deep-dives/contributing/pr-workflow.md
@@ -77,7 +77,13 @@ catches a dangling *file* reference but never checks whether `#anchor`
 actually exists on the target page, which is `check_doc_anchors.py`'s
 own job, run against the `site/` the mkdocs step just built (#3557/
 #3592: 42/42 line-number citations in `charter.md` had drifted,
-silently, before this script existed); `check_retired_config_keys_denylist.py`
+silently, before this script existed); that same script also carries two link-existence gates over
+`deep-dives/{decisions,proposals,contributing,spec}/` (#4021) and, since
+2026-09-11, an index-coverage gate: **a new ADR under
+`deep-dives/decisions/` needs a row in that directory's own `README.md`**,
+or the run is red (7 of 51 had none when it landed — nothing breaks when
+an ADR is unindexed, it just stops being read);
+`check_retired_config_keys_denylist.py`
 (#4327) is a separate, unrelated check in the same job — a retired
 top-level `reyn.yaml` key (renamed via #4174) must not appear, at
 YAML top level, in operator-facing docs or `reyn.local.yaml.example`.

--- a/docs/deep-dives/decisions/README.md
+++ b/docs/deep-dives/decisions/README.md
@@ -67,6 +67,17 @@ new ADR.
 | [0012](0012-auto-resume-default.md) | Auto-resume default + retry policy |
 | [0038](0038-user-facing-time-travel-rewind.md) | User-facing time-travel — global consistent-cut rewind + PITR snapshot generations (**Accepted + Implemented** 2026-06-13) |
 
+### Plan mode — all four SUPERSEDED, mechanism removed by [#1953](https://github.com/tya5/reyn/issues/1953)
+
+These are kept for their historical value (the ADR rule above: a superseded ADR is not deleted). They describe a plan-mode crash-resilience mechanism that PR [#2018](https://github.com/tya5/reyn/pull/2018) removed on 2026-06-21 — read them as a record of what was decided then, never as current behaviour.
+
+| ADR | Topic |
+|---|---|
+| [0022](0022-plan-mode-crash-fail-safe.md) | Plan-mode crash resilience Phase 1 — fail-safe + observability (SUPERSEDED) |
+| [0023](0023-plan-mode-forward-replay.md) | Plan-mode crash resilience Phase 2 — forward replay (SUPERSEDED; was Accepted + Implemented 2026-05-07) |
+| [0024](0024-plan-step-result-spill.md) | Plan step result spill-to-file (R-D10 mirror) (SUPERSEDED) |
+| [0025](0025-plan-step-llm-memoization.md) | Plan-step sub-loop LLM call memoization (R-D2 mirror) (SUPERSEDED) |
+
 ### User intervention
 
 | ADR | Topic |
@@ -107,8 +118,10 @@ new ADR.
 | [0027b](0027b-audit-seal-config-hash-scope.md) | `config_hash` scope for AuditSeal (Proposed, depends on 0027) |
 | [0027c](0027c-audit-seal-plan-mode-integration.md) | `seal_unit` and plan-mode integration for AuditSeal (Proposed, depends on 0027 + 0023) |
 | [0027d](0027d-audit-seal-writer-failure-semantics.md) | AuditContext writer failure semantics (Proposed, depends on 0027) |
+| [0027 (gates)](0027-phase-1-decisions.md) | ADR-0027 Phase 1 pre-implementation user-judgment gates — the five choices 0027a–d each recommend, consolidated into one confirmation checklist (**Pending user confirmation**). ⚠️ Shares the number 0027 with [0027](0027-audit-seal-separation.md) above but is a different document: that one DECIDES the separation, this one collects the questions it leaves to the user |
 | [0029](0029-mcp-install-permission.md) | `mcp_install` permission — install-time gating として permission system に追加 (Proposed) |
 | [0030](0030-universal-secret-handling.md) | Universal secret handling — `${VAR}` 全 yaml + `~/.reyn/secrets.env` + `reyn secret` CLI (Proposed) |
+| [0043](0043-generic-secret-provider-seam.md) | A generic `SecretProvider` seam — NEW consumers only, and the capability gate that already exists gets wired; the `${VAR}` expansion 0030 decides is left untouched (**Accepted** 2026-09-11; extends [0030](0030-universal-secret-handling.md), supersedes nothing; see [#4903](https://github.com/tya5/reyn/issues/4903)) |
 | [0033](0033-rag-extensible-os.md) | RAG-extensible OS — `embed` / `index_*` / `recall` ops + `index_docs` stdlib + `IndexBackend` protocol (**Accepted** 2026-05-10) |
 
 > Web UI direction (= 元 ADR-0028) は positioning doc に re-class、 `docs/deep-dives/research/positioning/web-ui-direction.md` 参照。 現在 vision は **`reyn chat` (= local + embedded Web UI server を session bind で同梱) + `reyn serve` (= explicit long-running server、 browser からアクセス)** の 2 commands。 業界慣行 (Ollama / vLLM / LangGraph) の `<tool> serve` pattern に整合、 remote TUI client は workspace location semantics の懸念で当面 scope 外 (= browser remote access で代替、 将来 concrete demand 出たら再判断)。 embedded thesis は `reyn chat` 内に温存。 実現性検討は未着手。
@@ -117,6 +130,7 @@ new ADR.
 
 | ADR | Topic |
 |---|---|
+| [0021](0021-g12-attractor-structural-fix-design.md) | G12 attractor — structural fix design options; detect + explicit failure UX, no auto-rescue (**Accepted**, Option F + Option G, 2026-05-04) |
 | [0035](0035-phase-tool-calls-unification.md) | Phase op-execution via native tool_calls (Phase ↔ chat/planner unification) (**Accepted, fully implemented** 2026-06-02) |
 | [0036](0036-history-compaction-force-close-unification.md) | Chat/plan/phase within-unit history + compaction + force-close unification (Fork 1: RouterLoop convergence) (**Accepted**) — the PR-F2b force-close handoff cap section superseded by [0042](0042-force-close-layer2-removal.md); the rest stands unchanged |
 | [0042](0042-force-close-layer2-removal.md) | force-close layer② removal — spill replaces the consolidate-and-retry path; **layer① (turn-budget force-close) is unaffected and still live** (**Accepted + Implemented** 2026-08-12; supersedes 0036's PR-F2b section only; see [#4381](https://github.com/tya5/reyn/issues/4381)) |

--- a/scripts/check_doc_anchors.py
+++ b/scripts/check_doc_anchors.py
@@ -68,6 +68,17 @@ only, no anchor check (there's no built HTML to check an anchor against).
 `main()` runs it first, unconditionally (no `site/` dependency), and folds
 its exit code into the script's own.
 
+## A third gate, same file: `check_decisions_index_coverage`
+
+The two gates above both ask "does this link's target exist". The opposite
+question — "is there a link at all" — is a different defect with the same
+consequence, and neither of them can see it: a directory with zero broken
+links can still hold a document nobody can reach. `check_decisions_index_
+coverage()` derives the ADR set from `deep-dives/decisions/` and fails when
+any of them has no row in that directory's own `README.md` (7 of 51 did when
+it landed, one accepted the same day). It needs no `site/` either, so
+`main()` runs it alongside the other two, before the build-dependent check.
+
 Run standalone: `python scripts/check_doc_anchors.py` (the deep-dives check
 runs immediately; the anchor check below it needs `mkdocs build --strict -f
 .mkdocs/mkdocs.yml` first, which this script assumes already ran and left
@@ -352,12 +363,100 @@ def check_deep_dives_incoming_link_existence() -> int:
     return 0
 
 
+#: Files under `deep-dives/decisions/` that `check_decisions_index_coverage`
+#: deliberately does NOT require an index row for, each with the reason it is
+#: exempt — the `UNSUPPORTED_WRAPPERS` shape (`core/op_runtime/exec_wrappers.py`):
+#: a named entry with a stated reason, never a silent skip. EMPTY today, and
+#: that is the intended steady state: every ADR in that directory is meant to
+#: be reachable from its own README. A future entry is a decision someone has
+#: to write down here, not a file that quietly stops being indexed.
+DECISIONS_INDEX_EXEMPT: dict[str, str] = {}
+
+
+def check_decisions_index_coverage() -> int:
+    """#5989 residue / lead-coder dispatch 2026-09-11: every ADR under
+    `deep-dives/decisions/` must be reachable from that directory's own
+    `README.md` index.
+
+    The two gates above ask "does this link's target exist"; this one asks
+    the opposite question — "is there a link at all". They are not the same
+    check and neither catches the other's defect: a directory can have zero
+    broken links and still hold a document nobody can find. Measured when
+    this gate landed: 7 of 51 ADRs (0021-0025, 0027-phase-1-decisions, 0043)
+    had no row in the index, one of them accepted the same day.
+
+    The failure this closes is silent by construction. Nothing breaks, no
+    build fails, no link dangles — the document simply stops being read.
+    #4021's own motivating instance (ADR-0034 unreadable for three months)
+    was the link-existence half of the same shape; this is the other half.
+
+    Derived, never curated: the file set comes from globbing the directory,
+    so a new ADR is covered the moment it is added, with no list to remember
+    to update (this repo's own completeness discipline — "cover all X" is
+    proved by enumerating the registry, not by a hand-kept subset). A `.ja.md`
+    mirror is excluded as a RULE, not an exemption: the index lists the EN
+    document and the mirror sits beside it, so requiring a second row would
+    make the index list each ADR twice.
+    """
+    decisions = DOCS / "deep-dives" / "decisions"
+    readme = decisions / "README.md"
+    if not readme.is_file():
+        raise SystemExit(f"FATAL: {readme} does not exist — this gate has no index to check against.")
+
+    linked = set(MD_LINK_RE.findall(readme.read_text(encoding="utf-8", errors="replace")))
+    # Normalize a leading `./` so `](./0001-x.md)` and `](0001-x.md)` are the
+    # same target — the index uses the bare form today, and a future `./`
+    # would otherwise read as "not indexed" and fail a correctly-indexed file.
+    linked = {name[2:] if name.startswith("./") else name for name in linked}
+
+    indexable = sorted(
+        path.name
+        for path in decisions.glob("*.md")
+        if path.name != "README.md" and not path.name.endswith(".ja.md")
+    )
+    _require_vacuity_floor(
+        len(indexable), 40,
+        f"Enumerated only {len(indexable)} indexable ADR(s) under {decisions} — "
+        "there were 51 when this gate landed. A glob that silently stops "
+        "matching would let this gate report 'every ADR is indexed' while "
+        "checking almost nothing, which is the exact vacuous-green this "
+        "repo's own test-review question 4 names. The floor is deliberately "
+        "below 51 to tolerate a superseded ADR being folded away, not a pin.",
+    )
+
+    unindexed = [
+        name for name in indexable
+        if name not in linked and name not in DECISIONS_INDEX_EXEMPT
+    ]
+
+    print(f"checked {len(indexable)} ADR(s) under deep-dives/decisions/ for an index row")
+    if DECISIONS_INDEX_EXEMPT:
+        print(f"exempt by name (reason stated in DECISIONS_INDEX_EXEMPT): {len(DECISIONS_INDEX_EXEMPT)}")
+        for name, reason in sorted(DECISIONS_INDEX_EXEMPT.items()):
+            print(f"  {name} — {reason}")
+    if unindexed:
+        print(f"\nNOT_REACHABLE_FROM_INDEX: {len(unindexed)}")
+        for name in unindexed:
+            print(f"  deep-dives/decisions/{name}")
+        print(
+            "\nAdd a row to deep-dives/decisions/README.md's Index, or — if the "
+            "file genuinely should not be listed — add it to "
+            "DECISIONS_INDEX_EXEMPT in this script WITH the reason."
+        )
+        return 1
+
+    print("every ADR under deep-dives/decisions/ is reachable from its README index")
+    return 0
+
+
 def main() -> int:
     # Both run before the SITE check below — neither needs a mkdocs build
     # (#4021 + its follow-up).
     deep_dives_exit = check_deep_dives_link_existence()
     print()
     deep_dives_incoming_exit = check_deep_dives_incoming_link_existence()
+    print()
+    decisions_index_exit = check_decisions_index_coverage()
     print()
 
     if not SITE.is_dir():
@@ -447,7 +546,7 @@ def main() -> int:
         return 1
 
     print("\nno dangling anchors into published pages")
-    return 1 if (deep_dives_exit or deep_dives_incoming_exit) else 0
+    return 1 if (deep_dives_exit or deep_dives_incoming_exit or decisions_index_exit) else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**[architect]** — **`deep-dives/decisions/` の ADR 7 本が README の索引から辿れませんでした。** ⭐ **索引に足し、同じ PR で クラスを閉じます。** `part of #5989`

## なぜ 7 本が「壊れていない」のに問題か

🔴 **索引から辿れない doc は、何も壊しません** ―― **build は通り、link は dangling ではなく、mkdocs は黙ります。** ⭐ **ただ読まれなくなるだけです。**
⚠️ **#4021 の動機だった「ADR-0034 が 3 ヶ月 読めなかった」は、この形の *link 側の半分* でした。** **これは もう半分です。**

## 私の census（**lead-coder の 7 と一致しました。私の初報 6 は誤りです**）

```
$ python3 -  # README の link 先 − ディレクトリの .md（README と .ja.md を除く）
files (en, excl README): 51
linked from README     : 44
MISSING from index     : 7
   0021-g12-attractor-structural-fix-design.md
   0022-plan-mode-crash-fail-safe.md
   0023-plan-mode-forward-replay.md
   0024-plan-step-result-spill.md
   0025-plan-step-llm-memoization.md
   0027-phase-1-decisions.md          ← ★ 私が最初 見落とした 1 本
   0043-generic-secret-provider-seam.md
linked but not a file  : []
```
⚠️ **`0067` は `../proposals/` 宛で正しい link**（lead-coder の確認どおり、私の needle でも「file でない link」は 0 件）。

## 置き方（**4 箇所。中身で決めました**）

| ADR | 置いた場所 | 理由 |
|---|---|---|
| **0043** | **Architecture、0030 の直下** | ⭐ **0030 を extends する関係**（supersede ではない）。**同日 Accepted** |
| **0027-phase-1-decisions** | **Architecture、0027d の直下** | ⚠️ **番号が `0027-audit-seal-separation.md` と衝突しています** ∴ **行の中で「別 doc」と明記**（**一方は分離を *決め*、もう一方は そこが user に残した問いを *集めた* もの**）。**例外表には入れません ―― これは実在の ADR family 文書です** |
| **0021** | **Runtime interaction model の先頭** | **router / LLM の振る舞いの決定** |
| **0022-0025** | 🔴 **新しい節「Plan mode — all four SUPERSEDED」** | ⚠️ **4 本とも #1953 / PR #2018 で機構ごと削除済**。**既存の節に混ぜると *現行の決定* に見えます** ∴ **節ごと分け、冒頭 2 行で「歴史的記録として読む」と宣言** |

## Gate（**手で維持する索引は また drift するので**）

### ⭐ なぜ新規 script でなく `check_doc_anchors.py` の拡張か（**理由 1 行の指定**）

🔴 **あの file は既に「`deep-dives/{decisions,proposals,contributing,spec}/` の link gate」を 2 本 抱えており**（#4021）、**docs path で CI が既に走らせています** ∴ **新しい workflow step も CLAUDE.md の新しい行も要りません**（⚠️ **CLAUDE.md は語数が ratchet されています**）。⭐ **主題も同じです** ―― **既存 2 本は「link 先は在るか」、本 gate は「link は在るか」。**

### 形

```python
DECISIONS_INDEX_EXEMPT: dict[str, str] = {}   # 名前 → 理由。今日は空

def check_decisions_index_coverage() -> int:
    ...
    indexable = sorted(                      # ★導出。curated list ではない
        p.name for p in decisions.glob("*.md")
        if p.name != "README.md" and not p.name.endswith(".ja.md")
    )
    _require_vacuity_floor(len(indexable), 40, ...)   # ★空振り緑を殺す
```
- ⭐ **導出**: **新しい ADR は 置いた瞬間から対象**。**更新を覚えておく list が在りません。**
- ⭐ **`.ja.md` は *規則* として除外**（**例外ではありません**）―― **索引は EN を載せ、mirror はその隣に在る** ∴ **要求すると索引が各 ADR を 2 度 並べます。**
- ⭐ **例外表は `UNSUPPORTED_WRAPPERS` と同じ形**（**名前＋理由、黙って skip しない**）。🔴 **今日は空で、それが意図した定常状態です** ―― **将来の 1 件は「誰かが理由を書く決定」であって、黙って索引から外れる file ではありません。**
- ⭐ **vacuity floor は `_require_vacuity_floor`**（**同 file の既存 idiom**。**`assert` は `python -O` で消えるので使いません** ―― `#4021` の follow-up 裁定）。

### 🔴 strip-falsify（**positive control 付き**）

```
$ # 索引から 0043 の行を 1 本 消す（★消えたことを assert で確認: no-op strip を殺す）
stripped the 0043 row (verified the text actually changed)
$ python scripts/check_doc_anchors.py; echo exit=$?
NOT_REACHABLE_FROM_INDEX: 1
  deep-dives/decisions/0043-generic-secret-provider-seam.md
exit=1                       ← ★赤

$ # 戻す
$ python scripts/check_doc_anchors.py; echo exit=$?
checked 51 ADR(s) under deep-dives/decisions/ for an index row
every ADR under deep-dives/decisions/ is reachable from its README index
exit=0                       ← ★緑
```
⭐ **floor も直接 叩いて 実際に raise することを確認しました**（`_require_vacuity_floor(3, 40, ...)` → `SystemExit`）―― ⚠️ **「floor が在る」と「floor が鳴る」は別の主張です。**

## ⚠️ 同時に直した 1 行

**`pr-workflow.md`** に **「`deep-dives/decisions/` に新しい ADR を置いたら README に行が要る」** を 1 文 足しました。
⭐ **理由は #6127 の裁定そのまま** ―― **規則は「読み手が既に居る場面」でしか効きません。** **このページは docs PR を開く直前に読まれます。**
⚠️ **既存の記述を偽にはしていません**（**あの段落は元々 anchor gate だけを説明しており、#4021 の 2 本にも触れていませんでした**）。

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — OK
- [x] `python scripts/check_doc_anchors.py` — OK（**51 本 全部 索引済**、既存 2 gate も緑）
- [x] `python scripts/check_retired_config_keys_denylist.py` — OK（0 hits）
- [x] `ruff check .` — All checks passed
- [x] **strip-falsify** — 上記。**赤にできることを確認済**
- [x] **vacuity floor** — 直接呼び出しで `SystemExit` を確認
- [x] (skipped — `pytest`: **`scripts/` の gate で `src/` も `tests/` も触っていません**)
- [x] (skipped — `mypy_ratchet.py`: **完走させていません。CI の `--full` が判定します**)
- [x] (skipped — Visual なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165mEawWkBCMCYixZoXDgow
