### PR TITLE
feat: part of #5825 stage 1 -- permissions.mode posture dial config key

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -597,7 +597,26 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
         # location is `llm.models`, handled in the `key == "llm"` branch
         # below.
         if key in ("models", "permissions") and isinstance(val, dict):
-            result[key] = {**result.get(key, {}), **val}
+            merged_dict = {**result.get(key, {}), **val}
+            if key == "permissions":
+                # #5825 stage 1 (FP-0069 §8): `disable_unbounded_mode` is
+                # sticky-OR across tiers, NOT last-tier-wins like every
+                # other permissions.* key above — "a session cannot
+                # re-enable it" (doc's own acceptance line) means a LATER
+                # tier's absence, or explicit `false`, must never clear a
+                # TRUE an earlier tier already set. Every other key in
+                # this dict keeps the ordinary override-wins merge; this
+                # is the one deliberate exception, confined to this one
+                # key so it does not become a silent precedent for
+                # `permissions.*` merging in general.
+                existing_permissions = result.get(key, {})
+                existing_lock = bool(
+                    existing_permissions.get("disable_unbounded_mode")
+                    if isinstance(existing_permissions, dict) else False
+                )
+                if existing_lock:
+                    merged_dict["disable_unbounded_mode"] = True
+            result[key] = merged_dict
         elif key == "mcp" and isinstance(val, dict):
             existing = result.get("mcp", {})
             existing_servers = existing.get("servers", {}) if isinstance(existing, dict) else {}

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -630,11 +630,23 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
                 # parse-failure branch above).
                 import logging
 
+                # lead-coder BLOCKING (co-vet re-check): the "did you
+                # mean" hint below is only SAFE to offer for a string
+                # value (a plausible `permissions.mode` dial-name typo,
+                # e.g. `permissions: ask`). A non-string non-dict value
+                # (e.g. `permissions: 3`) would suggest `{mode: 3}` —
+                # YAML-valid, but `parse_permission_mode(3)` itself
+                # raises, turning a WARNING an operator follows into a
+                # startup failure. Never advise a fix that is itself broken.
+                hint = (
+                    f" Did you mean 'permissions: {{mode: {val!r}}}'?"
+                    if isinstance(val, str) else ""
+                )
                 logging.getLogger(__name__).warning(
                     "config: 'permissions:' override is not a mapping "
                     "(got %r) — ignoring this tier's permissions override "
-                    "entirely. Did you mean 'permissions: {mode: %r}'?",
-                    val, val,
+                    "entirely.%s",
+                    val, hint,
                 )
                 merged_dict = dict(existing)
             if existing_lock:

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -596,27 +596,50 @@ def _merge(base: dict, override: dict, *, tier_label: str | None = None) -> dict
         # doesn't change shape while the operator migrates. The LIVE
         # location is `llm.models`, handled in the `key == "llm"` branch
         # below.
-        if key in ("models", "permissions") and isinstance(val, dict):
-            merged_dict = {**result.get(key, {}), **val}
-            if key == "permissions":
-                # #5825 stage 1 (FP-0069 §8): `disable_unbounded_mode` is
-                # sticky-OR across tiers, NOT last-tier-wins like every
-                # other permissions.* key above — "a session cannot
-                # re-enable it" (doc's own acceptance line) means a LATER
-                # tier's absence, or explicit `false`, must never clear a
-                # TRUE an earlier tier already set. Every other key in
-                # this dict keeps the ordinary override-wins merge; this
-                # is the one deliberate exception, confined to this one
-                # key so it does not become a silent precedent for
-                # `permissions.*` merging in general.
-                existing_permissions = result.get(key, {})
-                existing_lock = bool(
-                    existing_permissions.get("disable_unbounded_mode")
-                    if isinstance(existing_permissions, dict) else False
+        if key == "models" and isinstance(val, dict):
+            result[key] = {**result.get(key, {}), **val}
+        elif key == "permissions":
+            # #5825 stage 1 (FP-0069 §8) security co-vet (architect
+            # finding A, reproduced independently by lead-coder):
+            # `disable_unbounded_mode` must be derived from the FOLD
+            # across tiers ("did ANY tier ever set it true"), never from
+            # an ACCUMULATOR a later tier's own override can destroy.
+            # This branch fires for EVERY `permissions:` override
+            # regardless of shape — unlike the OLD version (nested inside
+            # `isinstance(val, dict)`, alongside "models"), which let a
+            # non-dict override (`permissions: "ask"` — a plausible typo
+            # now that stage 1 nests `mode` under this SAME key, instead
+            # of `permissions: {mode: "ask"}`) fall through to this
+            # function's generic `result[key] = val` tail, replacing the
+            # WHOLE dict — lock included — with the malformed value.
+            # Silently: downstream `_as_config_dict` defaults a non-dict
+            # `permissions:` to `{}` with only a WARNING, never a raise,
+            # so reyn still starts, lock gone, with nobody told.
+            existing = result.get("permissions", {})
+            if not isinstance(existing, dict):
+                existing = {}
+            existing_lock = bool(existing.get("disable_unbounded_mode"))
+            if isinstance(val, dict):
+                merged_dict = {**existing, **val}
+            else:
+                # A malformed override contributes NOTHING to the
+                # permissions dict (the prior tiers' own grants/lock are
+                # kept as-is) rather than wholesale-replacing it — loud,
+                # not silent (a WARNING, matching this file's own style
+                # for every other malformed-shape case, e.g. `_load_yaml`'s
+                # parse-failure branch above).
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "config: 'permissions:' override is not a mapping "
+                    "(got %r) — ignoring this tier's permissions override "
+                    "entirely. Did you mean 'permissions: {mode: %r}'?",
+                    val, val,
                 )
-                if existing_lock:
-                    merged_dict["disable_unbounded_mode"] = True
-            result[key] = merged_dict
+                merged_dict = dict(existing)
+            if existing_lock:
+                merged_dict["disable_unbounded_mode"] = True
+            result["permissions"] = merged_dict
         elif key == "mcp" and isinstance(val, dict):
             existing = result.get("mcp", {})
             existing_servers = existing.get("servers", {}) if isinstance(existing, dict) else {}

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -560,6 +560,22 @@ KEY_MEDIA_OVERSIZE = "media.oversize"
 #: has a REAL reader as of this PR: `require_network` (below), called
 #: from `op_runtime/sandboxed_exec.py`'s own seam.
 KEY_NETWORK = "network"
+#: FP-0069 §2 stage 1 (#5825): the posture dial itself — see
+#: :mod:`reyn.security.permissions.posture` for the value vocabulary
+#: (`read_only`/`ask`/`unbounded`; `bounded` deliberately not yet
+#: accepted, #5825 stage 2) and the parsing/ordering it owns. This
+#: registry only recognizes the KEY NAME; `posture.py` owns validating
+#: the VALUE.
+KEY_MODE = "mode"
+#: FP-0069 §2/§8 (#5825 stage 1): the "removable by config" half of
+#: `unbounded` (doc §8: "Removing unbounded by config is possible, and a
+#: session cannot re-enable it") — same shape as Claude Code's
+#: `disableBypassPermissionsMode` (a managed-precedence key, confirmed
+#: NOT in the SDK's own irreversible-exceptions list — architect's
+#: primary-source read, #5825 issue thread). See `posture.py`'s
+#: `resolve_permission_mode` for the merge semantics (sticky true, once
+#: any config tier sets it — never re-enabled by a LATER-merged tier).
+KEY_DISABLE_UNBOUNDED_MODE = "disable_unbounded_mode"
 #: The composite flat-string pre-approval key prefix (see the docstring
 #: above for why the fallback split cannot resolve a nested
 #: ``http.get: {host: ...}`` shape, so this flat form is the one that
@@ -586,6 +602,7 @@ PERMISSIONS_EXACT_CONFIG_KEYS: frozenset[str] = frozenset({
     KEY_MCP, KEY_FILE_READ, KEY_FILE_WRITE, KEY_HTTP_GET, KEY_SECRET_WRITE,
     KEY_ENV_EXPAND, KEY_SUBPROCESS, KEY_ENV, KEY_PYTHON,
     KEY_WEB_FETCH, KEY_MEDIA_OVERSIZE, KEY_NETWORK,
+    KEY_MODE, KEY_DISABLE_UNBOUNDED_MODE,
 }) | frozenset(
     # Legacy bool axes (#571 collapse arc Phase 5) — recognized here so
     # their OWN DeprecationWarning fires (from_dict's own loop over this

--- a/src/reyn/security/permissions/posture.py
+++ b/src/reyn/security/permissions/posture.py
@@ -1,0 +1,158 @@
+"""FP-0069 §2 — the permission posture dial (#5825 stage 1).
+
+``permissions.mode`` in ``reyn.yaml`` (overridable in ``reyn.local.yaml``,
+and at runtime), named by DISPOSITION — what an actor may do — not by
+rank. Owner-ratified 2026-09-06 (the proposal's own §10 records the three
+verbatim rulings): ``docs/deep-dives/proposals/0069-permission-posture-dial.md``.
+
+**Stage 1 scope, deliberately narrow** (lead-coder dispatch, #5825): the
+config key, the 3 values this stage accepts, their total order, and the
+"remove ``unbounded`` by config" seam. Wiring a mode's VALUE into actual
+enforcement (a capability denied by a restrict layer staying denied in
+every mode; ``bounded``'s own boundary replacing the prompt) is later
+stages' work, not this module's.
+
+**``bounded`` is a 4th value the doc already names (§2) but this stage
+does NOT accept** — it "Requires §6" (the doc's own table, verbatim): a
+``sandboxed_exec``-owned restrictive policy that does not exist yet
+(#5825 stage 2). Accepting the STRING today without the boundary behind
+it would ship a name that does not protect what it claims to — the exact
+"declared, never reached" shape #5849/#5862 already closed elsewhere in
+this same file's sibling registry. :func:`parse_permission_mode` refuses
+it with a message naming stage 2, rather than silently aliasing it to
+``ask`` — an alias would be worse than refusing: a config author who
+wrote ``bounded`` believing it meant a real boundary would read `ask`'s
+behavior as satisfying that belief.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class PermissionMode(str, enum.Enum):
+    """The 3 values #5825 stage 1 accepts (doc §2's own 4, minus
+    ``bounded`` — see module docstring). String-valued so a raw config
+    string compares equal to a member directly (``raw == PermissionMode.ASK``),
+    the same convenience :class:`~reyn.config_axis.Axis` already uses."""
+
+    READ_ONLY = "read_only"
+    ASK = "ask"
+    UNBOUNDED = "unbounded"
+
+
+#: Strict-to-permissive, total (doc §2: "Ordering is total and strict-to-
+#: permissive, so 'at least as strict as X' is expressible") — the single
+#: source both :func:`rank` and any future comparison read, never a second
+#: hand-written order that could drift from this one.
+PERMISSION_MODE_ORDER: "tuple[PermissionMode, ...]" = (
+    PermissionMode.READ_ONLY,
+    PermissionMode.ASK,
+    PermissionMode.UNBOUNDED,
+)
+
+#: doc §7 (Migration): "Existing projects keep working with mode: ask" —
+#: the ONE place this default is stated, per #5825 stage 1's acceptance
+#: criterion ("no silent default, or has a default stated in one place a
+#: test reads"). Byte-identical to pre-dial behavior: no ``permissions.mode``
+#: key at all resolves to exactly what an unconfigured project already did.
+DEFAULT_PERMISSION_MODE: PermissionMode = PermissionMode.ASK
+
+#: The doc's own 4th value, named explicitly here (not just absent from
+#: :class:`PermissionMode`) so :func:`parse_permission_mode` can give it a
+#: distinct, honest error rather than folding it into the generic
+#: "unrecognized value" message a genuine typo gets.
+_BOUNDED_NOT_YET_IMPLEMENTED = "bounded"
+
+
+class PermissionModeError(ValueError):
+    """A ``permissions.mode`` value this stage cannot honor. Base class for
+    both the generic-unrecognized and the ``bounded``-specific case below,
+    so a caller that only wants "refuse startup, log the reason" can catch
+    this one type and still get the more specific message in ``str(exc)``."""
+
+
+class BoundedModeNotImplementedError(PermissionModeError):
+    """``mode: bounded`` was configured — a real, doc-named value (§2),
+    just not one this stage accepts (see module docstring). Distinct from
+    :class:`PermissionModeError`'s generic case so a caller wanting to
+    special-case "not yet, not a typo" can — e.g. pointing an operator at
+    the tracking issue instead of `reyn config fields`."""
+
+
+def parse_permission_mode(raw: str) -> PermissionMode:
+    """Parse *raw* (a ``permissions.mode`` config value) into a
+    :class:`PermissionMode`.
+
+    Raises :class:`BoundedModeNotImplementedError` for ``"bounded"``
+    specifically (never silently aliased to :data:`PermissionMode.ASK` —
+    see module docstring for why an alias would be worse than a refusal),
+    and the base :class:`PermissionModeError` for any other value that
+    matches none of the 3 stage-1 members (a typo, or a value that never
+    existed)."""
+    if raw == _BOUNDED_NOT_YET_IMPLEMENTED:
+        raise BoundedModeNotImplementedError(
+            "permissions.mode: 'bounded' is not yet implemented (#5825 "
+            "stage 2 — it requires a sandboxed_exec-owned restrictive "
+            "policy that does not exist yet). Use 'read_only', 'ask', or "
+            "'unbounded' for now."
+        )
+    try:
+        return PermissionMode(raw)
+    except ValueError:
+        valid = ", ".join(repr(m.value) for m in PERMISSION_MODE_ORDER)
+        raise PermissionModeError(
+            f"permissions.mode: {raw!r} is not a recognized value. "
+            f"Valid values: {valid}."
+        ) from None
+
+
+def rank(mode: PermissionMode) -> int:
+    """*mode*'s position in :data:`PERMISSION_MODE_ORDER` — lower is
+    stricter. The one place a caller should compare two modes' relative
+    strictness; never compare `.value` strings or re-derive an order."""
+    return PERMISSION_MODE_ORDER.index(mode)
+
+
+def is_at_least_as_strict(mode: PermissionMode, floor: PermissionMode) -> bool:
+    """``True`` iff *mode* is *floor* or stricter — doc §2's own
+    "'at least as strict as X' is expressible" acceptance line, as a
+    direct callable rather than an inline rank comparison at every call
+    site (the seam a future enforcement stage will actually call)."""
+    return rank(mode) <= rank(floor)
+
+
+def resolve_permission_mode(
+    raw: "str | None", *, unbounded_disabled: bool,
+) -> PermissionMode:
+    """The one function a config-reading caller should use to get the
+    EFFECTIVE :class:`PermissionMode` — *raw* is the merged
+    ``permissions.mode`` config value (``None`` when unset, resolving to
+    :data:`DEFAULT_PERMISSION_MODE`), *unbounded_disabled* is the merged
+    ``permissions.disable_unbounded_mode`` flag (see
+    :func:`~reyn.config.loader._merge`'s sticky-OR handling of that one
+    key — never a plain last-tier-wins merge, doc §8: "a session cannot
+    re-enable it").
+
+    A configured ``unbounded`` while disabled does NOT raise — a locked-
+    down fleet's config should not crash an operator's session; it falls
+    back to :data:`DEFAULT_PERMISSION_MODE` (the safe, byte-identical-to-
+    today value) with a WARNING naming what was refused and why, so the
+    drift is visible rather than silent (CLAUDE.md band: observability).
+    A genuinely unrecognized value (a typo, or `bounded`) still raises —
+    unlike a disabled-but-otherwise-valid `unbounded`, there is no safe
+    value to substitute for a value that was never a real mode at all."""
+    mode = (
+        DEFAULT_PERMISSION_MODE if raw is None else parse_permission_mode(raw)
+    )
+    if mode is PermissionMode.UNBOUNDED and unbounded_disabled:
+        logger.warning(
+            "permissions.mode: 'unbounded' was configured but is disabled "
+            "by permissions.disable_unbounded_mode (set by this project or "
+            "a higher config tier) — falling back to %r.",
+            DEFAULT_PERMISSION_MODE.value,
+        )
+        return DEFAULT_PERMISSION_MODE
+    return mode

--- a/src/reyn/security/permissions/posture.py
+++ b/src/reyn/security/permissions/posture.py
@@ -139,11 +139,20 @@ def resolve_permission_mode(
     A configured ``unbounded`` while disabled does NOT raise — a locked-
     down fleet's config should not crash an operator's session; it falls
     back to :data:`DEFAULT_PERMISSION_MODE` (the safe, byte-identical-to-
-    today value) with a WARNING naming what was refused and why, so the
-    drift is visible rather than silent (CLAUDE.md band: observability).
-    A genuinely unrecognized value (a typo, or `bounded`) still raises —
-    unlike a disabled-but-otherwise-valid `unbounded`, there is no safe
-    value to substitute for a value that was never a real mode at all."""
+    today value) with a WARNING naming what was refused and why. That
+    WARNING reaches ``reyn.log`` unconditionally, but NOT the operator's
+    own screen in the shipped interactive configuration — ``chat.py``'s
+    ``_setup_interactive_logging`` only adds a ``StreamHandler`` when
+    ``not is_interactive`` (CLAUDE.md's own 2nd of 3 questions: "is this
+    visible with the shipped config?" — here, no). Surfacing this
+    downgrade on-screen (the posture surface doc §8 also names for
+    `bounded`'s own degraded-enforcement case) is a LATER stage's
+    responsibility, not this function's — this module only guarantees the
+    fallback is DURABLY RECORDED, not that an operator watching the
+    screen sees it in the moment. A genuinely unrecognized value (a typo,
+    or `bounded`) still raises — unlike a disabled-but-otherwise-valid
+    `unbounded`, there is no safe value to substitute for a value that
+    was never a real mode at all."""
     mode = (
         DEFAULT_PERMISSION_MODE if raw is None else parse_permission_mode(raw)
     )

--- a/tests/security/test_5825_permission_posture_dial.py
+++ b/tests/security/test_5825_permission_posture_dial.py
@@ -79,7 +79,12 @@ def test_an_unrecognized_value_raises_the_generic_error(raw: str) -> None:
     """Tier 1: a typo or a value that never existed at all gets the
     generic error, distinct from `bounded`'s own specific one -- and the
     message names the valid set so `reyn config validate`'s own output
-    is self-sufficient."""
+    is self-sufficient.
+
+    Disclosed (six questions ④): the loop below would stay green over an
+    EMPTY PERMISSION_MODE_ORDER too -- that vacuous case is killed by
+    test_permission_mode_order_covers_every_enum_member's own membership
+    invariant, not by a guard duplicated in this test."""
     with pytest.raises(PermissionModeError) as exc_info:
         parse_permission_mode(raw)
     assert not isinstance(exc_info.value, BoundedModeNotImplementedError)
@@ -110,11 +115,18 @@ def test_permission_mode_order_covers_every_enum_member() -> None:
 def test_the_order_is_total_every_pair_has_one_answer() -> None:
     """Tier 1: doc §2's own acceptance line — "Ordering is total and
     strict-to-permissive, so 'at least as strict as X' is expressible."
-    Exhaustive over all 9 pairs (3x3), not a sample: for every (a, b),
-    "a at least as strict as b" and "b at least as strict as a" must
-    never BOTH be false (a total order has an answer for every pair),
-    and for a != b must never both be true (a total order is antisymmetric
-    once equality is excluded)."""
+    Exhaustive over every pair PERMISSION_MODE_ORDER actually holds
+    (3x3 = 9 today, NOT a number this test itself pins), not a sample:
+    for every (a, b), "a at least as strict as b" and "b at least as
+    strict as a" must never BOTH be false (a total order has an answer
+    for every pair), and for a != b must never both be true (a total
+    order is antisymmetric once equality is excluded).
+
+    Disclosed (six questions ④): itertools.product over an EMPTY
+    PERMISSION_MODE_ORDER iterates zero times and this loop's body never
+    runs — that vacuous case is killed by
+    test_permission_mode_order_covers_every_enum_member's own membership
+    invariant, not by a guard duplicated here."""
     for a, b in itertools.product(PERMISSION_MODE_ORDER, repeat=2):
         a_vs_b = is_at_least_as_strict(a, b)
         b_vs_a = is_at_least_as_strict(b, a)
@@ -137,7 +149,12 @@ def test_read_only_is_the_strictest_and_unbounded_the_most_permissive() -> None:
 def test_a_mode_is_at_least_as_strict_as_itself() -> None:
     """Tier 1: reflexivity -- "at least as strict as" must include equal,
     per the phrase's own ordinary meaning (a floor of `ask` is satisfied
-    BY `ask`, not only by something stricter)."""
+    BY `ask`, not only by something stricter).
+
+    Disclosed (six questions ④): same vacuity risk as the two tests
+    above -- an empty PERMISSION_MODE_ORDER would pass this loop too,
+    and is killed by the same sibling membership invariant, not by a
+    guard duplicated here."""
     for mode in PERMISSION_MODE_ORDER:
         assert is_at_least_as_strict(mode, mode)
 
@@ -230,6 +247,45 @@ def test_disable_unbounded_mode_survives_an_explicit_later_false() -> None:
     merged = _merge(merged, {"permissions": {"disable_unbounded_mode": False}}, tier_label="project")
     merged = _merge(merged, {"permissions": {"disable_unbounded_mode": False}}, tier_label="project_local")
     assert merged["permissions"]["disable_unbounded_mode"] is True
+
+
+def test_disable_unbounded_mode_survives_a_later_tier_writing_a_non_dict_string(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: #5825 stage 1 security co-vet (architect finding A,
+    reproduced independently by lead-coder) -- the ORIGINAL bug this test
+    guards: `permissions: "ask"` (a plausible typo now that stage 1
+    nests `mode` UNDER this same `permissions:` key, instead of the
+    correct `permissions: {mode: "ask"}`) used to fall through to
+    `_merge`'s generic `result[key] = val` tail, replacing the WHOLE
+    permissions dict -- lock included -- with the string, SILENTLY
+    (downstream `_as_config_dict` defaults a non-dict `permissions:` to
+    `{}` with only a WARNING, never a raise, so reyn still started with
+    the lock gone and nobody told). The lock must survive; the malformed
+    override itself must be loudly ignored, not silently applied as a
+    mode or anything else."""
+    caplog.set_level("WARNING")
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"disable_unbounded_mode": True}}, tier_label="user_global")
+    merged = _merge(merged, {"permissions": "ask"}, tier_label="project_local")
+    assert merged["permissions"]["disable_unbounded_mode"] is True
+    assert isinstance(merged["permissions"], dict), (
+        "a non-dict override must not replace the permissions dict wholesale"
+    )
+    assert any("permissions" in r.message for r in caplog.records), (
+        "a malformed permissions: override must warn, not fail silently"
+    )
+
+
+def test_disable_unbounded_mode_survives_a_later_tier_writing_a_non_dict_list() -> None:
+    """Tier 1: the SAME class of malformed override as the string case
+    above, a different non-dict shape -- proves the fix is "any non-dict
+    value", not a string-specific special case."""
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"disable_unbounded_mode": True}}, tier_label="user_global")
+    merged = _merge(merged, {"permissions": ["ask"]}, tier_label="project_local")
+    assert merged["permissions"]["disable_unbounded_mode"] is True
+    assert isinstance(merged["permissions"], dict)
 
 
 def test_disable_unbounded_mode_off_by_default_stays_off_through_ordinary_merges() -> None:

--- a/tests/security/test_5825_permission_posture_dial.py
+++ b/tests/security/test_5825_permission_posture_dial.py
@@ -275,6 +275,28 @@ def test_disable_unbounded_mode_survives_a_later_tier_writing_a_non_dict_string(
     assert any("permissions" in r.message for r in caplog.records), (
         "a malformed permissions: override must warn, not fail silently"
     )
+    assert any("Did you mean" in r.message for r in caplog.records), (
+        "a string override IS a plausible mode-value typo -- the hint should fire"
+    )
+
+
+def test_a_non_string_malformed_override_gets_no_broken_advice(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: lead-coder BLOCKING (co-vet re-check) -- the "Did you mean
+    'permissions: {mode: ...}'?" hint is only SAFE for a string value (a
+    plausible dial-name typo). A non-string, non-dict value (e.g.
+    `permissions: 3`) would suggest `{mode: 3}` -- YAML-valid, but
+    `parse_permission_mode(3)` itself raises, turning a WARNING an
+    operator follows into a startup failure. Never advise a fix that is
+    itself broken."""
+    caplog.set_level("WARNING")
+    _merge({}, {"permissions": 3})
+    assert any("permissions" in r.message for r in caplog.records)
+    assert not any("Did you mean" in r.message for r in caplog.records), (
+        "a non-string override must not get mode-value advice -- the "
+        "suggested fix would itself fail to parse"
+    )
 
 
 def test_disable_unbounded_mode_survives_a_later_tier_writing_a_non_dict_list() -> None:
@@ -286,6 +308,23 @@ def test_disable_unbounded_mode_survives_a_later_tier_writing_a_non_dict_list() 
     merged = _merge(merged, {"permissions": ["ask"]}, tier_label="project_local")
     assert merged["permissions"]["disable_unbounded_mode"] is True
     assert isinstance(merged["permissions"], dict)
+
+
+def test_a_malformed_override_preserves_an_unrelated_prior_grant_too() -> None:
+    """Tier 1: lead-coder BLOCKING (co-vet re-check) -- the fix's own
+    behavior change is broader than the lock: a malformed
+    `permissions:` override now preserves EVERY prior tier's grant, not
+    just `disable_unbounded_mode` (the OLD code wholesale-replaced the
+    dict with `{}`, losing everything). Only the lock has its own
+    dedicated test above; without this one, a future change that goes
+    back to "wipe to {} on malformed input" would leave
+    disable_unbounded_mode's own tests green (nothing else was ever
+    locked) while silently discarding every OTHER prior grant -- pin the
+    broader claim directly, not just its one security-critical instance."""
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"network": "deny"}}, tier_label="user_global")
+    merged = _merge(merged, {"permissions": "ask"}, tier_label="project_local")
+    assert merged["permissions"]["network"] == "deny"
 
 
 def test_disable_unbounded_mode_off_by_default_stays_off_through_ordinary_merges() -> None:

--- a/tests/security/test_5825_permission_posture_dial.py
+++ b/tests/security/test_5825_permission_posture_dial.py
@@ -90,6 +90,23 @@ def test_an_unrecognized_value_raises_the_generic_error(raw: str) -> None:
 # ── total ordering ───────────────────────────────────────────────────────
 
 
+def test_permission_mode_order_covers_every_enum_member() -> None:
+    """Tier 1: lead-coder BLOCKING — PERMISSION_MODE_ORDER is a hand-
+    maintained tuple, separate from the PermissionMode enum it orders;
+    nothing makes them drift together automatically. rank()'s own
+    .index() means a member present in the enum but MISSING from the
+    tuple raises ValueError in production the first time anything ranks
+    it (e.g. stage 2 adding `bounded` to the enum and forgetting to
+    extend this tuple).
+
+    Deliberately does NOT pin the COUNT (3 today) — only that the two
+    collections' MEMBERSHIP matches, so stage 2 adding a real 4th value
+    to both together stays green; only a genuine update-miss (one
+    changed, the other not) goes red."""
+    assert set(PERMISSION_MODE_ORDER) == set(PermissionMode)
+    assert len(PERMISSION_MODE_ORDER) == len(set(PermissionMode))
+
+
 def test_the_order_is_total_every_pair_has_one_answer() -> None:
     """Tier 1: doc §2's own acceptance line — "Ordering is total and
     strict-to-permissive, so 'at least as strict as X' is expressible."

--- a/tests/security/test_5825_permission_posture_dial.py
+++ b/tests/security/test_5825_permission_posture_dial.py
@@ -1,0 +1,235 @@
+"""Tier 1: Contract — the FP-0069 §2 permission posture dial's stage-1
+surface (#5825 stage 1): ``reyn.security.permissions.posture``'s parsing,
+total ordering, and the ``permissions.disable_unbounded_mode`` sticky-OR
+merge in ``reyn.config.loader._merge``.
+
+Scope, matching #5825 stage 1's own dispatch: the config KEY, the 3
+values this stage accepts, their order, and the "remove unbounded by
+config" seam. Wiring a mode's value into actual enforcement (a denied
+capability staying denied in every mode; ``bounded``'s own boundary) is a
+later stage's own test file, not this one's.
+"""
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from reyn.config.loader import _merge
+from reyn.security.permissions.permissions import (
+    KEY_DISABLE_UNBOUNDED_MODE,
+    KEY_MODE,
+    unknown_permissions_config_keys,
+)
+from reyn.security.permissions.posture import (
+    DEFAULT_PERMISSION_MODE,
+    PERMISSION_MODE_ORDER,
+    BoundedModeNotImplementedError,
+    PermissionMode,
+    PermissionModeError,
+    is_at_least_as_strict,
+    parse_permission_mode,
+    rank,
+    resolve_permission_mode,
+)
+
+# ── parse_permission_mode ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("read_only", PermissionMode.READ_ONLY),
+        ("ask", PermissionMode.ASK),
+        ("unbounded", PermissionMode.UNBOUNDED),
+    ],
+)
+def test_parse_permission_mode_accepts_all_3_stage_1_values(
+    raw: str, expected: PermissionMode,
+) -> None:
+    """Tier 1: the 3 values #5825 stage 1 dispatches ("read_only / ask /
+    unbounded の3値") each parse to their own distinct member."""
+    assert parse_permission_mode(raw) is expected
+
+
+def test_bounded_is_refused_not_silently_aliased_to_ask() -> None:
+    """Tier 1: `bounded` is a REAL doc-named value (§2) this stage
+    explicitly does not accept (§6 requires a boundary that does not
+    exist yet, #5825 stage 2) — the dispatch's own explicit prohibition:
+    "ask の別名として黙って受けるのは禁止". Must raise, never return
+    PermissionMode.ASK."""
+    with pytest.raises(BoundedModeNotImplementedError) as exc_info:
+        parse_permission_mode("bounded")
+    # #5825 stage 2 must be named in the message -- an operator hitting
+    # this needs to know WHERE the real answer lives, not just that
+    # "bounded" failed.
+    assert "#5825" in str(exc_info.value)
+    assert "stage 2" in str(exc_info.value)
+
+
+def test_bounded_not_implemented_error_is_a_permission_mode_error() -> None:
+    """Tier 1: a caller catching the general PermissionModeError (e.g. to
+    refuse startup with one message) still catches the bounded-specific
+    case -- BoundedModeNotImplementedError subclasses it."""
+    assert issubclass(BoundedModeNotImplementedError, PermissionModeError)
+
+
+@pytest.mark.parametrize("raw", ["yolo", "", "READ_ONLY", "Ask", "strict"])
+def test_an_unrecognized_value_raises_the_generic_error(raw: str) -> None:
+    """Tier 1: a typo or a value that never existed at all gets the
+    generic error, distinct from `bounded`'s own specific one -- and the
+    message names the valid set so `reyn config validate`'s own output
+    is self-sufficient."""
+    with pytest.raises(PermissionModeError) as exc_info:
+        parse_permission_mode(raw)
+    assert not isinstance(exc_info.value, BoundedModeNotImplementedError)
+    for mode in PERMISSION_MODE_ORDER:
+        assert mode.value in str(exc_info.value)
+
+
+# ── total ordering ───────────────────────────────────────────────────────
+
+
+def test_the_order_is_total_every_pair_has_one_answer() -> None:
+    """Tier 1: doc §2's own acceptance line — "Ordering is total and
+    strict-to-permissive, so 'at least as strict as X' is expressible."
+    Exhaustive over all 9 pairs (3x3), not a sample: for every (a, b),
+    "a at least as strict as b" and "b at least as strict as a" must
+    never BOTH be false (a total order has an answer for every pair),
+    and for a != b must never both be true (a total order is antisymmetric
+    once equality is excluded)."""
+    for a, b in itertools.product(PERMISSION_MODE_ORDER, repeat=2):
+        a_vs_b = is_at_least_as_strict(a, b)
+        b_vs_a = is_at_least_as_strict(b, a)
+        assert a_vs_b or b_vs_a, f"no answer for the pair ({a!r}, {b!r})"
+        if a is not b:
+            assert not (a_vs_b and b_vs_a), f"both directions true for ({a!r}, {b!r})"
+
+
+def test_read_only_is_the_strictest_and_unbounded_the_most_permissive() -> None:
+    """Tier 1: the concrete order the doc's table lists, pinned directly
+    (not inferred from the total-ordering test above, which only proves
+    A total order exists -- this proves it is THIS one)."""
+    assert rank(PermissionMode.READ_ONLY) < rank(PermissionMode.ASK) < rank(
+        PermissionMode.UNBOUNDED
+    )
+    assert is_at_least_as_strict(PermissionMode.READ_ONLY, PermissionMode.UNBOUNDED)
+    assert not is_at_least_as_strict(PermissionMode.UNBOUNDED, PermissionMode.READ_ONLY)
+
+
+def test_a_mode_is_at_least_as_strict_as_itself() -> None:
+    """Tier 1: reflexivity -- "at least as strict as" must include equal,
+    per the phrase's own ordinary meaning (a floor of `ask` is satisfied
+    BY `ask`, not only by something stricter)."""
+    for mode in PERMISSION_MODE_ORDER:
+        assert is_at_least_as_strict(mode, mode)
+
+
+# ── resolve_permission_mode ──────────────────────────────────────────────
+
+
+def test_unset_mode_resolves_to_the_stated_default() -> None:
+    """Tier 1: doc §7 (Migration) -- "Existing projects keep working with
+    mode: ask" -- the one place this default is declared, and this test
+    is what reads it (#5825 stage 1's own acceptance criterion)."""
+    assert resolve_permission_mode(None, unbounded_disabled=False) is DEFAULT_PERMISSION_MODE
+    assert DEFAULT_PERMISSION_MODE is PermissionMode.ASK
+
+
+def test_unbounded_configured_and_allowed_stays_unbounded() -> None:
+    """Tier 1: deny side of the lock -- when NOT disabled, `unbounded`
+    resolves to itself, unchanged."""
+    assert resolve_permission_mode(
+        "unbounded", unbounded_disabled=False,
+    ) is PermissionMode.UNBOUNDED
+
+
+def test_unbounded_configured_but_disabled_falls_back_to_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 1: doc §8 -- "Removing unbounded by config is possible" — a
+    disabled `unbounded` does not crash the session (a locked-down fleet's
+    config should not refuse to start); it falls back to the same safe
+    default an unset mode gets, and the fallback is disclosed via a
+    WARNING naming what was refused (CLAUDE.md observability band)."""
+    caplog.set_level("WARNING")
+    resolved = resolve_permission_mode("unbounded", unbounded_disabled=True)
+    assert resolved is DEFAULT_PERMISSION_MODE
+    assert any("unbounded" in r.message and "disable_unbounded_mode" in r.message for r in caplog.records)
+
+
+def test_a_genuinely_invalid_mode_still_raises_even_with_the_lock_off() -> None:
+    """Tier 1: the disabled-fallback above is a SAFE-VALUE substitution,
+    not a general "never raise" policy -- an unrecognized value (never a
+    real mode to begin with) has no safe value to substitute, so it still
+    raises regardless of the lock's state."""
+    with pytest.raises(PermissionModeError):
+        resolve_permission_mode("yolo", unbounded_disabled=False)
+    with pytest.raises(BoundedModeNotImplementedError):
+        resolve_permission_mode("bounded", unbounded_disabled=True)
+
+
+# ── config-key recognition ───────────────────────────────────────────────
+
+
+def test_mode_and_disable_unbounded_mode_are_recognized_permissions_keys() -> None:
+    """Tier 1: #5825 stage 1's own new keys must not surface as
+    "unrecognized key(s) (not applied)" -- the exact #5849-class defect
+    this repo already closed once for every OTHER permissions.* key."""
+    unknown = unknown_permissions_config_keys(
+        {KEY_MODE: "ask", KEY_DISABLE_UNBOUNDED_MODE: True},
+    )
+    assert unknown == frozenset()
+
+
+def test_a_genuine_typo_key_is_still_reported_unknown() -> None:
+    """Tier 1: deny side -- adding the 2 new keys must not accidentally
+    widen the registry into accepting everything."""
+    unknown = unknown_permissions_config_keys({"mdoe": "ask"})
+    assert unknown == frozenset({"mdoe"})
+
+
+# ── the sticky-OR merge (disable_unbounded_mode "cannot be re-enabled") ──
+
+
+def test_disable_unbounded_mode_set_by_an_earlier_tier_survives_a_later_tiers_silence() -> None:
+    """Tier 1: doc §8 -- "a session cannot re-enable it". A later tier
+    that never mentions the key at all (the common case: a project's
+    reyn.yaml simply has no disable_unbounded_mode line) must not clear a
+    TRUE an earlier tier set."""
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"disable_unbounded_mode": True}})
+    merged = _merge(merged, {"permissions": {"mode": "unbounded"}})
+    assert merged["permissions"]["disable_unbounded_mode"] is True
+
+
+def test_disable_unbounded_mode_survives_an_explicit_later_false() -> None:
+    """Tier 1: the sharper case -- a LATER tier explicitly writing
+    `disable_unbounded_mode: false` (an operator trying to undo the
+    lock from a lower-authority file) must still not clear it. This is
+    the concrete shape "a session cannot re-enable it" rules out."""
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"disable_unbounded_mode": True}}, tier_label="user_global")
+    merged = _merge(merged, {"permissions": {"disable_unbounded_mode": False}}, tier_label="project")
+    merged = _merge(merged, {"permissions": {"disable_unbounded_mode": False}}, tier_label="project_local")
+    assert merged["permissions"]["disable_unbounded_mode"] is True
+
+
+def test_disable_unbounded_mode_off_by_default_stays_off_through_ordinary_merges() -> None:
+    """Tier 1: deny side -- when NO tier ever sets the lock, it must not
+    spuriously become True from the merge machinery itself (the sticky
+    logic must trigger only on a genuine True somewhere in the chain)."""
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"mode": "ask"}}, tier_label="user_global")
+    merged = _merge(merged, {"permissions": {"file.write": "allow"}}, tier_label="project")
+    assert not merged["permissions"].get("disable_unbounded_mode")
+
+
+def test_other_permissions_keys_keep_ordinary_last_tier_wins_merge() -> None:
+    """Tier 1: the sticky-OR exception is scoped to `disable_unbounded_mode`
+    ONLY -- every other permissions.* key (mode included) still uses the
+    ordinary override-wins merge, unaffected by this change."""
+    merged: dict = {}
+    merged = _merge(merged, {"permissions": {"mode": "ask"}}, tier_label="user_global")
+    merged = _merge(merged, {"permissions": {"mode": "unbounded"}}, tier_label="project_local")
+    assert merged["permissions"]["mode"] == "unbounded"


### PR DESCRIPTION
**[tui-coder]** — part of #5825 stage 1. Not closing #5825 — stages 2 (`bounded`) and 3 (opt-in declaration) remain.

## Scope (per lead-coder's explicit stage split)
The config key, the 3 values this stage accepts, their total order, and the "remove `unbounded` by config" seam. Wiring a mode's value into actual enforcement is a later stage's own work.

## New module: `reyn.security.permissions.posture`
- `PermissionMode`: `read_only` / `ask` / `unbounded` (str Enum)
- `PERMISSION_MODE_ORDER`: strict-to-permissive total order
- `parse_permission_mode()`: `"bounded"` (the doc's own 4th value, §2) is **explicitly refused** — `BoundedModeNotImplementedError`, never silently aliased to `ask`. A genuinely unrecognized value gets the generic `PermissionModeError`.
- `is_at_least_as_strict()`/`rank()`: doc's own "at least as strict as X is expressible" acceptance line, as a direct callable.
- `DEFAULT_PERMISSION_MODE = ask`: doc §7's migration guarantee, stated in the one place a test reads it.
- `resolve_permission_mode()`: the effective-mode seam a future enforcement stage will call — a disabled-but-configured `unbounded` falls back to the default with a `WARNING` (not a crash); a genuinely unrecognized value still raises.

## `permissions.py`
`mode` and `disable_unbounded_mode` added to `PERMISSIONS_EXACT_CONFIG_KEYS` (the #5849-class registry) — neither would otherwise surface as an "unrecognized key(s) (not applied)" warning.

## `config/loader.py`'s `_merge()`
`permissions.disable_unbounded_mode` gets a **sticky-OR merge** across config tiers, not the ordinary override-wins every other `permissions.*` key uses — doc §8's "a session cannot re-enable it" means a later tier's silence, or an explicit `false`, must never clear a `true` an earlier tier already set. Same shape as Claude Code's `disableBypassPermissionsMode` (architect confirmed against the SDK's own managed-precedence exceptions list — not in it). Scoped to this ONE key only.

## ⚠️ For architect's co-vet
This is the one genuinely under-specified design choice I made (not stated verbatim by owner/lead-coder): what happens when `unbounded` is configured but locked. I chose **fall back to `ask` with a WARNING**, not a hard refusal to start — reasoning is in `resolve_permission_mode`'s own docstring. Flagging explicitly since this is the security-relevant judgment call in an otherwise mechanical stage.

## Tests
`tests/security/test_5825_permission_posture_dial.py` (new, 17 tests): parsing all 3 values, `bounded`'s explicit refusal, exhaustive total-order verification (all 9 pairs), the default/lock resolution seam, config-key recognition, and the sticky-OR merge (including the sharper case: an explicit later `false` must not clear an earlier `true`).

Strip-falsified both load-bearing behaviors by hand (file-internal Edit, reverted): aliasing `bounded` to `ask`, and removing the sticky-OR special case — each independently reproduced the exact failure the corresponding test names.

## Test plan
- [x] `ruff check .`
- [x] `test_tier_audit.py --strict` (new test file)
- [x] `verify_module_docstrings.py` (3 changed/new src files)
- [x] `mypy_ratchet.py`
- [x] `flat_tests_ratchet.py`
- [x] `check_tests_path_literal_reference.py`
- [x] tests/-touching gates: bare-import ref, file-depth ref, subprocess-reyn-pin, no-core-dep-importorskip, time-dependence ratchet
- [x] (skipped — Visual, standing waiver)

Diff-scoped pytest: `pytest tests/security/test_5825_permission_posture_dial.py tests/config/test_5848_5849_permissions_config_key_registry.py tests/config/test_config_loader_pure_helpers.py -q` → **52 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn
