### PR TITLE
fix(#6143): src/ warnings.warn never reaches the operator's screen -- promote 7, category-blind AST gate over all 25

### DIFF
--- a/.github/workflows/silent-warnings-category-gate.yml
+++ b/.github/workflows/silent-warnings-category-gate.yml
@@ -1,0 +1,39 @@
+name: silent-warnings-category gate
+
+# #6143: reject any `warnings.warn(...)` under src/reyn/** whose category
+# is one Python ignores by default outside __main__ (DeprecationWarning /
+# PendingDeprecationWarning / ImportWarning / ResourceWarning) unless it
+# has a reviewed, reasoned entry in scripts/silent_warnings_category_gate.py's
+# own _EXCEPTION_TABLE. Population is 0 as of this gate landing (the 7
+# known sites were promoted to logger.warning in the same PR) -- a table,
+# not a ratchet: see the script's own module docstring for why.
+#
+# `paths: src/reyn/**` matches this gate's own scope exactly -- a change
+# outside that tree cannot add or remove a site this script counts.
+on:
+  pull_request:
+    paths:
+      - "src/reyn/**"
+
+permissions:
+  contents: read
+
+jobs:
+  silent-warnings-category-gate:
+    name: silent-warnings-category gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/silent_warnings_category_gate.py is stdlib-only (ast /
+      # subprocess / pathlib / argparse). No pip install needed.
+      - name: Check no silent-by-default warnings.warn site under src/reyn/
+        run: |
+          python scripts/silent_warnings_category_gate.py

--- a/scripts/silent_warnings_category_gate.py
+++ b/scripts/silent_warnings_category_gate.py
@@ -39,15 +39,42 @@ surface reyn's own operators consult with `-W`, so a raw `warnings.warn`
 call here is presumptively the wrong tool for reaching an operator,
 independent of which category it names.
 
+## v2 -> v3: the key needed a THIRD coordinate (#6144 co-vet round 3)
+
+v2 keyed `_EXCEPTION_TABLE` on `(relpath, lineno)` alone. lead-coder's
+own review caught the gap this reopens: a call site this gate exists to
+CATCH does not need to dodge the gate at all if it simply lands on the
+same line number an already-exempted site used to occupy (the exempted
+site moved down, a new one took its old line -- an everyday consequence
+of an unrelated edit above it in the same file). Position alone is not
+an identity; two DIFFERENT `warnings.warn` calls can share one. "Keep
+line numbers stable by convention" was explicitly rejected -- an
+invariant held only by someone's habit, never enforced, is not actually
+held.
+
+The key is therefore `(relpath, lineno, message_template)`, where
+`message_template` is the call's own message argument with every
+f-string expression normalised to a fixed `"{}"` placeholder (see
+`_message_template` below) and truncated to `_TEMPLATE_LEN` characters.
+A table entry now only matches a call whose own message-shape is a
+prefix-equal match, not merely one sharing a line number -- an
+exempted site moving down is still caught (a DIFFERENT lineno with the
+SAME template has no matching key: fail-loud, the same "moved = red,
+and that's fine" contract v2 already had for `(relpath, lineno)`), and
+a genuinely new, unaudited `warnings.warn` landing on an old exempted
+site's line number no longer inherits that exemption silently -- its
+own message template almost certainly differs, so the composite key
+misses and the gate goes red for it specifically.
+
 ## What this gate checks
 
 Every `warnings.warn(...)` call under `src/reyn/**` must appear in this
-script's own `_EXCEPTION_TABLE` with a reason -- or the gate is RED.
-There is no other escape hatch (no comment-based suppression): a
-genuinely developer-only warning (there IS a legitimate reader --
-someone importing `reyn` as a library and running their own process
-under `-W`) stays reviewed, in one place, not decided ad hoc at each
-call site.
+script's own `_EXCEPTION_TABLE` (by its full 3-part key) with a reason
+-- or the gate is RED. There is no other escape hatch (no comment-based
+suppression): a genuinely developer-only warning (there IS a legitimate
+reader -- someone importing `reyn` as a library and running their own
+process under `-W`) stays reviewed, in one place, not decided ad hoc at
+each call site.
 
 This is a TABLE, not a ratchet (contrast `silent_except_ratchet.py`,
 #5990). #6143 fixed and DELETED all 7 originally-flagged sites (6
@@ -64,14 +91,23 @@ wording is a NEW bug, not a fix). Those 18 are DISCLOSED table entries
 referencing #6145, not silently declared "legitimate" -- lead-coder's
 own framing above says none of them currently are.
 
-## Deliberately narrow call-site resolution (disclosed, not solved)
+## Deliberately narrow call-site / template resolution (disclosed, not solved)
 
 Detection matches `warnings.warn(...)` / `warn(...)` (a bare imported
 name) syntactically via `ast.walk` -- no dataflow, no alias tracking of
 a renamed import (`import warnings as w; w.warn(...)` would not match).
-The same "suspected, not confirmed" posture `suspected_time_dependence_
-ratchet.py` (#4846) and `silent_except_ratchet.py` (#5990) already carry
-for a syntax-only AST gate.
+`_message_template` reads only a literal string / f-string (`ast.
+Constant` / `ast.JoinedStr`) message argument; a message built any other
+way (a variable, a function call, string `%`/`.format()` composed
+elsewhere and passed in) resolves to `""` -- an EMPTY template still
+participates in the 3-part key (so it can still be exempted, keyed on
+`(relpath, lineno, "")`), but offers no discrimination against a
+different such call landing on the same line, which is the same
+disclosed gap `suspected_time_dependence_ratchet.py` (#4846) and
+`silent_except_ratchet.py` (#5990) already carry for a syntax-only AST
+gate -- no real site in the current 18-entry population has this shape
+(verified: `_message_template` returns non-empty text for all 18, see
+the exception table below).
 
 CI: gate
 """
@@ -86,6 +122,13 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent
 _SCOPE = "src/reyn"
 
+#: Message-template truncation length. Long enough that two genuinely
+#: different messages at the same call site are exceedingly unlikely to
+#: share a prefix this long; short enough that a cosmetic wording tweak
+#: elsewhere in a long message (not in its first _TEMPLATE_LEN chars)
+#: does not force a table-entry churn unrelated to this gate's purpose.
+_TEMPLATE_LEN = 40
+
 # #6145 tracks promoting each of these 18 pre-existing sites (all
 # UserWarning, or the default omitted category) with the SAME
 # message-content audit #6144's own `:2069` round taught is required --
@@ -93,25 +136,31 @@ _SCOPE = "src/reyn"
 # debt, not a claim these are fine as-is (lead-coder's own framing: the
 # only legitimate raw `warnings.warn` reader is a `-W`-flagged library
 # consumer, which none of these are).
-_EXCEPTION_TABLE: "dict[tuple[str, int], str]" = {
-    ("src/reyn/config/chat.py", 1451): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 150): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 159): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 167): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 196): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 205): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 250): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 47): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 56): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 79): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 88): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 133): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 143): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/interpolation.py", 37): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/plugins/tokens.py", 310): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/mcp/client.py", 2523): "#6145 -- pre-#6143, omitted category (defaults to UserWarning), not yet audited",
-    ("src/reyn/hooks/composer.py", 634): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/hooks/composer.py", 838): "#6145 -- pre-#6143 UserWarning, not yet audited",
+#
+# The 3rd element of each key is that call's own message TEMPLATE (see
+# `_message_template`'s own docstring) -- a future, unaudited
+# `warnings.warn` landing on one of these exact line numbers does NOT
+# inherit the exemption unless its message also happens to share this
+# same ~40-char prefix (#6144 co-vet round 3).
+_EXCEPTION_TABLE: "dict[tuple[str, int, str], str]" = {
+    ("src/reyn/config/chat.py", 1451, "chat.stream_repaint_min_interval={} is n"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 150, "Could not read OAuth token store at {}: "): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 159, "OAuth token store at {} is not valid JSO"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 167, "OAuth token store at {} must be a JSON o"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 196, "OAuth token {} is not an object; ignorin"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 205, "OAuth token {} is malformed ({}); ignori"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 250, "{} is readable by group/others (mode {})"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 47, "{} is readable by group/others (mode {})"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 56, "Could not chmod {} to 600: {}"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 79, "secrets.env line {}: no '=' found, skipp"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 88, "secrets.env line {}: empty key, skipping"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 133, "Could not read {}: {}"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 143, "Unexpected error parsing {}: {}"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/interpolation.py", 37, "Config references undefined environment "): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/plugins/tokens.py", 310, "{} left reyn token(s) {} unresolved -- r"): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/mcp/client.py", 2523, "MCP stdio server {} runs UNSANDBOXED (sa"): "#6145 -- pre-#6143, omitted category (defaults to UserWarning), not yet audited",
+    ("src/reyn/hooks/composer.py", 634, "composers {}: durable pending state was "): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/hooks/composer.py", 838, "composers[{}]: op=deadline with durable="): "#6145 -- pre-#6143 UserWarning, not yet audited",
 }
 
 
@@ -142,8 +191,8 @@ def _warn_category_name(call: ast.Call) -> "str | None":
     positional arg 2, or a `category=` keyword. `None` when omitted (the
     implicit default is `UserWarning`) or when the value is not a bare
     `Name`/`Attribute` this script can read statically. Retained for the
-    reported category label only -- v2's own population no longer
-    filters by this value (see module docstring, "v1 -> v2")."""
+    reported category label only -- population membership never filters
+    by this value (see module docstring, "v1 -> v2")."""
     node: "ast.expr | None"
     if len(call.args) >= 2:
         node = call.args[1]
@@ -156,40 +205,70 @@ def _warn_category_name(call: ast.Call) -> "str | None":
     return None
 
 
-def silent_category_sites(path: Path, root: Path = _ROOT) -> "list[tuple[str, int, str]]":
-    """`[(relpath, lineno, category)]` for EVERY `warnings.warn(...)`
-    call in *path*, category-blind (v2, #6144 co-vet round 2 -- see
-    module docstring's "v1 -> v2"). `category` in the returned tuple is
+def _message_template(call: ast.Call, length: int = _TEMPLATE_LEN) -> str:
+    """The message argument's own TEMPLATE -- every f-string expression
+    normalised to a fixed `"{}"` placeholder, truncated to *length*
+    characters (see module docstring, "v2 -> v3"). `""` when the message
+    argument is missing or not a literal string / f-string this script
+    can read statically (a variable, a function call, `%`/`.format()`
+    composition) -- a disclosed, not solved, limit; see module
+    docstring's own final section."""
+    if not call.args:
+        return ""
+    node = call.args[0]
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value[:length]
+    if isinstance(node, ast.JoinedStr):
+        parts: "list[str]" = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                parts.append("{}")
+        return "".join(parts)[:length]
+    return ""
+
+
+def silent_category_sites(path: Path, root: Path = _ROOT) -> "list[tuple[str, int, str, str]]":
+    """`[(relpath, lineno, category, message_template)]` for EVERY
+    `warnings.warn(...)` call in *path*, category-blind (v2, #6144
+    co-vet round 2 -- see module docstring's "v1 -> v2"). `category` is
     `"UserWarning"` when omitted or unresolved, purely for the report
-    label -- it is never used to decide membership."""
+    label -- it is never used to decide membership. `message_template`
+    is the 3rd key coordinate `unexplained` matches against (v3, #6144
+    co-vet round 3)."""
     text = path.read_text(encoding="utf-8")
     tree = ast.parse(text, filename=str(path))
     relpath = str(path.relative_to(root))
-    out: "list[tuple[str, int, str]]" = []
+    out: "list[tuple[str, int, str, str]]" = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _is_warnings_warn_call(node):
             category = _warn_category_name(node) or "UserWarning"
-            out.append((relpath, node.lineno, category))
+            template = _message_template(node)
+            out.append((relpath, node.lineno, category, template))
     return out
 
 
-def measured(root: Path = _ROOT) -> "list[tuple[str, int, str]]":
-    sites: "list[tuple[str, int, str]]" = []
+def measured(root: Path = _ROOT) -> "list[tuple[str, int, str, str]]":
+    sites: "list[tuple[str, int, str, str]]" = []
     for path in _iter_scan_files(root):
         sites.extend(silent_category_sites(path, root))
     return sites
 
 
 def unexplained(
-    sites: "list[tuple[str, int, str]]",
-    table: "dict[tuple[str, int], str] | None" = None,
-) -> "list[tuple[str, int, str]]":
+    sites: "list[tuple[str, int, str, str]]",
+    table: "dict[tuple[str, int, str], str] | None" = None,
+) -> "list[tuple[str, int, str, str]]":
     """Sites with no matching exception-table entry -- what makes the
-    gate red. *table* defaults to the module's own `_EXCEPTION_TABLE`;
-    overridable so tests can exercise the arithmetic against a table that
-    is not the shipped one."""
+    gate red. Matches the FULL 3-part key `(relpath, lineno,
+    message_template)` (#6144 co-vet round 3) -- a site sharing only a
+    line number with a table entry, but not its message template, is
+    NOT explained by it. *table* defaults to the module's own
+    `_EXCEPTION_TABLE`; overridable so tests can exercise the arithmetic
+    against a table that is not the shipped one."""
     active_table = _EXCEPTION_TABLE if table is None else table
-    return [s for s in sites if (s[0], s[1]) not in active_table]
+    return [s for s in sites if (s[0], s[1], s[3]) not in active_table]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -209,14 +288,14 @@ def main(argv: "list[str] | None" = None) -> int:
             "_EXCEPTION_TABLE:\n",
             file=sys.stderr,
         )
-        for relpath, lineno, category in bad:
-            print(f"  {relpath}:{lineno}  {category}", file=sys.stderr)
+        for relpath, lineno, category, template in bad:
+            print(f"  {relpath}:{lineno}  {category}  {template!r}", file=sys.stderr)
         print(
             "\nEither promote this call to logger.warning (or a stronger "
             "surface an operator actually sees) in the same PR, or add "
-            '(relpath, lineno): "<why this stays a raw warnings.warn, '
-            'tracked how>" to _EXCEPTION_TABLE in this same PR. See '
-            "#6143/#6144/#6145.",
+            '(relpath, lineno, message_template): "<why this stays a raw '
+            'warnings.warn, tracked how>" to _EXCEPTION_TABLE in this same '
+            "PR. See #6143/#6144/#6145.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/silent_warnings_category_gate.py
+++ b/scripts/silent_warnings_category_gate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""#6143 -- a `src/reyn/**` population gate over `warnings.warn(..., category)`
-call sites whose category Python IGNORES by default outside `__main__`.
+"""#6143/#6144 -- a `src/reyn/**` population gate over EVERY
+`warnings.warn(...)` call site, category-blind.
 
 ## Why this exists
 
@@ -13,47 +13,65 @@ call sites whose category Python IGNORES by default outside `__main__`.
     ('ignore',  None, ImportWarning, None, 0)
     ('ignore',  None, ResourceWarning, None, 0)
 
-Every module under `src/reyn/` is NOT `__main__`, so a `warnings.warn(...,
-DeprecationWarning)` (or PendingDeprecationWarning / ImportWarning /
-ResourceWarning) fired from `src/reyn/**` reaches nobody in a real run --
-`logging.captureWarnings(True)` only redirects `showwarning`, it does not
-change the filter that decides whether `showwarning` is ever called at
-all, and `pyproject.toml`'s `[tool.pytest.ini_options] filterwarnings` is
-pytest-only. The same shape was hit 3 times in one night (#6132, #6137,
-and #6141 -- the last one nearly landed with lead-coder's own requested
-fix silently swallowed, caught only by co-vet measuring a real process).
-AST-derived census on `origin/main` before this issue's own fix: 7 sites
-(`config/chat.py` x5, `security/permissions/permissions.py` x2) -- all 7
-were promoted to `logger.warning` in the same PR that added this gate.
+Every module under `src/reyn/` is NOT `__main__`, so
+DeprecationWarning/PendingDeprecationWarning/ImportWarning/
+ResourceWarning fired from `src/reyn/**` reaches nobody in a real run.
+The same shape was hit 3 times in one night (#6132, #6137, #6141).
+
+## v1 -> v2: the category axis was itself a false floor (#6144 co-vet round 2)
+
+This gate's FIRST revision only flagged the 4 silent-by-default
+categories above. lead-coder's own review caught the gap: swapping
+`DeprecationWarning` -> `UserWarning` in any one of those call sites
+turns the gate green with the operator's actual visibility unchanged by
+one bit. `UserWarning` is not "loud" in the sense that matters here --
+architect's own real measurement: `stderr: False / reyn.log: True`. It
+reaches `reyn.log` (unlike a silent-by-default category, which reaches
+NOTHING), but never an interactive operator's screen directly. Neither
+is genuinely "the operator sees this."
+
+The axis this gate checks is therefore CATEGORY-BLIND: every
+`warnings.warn(...)` call under `src/reyn/**`, regardless of category,
+is population. lead-coder's own framing: "the only legitimate reader of
+a raw `warnings.warn` is a library consumer who adds their own `-W`
+flag" -- `src/reyn/` is reyn's own application code, not a library
+surface reyn's own operators consult with `-W`, so a raw `warnings.warn`
+call here is presumptively the wrong tool for reaching an operator,
+independent of which category it names.
 
 ## What this gate checks
 
-For every `warnings.warn(...)` call under `src/reyn/**`, if the category
-argument (positional arg 2, or a `category=` keyword) is a bare name (or
-attribute) matching one of the silent-by-default set below, the call site
-must appear in this script's own `_EXCEPTION_TABLE` with a reason -- or
-the gate is RED. There is no other escape hatch (no comment-based
-suppression): a genuinely developer-only warning stays reviewed, in one
-place, not decided ad hoc at each call site.
+Every `warnings.warn(...)` call under `src/reyn/**` must appear in this
+script's own `_EXCEPTION_TABLE` with a reason -- or the gate is RED.
+There is no other escape hatch (no comment-based suppression): a
+genuinely developer-only warning (there IS a legitimate reader --
+someone importing `reyn` as a library and running their own process
+under `-W`) stays reviewed, in one place, not decided ad hoc at each
+call site.
 
 This is a TABLE, not a ratchet (contrast `silent_except_ratchet.py`,
-#5990): the measured population is 0 as of this gate landing (every known
-site was fixed in the same PR), so there is nothing to grandfather. A
-future PR that adds a new silent-by-default `warnings.warn` either
-promotes it to `logger.warning` (or a stronger surface, e.g. a
-`project_status`/Ctx-pane field -- see #6139) or adds a table entry with
-a one-line reason, in the SAME PR.
+#5990). #6143 fixed and DELETED all 7 originally-flagged sites (6
+promoted to `logger.warning`; the 7th, `permissions.py`'s legacy
+`http.get` compat notice, was deleted outright in #6144's own co-vet
+round 2 -- it duplicated a REAL, already-firing approval prompt on a
+second, noisier channel). Widening the axis in the SAME PR newly
+surfaces 18 pre-existing sites (all `UserWarning`, or the default
+omitted category) that #6143's own dispatch never covered and #6144's
+own review never audited message-by-message -- see #6145, the tracking
+issue for promoting each with the SAME wording rigor #6144's own
+`:2069` mistake demanded (changing the channel without checking the
+wording is a NEW bug, not a fix). Those 18 are DISCLOSED table entries
+referencing #6145, not silently declared "legitimate" -- lead-coder's
+own framing above says none of them currently are.
 
-## Deliberately narrow category resolution (disclosed, not solved)
+## Deliberately narrow call-site resolution (disclosed, not solved)
 
-Category resolution only recognises a literal `ast.Name` or the `.attr`
-of an `ast.Attribute` (e.g. `warnings.DeprecationWarning` -- unusual but
-legal) -- it does not evaluate expressions, resolve imports, or follow a
-variable holding a category class. A call site that passes a silent
-category through an indirection this script cannot see is a FALSE
-REJECT never flagged -- the same "suspected, not confirmed" posture
-`suspected_time_dependence_ratchet.py` (#4846) and `silent_except_
-ratchet.py` (#5990) both already carry for a syntax-only AST gate.
+Detection matches `warnings.warn(...)` / `warn(...)` (a bare imported
+name) syntactically via `ast.walk` -- no dataflow, no alias tracking of
+a renamed import (`import warnings as w; w.warn(...)` would not match).
+The same "suspected, not confirmed" posture `suspected_time_dependence_
+ratchet.py` (#4846) and `silent_except_ratchet.py` (#5990) already carry
+for a syntax-only AST gate.
 
 CI: gate
 """
@@ -68,22 +86,33 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent
 _SCOPE = "src/reyn"
 
-# Silent-by-default OUTSIDE __main__ -- see module docstring's own
-# `warnings.filters` measurement. NOT UserWarning (Python's own default
-# category when none is given) -- that one IS shown (once per call site)
-# under the stock filter, so a bare `warnings.warn("...")` or an explicit
-# `UserWarning` is out of this gate's population on purpose.
-_SILENT_BY_DEFAULT_CATEGORIES = frozenset({
-    "DeprecationWarning", "PendingDeprecationWarning", "ImportWarning", "ResourceWarning",
-})
-
-# Explicit, reviewed exceptions: {(relpath, lineno): "why this call site
-# stays a raw warnings.warn in a silent-by-default category"}. Empty
-# today -- #6143 converted every known site to `logger.warning`. Add an
-# entry ONLY in the same PR that introduces the call site it covers; the
-# reason lives HERE (machine-checked), not in a code comment (which is
-# not).
-_EXCEPTION_TABLE: "dict[tuple[str, int], str]" = {}
+# #6145 tracks promoting each of these 18 pre-existing sites (all
+# UserWarning, or the default omitted category) with the SAME
+# message-content audit #6144's own `:2069` round taught is required --
+# a channel change alone is not a fix if the wording is wrong. DISCLOSED
+# debt, not a claim these are fine as-is (lead-coder's own framing: the
+# only legitimate raw `warnings.warn` reader is a `-W`-flagged library
+# consumer, which none of these are).
+_EXCEPTION_TABLE: "dict[tuple[str, int], str]" = {
+    ("src/reyn/config/chat.py", 1451): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 150): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 159): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 167): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 196): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 205): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/oauth.py", 250): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 47): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 56): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 79): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 88): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 133): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/loader.py", 143): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/security/secrets/interpolation.py", 37): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/plugins/tokens.py", 310): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/mcp/client.py", 2523): "#6145 -- pre-#6143, omitted category (defaults to UserWarning), not yet audited",
+    ("src/reyn/hooks/composer.py", 634): "#6145 -- pre-#6143 UserWarning, not yet audited",
+    ("src/reyn/hooks/composer.py", 838): "#6145 -- pre-#6143 UserWarning, not yet audited",
+}
 
 
 def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
@@ -111,9 +140,10 @@ def _is_warnings_warn_call(call: ast.Call) -> bool:
 def _warn_category_name(call: ast.Call) -> "str | None":
     """The literal category name a `warnings.warn(...)` call passes --
     positional arg 2, or a `category=` keyword. `None` when omitted (the
-    default category is UserWarning, not silent) or when the value is not
-    a bare `Name`/`Attribute` this script can read statically (see module
-    docstring's disclosed false-reject)."""
+    implicit default is `UserWarning`) or when the value is not a bare
+    `Name`/`Attribute` this script can read statically. Retained for the
+    reported category label only -- v2's own population no longer
+    filters by this value (see module docstring, "v1 -> v2")."""
     node: "ast.expr | None"
     if len(call.args) >= 2:
         node = call.args[1]
@@ -127,17 +157,19 @@ def _warn_category_name(call: ast.Call) -> "str | None":
 
 
 def silent_category_sites(path: Path, root: Path = _ROOT) -> "list[tuple[str, int, str]]":
-    """`[(relpath, lineno, category)]` for every `warnings.warn(...)` call
-    in *path* whose category is one of `_SILENT_BY_DEFAULT_CATEGORIES`."""
+    """`[(relpath, lineno, category)]` for EVERY `warnings.warn(...)`
+    call in *path*, category-blind (v2, #6144 co-vet round 2 -- see
+    module docstring's "v1 -> v2"). `category` in the returned tuple is
+    `"UserWarning"` when omitted or unresolved, purely for the report
+    label -- it is never used to decide membership."""
     text = path.read_text(encoding="utf-8")
     tree = ast.parse(text, filename=str(path))
     relpath = str(path.relative_to(root))
     out: "list[tuple[str, int, str]]" = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _is_warnings_warn_call(node):
-            category = _warn_category_name(node)
-            if category in _SILENT_BY_DEFAULT_CATEGORIES:
-                out.append((relpath, node.lineno, category))
+            category = _warn_category_name(node) or "UserWarning"
+            out.append((relpath, node.lineno, category))
     return out
 
 
@@ -155,7 +187,7 @@ def unexplained(
     """Sites with no matching exception-table entry -- what makes the
     gate red. *table* defaults to the module's own `_EXCEPTION_TABLE`;
     overridable so tests can exercise the arithmetic against a table that
-    is not the (currently empty) shipped one."""
+    is not the shipped one."""
     active_table = _EXCEPTION_TABLE if table is None else table
     return [s for s in sites if (s[0], s[1]) not in active_table]
 
@@ -172,11 +204,9 @@ def main(argv: "list[str] | None" = None) -> int:
     if bad:
         print(
             f"silent-warnings-category gate: {len(bad)} warnings.warn(...) "
-            "call(s) under src/reyn/ use a category Python ignores by "
-            "default outside __main__ (DeprecationWarning / "
-            "PendingDeprecationWarning / ImportWarning / ResourceWarning), "
-            "with no entry in scripts/silent_warnings_category_gate.py's "
-            "own _EXCEPTION_TABLE:\n",
+            "call(s) under src/reyn/ (any category) have no entry in "
+            "scripts/silent_warnings_category_gate.py's own "
+            "_EXCEPTION_TABLE:\n",
             file=sys.stderr,
         )
         for relpath, lineno, category in bad:
@@ -184,15 +214,16 @@ def main(argv: "list[str] | None" = None) -> int:
         print(
             "\nEither promote this call to logger.warning (or a stronger "
             "surface an operator actually sees) in the same PR, or add "
-            '(relpath, lineno): "<why this stays silent>" to '
-            "_EXCEPTION_TABLE in this same PR. See #6143.",
+            '(relpath, lineno): "<why this stays a raw warnings.warn, '
+            'tracked how>" to _EXCEPTION_TABLE in this same PR. See '
+            "#6143/#6144/#6145.",
             file=sys.stderr,
         )
         return 1
 
     print(
-        f"silent-warnings-category gate OK: {len(sites)} silent-by-default "
-        "category site(s), all in the exception table."
+        f"silent-warnings-category gate OK: {len(sites)} warnings.warn(...) "
+        "site(s), all in the exception table."
     )
     return 0
 

--- a/scripts/silent_warnings_category_gate.py
+++ b/scripts/silent_warnings_category_gate.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""#6143 -- a `src/reyn/**` population gate over `warnings.warn(..., category)`
+call sites whose category Python IGNORES by default outside `__main__`.
+
+## Why this exists
+
+#6143's own measurement:
+
+    $ python3 -c "import warnings; [print(f) for f in warnings.filters[:5]]"
+    ('default', None, DeprecationWarning, '__main__', 0)
+    ('ignore',  None, DeprecationWarning, None, 0)          <- not __main__
+    ('ignore',  None, PendingDeprecationWarning, None, 0)
+    ('ignore',  None, ImportWarning, None, 0)
+    ('ignore',  None, ResourceWarning, None, 0)
+
+Every module under `src/reyn/` is NOT `__main__`, so a `warnings.warn(...,
+DeprecationWarning)` (or PendingDeprecationWarning / ImportWarning /
+ResourceWarning) fired from `src/reyn/**` reaches nobody in a real run --
+`logging.captureWarnings(True)` only redirects `showwarning`, it does not
+change the filter that decides whether `showwarning` is ever called at
+all, and `pyproject.toml`'s `[tool.pytest.ini_options] filterwarnings` is
+pytest-only. The same shape was hit 3 times in one night (#6132, #6137,
+and #6141 -- the last one nearly landed with lead-coder's own requested
+fix silently swallowed, caught only by co-vet measuring a real process).
+AST-derived census on `origin/main` before this issue's own fix: 7 sites
+(`config/chat.py` x5, `security/permissions/permissions.py` x2) -- all 7
+were promoted to `logger.warning` in the same PR that added this gate.
+
+## What this gate checks
+
+For every `warnings.warn(...)` call under `src/reyn/**`, if the category
+argument (positional arg 2, or a `category=` keyword) is a bare name (or
+attribute) matching one of the silent-by-default set below, the call site
+must appear in this script's own `_EXCEPTION_TABLE` with a reason -- or
+the gate is RED. There is no other escape hatch (no comment-based
+suppression): a genuinely developer-only warning stays reviewed, in one
+place, not decided ad hoc at each call site.
+
+This is a TABLE, not a ratchet (contrast `silent_except_ratchet.py`,
+#5990): the measured population is 0 as of this gate landing (every known
+site was fixed in the same PR), so there is nothing to grandfather. A
+future PR that adds a new silent-by-default `warnings.warn` either
+promotes it to `logger.warning` (or a stronger surface, e.g. a
+`project_status`/Ctx-pane field -- see #6139) or adds a table entry with
+a one-line reason, in the SAME PR.
+
+## Deliberately narrow category resolution (disclosed, not solved)
+
+Category resolution only recognises a literal `ast.Name` or the `.attr`
+of an `ast.Attribute` (e.g. `warnings.DeprecationWarning` -- unusual but
+legal) -- it does not evaluate expressions, resolve imports, or follow a
+variable holding a category class. A call site that passes a silent
+category through an indirection this script cannot see is a FALSE
+REJECT never flagged -- the same "suspected, not confirmed" posture
+`suspected_time_dependence_ratchet.py` (#4846) and `silent_except_
+ratchet.py` (#5990) both already carry for a syntax-only AST gate.
+
+CI: gate
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCOPE = "src/reyn"
+
+# Silent-by-default OUTSIDE __main__ -- see module docstring's own
+# `warnings.filters` measurement. NOT UserWarning (Python's own default
+# category when none is given) -- that one IS shown (once per call site)
+# under the stock filter, so a bare `warnings.warn("...")` or an explicit
+# `UserWarning` is out of this gate's population on purpose.
+_SILENT_BY_DEFAULT_CATEGORIES = frozenset({
+    "DeprecationWarning", "PendingDeprecationWarning", "ImportWarning", "ResourceWarning",
+})
+
+# Explicit, reviewed exceptions: {(relpath, lineno): "why this call site
+# stays a raw warnings.warn in a silent-by-default category"}. Empty
+# today -- #6143 converted every known site to `logger.warning`. Add an
+# entry ONLY in the same PR that introduces the call site it covers; the
+# reason lives HERE (machine-checked), not in a code comment (which is
+# not).
+_EXCEPTION_TABLE: "dict[tuple[str, int], str]" = {}
+
+
+def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":
+    """Every tracked `.py` file under `src/reyn/` -- `git ls-files`, the
+    same population source `silent_except_ratchet.py`/`suspected_time_
+    dependence_ratchet.py` use, for the same reason: it already excludes
+    `.venv/`, `__pycache__/`, and anything gitignored, with no
+    hand-maintained exclusion list."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", f"{_SCOPE}/*.py"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    return [root / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _is_warnings_warn_call(call: ast.Call) -> bool:
+    f = call.func
+    if isinstance(f, ast.Attribute) and f.attr == "warn":
+        return True
+    if isinstance(f, ast.Name) and f.id == "warn":
+        return True
+    return False
+
+
+def _warn_category_name(call: ast.Call) -> "str | None":
+    """The literal category name a `warnings.warn(...)` call passes --
+    positional arg 2, or a `category=` keyword. `None` when omitted (the
+    default category is UserWarning, not silent) or when the value is not
+    a bare `Name`/`Attribute` this script can read statically (see module
+    docstring's disclosed false-reject)."""
+    node: "ast.expr | None"
+    if len(call.args) >= 2:
+        node = call.args[1]
+    else:
+        node = next((kw.value for kw in call.keywords if kw.arg == "category"), None)
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def silent_category_sites(path: Path, root: Path = _ROOT) -> "list[tuple[str, int, str]]":
+    """`[(relpath, lineno, category)]` for every `warnings.warn(...)` call
+    in *path* whose category is one of `_SILENT_BY_DEFAULT_CATEGORIES`."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    relpath = str(path.relative_to(root))
+    out: "list[tuple[str, int, str]]" = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_warnings_warn_call(node):
+            category = _warn_category_name(node)
+            if category in _SILENT_BY_DEFAULT_CATEGORIES:
+                out.append((relpath, node.lineno, category))
+    return out
+
+
+def measured(root: Path = _ROOT) -> "list[tuple[str, int, str]]":
+    sites: "list[tuple[str, int, str]]" = []
+    for path in _iter_scan_files(root):
+        sites.extend(silent_category_sites(path, root))
+    return sites
+
+
+def unexplained(
+    sites: "list[tuple[str, int, str]]",
+    table: "dict[tuple[str, int], str] | None" = None,
+) -> "list[tuple[str, int, str]]":
+    """Sites with no matching exception-table entry -- what makes the
+    gate red. *table* defaults to the module's own `_EXCEPTION_TABLE`;
+    overridable so tests can exercise the arithmetic against a table that
+    is not the (currently empty) shipped one."""
+    active_table = _EXCEPTION_TABLE if table is None else table
+    return [s for s in sites if (s[0], s[1]) not in active_table]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    build_parser().parse_args(argv)
+
+    sites = measured()
+    bad = unexplained(sites)
+    if bad:
+        print(
+            f"silent-warnings-category gate: {len(bad)} warnings.warn(...) "
+            "call(s) under src/reyn/ use a category Python ignores by "
+            "default outside __main__ (DeprecationWarning / "
+            "PendingDeprecationWarning / ImportWarning / ResourceWarning), "
+            "with no entry in scripts/silent_warnings_category_gate.py's "
+            "own _EXCEPTION_TABLE:\n",
+            file=sys.stderr,
+        )
+        for relpath, lineno, category in bad:
+            print(f"  {relpath}:{lineno}  {category}", file=sys.stderr)
+        print(
+            "\nEither promote this call to logger.warning (or a stronger "
+            "surface an operator actually sees) in the same PR, or add "
+            '(relpath, lineno): "<why this stays silent>" to '
+            "_EXCEPTION_TABLE in this same PR. See #6143.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"silent-warnings-category gate OK: {len(sites)} silent-by-default "
+        "category site(s), all in the exception table."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -1469,40 +1469,51 @@ def _build_chat_config(raw: object) -> ChatConfig:
     # component_weights and auto-compaction is window-relative (no turn-count
     # limit, no 30K-absolute background trigger). Warn on all four removed keys
     # so operators clean up their YAML symmetrically.
+    #
+    # #6143: `warnings.warn(..., DeprecationWarning)` is SILENT here — a
+    # non-``__main__`` module (every ``src/reyn/*`` module) gets Python's
+    # default "ignore" filter for DeprecationWarning, and neither
+    # `logging.captureWarnings` (only redirects `showwarning`, does not
+    # change the filter) nor pyproject's `filterwarnings` (pytest-only)
+    # changes that for a real run. This notice is meant for the operator
+    # (it names a reyn.yaml key to remove), so it needs `logger.warning`
+    # or stronger — same shape as the hooks.yaml token warning in
+    # `config/loader.py`.
     _removed_compaction_keys = (
         "head_size", "tail_size", "trigger_total_tokens", "min_compact_batch",
     )
     if any(k in compaction_raw for k in _removed_compaction_keys):
-        import warnings
-        warnings.warn(
+        import logging
+        logging.getLogger(__name__).warning(
             "chat.compaction.head_size/tail_size/trigger_total_tokens/"
             "min_compact_batch are deprecated and ignored — removed in #1128. "
             "head/tail sizing is now token-budget via component_weights, and "
-            "auto-compaction is window-relative. Remove these keys.",
-            DeprecationWarning, stacklevel=2,
+            "auto-compaction is window-relative. Remove these keys."
         )
     # #5629: accept the old name for one version while warning operators to
-    # migrate to the precise fold-persistence name.
+    # migrate to the precise fold-persistence name. #6143: promoted from a
+    # silent-by-default `warnings.warn` to `logger.warning` — see the note
+    # above this function's first such conversion.
     if "recovery_policy" in compaction_raw:
-        import warnings
-        warnings.warn(
+        import logging
+        logging.getLogger(__name__).warning(
             "chat.compaction.recovery_policy is deprecated; use "
-            "fold_persist_policy instead.",
-            DeprecationWarning, stacklevel=2,
+            "fold_persist_policy instead."
         )
     # #5623: max_shrink_iterations is orphaned since #5531 PR-3 — unlike the
     # four keys above, the field itself is NOT removed yet (kept parsing for
     # ONE version, see the field's own comment on CompactionConfig), only
     # its value validation is dropped. Warn once so an operator who
     # explicitly set it learns it has no effect, without breaking their load.
+    # #6143: promoted from a silent-by-default `warnings.warn` — see the
+    # note above this function's first such conversion.
     if "max_shrink_iterations" in compaction_raw:
-        import warnings
-        warnings.warn(
+        import logging
+        logging.getLogger(__name__).warning(
             "chat.compaction.max_shrink_iterations is retired since #5531 "
             "and has no effect — retry_loop's own iteration cap was "
             "replaced by a proven termination measure, and nothing reads "
-            "this field any more. Remove it from reyn.yaml.",
-            DeprecationWarning, stacklevel=2,
+            "this field any more. Remove it from reyn.yaml."
         )
     section_raw = compaction_raw.get("section_token_caps") or {}
     if not isinstance(section_raw, dict):
@@ -1784,14 +1795,19 @@ def _build_cost_limit(raw: object) -> CostLimitConfig:
     # ``safety.on_limit`` 3-mode policy (clean-break, no shim). Warn an
     # operator who still sets the removed key so they migrate to
     # ``safety.on_limit.mode`` — safety config, so a silent drop is worse.
+    # #6143: promoted from a silent-by-default `warnings.warn` (a
+    # non-``__main__`` module's DeprecationWarning is ignored by Python's
+    # default filter, and neither `logging.captureWarnings` nor pyproject's
+    # pytest-only `filterwarnings` changes that in a real run) — safety
+    # config, so it needs `logger.warning` or stronger to actually reach
+    # the operator.
     if "ask_on_exceed" in raw:
-        import warnings
-        warnings.warn(
+        import logging
+        logging.getLogger(__name__).warning(
             "cost.*.ask_on_exceed is deprecated and ignored — removed in #1877. "
             "The cap exceed flow is now driven by "
             "safety.on_limit.mode (interactive / auto_extend / unattended). "
-            "Remove this key; set safety.on_limit.mode instead.",
-            DeprecationWarning, stacklevel=2,
+            "Remove this key; set safety.on_limit.mode instead."
         )
     # #4522: ``extension_calls`` removed — its only real, tested implementation
     # was the `per_chain_skill_calls` dimension (#1877/#1879's
@@ -1801,15 +1817,15 @@ def _build_cost_limit(raw: object) -> CostLimitConfig:
     # every CostLimitConfig (daily_tokens/per_agent_tokens/etc.) shares this
     # one dataclass — none of THOSE dimensions ever had a working consumer
     # for it (CostLimitConfig's own docstring has the full trace). Same
-    # deprecation shape as ``ask_on_exceed`` above.
+    # deprecation shape as ``ask_on_exceed`` above. #6143: promoted from a
+    # silent-by-default `warnings.warn` for the same reason.
     if "extension_calls" in raw:
-        import warnings
-        warnings.warn(
+        import logging
+        logging.getLogger(__name__).warning(
             "cost.*.extension_calls is deprecated and ignored — removed in "
             "#4522. Its only real implementation (the per_chain_skill_calls "
             "budget-extension flow) was removed in #2448; it was never wired "
-            "for any other cost dimension. Remove this key.",
-            DeprecationWarning, stacklevel=2,
+            "for any other cost dimension. Remove this key."
         )
     return CostLimitConfig(
         hard_limit=hard,

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1938,13 +1938,17 @@ class PermissionResolver:
           ``<actor>/http.get/<host>`` persistence; ALWAYS / NEVER
           choices apply per-host.
         - **No declaration**: legacy ``web.fetch`` compat fallback — a
-          one-time approval prompt fires on EVERY call (deprecation-
-          warned via ``logger.warning``, #6143). #6143 co-vet: NOT "will
-          become a hard error in a future release" — #5825's own ruling
-          1 (revised, owner-accepted §5) settled that a declaration is
-          opt-in, so nothing here escalates over time; declaring
-          ``http.get`` explicitly only turns the repeat prompt into a
-          standing grant, it does not avert a future failure.
+          real approval prompt fires on EVERY call, its own text naming
+          the missing declaration (#6143 co-vet round 2: no SEPARATE
+          `logger.warning` alongside it — that would duplicate the same
+          notice on a second channel right before the operator sees the
+          prompt itself, "cried wolf every time" moved from silent to
+          noisy, not fixed). NOT "will become a hard error in a future
+          release" — #5825's own ruling 1 (revised, owner-accepted §5)
+          settled that a declaration is opt-in, so nothing here
+          escalates over time; declaring ``http.get`` explicitly only
+          turns the repeat prompt into a standing grant, it does not
+          avert a future failure.
 
         Backward-compat:
 
@@ -2066,32 +2070,15 @@ class PermissionResolver:
         # ``http.get`` explicitly is what turns the repeat prompt into a
         # standing grant, never a deadline the operator must beat.
         #
-        # #6143: this was `warnings.warn(..., DeprecationWarning)`, which is
-        # SILENT here — same reason as the legacy-bool-axis warning above
-        # (default filter ignores DeprecationWarning outside ``__main__``,
-        # and neither `captureWarnings` nor pytest's `filterwarnings` fixes
-        # that in a real run) — promoted to `logger.warning`.
-        #
-        # #6143 co-vet (lead-coder): promoting the CHANNEL was not enough —
-        # the WORDING ("This will become a hard error in a future
-        # release") is false and, now that it actually reaches an
-        # operator, actively misleading: #5825's own ruling 1 (revised,
-        # owner-accepted §5) settled that a declaration is opt-in, so
-        # "declare it or it breaks later" is a conclusion this codebase
-        # does not reach. Rewritten to describe what happens NOW (a
-        # one-time approval prompt every call, below), not a threatened
-        # future this code never enforces.
-        logger.warning(
-            "HTTP access to host %r from actor %r has no http.get "
-            "declaration -- prompting for one-time approval (legacy "
-            "compat path). To grant it permanently instead, declare it "
-            "under reyn.yaml's permissions.http.get:\n"
-            "  permissions:\n"
-            "    http.get:\n"
-            "      - host: '*'   # LLM-driven host selection\n"
-            "or list specific hosts.",
-            host, actor,
-        )
+        # #6143 co-vet round 2 (lead-coder): a `logger.warning` here was
+        # STILL wrong, even with the wording fixed — this branch already
+        # falls straight into a REAL, operator-visible prompt below
+        # (`Allow fetching from {host!r}?`, on the surface the operator is
+        # already looking at); a log line firing on EVERY call, right
+        # before that prompt, is a duplicate notice on a NEW channel — the
+        # "cried wolf every time" shape, just moved from silent to noisy.
+        # "declaring it stops the repeat ask" belongs IN the prompt text
+        # itself (one line, below), not as a second, separate emission.
         if bus is None:
             raise PermissionError(
                 f"HTTP access to host {host!r} not declared and no "
@@ -2101,7 +2088,11 @@ class PermissionResolver:
             KEY_WEB_FETCH,  # legacy key — shared across all hosts during the compat window
             f"web fetch from host: {host!r} (legacy compat)",
             bus,
-            user_prompt=f"Allow fetching from {host!r}?",
+            user_prompt=(
+                f"Allow fetching from {host!r}? (no http.get declaration for "
+                f"this host -- add one under reyn.yaml's permissions.http.get "
+                f"to stop being asked)"
+            ),
         )
         if not approved:
             raise PermissionError(

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -413,16 +413,22 @@ class PermissionDecl:
         # themselves are no longer consulted — actors must declare the
         # equivalent file.write / http.get / secret.write entries
         # explicitly.
+        #
+        # #6143: this was `warnings.warn(..., DeprecationWarning)`, which is
+        # SILENT for a non-``__main__`` module (every `src/reyn/*` module) —
+        # Python's default filter ignores DeprecationWarning there, and
+        # neither `logging.captureWarnings` (only redirects `showwarning`)
+        # nor pyproject's pytest-only `filterwarnings` changes that in a
+        # real run. This is a *permission-config* migration prompt, so it
+        # needs `logger.warning` or stronger to actually reach the operator.
         for legacy_key in cls._LEGACY_BOOL_AXIS_KEYS:
             if d.get(legacy_key):
-                import warnings
-                warnings.warn(
-                    f"permissions.{legacy_key}: <bool> is removed in the "
-                    f"#571 collapse arc (Phase 5). Replace it with the "
-                    f"explicit list axes: file.write / http.get / secret.write. "
-                    f"See docs/concepts/runtime/permission-model.md → Collapse arc.",
-                    DeprecationWarning,
-                    stacklevel=3,
+                logger.warning(
+                    "permissions.%s: <bool> is removed in the #571 collapse "
+                    "arc (Phase 5). Replace it with the explicit list axes: "
+                    "file.write / http.get / secret.write. See "
+                    "docs/concepts/runtime/permission-model.md → Collapse arc.",
+                    legacy_key,
                 )
         return cls(
             mcp=_normalize_paths(d.get(KEY_MCP)),
@@ -2052,17 +2058,23 @@ class PermissionResolver:
         # for the segmented migration window. Actors that previously
         # relied on the Tier-1 default-allow behaviour still work
         # while we wait for them to declare ``http.get`` explicitly.
-        import warnings
-        warnings.warn(
-            f"HTTP access to host {host!r} from actor {actor!r} "
-            f"without an http.get declaration. This will become a hard "
-            f"error in a future release. Add to reyn.yaml permissions:\n"
-            f"  permissions:\n"
-            f"    http.get:\n"
-            f"      - host: '*'   # LLM-driven host selection\n"
-            f"or list specific hosts.",
-            DeprecationWarning,
-            stacklevel=2,
+        #
+        # #6143: this was `warnings.warn(..., DeprecationWarning)`, which is
+        # SILENT here — same reason as the legacy-bool-axis warning above
+        # (default filter ignores DeprecationWarning outside ``__main__``,
+        # and neither `captureWarnings` nor pytest's `filterwarnings` fixes
+        # that in a real run). This notice tells an operator their config
+        # is about to start failing hard, so it needs `logger.warning` or
+        # stronger.
+        logger.warning(
+            "HTTP access to host %r from actor %r without an http.get "
+            "declaration. This will become a hard error in a future "
+            "release. Add to reyn.yaml permissions:\n"
+            "  permissions:\n"
+            "    http.get:\n"
+            "      - host: '*'   # LLM-driven host selection\n"
+            "or list specific hosts.",
+            host, actor,
         )
         if bus is None:
             raise PermissionError(

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1937,9 +1937,14 @@ class PermissionResolver:
           the prompt fires here at the actual host gate. Same
           ``<actor>/http.get/<host>`` persistence; ALWAYS / NEVER
           choices apply per-host.
-        - **No declaration**: legacy ``web.fetch`` compat fallback
-          (deprecation-warned). Will become a hard error in a future
-          release.
+        - **No declaration**: legacy ``web.fetch`` compat fallback — a
+          one-time approval prompt fires on EVERY call (deprecation-
+          warned via ``logger.warning``, #6143). #6143 co-vet: NOT "will
+          become a hard error in a future release" — #5825's own ruling
+          1 (revised, owner-accepted §5) settled that a declaration is
+          opt-in, so nothing here escalates over time; declaring
+          ``http.get`` explicitly only turns the repeat prompt into a
+          standing grant, it does not avert a future failure.
 
         Backward-compat:
 
@@ -2056,20 +2061,31 @@ class PermissionResolver:
 
         # No declaration at all — legacy ``web_fetch`` compat path
         # for the segmented migration window. Actors that previously
-        # relied on the Tier-1 default-allow behaviour still work
-        # while we wait for them to declare ``http.get`` explicitly.
+        # relied on the Tier-1 default-allow behaviour still work: this
+        # prompts (or raises with no bus) EVERY time, below — declaring
+        # ``http.get`` explicitly is what turns the repeat prompt into a
+        # standing grant, never a deadline the operator must beat.
         #
         # #6143: this was `warnings.warn(..., DeprecationWarning)`, which is
         # SILENT here — same reason as the legacy-bool-axis warning above
         # (default filter ignores DeprecationWarning outside ``__main__``,
         # and neither `captureWarnings` nor pytest's `filterwarnings` fixes
-        # that in a real run). This notice tells an operator their config
-        # is about to start failing hard, so it needs `logger.warning` or
-        # stronger.
+        # that in a real run) — promoted to `logger.warning`.
+        #
+        # #6143 co-vet (lead-coder): promoting the CHANNEL was not enough —
+        # the WORDING ("This will become a hard error in a future
+        # release") is false and, now that it actually reaches an
+        # operator, actively misleading: #5825's own ruling 1 (revised,
+        # owner-accepted §5) settled that a declaration is opt-in, so
+        # "declare it or it breaks later" is a conclusion this codebase
+        # does not reach. Rewritten to describe what happens NOW (a
+        # one-time approval prompt every call, below), not a threatened
+        # future this code never enforces.
         logger.warning(
-            "HTTP access to host %r from actor %r without an http.get "
-            "declaration. This will become a hard error in a future "
-            "release. Add to reyn.yaml permissions:\n"
+            "HTTP access to host %r from actor %r has no http.get "
+            "declaration -- prompting for one-time approval (legacy "
+            "compat path). To grant it permanently instead, declare it "
+            "under reyn.yaml's permissions.http.get:\n"
             "  permissions:\n"
             "    http.get:\n"
             "      - host: '*'   # LLM-driven host selection\n"

--- a/tests/config/test_cost_extension_calls_removed_4522.py
+++ b/tests/config/test_cost_extension_calls_removed_4522.py
@@ -11,27 +11,31 @@ only because every `CostLimitConfig` (`daily_tokens`/`per_agent_tokens`/
 etc.) shares one dataclass — none of THOSE dimensions ever had a working
 consumer of their own. Declared, parsed, never read — CLAUDE.md's
 testing-policy six-questions ③ names this exact class (#3850).
+
+#6143: the notice was `warnings.warn(..., DeprecationWarning)` -- SILENT
+outside `__main__` under Python's own default filter (never reaches a
+real operator from `src/reyn/**`), so it was promoted to
+`logger.warning`; this file's own witness tests read `caplog` instead of
+`warnings.catch_warnings` for the same reason.
 """
 from __future__ import annotations
 
-import warnings
+import logging
 
 from reyn.config.chat import _build_cost_limit
 from reyn.runtime.budget.budget import CostLimitConfig
 
 
-def test_extension_calls_key_emits_a_deprecation_warning():
+def test_extension_calls_key_emits_a_deprecation_warning(caplog):
     """Tier 1: an operator who still sets `extension_calls` gets a
-    DeprecationWarning naming #4522 and #2448 — safety/budget config, so
-    a silent drop (matching `ask_on_exceed`'s own precedent) is worse
-    than staying silent."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    warning naming #4522 and #2448 — safety/budget config, so a silent
+    drop (matching `ask_on_exceed`'s own precedent) is worse than staying
+    silent."""
+    with caplog.at_level(logging.WARNING):
         _build_cost_limit({"hard_limit": 10.0, "extension_calls": 5})
-    deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-    assert any("extension_calls" in str(w.message) for w in deprecation), (
-        f"expected a DeprecationWarning naming extension_calls, got: "
-        f"{[str(w.message) for w in caught]}"
+    assert any("extension_calls" in r.message for r in caplog.records), (
+        f"expected a warning naming extension_calls, got: "
+        f"{[r.message for r in caplog.records]}"
     )
 
 
@@ -51,14 +55,12 @@ def test_hard_limit_and_warn_ratio_still_parse_unaffected():
     assert cfg.warn_ratio == 0.5
 
 
-def test_no_extension_calls_key_emits_no_warning():
+def test_no_extension_calls_key_emits_no_warning(caplog):
     """Tier 1: accept-side — a config that never mentions extension_calls
     (the common, correct case going forward) triggers no warning at all."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         _build_cost_limit({"hard_limit": 10.0})
-    deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-    assert not any("extension_calls" in str(w.message) for w in deprecation)
+    assert not any("extension_calls" in r.message for r in caplog.records)
 
 
 def test_cost_limit_config_dataclass_has_no_extension_calls_field():

--- a/tests/core/test_4957_max_shrink_iterations_config.py
+++ b/tests/core/test_4957_max_shrink_iterations_config.py
@@ -23,19 +23,25 @@ driver_call`) was removed for the same reason.
 #5623: retirement, kept for ONE version. The field still parses (this
 file's parse tests below are unchanged in shape) but its `>= 1` validation
 is GONE — a retired key must not reject a config — and setting it now
-emits a `DeprecationWarning` once at load, mirroring
+emits a `logger.warning` once at load, mirroring
 `test_stream_repaint_interval_config.py`'s own Tier 1/2 shape for a
 sibling `chat.*` rejection warning (unit-level via `_build_chat_config`,
 then a real `load_config()` round trip). Removing the field/schema itself,
 and registering the key in `check_retired_config_keys_denylist.py`'s
 denylist, is a disclosed, separate follow-up.
+
+#6143: the notice was `warnings.warn(..., DeprecationWarning)` -- SILENT
+outside `__main__` under Python's own default filter (`src/reyn/**` is
+never `__main__`), so it never reached a real operator. Promoted to
+`logger.warning`; this file's own warning-witness tests below were
+updated from `pytest.warns` to `caplog` at WARNING level for the same
+reason.
 """
 from __future__ import annotations
 
-import warnings
+import logging
 from pathlib import Path
 
-import pytest
 import yaml
 
 from reyn.config.chat import CompactionConfig, _build_chat_config
@@ -89,27 +95,31 @@ def test_max_shrink_iterations_below_1_no_longer_raises() -> None:
     assert CompactionConfig(max_shrink_iterations=-1).max_shrink_iterations == -1
 
 
-def test_setting_max_shrink_iterations_warns_it_is_retired() -> None:
-    """Tier 1: #5623 — explicitly setting the key emits a `DeprecationWarning`
+def test_setting_max_shrink_iterations_warns_it_is_retired(caplog) -> None:
+    """Tier 1: #5623 — explicitly setting the key emits a `logger.warning`
     naming the field and #5531, the real warning/log surface
     `_build_chat_config`'s sibling deprecations already use (`ask_on_exceed`,
     `extension_calls`, the #1128 removed-compaction-keys group) — no
-    MagicMock/patch, this is the real `warnings` call the parser makes."""
-    with pytest.warns(DeprecationWarning, match="max_shrink_iterations"):
+    MagicMock/patch, this is the real `logging` call the parser makes.
+    `warnings.warn` reached here before #6143 — that emission is SILENT
+    outside `__main__` under Python's own default filter, so this test now
+    reads the real, operator-visible surface instead."""
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {"max_shrink_iterations": 3}})
+    assert any("max_shrink_iterations" in r.message for r in caplog.records)
 
 
-def test_omitting_max_shrink_iterations_is_silent() -> None:
+def test_omitting_max_shrink_iterations_is_silent(caplog) -> None:
     """Tier 1: deny sibling — the warning fires on the key's PRESENCE, not
     on every compaction parse. Without this pair, a parser that warned
     unconditionally would also pass the test above."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {"body_token_cap": 5000}})
+    assert caplog.records == []
 
 
 def test_max_shrink_iterations_in_reyn_yaml_warns_at_real_load(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, caplog,
 ) -> None:
     """Tier 2: #5623 — a real `reyn.yaml` on disk, loaded through
     `load_config()` (not just `_build_chat_config` in isolation — the same
@@ -123,14 +133,15 @@ def test_max_shrink_iterations_in_reyn_yaml_warns_at_real_load(
         {"chat": {"compaction": {"max_shrink_iterations": 3}}},
     )
 
-    with pytest.warns(DeprecationWarning, match="max_shrink_iterations"):
+    with caplog.at_level(logging.WARNING):
         cfg = load_config(tmp_path)
 
+    assert any("max_shrink_iterations" in r.message for r in caplog.records)
     assert cfg.chat.compaction.max_shrink_iterations == 3
 
 
 def test_absent_from_reyn_yaml_emits_no_retirement_warning_at_real_load(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, caplog,
 ) -> None:
     """Tier 2: deny sibling for the real-load test above — a `reyn.yaml`
     that never sets the retired key loads through the same real
@@ -142,9 +153,8 @@ def test_absent_from_reyn_yaml_emits_no_retirement_warning_at_real_load(
         {"chat": {"compaction": {"body_token_cap": 5000}}},
     )
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         cfg = load_config(tmp_path)
 
     assert cfg.chat.compaction.max_shrink_iterations == 8
-    assert not any("max_shrink_iterations" in str(w.message) for w in caught)
+    assert not any("max_shrink_iterations" in r.message for r in caplog.records)

--- a/tests/core/test_4957_max_shrink_iterations_config.py
+++ b/tests/core/test_4957_max_shrink_iterations_config.py
@@ -115,7 +115,11 @@ def test_omitting_max_shrink_iterations_is_silent(caplog) -> None:
     unconditionally would also pass the test above."""
     with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {"body_token_cap": 5000}})
-    assert caplog.records == []
+    # #6144 unfiltered-caplog-consumption gate: filtered to the subject
+    # (never a bare `caplog.records == []`) -- under `-n auto` an
+    # unrelated test's record on a different logger can land in the same
+    # capture window.
+    assert not any("max_shrink_iterations" in r.message for r in caplog.records)
 
 
 def test_max_shrink_iterations_in_reyn_yaml_warns_at_real_load(

--- a/tests/core/test_5296_recovery_policy_config.py
+++ b/tests/core/test_5296_recovery_policy_config.py
@@ -1,6 +1,8 @@
 """Tier 1: #5296 recovery-policy configuration contract."""
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from reyn.config.chat import CompactionConfig, _build_chat_config
@@ -18,10 +20,14 @@ def test_fold_persist_policy_parses_never_and_next_turn() -> None:
         assert cfg.compaction.fold_persist_policy == policy
 
 
-def test_recovery_policy_alias_warns_and_preserves_value() -> None:
-    """Tier 1: the old key warns once while retaining its value."""
-    with pytest.warns(DeprecationWarning, match="recovery_policy"):
+def test_recovery_policy_alias_warns_and_preserves_value(caplog) -> None:
+    """Tier 1: the old key warns once while retaining its value. Was
+    `pytest.warns(DeprecationWarning, ...)` before #6143 -- that emission
+    is SILENT outside `__main__` under Python's own default filter, so
+    the notice is now `logger.warning`, read here via `caplog`."""
+    with caplog.at_level(logging.WARNING):
         cfg = _build_chat_config({"compaction": {"recovery_policy": "never"}})
+    assert any("recovery_policy" in r.message for r in caplog.records)
     assert cfg.compaction.fold_persist_policy == "never"
 
 

--- a/tests/runtime/test_1128_step3_token_budget_headtail.py
+++ b/tests/runtime/test_1128_step3_token_budget_headtail.py
@@ -2,8 +2,12 @@
 
 Two tests pin the new behaviours introduced in #1128 step 3:
 
-1. Deprecation warning: loading a YAML config with ``chat.compaction.head_size``
-   or ``chat.compaction.tail_size`` emits a ``DeprecationWarning``.
+1. Deprecation notice: loading a YAML config with ``chat.compaction.head_size``
+   or ``chat.compaction.tail_size`` emits a ``logger.warning`` (was
+   ``warnings.warn(..., DeprecationWarning)`` before #6143 — SILENT
+   outside ``__main__`` under Python's own default filter, so it never
+   reached a real operator; the warning-witness tests below read
+   ``caplog`` instead of ``pytest.warns`` for the same reason).
 
 2. The window-utilization case for ``build_history``: a small chat (total
    tokens well under any real trigger) returns ALL turns raw, no
@@ -22,7 +26,7 @@ Policy compliance:
 """
 from __future__ import annotations
 
-import warnings
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -41,9 +45,9 @@ def _now() -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_head_size_tail_size_emit_deprecation_warning() -> None:
+def test_head_size_tail_size_emit_deprecation_warning(caplog) -> None:
     """Tier 2: loading a YAML config with ``chat.compaction.head_size`` or
-    ``chat.compaction.tail_size`` emits a ``DeprecationWarning``.
+    ``chat.compaction.tail_size`` emits a ``logger.warning``.
 
     Uses the real ``_build_chat_config`` loader path — no mocks.  The old
     keys are silently ignored (head/tail sizing is now controlled by
@@ -52,7 +56,7 @@ def test_head_size_tail_size_emit_deprecation_warning() -> None:
     from reyn.config import _build_chat_config  # noqa: PLC0415
 
     # Both keys present — must emit the warning.
-    with pytest.warns(DeprecationWarning, match="deprecated and ignored"):
+    with caplog.at_level(logging.WARNING):
         cfg = _build_chat_config({
             "compaction": {
                 "head_size": 6,
@@ -60,6 +64,7 @@ def test_head_size_tail_size_emit_deprecation_warning() -> None:
                 "body_token_cap": 1500,
             }
         })
+    assert any("deprecated and ignored" in r.message for r in caplog.records)
 
     # The resulting CompactionConfig must NOT have head_size/tail_size fields.
     import dataclasses
@@ -72,34 +77,36 @@ def test_head_size_tail_size_emit_deprecation_warning() -> None:
     )
 
 
-def test_head_size_only_also_warns() -> None:
+def test_head_size_only_also_warns(caplog) -> None:
     """Tier 2: ``head_size`` alone (without ``tail_size``) also emits the deprecation."""
     from reyn.config import _build_chat_config  # noqa: PLC0415
 
-    with pytest.warns(DeprecationWarning, match="deprecated and ignored"):
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {"head_size": 12}})
+    assert any("deprecated and ignored" in r.message for r in caplog.records)
 
 
 @pytest.mark.parametrize("removed_key", ["trigger_total_tokens", "min_compact_batch"])
-def test_axis1_config_keys_also_warn(removed_key) -> None:
+def test_axis1_config_keys_also_warn(removed_key, caplog) -> None:
     """Tier 2: #1128 PR-a — the axis-1 config keys ``trigger_total_tokens`` and
     ``min_compact_batch`` are removed too, so they warn symmetrically with
     ``head_size``/``tail_size`` (all four are operator-facing chat.compaction
     keys; none should silently ignore)."""
     from reyn.config import _build_chat_config  # noqa: PLC0415
 
-    with pytest.warns(DeprecationWarning, match="deprecated and ignored"):
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {removed_key: 2000}})
+    assert any("deprecated and ignored" in r.message for r in caplog.records)
 
 
-def test_clean_config_no_warning() -> None:
-    """Tier 2: a config without ``head_size``/``tail_size`` emits no DeprecationWarning."""
+def test_clean_config_no_warning(caplog) -> None:
+    """Tier 2: a config without ``head_size``/``tail_size`` emits no
+    deprecation notice."""
     from reyn.config import _build_chat_config  # noqa: PLC0415
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        # Must not raise — no deprecated key present.
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {"body_token_cap": 1500}})
+    assert caplog.records == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_1128_step3_token_budget_headtail.py
+++ b/tests/runtime/test_1128_step3_token_budget_headtail.py
@@ -106,7 +106,11 @@ def test_clean_config_no_warning(caplog) -> None:
 
     with caplog.at_level(logging.WARNING):
         _build_chat_config({"compaction": {"body_token_cap": 1500}})
-    assert caplog.records == []
+    # #6144 unfiltered-caplog-consumption gate: filtered to the subject
+    # (never a bare `caplog.records == []`) -- under `-n auto` an
+    # unrelated test's record on a different logger can land in the same
+    # capture window.
+    assert not any("deprecated and ignored" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/fixtures/silent_warnings_category_6143/loud_categories.py
+++ b/tests/scripts/fixtures/silent_warnings_category_6143/loud_categories.py
@@ -1,0 +1,21 @@
+"""Fixture for test_silent_warnings_category_gate_6143.py -- the
+false-reject-side witness. Every call here uses a category Python does
+NOT ignore by default (UserWarning, explicit or omitted), or a real
+`logger.warning` -- none of these should ever be flagged.
+"""
+from __future__ import annotations
+
+import logging
+import warnings
+
+
+def explicit_user_warning() -> None:
+    warnings.warn("visible by default", UserWarning, stacklevel=2)
+
+
+def omitted_category_defaults_to_user_warning() -> None:
+    warnings.warn("visible by default, category omitted", stacklevel=2)
+
+
+def already_promoted_to_logger() -> None:
+    logging.getLogger(__name__).warning("this reaches reyn.log / stderr")

--- a/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/caller_mod.py
+++ b/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/caller_mod.py
@@ -1,0 +1,9 @@
+"""Middle frame -- see lib_mod.py's own docstring. Also never run as
+__main__."""
+from __future__ import annotations
+
+import lib_mod
+
+
+def call_it() -> None:
+    lib_mod.warn_something()

--- a/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/entry.py
+++ b/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/entry.py
@@ -1,0 +1,13 @@
+"""Process entry point -- THIS module (and only this one, in this
+fixture) is __main__ when run directly. Deliberately does not call
+`warnings.warn` itself, so no frame in the chain it drives is `__main__`
+at the point the warning fires -- the realistic shape of a warning raised
+deep inside `src/reyn/**`, several imports away from any process entry
+point. Run with plain `python3 entry.py` (no -W flag, no injected
+filter) to read Python's own stock default behaviour, not a test
+harness's own filter."""
+from __future__ import annotations
+
+import caller_mod
+
+caller_mod.call_it()

--- a/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/entry_direct_warn.py
+++ b/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/entry_direct_warn.py
@@ -1,0 +1,11 @@
+"""Contrast fixture: THIS module calls `warnings.warn` directly, at
+`stacklevel=1` (the default), while running as `__main__` itself -- the
+one case Python's own stock filter DOES show
+(`('default', None, DeprecationWarning, '__main__', 0)`). Exists so the
+production-filter witness test proves a real difference (silent vs.
+visible), not just "silent, because nothing ever shows"."""
+from __future__ import annotations
+
+import warnings
+
+warnings.warn("visible -- this frame IS __main__", DeprecationWarning)

--- a/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/lib_mod.py
+++ b/tests/scripts/fixtures/silent_warnings_category_6143/production_filter_witness/lib_mod.py
@@ -1,0 +1,17 @@
+"""Deepest frame in the production-filter witness (see
+test_silent_warnings_category_gate_6143.py). Never run as __main__ --
+always imported. `stacklevel=2` blames the CALLER's frame (`caller_mod`),
+never this module and never `__main__`, matching how a real
+`src/reyn/**` warnings.warn call site is several frames below any process
+entry point."""
+from __future__ import annotations
+
+import warnings
+
+
+def warn_something() -> None:
+    warnings.warn(
+        "silent under the stock default filter -- caller is not __main__",
+        DeprecationWarning,
+        stacklevel=2,
+    )

--- a/tests/scripts/fixtures/silent_warnings_category_6143/silent_categories.py
+++ b/tests/scripts/fixtures/silent_warnings_category_6143/silent_categories.py
@@ -1,0 +1,31 @@
+"""Fixture for test_silent_warnings_category_gate_6143.py -- NOT scanned by
+the real gate (only `src/reyn/**` is in scope); read directly by the tests
+via `silent_category_sites()`.
+
+Deliberately holds one call per silent-by-default category, plus a
+keyword-form call, so the detector's category resolution is exercised both
+positionally and by keyword.
+"""
+from __future__ import annotations
+
+import warnings
+
+
+def positional_deprecation() -> None:
+    warnings.warn("old thing", DeprecationWarning, stacklevel=2)
+
+
+def positional_pending_deprecation() -> None:
+    warnings.warn("will be deprecated", PendingDeprecationWarning, stacklevel=2)
+
+
+def positional_import() -> None:
+    warnings.warn("import shim", ImportWarning, stacklevel=2)
+
+
+def positional_resource() -> None:
+    warnings.warn("leaked", ResourceWarning, stacklevel=2)
+
+
+def keyword_deprecation() -> None:
+    warnings.warn("old thing", category=DeprecationWarning, stacklevel=2)

--- a/tests/scripts/test_silent_warnings_category_gate_6143.py
+++ b/tests/scripts/test_silent_warnings_category_gate_6143.py
@@ -1,0 +1,183 @@
+"""Tier 1/2: `silent_warnings_category_gate.py`'s own detector logic
+(#6143).
+
+lead-coder's own review point (same lesson #5990's ratchet test drew): a
+strip-falsify that only reverts the DETECTOR's category-matching logic
+never proves the underlying claim -- "a `warnings.warn(...,
+DeprecationWarning)` fired from `src/reyn/**` reaches nobody" -- is
+actually true in a real process.
+`test_a_silent_category_site_is_genuinely_silent_under_the_stock_default_filter`
+below is that witness: it runs real subprocesses with Python's OWN
+default filters (no `-W` flag, no `simplefilter("always")`, no
+pytest-injected filter) -- a test that adds `simplefilter("always")`
+itself measures its own filter, not production's.
+"""
+# EXEMPT: the sys.executable spawns below run entry.py/entry_direct_warn.py,
+# throwaway fixture modules under production_filter_witness/ that only call
+# warnings.warn -- none of them imports reyn.
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.silent_warnings_category_gate import (
+    _EXCEPTION_TABLE,
+    measured,
+    silent_category_sites,
+    unexplained,
+)
+from tests._support.paths import REPO_ROOT
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "silent_warnings_category_6143"
+_PROD_FILTER_FIXTURES = _FIXTURES / "production_filter_witness"
+
+
+# ── the detector's own category-matching logic ──────────────────────────
+
+
+def test_every_silent_by_default_category_is_counted():
+    """Tier 1: the false-accept-side witness -- one call per silent-by-
+    default category (DeprecationWarning / PendingDeprecationWarning /
+    ImportWarning / ResourceWarning), positional form, all counted.
+    `silent_categories.py` carries exactly 5 such calls (4 positional + 1
+    keyword, see the next test) -- this test only checks the positional
+    4 by name so a category this detector fails to recognise cannot hide
+    behind an aggregate count."""
+    sites = silent_category_sites(_FIXTURES / "silent_categories.py", root=_FIXTURES)
+    categories = sorted(category for _, _, category in sites)
+    assert categories == [
+        "DeprecationWarning",
+        "DeprecationWarning",
+        "ImportWarning",
+        "PendingDeprecationWarning",
+        "ResourceWarning",
+    ], categories
+
+
+def test_keyword_category_form_is_recognised():
+    """Tier 1: `category=DeprecationWarning` (keyword) must be recognised
+    the same as positional arg 2 -- `silent_categories.py`'s
+    `keyword_deprecation` function is the one keyword-form call among its
+    5 total sites."""
+    sites = silent_category_sites(_FIXTURES / "silent_categories.py", root=_FIXTURES)
+    lines = {lineno for _, lineno, _ in sites}
+    text = (_FIXTURES / "silent_categories.py").read_text(encoding="utf-8")
+    keyword_call_line = next(
+        i + 1 for i, line in enumerate(text.splitlines()) if "category=DeprecationWarning" in line
+    )
+    assert keyword_call_line in lines, (
+        "the keyword-form warnings.warn(..., category=DeprecationWarning) "
+        "call was not detected -- category resolution only handled the "
+        "positional form"
+    )
+
+
+def test_a_user_warning_or_omitted_category_is_never_counted():
+    """Tier 1: the false-reject-side witness, required alongside the test
+    above so a detector that flags every `warnings.warn` call
+    unconditionally (which would ALSO pass the silent-categories test)
+    cannot pass this suite. `loud_categories.py`'s two `warnings.warn`
+    calls (explicit UserWarning, omitted category) are both visible under
+    the stock default filter and must not be flagged; its
+    `logger.warning` call is not even a `warnings.warn` call."""
+    sites = silent_category_sites(_FIXTURES / "loud_categories.py", root=_FIXTURES)
+    assert sites == []
+
+
+# ── the exception-table arithmetic ───────────────────────────────────────
+
+
+def test_a_site_with_no_table_entry_is_unexplained():
+    """Tier 2: the gate's own pass/fail arithmetic -- a measured site
+    absent from `_EXCEPTION_TABLE` is what makes the gate red."""
+    sites = [("some/file.py", 10, "DeprecationWarning")]
+    assert unexplained(sites) == sites
+
+
+def test_a_site_matching_a_table_entry_is_explained():
+    """Tier 2: deny side -- a site whose (relpath, lineno) IS in the
+    table is not reported, regardless of the category string (the table
+    key is positional identity, not category)."""
+    sites = [("some/file.py", 10, "DeprecationWarning")]
+    assert unexplained(sites, table={("some/file.py", 10): "reviewed, dev-only"}) == []
+
+
+def test_the_shipped_exception_table_is_empty():
+    """Tier 2: #6143's own claim -- every known silent-by-default site
+    was promoted to `logger.warning` in the SAME PR that added this
+    gate, so nothing needs grandfathering. A future PR that adds a table
+    entry does so deliberately; this test only pins today's starting
+    point so a silent, undiscussed table addition would show as a diff
+    here."""
+    assert _EXCEPTION_TABLE == {}
+
+
+def test_the_real_scan_against_the_current_tree_has_nothing_unexplained() -> None:
+    """Tier 1: the load-bearing witness -- running the real scan against
+    the real repo tree, right now, must find nothing outside the
+    exception table. Mirrors `silent_except_ratchet.py`'s own identically
+    -shaped tree-scan test."""
+    sites = measured(REPO_ROOT)
+    assert unexplained(sites) == [], (
+        "a warnings.warn(...) call under src/reyn/ uses a silent-by-"
+        "default category with no _EXCEPTION_TABLE entry -- promote it "
+        "to logger.warning or add a reasoned table entry"
+    )
+
+
+def test_a_new_uncommitted_silent_site_would_be_caught() -> None:
+    """Tier 2: integration -- planting the silent-categories fixture as a
+    fresh "file" beyond the (empty) table is measured as unexplained.
+    Confirms the table-arithmetic is wired to the real detector, not
+    just unit-tested in isolation above."""
+    sites = silent_category_sites(_FIXTURES / "silent_categories.py", root=_FIXTURES)
+    assert len(unexplained(sites)) == 5
+
+
+# ── production-filter witness: is the underlying claim even true? ───────
+
+
+def test_a_silent_category_site_is_genuinely_silent_under_the_stock_default_filter() -> None:
+    """Tier 3a: the claim this whole gate exists to enforce, checked
+    directly -- NOT via this test's own `simplefilter`, which would only
+    prove the test's own filter setting, never production's. Runs a real
+    `python3` subprocess with NO `-W` flag and no injected filter (the
+    same defaults any real reyn invocation starts with) against a 3-frame
+    fixture (`entry.py` -> `caller_mod.py` -> `lib_mod.py`) where the
+    `warnings.warn(..., DeprecationWarning, stacklevel=2)` call is
+    several imports below the only `__main__` frame -- the realistic
+    shape of a `src/reyn/**` call site, never itself the process entry
+    point.
+
+    NON-VACUITY: `test_the_SAME_category_IS_visible_when_the_call_site_
+    IS_main` below is the required contrast -- without it, "produces no
+    stderr" could just as well mean "this subprocess produces no stderr
+    for anything", which would pass trivially."""
+    result = subprocess.run(
+        [sys.executable, "entry.py"],
+        cwd=_PROD_FILTER_FIXTURES, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == "", (
+        f"expected NO warning output under Python's stock default filter "
+        f"(the call site is 2 frames below __main__), got: {result.stderr!r}"
+    )
+
+
+def test_the_same_category_is_visible_when_the_call_site_is_main() -> None:
+    """Tier 3a: the required contrast for the test above -- the identical
+    category, fired directly from a module that IS `__main__` when run,
+    DOES produce stderr output under the same stock default filter
+    (`('default', None, DeprecationWarning, '__main__', 0)`). Proves the
+    silence above is the filter discriminating on the caller's module,
+    not this subprocess harness swallowing everything."""
+    result = subprocess.run(
+        [sys.executable, "entry_direct_warn.py"],
+        cwd=_PROD_FILTER_FIXTURES, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "DeprecationWarning" in result.stderr, (
+        f"expected the stock default filter to show a DeprecationWarning "
+        f"fired directly from __main__, got: {result.stderr!r}"
+    )

--- a/tests/scripts/test_silent_warnings_category_gate_6143.py
+++ b/tests/scripts/test_silent_warnings_category_gate_6143.py
@@ -23,6 +23,17 @@ match (`test_a_user_warning_or_omitted_category_is_never_counted`
 inverted into `test_every_warnings_warn_call_is_counted_regardless_of_
 category`, and the shipped-table tests now check the 18
 `#6145`-tracked pre-existing entries rather than an empty table).
+
+#6144 co-vet round 3 (lead-coder): v2's `(relpath, lineno)` key was
+ITSELF gameable -- not by an author dodging the gate, but by an
+ordinary edit: an exempted site moves down (any edit above it does
+this), and a genuinely NEW, unaudited `warnings.warn` lands on the now-
+vacant line number, silently inheriting the old exemption. Position
+alone is not identity. The key gained a 3rd coordinate,
+`message_template` (the message argument with every f-string expression
+normalised to `"{}"`, truncated to 40 chars) -- `test_a_different_
+message_at_an_exempted_line_is_not_silently_exempted` below is the
+direct witness for exactly the scenario lead-coder described.
 """
 # EXEMPT: the sys.executable spawns below run entry.py/entry_direct_warn.py,
 # throwaway fixture modules under production_filter_witness/ that only call
@@ -57,7 +68,7 @@ def test_every_silent_by_default_category_is_counted():
     4 by name so a category this detector fails to recognise cannot hide
     behind an aggregate count."""
     sites = silent_category_sites(_FIXTURES / "silent_categories.py", root=_FIXTURES)
-    categories = sorted(category for _, _, category in sites)
+    categories = sorted(category for _, _, category, _ in sites)
     assert categories == [
         "DeprecationWarning",
         "DeprecationWarning",
@@ -73,7 +84,7 @@ def test_keyword_category_form_is_recognised():
     `keyword_deprecation` function is the one keyword-form call among its
     5 total sites."""
     sites = silent_category_sites(_FIXTURES / "silent_categories.py", root=_FIXTURES)
-    lines = {lineno for _, lineno, _ in sites}
+    lines = {lineno for _, lineno, _, _ in sites}
     text = (_FIXTURES / "silent_categories.py").read_text(encoding="utf-8")
     keyword_call_line = next(
         i + 1 for i, line in enumerate(text.splitlines()) if "category=DeprecationWarning" in line
@@ -98,7 +109,7 @@ def test_every_warnings_warn_call_is_counted_regardless_of_category():
     sites = silent_category_sites(_FIXTURES / "loud_categories.py", root=_FIXTURES)
     # exactly 2 sites -- unpacking itself raises if the count is off
     (_site_a, _site_b) = sites
-    assert sorted(category for _, _, category in sites) == ["UserWarning", "UserWarning"]
+    assert sorted(category for _, _, category, _ in sites) == ["UserWarning", "UserWarning"]
 
 
 # ── the exception-table arithmetic ───────────────────────────────────────
@@ -106,17 +117,35 @@ def test_every_warnings_warn_call_is_counted_regardless_of_category():
 
 def test_a_site_with_no_table_entry_is_unexplained():
     """Tier 2: the gate's own pass/fail arithmetic -- a measured site
-    absent from `_EXCEPTION_TABLE` is what makes the gate red."""
-    sites = [("some/file.py", 10, "DeprecationWarning")]
+    whose full (relpath, lineno, message_template) key is absent from
+    `_EXCEPTION_TABLE` is what makes the gate red."""
+    sites = [("some/file.py", 10, "DeprecationWarning", "some message")]
     assert unexplained(sites) == sites
 
 
 def test_a_site_matching_a_table_entry_is_explained():
-    """Tier 2: deny side -- a site whose (relpath, lineno) IS in the
-    table is not reported, regardless of the category string (the table
-    key is positional identity, not category)."""
-    sites = [("some/file.py", 10, "DeprecationWarning")]
-    assert unexplained(sites, table={("some/file.py", 10): "reviewed, dev-only"}) == []
+    """Tier 2: deny side -- a site whose (relpath, lineno,
+    message_template) IS in the table is not reported, regardless of the
+    category string (the table key is positional+message identity,
+    never category)."""
+    sites = [("some/file.py", 10, "DeprecationWarning", "some message")]
+    assert unexplained(
+        sites, table={("some/file.py", 10, "some message"): "reviewed, dev-only"},
+    ) == []
+
+
+def test_a_different_message_at_an_exempted_line_is_not_silently_exempted():
+    """Tier 2: the DIRECT witness for #6144 co-vet round 3's own
+    scenario -- an ordinary edit moves an exempted site down, and a
+    genuinely new, unaudited `warnings.warn` lands on the now-vacant
+    line number. Sharing only (relpath, lineno) with a table entry must
+    NOT be enough: the message differs, so the composite key misses, and
+    this new site is unexplained -- exactly what a `(relpath, lineno)`-
+    only key (v2) would have missed."""
+    sites = [("some/file.py", 10, "UserWarning", "a completely different message")]
+    assert unexplained(
+        sites, table={("some/file.py", 10, "the OLD exempted message"): "reviewed, dev-only"},
+    ) == sites
 
 
 def test_the_shipped_exception_table_matches_the_real_measured_population():
@@ -132,7 +161,9 @@ def test_the_shipped_exception_table_matches_the_real_measured_population():
     reference #6145, the tracking issue for auditing and promoting them
     -- never a bare "fine as-is", which #6144's own review already ruled
     none of these currently are."""
-    measured_keys = {(relpath, lineno) for relpath, lineno, _ in measured(REPO_ROOT)}
+    measured_keys = {
+        (relpath, lineno, template) for relpath, lineno, _, template in measured(REPO_ROOT)
+    }
     assert set(_EXCEPTION_TABLE) == measured_keys, (
         f"table declares {set(_EXCEPTION_TABLE) - measured_keys} that no "
         f"longer exist, and is missing {measured_keys - set(_EXCEPTION_TABLE)}"

--- a/tests/scripts/test_silent_warnings_category_gate_6143.py
+++ b/tests/scripts/test_silent_warnings_category_gate_6143.py
@@ -1,5 +1,5 @@
 """Tier 1/2: `silent_warnings_category_gate.py`'s own detector logic
-(#6143).
+(#6143/#6144).
 
 lead-coder's own review point (same lesson #5990's ratchet test drew): a
 strip-falsify that only reverts the DETECTOR's category-matching logic
@@ -11,6 +11,18 @@ below is that witness: it runs real subprocesses with Python's OWN
 default filters (no `-W` flag, no `simplefilter("always")`, no
 pytest-injected filter) -- a test that adds `simplefilter("always")`
 itself measures its own filter, not production's.
+
+#6144 co-vet round 2 (lead-coder): the gate's v1 axis (silent-by-default
+categories only) was itself trivially defeated -- swap
+`DeprecationWarning` -> `UserWarning` in any one call site and the gate
+goes green with the operator's actual visibility unchanged (architect's
+own measurement: `UserWarning` reaches `reyn.log`, never an interactive
+operator's screen). v2's population is EVERY `warnings.warn(...)` call
+under `src/reyn/**`, category-blind -- the tests below were updated to
+match (`test_a_user_warning_or_omitted_category_is_never_counted`
+inverted into `test_every_warnings_warn_call_is_counted_regardless_of_
+category`, and the shipped-table tests now check the 18
+`#6145`-tracked pre-existing entries rather than an empty table).
 """
 # EXEMPT: the sys.executable spawns below run entry.py/entry_direct_warn.py,
 # throwaway fixture modules under production_filter_witness/ that only call
@@ -73,16 +85,20 @@ def test_keyword_category_form_is_recognised():
     )
 
 
-def test_a_user_warning_or_omitted_category_is_never_counted():
-    """Tier 1: the false-reject-side witness, required alongside the test
-    above so a detector that flags every `warnings.warn` call
-    unconditionally (which would ALSO pass the silent-categories test)
-    cannot pass this suite. `loud_categories.py`'s two `warnings.warn`
-    calls (explicit UserWarning, omitted category) are both visible under
-    the stock default filter and must not be flagged; its
-    `logger.warning` call is not even a `warnings.warn` call."""
+def test_every_warnings_warn_call_is_counted_regardless_of_category():
+    """Tier 1: v2's own axis (#6144 co-vet round 2) -- EVERY
+    `warnings.warn(...)` call counts, category-blind, so a call site
+    cannot dodge the gate by swapping to `UserWarning` or omitting the
+    category. `loud_categories.py`'s two `warnings.warn` calls (explicit
+    UserWarning, omitted category) must BOTH be counted; its
+    `logger.warning` call is not even a `warnings.warn` call and must
+    not be (the false-reject-side witness, required alongside this test
+    so a detector that counts every CALL in the file, not just
+    `warnings.warn` ones, cannot also pass)."""
     sites = silent_category_sites(_FIXTURES / "loud_categories.py", root=_FIXTURES)
-    assert sites == []
+    # exactly 2 sites -- unpacking itself raises if the count is off
+    (_site_a, _site_b) = sites
+    assert sorted(category for _, _, category in sites) == ["UserWarning", "UserWarning"]
 
 
 # ── the exception-table arithmetic ───────────────────────────────────────
@@ -103,14 +119,25 @@ def test_a_site_matching_a_table_entry_is_explained():
     assert unexplained(sites, table={("some/file.py", 10): "reviewed, dev-only"}) == []
 
 
-def test_the_shipped_exception_table_is_empty():
-    """Tier 2: #6143's own claim -- every known silent-by-default site
-    was promoted to `logger.warning` in the SAME PR that added this
-    gate, so nothing needs grandfathering. A future PR that adds a table
-    entry does so deliberately; this test only pins today's starting
-    point so a silent, undiscussed table addition would show as a diff
-    here."""
-    assert _EXCEPTION_TABLE == {}
+def test_the_shipped_exception_table_matches_the_real_measured_population():
+    """Tier 1: #6143 fixed and DELETED all 7 originally-flagged sites (6
+    promoted to `logger.warning`, the 7th -- `permissions.py`'s legacy
+    `http.get` compat notice -- deleted outright in #6144's co-vet round
+    2, since it duplicated an already-firing real prompt). Widening the
+    axis to category-blind (#6144 co-vet round 2) newly surfaces
+    pre-existing sites this PR's own dispatch never covered -- this test
+    pins BEHAVIOR, not a bare count: the table's own keys must equal
+    EXACTLY the real tree's measured population (neither a stale entry
+    for a site that no longer exists, nor a gap), and every reason must
+    reference #6145, the tracking issue for auditing and promoting them
+    -- never a bare "fine as-is", which #6144's own review already ruled
+    none of these currently are."""
+    measured_keys = {(relpath, lineno) for relpath, lineno, _ in measured(REPO_ROOT)}
+    assert set(_EXCEPTION_TABLE) == measured_keys, (
+        f"table declares {set(_EXCEPTION_TABLE) - measured_keys} that no "
+        f"longer exist, and is missing {measured_keys - set(_EXCEPTION_TABLE)}"
+    )
+    assert all("#6145" in reason for reason in _EXCEPTION_TABLE.values()), _EXCEPTION_TABLE
 
 
 def test_the_real_scan_against_the_current_tree_has_nothing_unexplained() -> None:
@@ -120,9 +147,9 @@ def test_the_real_scan_against_the_current_tree_has_nothing_unexplained() -> Non
     -shaped tree-scan test."""
     sites = measured(REPO_ROOT)
     assert unexplained(sites) == [], (
-        "a warnings.warn(...) call under src/reyn/ uses a silent-by-"
-        "default category with no _EXCEPTION_TABLE entry -- promote it "
-        "to logger.warning or add a reasoned table entry"
+        "a warnings.warn(...) call under src/reyn/ has no "
+        "_EXCEPTION_TABLE entry -- promote it to logger.warning or add "
+        "a reasoned table entry"
     )
 
 

--- a/tests/security/test_permission_collapse_phase2.py
+++ b/tests/security/test_permission_collapse_phase2.py
@@ -32,6 +32,8 @@ bare `.reyn/` files) are never canonical/recovery-core under any root.
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from reyn.security.permissions.permissions import (
@@ -136,13 +138,20 @@ def test_explicit_file_write_no_canonical_implicit():
         assert canonical not in paths
 
 
-def test_legacy_bool_keys_emit_deprecation_warning():
-    """Tier 2: legacy bool-axis keys parse as no-ops but emit DeprecationWarning."""
+def test_legacy_bool_keys_emit_deprecation_warning(caplog):
+    """Tier 2: legacy bool-axis keys parse as no-ops but emit a
+    deprecation notice. Was `pytest.warns(DeprecationWarning, ...)`
+    before #6143 -- that emission is SILENT outside `__main__` under
+    Python's own default filter, so it never reached a real operator's
+    permissions.yaml migration; promoted to `logger.warning`, read here
+    via `caplog`."""
     for legacy_key in ("mcp_install", "mcp_drop_server", "cron_register", "index_drop"):
-        with pytest.warns(DeprecationWarning, match=legacy_key):
+        with caplog.at_level(logging.WARNING):
             decl = PermissionDecl.from_dict({legacy_key: True})
+        assert any(legacy_key in r.message for r in caplog.records), legacy_key
         # The legacy attribute is gone; the value contributed nothing to the decl.
         assert not hasattr(decl, legacy_key)
+        caplog.clear()
 
 
 def test_canonical_path_via_explicit_file_write_requires_startup_approval(tmp_path, monkeypatch):

--- a/tests/security/test_permission_collapse_phase3.py
+++ b/tests/security/test_permission_collapse_phase3.py
@@ -81,35 +81,32 @@ def test_legacy_bool_keys_do_not_expand_to_http_get_or_secret_write():
     Phase 3 introduced a compat-shim expansion (`mcp_install: true` →
     http.get [registry host]) so existing skills kept working. Phase 5
     removed both the bool axis AND the shim. Legacy keys parse with a
-    DeprecationWarning but contribute nothing to the decl.
+    deprecation notice (`logger.warning` since #6143 -- was
+    `warnings.warn(..., DeprecationWarning)`, silent outside `__main__`)
+    but contribute nothing to the decl.
     """
-    import warnings
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        for axis in ("mcp_install", "mcp_drop_server", "cron_register", "index_drop"):
-            decl = PermissionDecl.from_dict({axis: True})
-            assert decl.http_get == [], f"{axis} must not expand to http_get post-Phase-5"
-            assert decl.secret_write == [], f"{axis} must not expand to secret_write"
+    for axis in ("mcp_install", "mcp_drop_server", "cron_register", "index_drop"):
+        decl = PermissionDecl.from_dict({axis: True})
+        assert decl.http_get == [], f"{axis} must not expand to http_get post-Phase-5"
+        assert decl.secret_write == [], f"{axis} must not expand to secret_write"
 
 
 # ── PermissionResolver gates ──────────────────────────────────────────────────
 
 
 def test_require_http_get_raises_for_undeclared_host(tmp_path):
-    """Tier 2: require_http_get raises with DeprecationWarning fallback for undeclared hosts.
+    """Tier 2: require_http_get raises with a deprecation-notice fallback
+    for undeclared hosts.
 
     #571 Phase 7: with no http.get declaration at all, the resolver
-    emits a DeprecationWarning and falls back to the legacy
-    ``web.fetch`` prompt. Without a bus, it raises with a clear
-    "not declared" message.
+    emits a deprecation notice (`logger.warning` since #6143) and falls
+    back to the legacy ``web.fetch`` prompt. Without a bus, it raises
+    with a clear "not declared" message.
     """
-    import warnings
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
     decl = PermissionDecl(http_get=[{"host": "api.github.com"}])
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        with pytest.raises(PermissionError, match="example.com"):
-            asyncio.run(resolver.require_http_get(decl, "example.com"))
+    with pytest.raises(PermissionError, match="example.com"):
+        asyncio.run(resolver.require_http_get(decl, "example.com"))
 
 
 def test_require_http_get_passes_for_declared_host(tmp_path):
@@ -194,9 +191,13 @@ def test_require_http_get_wildcard_without_bus_raises(tmp_path):
         asyncio.run(resolver.require_http_get(decl, "example.com", None, "test_skill"))
 
 
-def test_require_http_get_no_decl_emits_deprecation_warning(tmp_path):
-    """Tier 2: no http.get declaration → DeprecationWarning + legacy compat path."""
-    import warnings
+def test_require_http_get_no_decl_emits_deprecation_warning(tmp_path, caplog):
+    """Tier 2: no http.get declaration → deprecation notice + legacy
+    compat path. Was `warnings.catch_warnings`/`DeprecationWarning`
+    before #6143 -- that emission is SILENT outside `__main__` under
+    Python's own default filter, so it never reached a real operator;
+    promoted to `logger.warning`, read here via `caplog`."""
+    import logging
 
     from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
 
@@ -208,12 +209,10 @@ def test_require_http_get_no_decl_emits_deprecation_warning(tmp_path):
     decl = PermissionDecl()  # no http.get declared at all
     bus = _AlwaysBus()
 
-    with warnings.catch_warnings(record=True) as recorded:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
-    deprecation_warnings = [w for w in recorded if issubclass(w.category, DeprecationWarning)]
-    assert deprecation_warnings, "missing http.get declaration must emit a DeprecationWarning"
-    assert "http.get" in str(deprecation_warnings[0].message)
+    assert caplog.records, "missing http.get declaration must emit a warning"
+    assert "http.get" in caplog.records[0].message
 
 
 def test_require_http_get_legacy_web_fetch_allow_pre_approves(tmp_path):

--- a/tests/security/test_permission_collapse_phase3.py
+++ b/tests/security/test_permission_collapse_phase3.py
@@ -191,18 +191,31 @@ def test_require_http_get_wildcard_without_bus_raises(tmp_path):
         asyncio.run(resolver.require_http_get(decl, "example.com", None, "test_skill"))
 
 
-def test_require_http_get_no_decl_emits_deprecation_warning(tmp_path, caplog):
-    """Tier 2: no http.get declaration → deprecation notice + legacy
-    compat path. Was `warnings.catch_warnings`/`DeprecationWarning`
-    before #6143 -- that emission is SILENT outside `__main__` under
-    Python's own default filter, so it never reached a real operator;
-    promoted to `logger.warning`, read here via `caplog`."""
+def test_require_http_get_no_decl_names_the_missing_declaration_in_the_real_prompt(
+    tmp_path, caplog,
+):
+    """Tier 2: no http.get declaration → the REAL approval prompt (the
+    surface an operator is already looking at) names the missing
+    declaration -- not a separate `logger.warning` alongside it.
+
+    #6143 co-vet round 2 (lead-coder): a `logger.warning` here was wrong
+    even with correct wording, because this path already falls straight
+    into a real, operator-visible prompt on every call -- a log line
+    right before it duplicates the same notice on a second, noisier
+    channel ("cried wolf every time", moved from silent to noisy, not
+    fixed). The declare-to-stop-being-asked note now lives IN the prompt
+    text itself, captured here via the bus (the real consumer of
+    `UserIntervention.prompt`), and `caplog` stays a DENY witness: this
+    path must emit no log record at all."""
     import logging
 
     from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
 
+    captured: "list[UserIntervention]" = []
+
     class _AlwaysBus(InterventionBus):
         async def request(self, iv: UserIntervention) -> InterventionAnswer:
+            captured.append(iv)
             return InterventionAnswer(choice_id="always")
 
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
@@ -211,8 +224,19 @@ def test_require_http_get_no_decl_emits_deprecation_warning(tmp_path, caplog):
 
     with caplog.at_level(logging.WARNING):
         asyncio.run(resolver.require_http_get(decl, "example.com", bus, "test_skill"))
-    assert caplog.records, "missing http.get declaration must emit a warning"
-    assert "http.get" in caplog.records[0].message
+
+    # #6144 unfiltered-caplog-consumption gate: filtered to the subject
+    # (never a bare `caplog.records == []`) -- under `-n auto` an
+    # unrelated test's record on a different logger can land in the same
+    # capture window.
+    assert not any("http.get" in r.message for r in caplog.records), (
+        "no separate log line should fire alongside the real prompt below"
+    )
+    (iv,) = captured  # exactly one prompt -- unpacking itself raises otherwise
+    assert "http.get" in iv.prompt, (
+        f"the real prompt text must name the missing declaration, got: "
+        f"{iv.prompt!r}"
+    )
 
 
 def test_require_http_get_legacy_web_fetch_allow_pre_approves(tmp_path):


### PR DESCRIPTION
**[tui-coder]** — Closes #6143.

## Summary

7 `warnings.warn(..., DeprecationWarning)` call sites under `src/reyn/` (`config/chat.py` x5, `security/permissions/permissions.py` x2) were silent in a real run: every module under `src/reyn/` is NOT `__main__`, and Python's own default filter ignores DeprecationWarning/PendingDeprecationWarning/ImportWarning/ResourceWarning outside `__main__`. `logging.captureWarnings(True)` only redirects `showwarning`, it does not change the filter; `pyproject.toml`'s `filterwarnings` is pytest-only. All 7 named a `reyn.yaml` key an operator should remove, so all 7 were promoted to `logger.warning`.

This is the third time this exact shape landed in one night (#6132, #6137, #6141) — a structural gap, not 3 unrelated mistakes.

## Gate

Adds `scripts/silent_warnings_category_gate.py`: an AST-derived population gate over every `warnings.warn(...)` under `src/reyn/**` whose category is one of the 4 silent-by-default ones. A call site with no entry in the script's own `_EXCEPTION_TABLE` (empty today) fails the gate. A **table**, not a ratchet (contrast `silent_except_ratchet.py`, #5990) — the starting population is 0, so nothing needs grandfathering; a future genuinely developer-only site needs a reasoned table entry in the same PR that adds it. Wired via `.github/workflows/silent-warnings-category-gate.yml`, `paths: src/reyn/**`.

## Strip-falsify (verified by hand, file-internal Edit only, reverted)

1. The gate's own category-matching logic — stripping `_warn_category_name`'s Name/Attribute resolution turns 3 of its own tests red.
2. One real promoted site (`permissions.py`'s legacy-bool-axis warning) — reverting `logger.warning` to a no-op turns its own test red.

## Production-filter witness (lead-coder's explicit review point 3)

The underlying claim — "this category is genuinely silent under the stock default filter" — is witnessed by a real `python3` subprocess run with NO injected filter (no `-W`, no `simplefilter("always")`), because a test that adds its own `simplefilter` only measures the test's own filter, not production's. `test_a_silent_category_site_is_genuinely_silent_under_the_stock_default_filter`, paired with a same-category-but-`__main__` contrast test, is that witness — both run in `tests/scripts/test_silent_warnings_category_gate_6143.py`.

## Test updates

Every pre-existing test asserting on the old `warnings.warn`/`pytest.warns(DeprecationWarning)` behaviour for these 7 sites now reads `caplog` at WARNING level instead: `test_4957_max_shrink_iterations_config.py`, `test_1128_step3_token_budget_headtail.py`, `test_5296_recovery_policy_config.py`, `test_cost_extension_calls_removed_4522.py`, `test_permission_collapse_phase2.py`, `test_permission_collapse_phase3.py`.

## Gates run (scoped)

- `ruff check .` — clean
- `scripts/test_tier_audit.py --strict` on all 7 touched/new test files — 71/71 + the new file's 10 — all OK
- `scripts/verify_module_docstrings.py` on touched src files — OK
- `scripts/mypy_ratchet.py` — OK (changed-files)
- `scripts/flat_tests_ratchet.py` — OK
- `scripts/check_tests_path_literal_reference.py` — OK
- tests/-path gates (`check_bare_tests_import_reference`, `check_file_depth_reference`, `check_subprocess_reyn_pin` — with an `# EXEMPT:` marker on the one fixture file, `check_no_core_dep_importorskip`, `suspected_time_dependence_ratchet`) — all OK
- `scripts/check_ci_role_declared.py` — OK (new gate script declares `CI: gate`)
- diff-scoped pytest across all 7 touched/new test files — 72/72 passed
- the new gate run against the real tree — `0 silent-by-default category site(s)`

## Test plan

- [x] `pytest tests/scripts/test_silent_warnings_category_gate_6143.py tests/config/test_cost_extension_calls_removed_4522.py tests/core/test_4957_max_shrink_iterations_config.py tests/core/test_5296_recovery_policy_config.py tests/runtime/test_1128_step3_token_budget_headtail.py tests/security/test_permission_collapse_phase2.py tests/security/test_permission_collapse_phase3.py` — 72 passed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn