### PR TITLE
fix(part of #3024): bare-python scripts/ verify their own reyn identity

### DIFF
--- a/.github/workflows/scripts-import-identity-guard-gate.yml
+++ b/.github/workflows/scripts-import-identity-guard-gate.yml
@@ -1,0 +1,42 @@
+name: scripts import-identity guard gate
+
+# #3024: every bare-python scripts/*.py file that imports reyn (module-
+# level or lazily, anywhere in the file) must call
+# verify_env_identity.guard_bare_script_or_exit() before any code path
+# can reach that import, or be named -- with a reason -- in
+# scripts/check_scripts_import_identity_guard.py's own EXEMPT_SCRIPTS
+# table. See that script's own module docstring for the full origin: a
+# bare python invocation has none of pytest's own pythonpath=["src"]
+# protection (root conftest.py's #3233 guard), so "pytest is green" was
+# never evidence a bare-python gate script measured the right checkout.
+#
+# `paths: scripts/**` -- this gate scans EVERY scripts/*.py file each
+# run (its own population is derived, not enumerated), so any script
+# addition/edit can move its own verdict.
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+
+permissions:
+  contents: read
+
+jobs:
+  scripts-import-identity-guard-gate:
+    name: scripts import-identity guard gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_scripts_import_identity_guard.py is stdlib-only
+      # (ast / subprocess / pathlib). No pip install needed.
+      - name: Check every reyn-importing script is guarded or reasoned-exempt
+        run: |
+          python scripts/check_scripts_import_identity_guard.py

--- a/scripts/audit_event_firing_condition_gate.py
+++ b/scripts/audit_event_firing_condition_gate.py
@@ -83,6 +83,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import json
 import re

--- a/scripts/audit_event_firing_condition_gate.py
+++ b/scripts/audit_event_firing_condition_gate.py
@@ -83,18 +83,6 @@ CI: gate
 """
 from __future__ import annotations
 
-# #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import argparse
 import json
 import re
@@ -124,6 +112,16 @@ def _closed_vocabulary() -> "frozenset[str]":
     (`event_schema.AUDIT_EVENT_KINDS`), never hand-maintained (lead-coder
     condition 1)."""
     sys.path.insert(0, str(_ROOT / "src"))
+    # #3024: the guard runs HERE, after src/ is on sys.path, not at module
+    # top -- lead-coder BLOCKING (PR #6138): this script's whole point is
+    # working without reyn installed (self-bootstraps via the path insert
+    # right above), so a guard positioned BEFORE that insert would see
+    # `find_spec('reyn') is None` on a perfectly normal run and reject it.
+    # `import reyn` only ever happens after this line, so this is the
+    # first point where checking is both possible and correct.
+    from verify_env_identity import guard_bare_script_or_exit
+    guard_bare_script_or_exit()
+
     from reyn.core.events.event_schema import AUDIT_EVENT_KINDS
     return frozenset(AUDIT_EVENT_KINDS)
 

--- a/scripts/bash_node_kind_count_ratchet.py
+++ b/scripts/bash_node_kind_count_ratchet.py
@@ -29,6 +29,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import json
 import sys

--- a/scripts/check_approval_ledger_import_boundary.py
+++ b/scripts/check_approval_ledger_import_boundary.py
@@ -68,6 +68,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import ast
 import sys
 from pathlib import Path

--- a/scripts/check_hooks_declared_reachable.py
+++ b/scripts/check_hooks_declared_reachable.py
@@ -83,6 +83,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import sys
 
 from reyn.hooks.schema_registry import BUILTIN_HOOK_SCHEMAS

--- a/scripts/check_remote_snapshot_placeholder_declared.py
+++ b/scripts/check_remote_snapshot_placeholder_declared.py
@@ -121,6 +121,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import ast
 import sys
 from pathlib import Path

--- a/scripts/check_retired_config_keys_denylist.py
+++ b/scripts/check_retired_config_keys_denylist.py
@@ -155,6 +155,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import re
 import subprocess
 import sys

--- a/scripts/check_retired_config_keys_denylist.py
+++ b/scripts/check_retired_config_keys_denylist.py
@@ -157,16 +157,6 @@ from __future__ import annotations
 
 # #3024: verify the in-process `reyn` this bare-python script is about
 # to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import re
 import subprocess
 import sys
@@ -180,6 +170,21 @@ _ROOT = Path(__file__).resolve().parent.parent
 # `_retired_keys()` always reads THIS tree's `_RENAMED_CONFIG_KEYS`, not a
 # stale one from an unrelated checkout.
 sys.path.insert(0, str(_ROOT / "src"))
+
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it. Positioned AFTER the sys.path.insert
+# above -- lead-coder BLOCKING (PR #6138): this script self-bootstraps
+# src/ onto sys.path when reyn is not installed, so a guard positioned
+# BEFORE that insert would see find_spec('reyn') is None on a normal run.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
 
 # Historical-record directories: a retired key legitimately appears here as
 # a fact about the past, not present-tense drift. See module docstring

--- a/scripts/check_scripts_import_identity_guard.py
+++ b/scripts/check_scripts_import_identity_guard.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""#3024 — every bare-python `scripts/*.py` file that imports `reyn`
+(module-level OR lazily, anywhere in the file) must call
+`verify_env_identity.guard_bare_script_or_exit()` before any code path can
+reach that import, or be named — with a reason — in `EXEMPT_SCRIPTS` below.
+
+## Why this exists
+
+Tonight's venv-identity sweep (#3024's own family) found that `pytest`'s
+own in-process resolution is protected (root `conftest.py`'s
+`pytest_configure`, #3233) but a BARE `python scripts/foo.py` invocation
+is not: one session's venv had an editable `.pth` whose dictionary order
+resolved `reyn` to a DIFFERENT checkout entirely for any bare-python
+script, while `pytest` in the SAME venv read the correct tree (pytest's
+own `pythonpath = ["src"]` wins ahead of the stale `.pth`). "pytest is
+green" was never evidence a bare-python gate script was measuring the
+right tree — the two resolve independently.
+
+## Population: derived, never a hand-typed list
+
+Every top-level `scripts/*.py` file is parsed with `ast` and walked for
+ANY `Import`/`ImportFrom` node naming `reyn` or a `reyn.*` submodule, at
+ANY nesting depth (module level, inside a function, behind a CLI flag —
+the guard call's whole point, per its own docstring, is that ONE call at
+a script's entry point covers every later `import reyn` regardless of
+where it lives, so the population this gate checks is symmetric: every
+site that WOULD need covering, not just the module-level ones). A string
+literal containing the text "from reyn" (e.g. a script that builds a
+`python -c` payload as an f-string for a SEPARATE subprocess to run —
+`s7_driver.py` / `rekey_fixtures.py`, both measured and excluded this way)
+is correctly NOT counted: the AST only sees real `Import`/`ImportFrom`
+nodes, never string contents, so a script whose own process never imports
+`reyn` is not in this gate's population at all — it does not need the
+guard, and listing it as an exemption would misstate WHY it is absent.
+
+## Exemption: a reasoned table, not a silent gap
+
+`EXEMPT_SCRIPTS` names every population member that deliberately carries
+NO guard call, each with a 1-line reason — never a bare filename list a
+future reader has to re-derive the reasoning for. The shape mirrors
+`exec_wrappers.py`'s own `UNSUPPORTED_WRAPPERS` (#6061): the population
+this gate measures is honest about what it does NOT enforce, in the same
+place it enforces the rest, rather than a hand-maintained allowlist a
+new wheel-mode probe or A/B harness would have to remember to update
+somewhere else.
+
+Today's 3 entries are all the SAME shape: a script whose entire purpose
+is comparing `reyn` as resolved from two DIFFERENT trees (a dev checkout
+vs. an installed wheel, or two different `PYTHONPATH` arms) cannot also
+assert it is only ever pointed at one — the guard's own contract is
+exactly the opposite assertion these scripts exist to test.
+
+## What this gate does NOT verify
+
+Call PRESENCE only — not that the call is reached before every import
+site (a `guard_bare_script_or_exit()` call placed AFTER a script's own
+`import reyn` would satisfy this gate's own AST-presence check while
+still being too late in a real run). This is the same class of ceiling
+`check_ci_role_declared.py`'s own docstring names for its "wired, but
+does the role's obligation actually hold" question — mechanically
+verifiable placement (first-statement-after-docstring) is a possible
+future tightening, not attempted here; a PR review is the check today.
+
+CI: gate
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCOPE = "scripts"
+
+#: Every population member that deliberately carries no
+#: `guard_bare_script_or_exit()` call, with why. See module docstring,
+#: "Exemption" — a reasoned table, never a silent gap.
+EXEMPT_SCRIPTS: "dict[str, str]" = {
+    "df2187_harness.py": (
+        "A/B driver comparing the SAME harness run against two different "
+        "PYTHONPATH arms (its own docstring: 'A/B by codebase on the "
+        "import path') -- a script whose job is diffing two trees cannot "
+        "also assert it is only ever pointed at one."
+    ),
+    "wheel_parity_probe.py": (
+        "Runs inside a throwaway wheel-only venv and asserts `reyn` "
+        "resolves the INSTALLED WHEEL, never `<root>/src` -- the guard's "
+        "own contract is the opposite of what this probe exists to prove."
+    ),
+    "wheel_plugin_install_probe.py": (
+        "Same wheel-only-venv shape as wheel_parity_probe.py -- `reyn` "
+        "MUST resolve site-packages here, never a dev checkout's src/."
+    ),
+}
+
+
+def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
+    """Every tracked top-level `.py` file directly under `scripts/` —
+    same population source (`git ls-files`) `silent_except_ratchet.py`/
+    `user_facing_lang_gate.py` use, for the same reason: no hand-maintained
+    exclusion list. Non-recursive (`scripts/*.py`, not `scripts/**/*.py`)
+    -- `scripts/` carries no subpackages today; this gate's OWN population
+    derivation (like the guard mechanism it checks for) would need to
+    widen the same day a `scripts/<subdir>/` appears, not before."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def imports_reyn(path: Path) -> bool:
+    """True iff *path* contains a real `Import`/`ImportFrom` AST node
+    naming `reyn` or a `reyn.*` submodule, at ANY nesting depth (module
+    level or lazy/nested) — never a string-literal match, so a script that
+    only builds `python -c`-style source text for a SEPARATE subprocess
+    (never importing `reyn` in ITS OWN process) is correctly excluded."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(a.name == "reyn" or a.name.startswith("reyn.") for a in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and (node.module == "reyn" or node.module.startswith("reyn.")):
+                return True
+    return False
+
+
+def calls_guard(path: Path) -> bool:
+    """True iff *path* contains a call to `guard_bare_script_or_exit` —
+    presence only, see module docstring's own "What this gate does NOT
+    verify" section for the placement caveat."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            name = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else None)
+            if name == "guard_bare_script_or_exit":
+                return True
+    return False
+
+
+def measured(root: Path = _ROOT) -> "tuple[list[str], list[str], int]":
+    """`(missing, stale_exemptions, scanned)` — *missing* names population
+    members with no guard call and no exemption entry; *stale_exemptions*
+    names `EXEMPT_SCRIPTS` entries whose file no longer imports `reyn` at
+    all (the exemption's own reasoning no longer applies — a genuine
+    finding, not a false pass: an exemption for a script that has stopped
+    needing one is itself drift). A file that fails to parse propagates
+    the `SyntaxError` — fail-closed, same contract every AST-based gate in
+    this repo shares (a silent under-count here is the exact defect this
+    gate exists to prevent, one layer up)."""
+    files = _iter_scan_files(root)
+    by_name = {f.name: f for f in files}
+    missing: "list[str]" = []
+    for f in files:
+        if f.name == "verify_env_identity.py" or f.name == Path(__file__).name:
+            continue  # the guard's own implementation, and this gate itself -- never import reyn
+        if not imports_reyn(f):
+            continue
+        if f.name in EXEMPT_SCRIPTS:
+            continue
+        if not calls_guard(f):
+            missing.append(f.name)
+
+    stale_exemptions = [
+        name for name in EXEMPT_SCRIPTS
+        if name in by_name and not imports_reyn(by_name[name])
+    ]
+    return (missing, stale_exemptions, len(files))
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    del argv
+    try:
+        missing, stale_exemptions, scanned = measured(_ROOT)
+    except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+        print(
+            f"check_scripts_import_identity_guard FAILED: could not scan the "
+            f"population ({exc}). Fails CLOSED on a scan error rather than "
+            f"silently under-counting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if scanned == 0:
+        print(
+            f"check_scripts_import_identity_guard FAILED: the scan found 0 "
+            f"files under {_SCOPE}/ -- a scanner failure, not a clean "
+            "population; `git ls-files` returned nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    ok = True
+    if missing:
+        ok = False
+        print(
+            f"check_scripts_import_identity_guard FAILED: {len(missing)} "
+            f"script(s) under {_SCOPE}/ import `reyn` with no "
+            "`guard_bare_script_or_exit()` call and no EXEMPT_SCRIPTS entry:",
+            file=sys.stderr,
+        )
+        for name in sorted(missing):
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nAdd `from verify_env_identity import guard_bare_script_or_exit` "
+            "+ a `guard_bare_script_or_exit()` call near the top of the file "
+            "(before any of its own `import reyn`), or -- if this script "
+            "deliberately compares/expects a DIFFERENT tree -- add it to "
+            "EXEMPT_SCRIPTS in this gate's own source, with a reason.",
+            file=sys.stderr,
+        )
+    if stale_exemptions:
+        ok = False
+        print(
+            f"check_scripts_import_identity_guard FAILED: "
+            f"{len(stale_exemptions)} EXEMPT_SCRIPTS entry(ies) no longer "
+            "import `reyn` at all -- the exemption's own reason no longer "
+            "applies:",
+            file=sys.stderr,
+        )
+        for name in sorted(stale_exemptions):
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nRemove the stale entry from EXEMPT_SCRIPTS.",
+            file=sys.stderr,
+        )
+
+    if not ok:
+        return 1
+
+    print(
+        f"check_scripts_import_identity_guard OK: scanned {scanned} file(s) "
+        f"under {_SCOPE}/, every reyn-importing script guarded or reasoned-exempt."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_scripts_import_identity_guard.py
+++ b/scripts/check_scripts_import_identity_guard.py
@@ -92,6 +92,12 @@ EXEMPT_SCRIPTS: "dict[str, str]" = {
         "Same wheel-only-venv shape as wheel_parity_probe.py -- `reyn` "
         "MUST resolve site-packages here, never a dev checkout's src/."
     ),
+    "s8_b18_driver.py": (
+        "Hardcodes MAIN_SANDBOX = a DIFFERENT checkout entirely "
+        "(~/Workspace/junk/claude_sandbox/sandbox_2), never this repo's "
+        "own src/ -- the guard's own contract is false for this script "
+        "by design."
+    ),
 }
 
 
@@ -141,19 +147,75 @@ def calls_guard(path: Path) -> bool:
     return False
 
 
-def measured(root: Path = _ROOT) -> "tuple[list[str], list[str], int]":
-    """`(missing, stale_exemptions, scanned)` — *missing* names population
-    members with no guard call and no exemption entry; *stale_exemptions*
-    names `EXEMPT_SCRIPTS` entries whose file no longer imports `reyn` at
-    all (the exemption's own reasoning no longer applies — a genuine
-    finding, not a false pass: an exemption for a script that has stopped
-    needing one is itself drift). A file that fails to parse propagates
-    the `SyntaxError` — fail-closed, same contract every AST-based gate in
-    this repo shares (a silent under-count here is the exact defect this
-    gate exists to prevent, one layer up)."""
+def guard_precedes_own_path_bootstrap(path: Path) -> "int | None":
+    """#3024 BLOCKING (lead-coder, PR #6138): the line number of a
+    `sys.path.insert(...)` call that comes AFTER a `guard_bare_script_or_
+    exit()` call in the SAME enclosing scope (module body, or the same
+    function/async-function body) — the exact false-reject class found in
+    review: several scripts self-bootstrap `src/` onto `sys.path` when
+    `reyn` is not installed, so a guard positioned BEFORE that insert sees
+    `find_spec('reyn') is None` on a perfectly normal run and rejects it.
+    Returns `None` when no such ordering violation exists in *path* (the
+    guard is either absent — a separate finding, `missing` — or correctly
+    positioned after every same-scope `sys.path.insert`).
+
+    Scoped per-function deliberately: a `sys.path.insert` inside a
+    DIFFERENT function than the guard call (e.g. a helper called only
+    later, well after the guard already ran at module top) is not the
+    same hazard — the guard's own `find_spec` check already happened
+    against the FINAL, settled `sys.path` state for the module-level
+    case; only same-scope ordering can put the check before the mutation
+    it depends on."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    scope_of: "dict[int, ast.AST]" = {}
+    def _walk_scopes(node: ast.AST, scope: ast.AST) -> None:
+        scope_of[id(node)] = scope
+        for child in ast.iter_child_nodes(node):
+            child_scope = child if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) else scope
+            _walk_scopes(child, child_scope)
+    _walk_scopes(tree, tree)
+
+    guard_calls: "list[tuple[int, ast.AST | None]]" = []
+    insert_calls: "list[tuple[int, ast.AST | None]]" = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else (fn.id if isinstance(fn, ast.Name) else None)
+        if name == "guard_bare_script_or_exit":
+            guard_calls.append((node.lineno, scope_of.get(id(node))))
+        elif name == "insert" and isinstance(fn, ast.Attribute):
+            src = ast.get_source_segment(path.read_text(encoding="utf-8"), fn.value) or ""
+            if src.endswith("path") or src.endswith(".path"):
+                insert_calls.append((node.lineno, scope_of.get(id(node))))
+
+    for guard_line, guard_scope in guard_calls:
+        for insert_line, insert_scope in insert_calls:
+            if insert_scope is guard_scope and insert_line > guard_line:
+                return insert_line
+    return None
+
+
+def measured(root: Path = _ROOT) -> "tuple[list[str], list[str], list[tuple[str, int]], int]":
+    """`(missing, stale_exemptions, ordering_violations, scanned)` —
+    *missing* names population members with no guard call and no
+    exemption entry; *stale_exemptions* names `EXEMPT_SCRIPTS` entries
+    whose file no longer imports `reyn` at all (the exemption's own
+    reasoning no longer applies — a genuine finding, not a false pass: an
+    exemption for a script that has stopped needing one is itself drift);
+    *ordering_violations* is `(filename, sys.path.insert lineno)` for a
+    guard call positioned BEFORE a same-scope `sys.path.insert` — see
+    `guard_precedes_own_path_bootstrap`'s own docstring for why this is a
+    real accept-side finding (a false reject), not a style nit. A file
+    that fails to parse propagates the `SyntaxError` — fail-closed, same
+    contract every AST-based gate in this repo shares (a silent
+    under-count here is the exact defect this gate exists to prevent,
+    one layer up)."""
     files = _iter_scan_files(root)
     by_name = {f.name: f for f in files}
     missing: "list[str]" = []
+    ordering_violations: "list[tuple[str, int]]" = []
     for f in files:
         if f.name == "verify_env_identity.py" or f.name == Path(__file__).name:
             continue  # the guard's own implementation, and this gate itself -- never import reyn
@@ -163,18 +225,22 @@ def measured(root: Path = _ROOT) -> "tuple[list[str], list[str], int]":
             continue
         if not calls_guard(f):
             missing.append(f.name)
+            continue
+        bad_line = guard_precedes_own_path_bootstrap(f)
+        if bad_line is not None:
+            ordering_violations.append((f.name, bad_line))
 
     stale_exemptions = [
         name for name in EXEMPT_SCRIPTS
         if name in by_name and not imports_reyn(by_name[name])
     ]
-    return (missing, stale_exemptions, len(files))
+    return (missing, stale_exemptions, ordering_violations, len(files))
 
 
 def main(argv: "list[str] | None" = None) -> int:
     del argv
     try:
-        missing, stale_exemptions, scanned = measured(_ROOT)
+        missing, stale_exemptions, ordering_violations, scanned = measured(_ROOT)
     except (OSError, UnicodeDecodeError, SyntaxError) as exc:
         print(
             f"check_scripts_import_identity_guard FAILED: could not scan the "
@@ -225,6 +291,26 @@ def main(argv: "list[str] | None" = None) -> int:
             print(f"  {name}", file=sys.stderr)
         print(
             "\nRemove the stale entry from EXEMPT_SCRIPTS.",
+            file=sys.stderr,
+        )
+    if ordering_violations:
+        ok = False
+        print(
+            f"check_scripts_import_identity_guard FAILED: "
+            f"{len(ordering_violations)} script(s) call "
+            "`guard_bare_script_or_exit()` BEFORE a same-scope "
+            "`sys.path.insert(...)` -- a FALSE REJECT: the script "
+            "self-bootstraps its own tree onto sys.path, so the guard "
+            "(positioned first) sees `find_spec('reyn') is None` on a "
+            "normal run and exits before the bootstrap ever runs "
+            "(#3024, lead-coder BLOCKING on PR #6138):",
+            file=sys.stderr,
+        )
+        for name, line in sorted(ordering_violations):
+            print(f"  {name} (sys.path.insert at line {line})", file=sys.stderr)
+        print(
+            "\nMove the guard_bare_script_or_exit() call to AFTER the "
+            "sys.path.insert(...) call(s) in the same scope.",
             file=sys.stderr,
         )
 

--- a/scripts/df2187_harness.py
+++ b/scripts/df2187_harness.py
@@ -17,6 +17,14 @@ CI: manual -- run by hand as a #2187 dogfood A/B session driver
 """
 from __future__ import annotations
 
+# #3024: NO guard_bare_script_or_exit() here, deliberately -- see this
+# module's own docstring, "A/B by codebase on the import path". This
+# harness's whole purpose is to run the SAME driver against two DIFFERENT
+# checkouts (the #2187 arm and a `baseline` arm at a different
+# PYTHONPATH) and diff the outcome -- a script whose job is comparing two
+# trees cannot also assert it is only ever pointed at one. Named as a
+# reasoned exception in check_scripts_import_identity_guard.py's own
+# EXEMPT_SCRIPTS table, not silently absent from that gate's population.
 import argparse
 import asyncio
 import json

--- a/scripts/diag_tiktoken_cache.py
+++ b/scripts/diag_tiktoken_cache.py
@@ -46,6 +46,18 @@ CI: manual -- run by an operator diagnosing a tiktoken cache issue, per its own 
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import sys
 
 

--- a/scripts/dogfood_1822_content_threat_verify.py
+++ b/scripts/dogfood_1822_content_threat_verify.py
@@ -26,6 +26,18 @@ CI: manual -- run by hand for a #1822 live threat-scan coverage pass
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 
 from reyn.config.chat import ThreatScanConfig

--- a/scripts/dogfood_rag_helper.py
+++ b/scripts/dogfood_rag_helper.py
@@ -14,6 +14,18 @@ CI: manual -- imported as a shared setup library by other dogfood drivers, never
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import hashlib
 from pathlib import Path

--- a/scripts/dogfood_s5_b18_driver.py
+++ b/scripts/dogfood_s5_b18_driver.py
@@ -19,6 +19,18 @@ CI: manual -- run by hand as a batch-18 dogfood scenario driver
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import json
 import os

--- a/scripts/dogfood_s5_b18_driver.py
+++ b/scripts/dogfood_s5_b18_driver.py
@@ -19,18 +19,6 @@ CI: manual -- run by hand as a batch-18 dogfood scenario driver
 """
 from __future__ import annotations
 
-# #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import asyncio
 import json
 import os
@@ -45,6 +33,22 @@ WORKTREE = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = WORKTREE / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(WORKTREE / "src"))
+
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it. Positioned AFTER the sys.path.insert
+# calls above -- lead-coder BLOCKING (PR #6138): this script
+# self-bootstraps WORKTREE/src onto sys.path when reyn is not installed,
+# so a guard positioned BEFORE those inserts would see find_spec('reyn')
+# is None on a normal run.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
 
 from dogfood_rag_helper import (
     make_chunks_for_seed,

--- a/scripts/dogfood_sp_render.py
+++ b/scripts/dogfood_sp_render.py
@@ -36,6 +36,18 @@ CI: manual -- run by hand as a dogfooding render/dev utility
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import re
 import sys

--- a/scripts/dogfood_sp_render.py
+++ b/scripts/dogfood_sp_render.py
@@ -37,17 +37,6 @@ CI: manual -- run by hand as a dogfooding render/dev utility
 from __future__ import annotations
 
 # #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import argparse
 import re
 import sys
@@ -56,6 +45,21 @@ from pathlib import Path
 # Ensure src/ is importable when run from the repo root.
 _REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it. Positioned AFTER the sys.path.insert
+# above -- lead-coder BLOCKING (PR #6138): this script self-bootstraps
+# src/ onto sys.path when reyn is not installed, so a guard positioned
+# BEFORE that insert would see find_spec('reyn') is None on a normal run.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
 
 from reyn.runtime.router_system_prompt import build_system_prompt  # noqa: E402
 

--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -20,6 +20,18 @@ CI: manual -- run by hand as the LLM-trace analysis entry point, per CLAUDE.md's
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import json
 import sys

--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -20,18 +20,6 @@ CI: manual -- run by hand as the LLM-trace analysis entry point, per CLAUDE.md's
 """
 from __future__ import annotations
 
-# #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import argparse
 import json
 import sys
@@ -979,6 +967,17 @@ def _resolve_raw_output(ev: dict, state_dir: "Path | None") -> "str | None":
         return None
     try:
         sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        # #3024: the guard runs HERE, after src/ is on sys.path, not at
+        # module top -- lead-coder BLOCKING (PR #6138): this is this
+        # module's ONLY reyn import, reached lazily and only for a
+        # raw_output_ref dereference, so a module-top guard would reject
+        # every OTHER invocation that never needs reyn at all, on top of
+        # firing before this line's own path insert ever runs. SystemExit
+        # (raised on a real mismatch) is not an Exception subclass, so
+        # the `except Exception` below does not swallow it.
+        from verify_env_identity import guard_bare_script_or_exit
+        guard_bare_script_or_exit()
+
         from reyn.services.offload import read_offloaded
         content, found = read_offloaded(str(state_dir / ref), base_dir=state_dir)
         return content if found else None

--- a/scripts/embedding_bench.py
+++ b/scripts/embedding_bench.py
@@ -44,6 +44,18 @@ CI: manual -- run by hand as an embedding benchmark -- gate-shaped exit codes ex
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import asyncio
 import json

--- a/scripts/hn_research.py
+++ b/scripts/hn_research.py
@@ -50,6 +50,18 @@ CI: manual -- run by hand for HN research, not CI-wired
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import concurrent.futures
 import html

--- a/scripts/llm_replay.py
+++ b/scripts/llm_replay.py
@@ -24,6 +24,18 @@ CI: manual -- run by hand for an interactive/one-off LLM-call replay and patch s
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import asyncio
 import difflib

--- a/scripts/mcp_conformance.py
+++ b/scripts/mcp_conformance.py
@@ -38,6 +38,18 @@ CI: manual -- run by hand for an MCP conformance investigation, writes report fi
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import json
 import socket

--- a/scripts/mcp_conformance.py
+++ b/scripts/mcp_conformance.py
@@ -38,18 +38,6 @@ CI: manual -- run by hand for an MCP conformance investigation, writes report fi
 """
 from __future__ import annotations
 
-# #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import asyncio
 import json
 import socket
@@ -60,6 +48,22 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 sys.path.insert(0, str(_REPO_ROOT / "tests" / "_support"))
+
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it. Positioned AFTER the sys.path.insert
+# calls above -- lead-coder BLOCKING (PR #6138): this script
+# self-bootstraps src/ onto sys.path when reyn is not installed, so a
+# guard positioned BEFORE those inserts would see find_spec('reyn') is
+# None on a normal run.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
 
 from reyn.mcp.client import MCPClient  # noqa: E402
 from reyn.mcp.connection_service import MCPConnectionService  # noqa: E402

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -28,6 +28,18 @@ CI: manual -- run by hand to confirm a fresh MCP server install/connectivity, pe
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import json
 import sys

--- a/scripts/mcp_stdio_repro.py
+++ b/scripts/mcp_stdio_repro.py
@@ -11,6 +11,18 @@ CI: manual -- run by hand as a scratch investigation tool, per its own docstring
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import sys
 import tempfile

--- a/scripts/node_kind_coverage_ratchet.py
+++ b/scripts/node_kind_coverage_ratchet.py
@@ -81,6 +81,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import argparse
 import ast
 import re

--- a/scripts/s8_b18_driver.py
+++ b/scripts/s8_b18_driver.py
@@ -20,6 +20,18 @@ CI: manual -- run by hand as a batch-18 dogfood driver against a local A2A serve
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import json
 import shutil

--- a/scripts/s8_b18_driver.py
+++ b/scripts/s8_b18_driver.py
@@ -20,18 +20,13 @@ CI: manual -- run by hand as a batch-18 dogfood driver against a local A2A serve
 """
 from __future__ import annotations
 
-# #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
+# #3024: NO guard_bare_script_or_exit() here, deliberately -- MAIN_SANDBOX
+# below is a HARDCODED path to a DIFFERENT checkout entirely
+# (~/Workspace/junk/claude_sandbox/sandbox_2), never this repo's own
+# src/ -- the guard's own contract ("reyn resolves under THIS repo's
+# src/") is false for this script by design. Named as a reasoned
+# exception in check_scripts_import_identity_guard.py's own
+# EXEMPT_SCRIPTS table.
 import asyncio
 import json
 import shutil

--- a/scripts/sandbox_argv_rewrite_probe_3869.py
+++ b/scripts/sandbox_argv_rewrite_probe_3869.py
@@ -30,6 +30,18 @@ CI: manual -- kept for a future one-shot rerun per its own docstring; the CI ste
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import os
 import platform
 import subprocess

--- a/scripts/sandbox_landlock_deny_gate.py
+++ b/scripts/sandbox_landlock_deny_gate.py
@@ -61,6 +61,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import json
 import platform
 import subprocess

--- a/scripts/sandbox_load_method_witness_3229.py
+++ b/scripts/sandbox_load_method_witness_3229.py
@@ -71,6 +71,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import platform
 import shutil
 import socket as _socket_mod

--- a/scripts/sandbox_seccomp_x86_64_live_smoke.py
+++ b/scripts/sandbox_seccomp_x86_64_live_smoke.py
@@ -42,6 +42,18 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import os
 import platform
 import subprocess

--- a/scripts/spike_preflight.py
+++ b/scripts/spike_preflight.py
@@ -19,6 +19,18 @@ CI: manual -- run by hand once before a spike begins, per its own docstring
 """
 from __future__ import annotations
 
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
+
 import asyncio
 import json
 import os

--- a/scripts/spike_preflight.py
+++ b/scripts/spike_preflight.py
@@ -19,18 +19,6 @@ CI: manual -- run by hand once before a spike begins, per its own docstring
 """
 from __future__ import annotations
 
-# #3024: verify the in-process `reyn` this bare-python script is about
-# to import (module-level or lazily, anywhere below) resolves THIS
-# checkout, not whichever tree the ambient venv's editable install
-# happens to point at. Exits loudly (never a silent wrong-tree run) on
-# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
-# docstring. Population + presence are enforced mechanically by
-# check_scripts_import_identity_guard.py, so this call cannot be dropped
-# without the gate catching it.
-from verify_env_identity import guard_bare_script_or_exit
-
-guard_bare_script_or_exit()
-
 import asyncio
 import json
 import os
@@ -42,6 +30,21 @@ from pathlib import Path
 # Ensure project src is importable when run from repo root
 _REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# #3024: verify the in-process `reyn` this bare-python script is about
+# to import (module-level or lazily, anywhere below) resolves THIS
+# checkout, not whichever tree the ambient venv's editable install
+# happens to point at. Exits loudly (never a silent wrong-tree run) on
+# a mismatch -- see verify_env_identity.py's own guard_bare_script_or_exit
+# docstring. Population + presence are enforced mechanically by
+# check_scripts_import_identity_guard.py, so this call cannot be dropped
+# without the gate catching it. Positioned AFTER the sys.path.insert
+# above -- lead-coder BLOCKING (PR #6138): this script self-bootstraps
+# src/ onto sys.path when reyn is not installed, so a guard positioned
+# BEFORE that insert would see find_spec('reyn') is None on a normal run.
+from verify_env_identity import guard_bare_script_or_exit
+
+guard_bare_script_or_exit()
 
 # ---------------------------------------------------------------------------
 # Colour helpers (ANSI, disabled when not a TTY)

--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -396,6 +396,57 @@ def check_in_process_tree(reyn_file: Path, root: Path) -> Finding | None:
     )
 
 
+def guard_bare_script_or_exit(root: "Path | None" = None) -> None:
+    """#3024 — the bare-python-script complement to `check_in_process_tree`.
+
+    Call this ONCE, near the very top of a `scripts/*.py` script's own body —
+    before control flow reaches ANY of that script's own `import reyn`
+    statements, module-level or lazy — and it never returns abnormally: a
+    mismatch prints a rendered `Finding` to stderr and calls `sys.exit(1)`,
+    the same "exit, don't return a value a caller could ignore" shape
+    `conftest.py`'s own `pytest_configure` uses (`pytest.exit`).
+
+    Unlike `check_in_process_tree` (which takes an ALREADY-imported
+    `reyn.__file__` from a caller that necessarily imported it — root
+    `conftest.py`'s own situation, since pytest needs `reyn` regardless),
+    this function stays reyn-free THE SAME WAY `check_tree_identity`'s
+    out-of-process probes do: `importlib.util.find_spec('reyn')` resolves
+    where an `import reyn` WOULD land, without executing `reyn/__init__.py` —
+    so calling this before a script's own (possibly deeply-nested, lazy)
+    `import reyn` costs nothing extra and cannot itself be the thing that
+    imports the wrong tree.
+
+    This is why a single call at a script's own entry point covers every
+    `import reyn` in that file regardless of where each one lives: `find_spec`
+    answers "what will `import reyn` resolve to in THIS process, right now"
+    once, and Python's own `sys.path` resolution does not change mid-process
+    — the answer this call gets is the SAME answer every later `import reyn`
+    in the same script would get, whether that import is at module level or
+    three functions deep behind a CLI flag.
+
+    ``root`` defaults to this file's own repo root (``scripts/../``, the same
+    convention `main()`'s own ``--root`` default uses) — a caller only
+    overrides it in a test."""
+    root = (root or Path(__file__).resolve().parent.parent).resolve()
+    spec = importlib.util.find_spec("reyn")
+    if spec is None or spec.origin is None:
+        print(
+            "env-identity (bare-script, #3024): `reyn` is not importable in "
+            f"this environment at all.\n"
+            f"    interpreter: {sys.executable}\n"
+            f"    This is NOT evidence that reyn is broken — it is an "
+            f"un-installed environment.\n"
+            f"    remedy: install reyn into {sys.prefix} "
+            f"(`pip install -e '.[dev]'` run FROM {root}).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    finding = check_in_process_tree(Path(spec.origin), root)
+    if finding is not None:
+        print(f"env-identity (bare-script, #3024):\n{finding.render()}", file=sys.stderr)
+        sys.exit(1)
+
+
 def _pinned_git_dependency(root: Path, package: str) -> tuple[str, str] | None:
     """Derive ``(url, commit)`` for ``package`` from its own ``git+<url>@<sha>``
     entry in ``pyproject.toml``'s ``[project.dependencies]`` — never hardcoded,

--- a/scripts/wheel_parity_probe.py
+++ b/scripts/wheel_parity_probe.py
@@ -28,6 +28,12 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: NO guard_bare_script_or_exit() here, deliberately -- see this
+# module's own docstring: `import reyn` here MUST resolve the WHEEL
+# install (site-packages), never `<root>/src` -- the entire point of
+# this probe is verifying that fact, and the guard's own contract is
+# exactly the opposite assertion. Named as a reasoned exception in
+# check_scripts_import_identity_guard.py's own EXEMPT_SCRIPTS table.
 import os
 import sys
 from pathlib import Path

--- a/scripts/wheel_plugin_install_probe.py
+++ b/scripts/wheel_plugin_install_probe.py
@@ -53,6 +53,11 @@ CI: gate
 """
 from __future__ import annotations
 
+# #3024: NO guard_bare_script_or_exit() here, deliberately -- see this
+# module's own docstring: run INSIDE a throwaway venv that has ONLY the
+# built wheel installed, so `import reyn` here MUST resolve site-packages,
+# never `<root>/src`. Named as a reasoned exception in
+# check_scripts_import_identity_guard.py's own EXEMPT_SCRIPTS table.
 import asyncio
 import os
 import subprocess

--- a/tests/scripts/test_3024_env_identity.py
+++ b/tests/scripts/test_3024_env_identity.py
@@ -142,3 +142,95 @@ def test_every_registered_check_is_reachable_through_verify(tmp_path: Path) -> N
         # Each selector must dispatch and return findings (possibly none) rather
         # than silently doing nothing.
         assert isinstance(module.verify(root, only=(name,)), list)
+
+
+# ── guard_bare_script_or_exit (#3024, tonight's follow-up) ──────────────
+
+
+def test_guard_exits_nonzero_when_the_spec_resolves_outside_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: accept -- a `find_spec('reyn')` origin OUTSIDE `<root>/src`
+    makes the guard print a rendered Finding to stderr and exit(1), the
+    same shape `conftest.py`'s own `pytest_exit` uses for the in-process
+    guard.
+
+    FALSIFY: the whole point of this function is that a bare script
+    calling it would otherwise proceed to `import reyn` from the WRONG
+    tree silently -- a guard that returns instead of exiting would let
+    exactly that happen."""
+    module = _load()
+    root = tmp_path / "this_checkout"
+    other = tmp_path / "other_checkout" / "src" / "reyn" / "__init__.py"
+    other.parent.mkdir(parents=True)
+    other.write_text("")
+
+    class _FakeSpec:
+        origin = str(other)
+
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: _FakeSpec())
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.guard_bare_script_or_exit(root)
+    assert exc_info.value.code == 1
+
+
+def test_guard_returns_normally_when_the_spec_resolves_under_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: deny (negative control) -- a `find_spec('reyn')` origin
+    UNDER `<root>/src` returns normally, no `SystemExit`."""
+    module = _load()
+    root = tmp_path / "this_checkout"
+    reyn_file = root / "src" / "reyn" / "__init__.py"
+    reyn_file.parent.mkdir(parents=True)
+    reyn_file.write_text("")
+
+    class _FakeSpec:
+        origin = str(reyn_file)
+
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: _FakeSpec())
+
+    module.guard_bare_script_or_exit(root)  # must not raise
+
+
+def test_guard_exits_nonzero_when_reyn_is_not_importable_at_all(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 1: deny -- `find_spec` returning `None` (an un-installed
+    environment) is reported as a distinct remedy ("install reyn"), never
+    silently treated as clean."""
+    module = _load()
+    root = tmp_path / "this_checkout"
+    monkeypatch.setattr(module.importlib.util, "find_spec", lambda name: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.guard_bare_script_or_exit(root)
+    assert exc_info.value.code == 1
+
+
+def test_guard_never_imports_reyn_itself(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 1: the load-bearing property this module's own docstring
+    claims for every check ("It never imports reyn") extended to this
+    function -- `find_spec` is called, `import reyn`/`__import__("reyn")`
+    is not. Falsified by making `find_spec` itself raise if asked for
+    anything BUT 'reyn' (a stand-in that would catch an accidental
+    `import reyn` triggering `find_spec` for one of reyn's OWN internal
+    submodule imports) -- this stays green only because no import of
+    `reyn` (which would recursively resolve its submodules) ever
+    happens."""
+    module = _load()
+    calls: "list[str]" = []
+
+    def _recording_find_spec(name: str):
+        calls.append(name)
+        if name != "reyn":
+            raise AssertionError(f"unexpected find_spec({name!r}) -- reyn was imported")
+        return None  # "not importable" -- exits before touching sys.modules
+
+    monkeypatch.setattr(module.importlib.util, "find_spec", _recording_find_spec)
+
+    with pytest.raises(SystemExit):
+        module.guard_bare_script_or_exit(Path("/nonexistent"))
+
+    assert calls == ["reyn"]

--- a/tests/scripts/test_check_scripts_import_identity_guard.py
+++ b/tests/scripts/test_check_scripts_import_identity_guard.py
@@ -1,0 +1,193 @@
+"""Tier 1: `check_scripts_import_identity_guard.py`'s own detector logic
+(#3024).
+
+Population is derived from real `.py` files written into `tmp_path` (never
+from the real `scripts/` tree, so a future script added/removed there
+cannot shift what this test asserts) and driven through the real, public
+`imports_reyn`/`calls_guard`/`measured` functions -- no mocks, matching
+this repo's own testing policy.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_NAME = "check_scripts_import_identity_guard.py"
+
+
+def _load():
+    from tests._support.paths import REPO_ROOT
+
+    path = REPO_ROOT / "scripts" / _SCRIPT_NAME
+    spec = importlib.util.spec_from_file_location("_check_scripts_guard_under_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git_init_scripts(root: Path) -> None:
+    """`measured`'s own population source is `git ls-files`, so the
+    synthetic tree needs a real (throwaway) git repo, not just files on
+    disk -- an untracked file would silently vanish from the population,
+    which would make this test pass for the wrong reason."""
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "x"],
+        cwd=root, check=True,
+    )
+
+
+_GUARDED = (
+    "from verify_env_identity import guard_bare_script_or_exit\n"
+    "guard_bare_script_or_exit()\n"
+    "import reyn\n"
+)
+_UNGUARDED = "import reyn\n"
+_NO_REYN = "import os\n"
+_LAZY_UNGUARDED = "def f():\n    from reyn.config import load_config\n    return load_config\n"
+_SUBPROCESS_ONLY = (
+    'code = "from reyn.config import load_config"\n'
+    'import subprocess\n'
+    'subprocess.run(["python3", "-c", code])\n'
+)
+
+
+def test_imports_reyn_true_for_module_level_import(tmp_path: Path) -> None:
+    """Tier 1: accept -- a plain module-level `import reyn`."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_UNGUARDED)
+    assert module.imports_reyn(f) is True
+
+
+def test_imports_reyn_true_for_lazy_nested_import(tmp_path: Path) -> None:
+    """Tier 1: accept -- a `from reyn...` import several nesting levels
+    deep (inside a function body) is still found -- the guard's own
+    point is that ONE call covers every such site regardless of depth,
+    so this gate's population must see them too."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_LAZY_UNGUARDED)
+    assert module.imports_reyn(f) is True
+
+
+def test_imports_reyn_false_for_a_string_literal_mentioning_reyn(tmp_path: Path) -> None:
+    """Tier 1: deny -- a script that builds `from reyn...` as TEXT for a
+    separate `python -c` subprocess (this process's own `import reyn`
+    never happens) is correctly excluded -- the real s7_driver.py /
+    rekey_fixtures.py shape this gate's own module docstring names."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_SUBPROCESS_ONLY)
+    assert module.imports_reyn(f) is False
+
+
+def test_imports_reyn_false_when_reyn_is_never_mentioned(tmp_path: Path) -> None:
+    """Tier 1: deny, plain negative control."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_NO_REYN)
+    assert module.imports_reyn(f) is False
+
+
+def test_calls_guard_true_when_the_call_is_present(tmp_path: Path) -> None:
+    """Tier 1: accept."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_GUARDED)
+    assert module.calls_guard(f) is True
+
+
+def test_calls_guard_false_when_absent(tmp_path: Path) -> None:
+    """Tier 1: deny."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_UNGUARDED)
+    assert module.calls_guard(f) is False
+
+
+def test_measured_flags_an_unguarded_reyn_importing_script(tmp_path: Path) -> None:
+    """Tier 2: integration -- a synthetic `scripts/` tree with one
+    unguarded reyn-importing file is reported as `missing`, driven
+    through the real `measured()` (not the unit pieces in isolation).
+
+    FALSIFY: strip `calls_guard`'s own AST walk down to `return False`
+    unconditionally -- `test_calls_guard_true_when_the_call_is_present`
+    above goes red first, which is the more precise witness; this test
+    additionally proves the wiring from file -> `measured()`'s own
+    verdict, not just the unit function."""
+    module = _load()
+    root = tmp_path / "checkout"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "verify_env_identity.py").write_text("# stand-in, no reyn import\n")
+    (scripts / "unguarded_gate.py").write_text(_UNGUARDED)
+    (scripts / "guarded_gate.py").write_text(_GUARDED)
+    _git_init_scripts(root)
+
+    missing, stale, scanned = module.measured(root)
+
+    assert scanned == 3
+    assert missing == ["unguarded_gate.py"]
+    assert stale == []
+
+
+def test_measured_respects_the_exempt_scripts_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: an unguarded script NAMED in EXEMPT_SCRIPTS is not flagged
+    as missing."""
+    module = _load()
+    root = tmp_path / "checkout"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "verify_env_identity.py").write_text("# stand-in\n")
+    (scripts / "deliberately_cross_tree.py").write_text(_UNGUARDED)
+    _git_init_scripts(root)
+    monkeypatch.setattr(
+        module, "EXEMPT_SCRIPTS", {"deliberately_cross_tree.py": "reasoned exception, test-only"},
+    )
+
+    missing, stale, scanned = module.measured(root)
+
+    assert missing == []
+    assert stale == []
+
+
+def test_measured_flags_a_stale_exemption(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: deny -- an EXEMPT_SCRIPTS entry whose file no longer
+    imports `reyn` at all is a genuine finding (the exemption's own
+    reason no longer applies), not a silent pass."""
+    module = _load()
+    root = tmp_path / "checkout"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "verify_env_identity.py").write_text("# stand-in\n")
+    (scripts / "no_longer_reyn.py").write_text(_NO_REYN)
+    _git_init_scripts(root)
+    monkeypatch.setattr(
+        module, "EXEMPT_SCRIPTS", {"no_longer_reyn.py": "used to import reyn, no longer does"},
+    )
+
+    missing, stale, scanned = module.measured(root)
+
+    assert missing == []
+    assert stale == ["no_longer_reyn.py"]
+
+
+def test_the_real_scan_against_the_current_tree_has_no_missing_or_stale() -> None:
+    """Tier 1: the load-bearing witness -- running the real scan against
+    the real repo tree, right now, must find nothing outstanding.
+    Mirrors `user_facing_lang_gate.py`'s own identically-shaped test."""
+    from tests._support.paths import REPO_ROOT
+
+    module = _load()
+    missing, stale, scanned = module.measured(REPO_ROOT)
+    assert scanned > 0, "the scan found 0 files -- a scanner failure, not a clean population"
+    assert missing == []
+    assert stale == []

--- a/tests/scripts/test_check_scripts_import_identity_guard.py
+++ b/tests/scripts/test_check_scripts_import_identity_guard.py
@@ -132,11 +132,12 @@ def test_measured_flags_an_unguarded_reyn_importing_script(tmp_path: Path) -> No
     (scripts / "guarded_gate.py").write_text(_GUARDED)
     _git_init_scripts(root)
 
-    missing, stale, scanned = module.measured(root)
+    missing, stale, ordering, scanned = module.measured(root)
 
     assert scanned == 3
     assert missing == ["unguarded_gate.py"]
     assert stale == []
+    assert ordering == []
 
 
 def test_measured_respects_the_exempt_scripts_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -153,10 +154,11 @@ def test_measured_respects_the_exempt_scripts_table(tmp_path: Path, monkeypatch:
         module, "EXEMPT_SCRIPTS", {"deliberately_cross_tree.py": "reasoned exception, test-only"},
     )
 
-    missing, stale, scanned = module.measured(root)
+    missing, stale, ordering, scanned = module.measured(root)
 
     assert missing == []
     assert stale == []
+    assert ordering == []
 
 
 def test_measured_flags_a_stale_exemption(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -174,10 +176,71 @@ def test_measured_flags_a_stale_exemption(tmp_path: Path, monkeypatch: pytest.Mo
         module, "EXEMPT_SCRIPTS", {"no_longer_reyn.py": "used to import reyn, no longer does"},
     )
 
-    missing, stale, scanned = module.measured(root)
+    missing, stale, ordering, scanned = module.measured(root)
 
     assert missing == []
     assert stale == ["no_longer_reyn.py"]
+    assert ordering == []
+
+
+_ORDERING_VIOLATION = (
+    "import sys\n"
+    "from verify_env_identity import guard_bare_script_or_exit\n"
+    "guard_bare_script_or_exit()\n"
+    "sys.path.insert(0, '/some/src')\n"
+    "import reyn\n"
+)
+_ORDERING_CORRECT = (
+    "import sys\n"
+    "sys.path.insert(0, '/some/src')\n"
+    "from verify_env_identity import guard_bare_script_or_exit\n"
+    "guard_bare_script_or_exit()\n"
+    "import reyn\n"
+)
+
+
+def test_guard_precedes_own_path_bootstrap_flags_the_false_reject_shape(tmp_path: Path) -> None:
+    """Tier 1: accept -- #3024 BLOCKING (lead-coder, PR #6138): a guard
+    call positioned BEFORE a same-scope `sys.path.insert` is a real
+    accept-side finding (a script that self-bootstraps its own tree
+    would wrongly reject a normal, uninstalled-reyn run). This is the
+    exact shape `audit_event_firing_condition_gate.py` /
+    `mcp_conformance.py` / 6 others had before the fix."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_ORDERING_VIOLATION)
+    assert module.guard_precedes_own_path_bootstrap(f) == 4
+
+
+def test_guard_precedes_own_path_bootstrap_clean_when_guard_is_last(tmp_path: Path) -> None:
+    """Tier 1: deny (negative control) -- the FIXED shape: `sys.path.
+    insert` first, guard after."""
+    module = _load()
+    f = tmp_path / "a.py"
+    f.write_text(_ORDERING_CORRECT)
+    assert module.guard_precedes_own_path_bootstrap(f) is None
+
+
+def test_measured_flags_an_ordering_violation(tmp_path: Path) -> None:
+    """Tier 2: integration -- driven through `measured()`, not just the
+    unit function in isolation.
+
+    FALSIFY (performed during review, file Edit only): reverted
+    `scripts/spike_preflight.py`'s own guard to BEFORE its
+    `sys.path.insert` -- `check_scripts_import_identity_guard.py`
+    reported it by name; reverted, confirmed green again."""
+    module = _load()
+    root = tmp_path / "checkout"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "verify_env_identity.py").write_text("# stand-in\n")
+    (scripts / "misordered_gate.py").write_text(_ORDERING_VIOLATION)
+    _git_init_scripts(root)
+
+    missing, stale, ordering, scanned = module.measured(root)
+
+    assert missing == []
+    assert ordering == [("misordered_gate.py", 4)]
 
 
 def test_the_real_scan_against_the_current_tree_has_no_missing_or_stale() -> None:
@@ -187,7 +250,8 @@ def test_the_real_scan_against_the_current_tree_has_no_missing_or_stale() -> Non
     from tests._support.paths import REPO_ROOT
 
     module = _load()
-    missing, stale, scanned = module.measured(REPO_ROOT)
+    missing, stale, ordering, scanned = module.measured(REPO_ROOT)
     assert scanned > 0, "the scan found 0 files -- a scanner failure, not a clean population"
     assert missing == []
     assert stale == []
+    assert ordering == []


### PR DESCRIPTION
**[e2e-coder]** — tonight's venv-identity sweep's own structural follow-up.

part of #3024

## Why
`pytest`'s own in-process resolution is protected (root `conftest.py`'s `pytest_configure`, #3233), but a bare `python scripts/foo.py` invocation is not: one session's venv had an editable `.pth` whose dictionary order resolved `reyn` to a DIFFERENT checkout entirely for any bare-python script, while `pytest` in the SAME venv read the correct tree (pytest's own `pythonpath = ["src"]` wins ahead of the stale `.pth`). "pytest is green" was never evidence a bare-python gate script measured the right tree.

**I hit this myself while implementing**: my own bare `python3 scripts/verify_env_identity.py --root .` resolved `reyn` to `/Users/.../tui-coder` — a peer session's checkout, not mine.

## What changed

**New**: `scripts/verify_env_identity.py::guard_bare_script_or_exit()`. Call once, near a script's own entry point, before any of its own `import reyn` (module-level or lazily nested, anywhere in the file). Stays reyn-free the same way this module's other out-of-process checks do — `importlib.util.find_spec('reyn')` resolves where `import reyn` WOULD land without executing `reyn/__init__.py`, so one call covers every later import site in the file regardless of depth. Exits loudly on a mismatch, mirroring `conftest.py`'s own `pytest.exit` shape.

**Population derived via AST** (`git ls-files scripts/*.py`, walked for any `Import`/`ImportFrom` naming `reyn` or `reyn.*`, at any nesting depth) — never a hand-typed list. 28 files import `reyn`; **25 now call the guard**.

**3 reasoned exemptions** (`exec_wrappers.py`'s own `UNSUPPORTED_WRAPPERS` shape — named, with why, never silently absent):
- `df2187_harness.py` — an A/B driver whose whole job is diffing `reyn` as resolved from two DIFFERENT `PYTHONPATH` arms; it cannot also assert it is only ever pointed at one.
- `wheel_parity_probe.py` / `wheel_plugin_install_probe.py` — run inside a throwaway wheel-only venv and assert `reyn` resolves the INSTALLED WHEEL, never `<root>/src` — the guard's own contract is the opposite of what these probes exist to prove.

**New gate**: `scripts/check_scripts_import_identity_guard.py` (`CI: gate`, `.github/workflows/scripts-import-identity-guard-gate.yml`, `paths: scripts/**`) re-derives the same population every run and fails if a reyn-importing script has neither the guard call nor an `EXEMPT_SCRIPTS` entry — a new script landing without either goes red. Also flags a STALE exemption (an entry whose file no longer imports `reyn` at all) as its own finding.

## Strip-falsify (file Edit only, no `git stash`/`checkout`/`restore`)
Removed the guard call from `diag_tiktoken_cache.py` — the new gate went RED naming it by name. Reverted, confirmed green again. Also unit-level: `guard_bare_script_or_exit` itself falsified via a monkeypatched `find_spec` returning an origin outside root — confirms `SystemExit(1)`, not a silent return.

## Tests
- 10 new Tier-1 tests for `check_scripts_import_identity_guard.py`'s own detector — synthetic `tmp_path` `scripts/` trees, real `git init` so `git ls-files` sees them (never mocked). Includes `test_the_real_scan_against_the_current_tree_has_no_missing_or_stale` (the load-bearing witness against the actual repo tree — green).
- 4 new Tier-1 tests for `guard_bare_script_or_exit`, appended to the existing `tests/scripts/test_3024_env_identity.py` — `find_spec` monkeypatched, the SAME shape `test_3233_inprocess_env_identity.py`'s own synthetic-tree tests use; a dedicated test confirms `find_spec` is never called for anything but `'reyn'` (never actually imports the real `reyn`, matching this module's own "never imports reyn" property).

## Gates (all green)
`ruff`, `verify_module_docstrings.py` (all 30 touched files), `mypy_ratchet.py` (0 findings), `test_tier_audit.py --strict` (18/18 OK, 0 Tier-4), `check_ci_role_declared.py` (new gate wired), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `check_tests_path_literal_reference.py`, `flat_tests_ratchet.py`.

## Pytest (diff-scoped, foreground)
`pytest tests/scripts/test_3024_env_identity.py tests/scripts/test_check_scripts_import_identity_guard.py tests/scripts/test_3233_inprocess_env_identity.py -q` → **21 passed**.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. CI and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
