### PR TITLE
feat(part of #5825 stage 3): FP-0069 §5 declaration-opt-in acceptance, pinned

### DIFF
--- a/docs/concepts/runtime/permission-model.ja.md
+++ b/docs/concepts/runtime/permission-model.ja.md
@@ -287,7 +287,7 @@ side-effect を実行する surface を強制力の強い順に:
 | Web Permissions API | feature ごとに query | per-permission prompt | Origin-scoped（= per-domain capability）| Browser sandbox |
 | Anthropic Claude Code | Tool list（Bash / Edit / Read / Write）| デフォルトでは無、 sandbox-mode で opt-in | Tool 名（path scope なし）| Seatbelt（sandbox-mode）または trust |
 | MCP servers | server side で tool list 公開 | server がオーナーシップ | per-tool、 server 定義 | プロセス境界 |
-| **Reyn** | `permissions:` ブロック（list 軸主体、 bool は `shell` のみ）| startup_guard + first-use interactive | per-path / per-host / per-server（resource scope）| safe-mode は AST + `reyn.api.safe.*` honor system / `sandboxed_exec` のみ kernel |
+| **Reyn** | `permissions:` ブロック（list 軸主体、 bool は `shell` のみ）、[FP-0069](../../deep-dives/proposals/0069-permission-posture-dial.md) §5（owner 2026-09-06 承認）以降 `read_only` 以外では optional | 実使用時点の interactive prompt、startup 時ではない（#5825 段 3: 以前の draft が名指した `startup_guard` は `src/` に実在しない、`git grep -n startup_guard -- src/` は 0 件 — 機構は各行が述べる per-`require_*`-gate の JIT prompt と同一） | per-path / per-host / per-server（resource scope）| safe-mode は AST + `reyn.api.safe.*` honor system / `sandboxed_exec` のみ kernel |
 
 Reyn は iOS / Android の 「capability + first-use prompt」 主流から 2 軸で乖離する:
 
@@ -312,9 +312,9 @@ Phase 1–4 の間、 bool 形式（= `mcp_install: true`）は compat shim と�
 
 Phase 7 は `http.get` 軸を `file.write` と同じ prompt model に揃えて alignment を仕上げる:
 
-- **Specific declared host**（`http.get: [{host: "api.github.com"}]`）— `startup_guard` が `<skill, host>` ごとに 1 回 operator に prompt し、 結果を approvals.jsonl に `<skill>/http.get/<host>` で persist。 runtime は silent。 default zone 外 path に対する `file.write` と同 pattern。
-- **Wildcard**（`http.get: [{host: "*"}]` または `["*"]`）— host が write-time に不明（= LLM が runtime に決める、 例: `web_search` 結果 URL を `web_fetch` で follow）なので、 prompt は `require_http_get` 内の実 host gate で fire。 persistence key も同形 `<skill>/http.get/<host>`、 ALWAYS / NEVER は per-host で効く。
-- **宣言なし** — legacy `web.fetch` compat path + `DeprecationWarning`、 segmented migration window 期間中。 Tier-1 default-allow に依存していた既存ワークフローはそのまま動く。
+- **Specific declared host**（`http.get: [{host: "api.github.com"}]`）— runtime prompt が `<actor, host>` ごとに 1 回、実使用時点で fire し（startup 時ではない — #5825 段 3: `src/` に startup 時 prompt pass は存在しない）、結果を `.reyn/approvals.jsonl` に `<actor>/http.get/<host>` で persist。以後の run は silent。 default zone 外 path に対する `file.write` と同 pattern。
+- **Wildcard**（`http.get: [{host: "*"}]` または `["*"]`）— host が write-time に不明（= LLM が runtime に決める、 例: `web_search` 結果 URL を `web_fetch` で follow）なので、 prompt は `require_http_get` 内の実 host gate で fire。 persistence key も同形 `<actor>/http.get/<host>`、 ALWAYS / NEVER は per-host で効く。
+- **宣言なし** — [FP-0069](../../deep-dives/proposals/0069-permission-posture-dial.md) §5（owner 2026-09-06 承認）: 宣言は `read_only` 以外では **optional**、終了日のある deprecation window ではない。legacy `web.fetch` compat path は operator に実 prompt（`Allow fetching from <host>?`）を毎回 1 回出し、宣言済みパスと同じ `<actor>/http.get/<host>` key で per-host に persist する（#6140/#6141 が compat path 自身の旧 all-hosts-一括 grant という別の consent defect を修正済）— 本節が以前 書いていた「`DeprecationWarning` の先に将来 hard error」ではない。あの warning 自体 Python の既定 filter 下で silent であり（#6143/#6144 で修正）、「hard error」の予告も ratify されたことは無かった — §5 は逆に決着した。
 
 `web_fetch` op handler は legacy `require_web_fetch` でなく `require_http_get` 経由化、 chat router の PermissionDecl は `http.get: [{host: "*"}]` 宣言で LLM-driven fetch を wildcard branch に流す。 `reyn.api.safe.http` subprocess path は preprocessor で wildcard entry を strip — sync subprocess は prompt 不可なので wildcard host fetch は `web_fetch` op route 必須。
 

--- a/docs/concepts/runtime/permission-model.md
+++ b/docs/concepts/runtime/permission-model.md
@@ -115,7 +115,9 @@ permissions:
 
 This grants project-wide pre-approval for the local environment without affecting
 committed `reyn.yaml` or production users.  Interactive TTY runs elsewhere still see
-startup_guard prompts as documented.
+the same first-use prompt described above — at the point of actual use, never at
+startup (#5825 stage 3 investigation: no startup-time prompt pass exists in `src/`;
+see the note under [Industry comparison](#industry-comparison)).
 
 ## Why actor-scoped keys
 
@@ -429,7 +431,7 @@ it explicitly.
 | OpenClaw | No declaration; `tools.exec.mode` (`deny`/`allowlist`/`ask`/`auto`/`full`) | Allowlist miss → human, or auto-reviewer in `auto` | Binary-path or command-name glob + optional argv regex; approvals bind argv + cwd | Container + host floor; effective policy is the stricter of tool policy and approvals |
 | Hermes Agent | No declaration; `approvals.mode` (`smart`/`manual`/`off`) + sandbox backend | Dangerous-command check on the `local` backend only; `smart` asks an auxiliary LLM first | Command pattern only — **no per-path or per-tool scope** | Container backends are the boundary (checks skipped there); unoverridable hardline blocklist |
 | MCP servers | Server-side tool list exposed to client | Server owns its boundary | Per-tool, server-defined | Process boundary |
-| **Reyn** | `permissions:` block (list-axis dominant; one bool: `shell`) | startup_guard + interactive on first use | per-path / per-host / per-server (resource scope) | AST + `reyn.api.safe.*` honor-system for safe-mode; kernel for `sandboxed_exec` |
+| **Reyn** | `permissions:` block (list-axis dominant; one bool: `shell`), and — since [FP-0069](../../deep-dives/proposals/0069-permission-posture-dial.md) §5 (owner-accepted 2026-09-06) — optional outside `read_only` | interactive prompt at the point of first use, not at startup (#5825 stage 3: `startup_guard` named in an earlier draft of this table does not exist in `src/`, `git grep -n startup_guard -- src/` is 0 hits — the mechanism is the same per-`require_*`-gate JIT prompt every row above describes for itself) | per-path / per-host / per-server (resource scope) | AST + `reyn.api.safe.*` honor-system for safe-mode; kernel for `sandboxed_exec` |
 
 A per-system breakdown of the four coding agents above — their mode dials, what persists, and where Reyn sits — is in
 [research/competitive/permission-modes.md](../../deep-dives/research/competitive/permission-modes.md) (measured 2026-09-06).
@@ -460,9 +462,9 @@ During Phases 1–4 the bool form (= `mcp_install: true`) is accepted as a compa
 
 Phase 7 finishes the alignment by giving the `http.get` axis the same prompt model as `file.write`:
 
-- **Specific declared host** (`http.get: [{host: "api.github.com"}]`) — `startup_guard` prompts the operator once per `<skill, host>` and persists the decision to approvals.jsonl under `<skill>/http.get/<host>`. Runtime is then silent. Mirrors `file.write` for paths outside the default zone.
-- **Wildcard** (`http.get: [{host: "*"}]` or `["*"]`) — host set is unknown at write-time (= LLM picks at runtime, e.g. `web_fetch` follow-up of `web_search` results), so the prompt fires at the actual host gate inside `require_http_get`. Same `<skill>/http.get/<host>` persistence; ALWAYS / NEVER choices apply per host.
-- **No declaration** — legacy `web.fetch` compat path with a `DeprecationWarning` until the segmented-migration window closes; existing workflows that relied on Tier-1 default-allow keep working.
+- **Specific declared host** (`http.get: [{host: "api.github.com"}]`) — the runtime prompt fires once per `<actor, host>`, at the point of actual use (not at startup — #5825 stage 3: no startup-time prompt pass exists in `src/`), and persists the decision to `.reyn/approvals.jsonl` under `<actor>/http.get/<host>`. A subsequent run is then silent. Mirrors `file.write` for paths outside the default zone.
+- **Wildcard** (`http.get: [{host: "*"}]` or `["*"]`) — host set is unknown at write-time (= LLM picks at runtime, e.g. `web_fetch` follow-up of `web_search` results), so the prompt fires at the actual host gate inside `require_http_get`. Same `<actor>/http.get/<host>` persistence; ALWAYS / NEVER choices apply per host.
+- **No declaration** — [FP-0069](../../deep-dives/proposals/0069-permission-posture-dial.md) §5 (owner-accepted 2026-09-06): the declaration is **optional outside `read_only`**, not a deprecation window with an end date. The legacy `web.fetch` compat path prompts the operator (`Allow fetching from <host>?`), one real prompt every call, indexed per-host under the SAME `<actor>/http.get/<host>` key the declared paths above use (#6140/#6141 fixed the compat path's own prior all-hosts-at-once grant, a separate consent defect) — not a `DeprecationWarning` heading toward a hard error in a future release, which this section previously said and #6143/#6144 corrected (that warning was itself silent under Python's own default filter, and the "hard error" it promised was never ratified — §5 settled the opposite).
 
 The `web_fetch` op handler routes through `require_http_get` instead of the legacy `require_web_fetch`; the chat router's PermissionDecl declares `http.get: [{host: "*"}]` so LLM-driven fetches go through the wildcard branch. The `reyn.api.safe.http` subprocess path strips wildcard entries at the preprocessor — sync subprocesses can't prompt, so wildcard-host fetches must go through the async `web_fetch` op route.
 

--- a/docs/concepts/tools-integrations/mcp.ja.md
+++ b/docs/concepts/tools-integrations/mcp.ja.md
@@ -235,7 +235,7 @@ MCP の操作は 2 つのポイントでゲートされます：
 
 MCP サーバーを設定に追加する際、install op の書き込みは OS の標準 list-axis gate を通ります。 旧 `permissions.mcp_install: ask | allow | deny` bool 軸は collapse arc で撤去され、 install 制御は以下の経路に統一されました:
 
-- `.reyn/config/mcp.yaml` への `file.write` (= canonical mutation target)。 `startup_guard` が workflow+path ごとに 1 回 operator に prompt、 承認後の runtime は silent。
+- `.reyn/config/mcp.yaml` への `file.write` (= canonical mutation target)。 実使用時点で（startup 時ではない — #5825 段 3: `src/` に startup 時 prompt pass は存在しない）workflow+path ごとに 1 回 interactive prompt が出て、 承認後の runtime は silent。
 - `registry.modelcontextprotocol.io` への `http.get` (= registry fetch)。 同じ prompt model。
 - registry が `isSecret` 指定する env-var key への `secret.write` (= key set が runtime 決定なので wildcard `"*"`)。
 

--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -257,7 +257,7 @@ MCP operations are gated at two points:
 
 Before any MCP server can be added to the configuration, the install op's writes go through the OS's standard list-axis gates. The legacy `permissions.mcp_install: ask | allow | deny` bool axis was removed in the collapse arc — install gating now flows through:
 
-- `file.write` on `.reyn/config/mcp.yaml` (= the canonical mutation target). `startup_guard` prompts the operator once per workflow+path; runtime is silent after approval.
+- `file.write` on `.reyn/config/mcp.yaml` (= the canonical mutation target). The interactive prompt fires once per workflow+path, at the point of actual use (not at startup — #5825 stage 3: no startup-time prompt pass exists in `src/`); runtime is silent after approval.
 - `http.get` on `registry.modelcontextprotocol.io` (= the registry fetch). Same prompt model.
 - `secret.write` on the env-var keys the registry declares as `isSecret` (= wildcard `"*"` because the key set is runtime-determined).
 

--- a/docs/deep-dives/proposals/0069-permission-posture-dial.md
+++ b/docs/deep-dives/proposals/0069-permission-posture-dial.md
@@ -58,7 +58,9 @@ Restated as a floor: **`unbounded` does not reach them either.** Hermes's hardli
 
 Layer 2 (`permissions:` in `reyn.yaml`) has **no analogue in any of the four**; all gate at the moment of use. This is the main source of "reyn is heavy", and it is **ceremony-by-default, not security-by-default**: removing it leaves the just-in-time gate untouched, so almost no enforcement is lost.
 
-**Proposal:** the declaration becomes **required only in `read_only` and `ask`-with-`strict_declaration`**, and optional elsewhere. What it buys — a permission inventory readable before anything runs — is preserved as a posture you can choose rather than the only path.
+**Proposal:** the declaration becomes **required only in `read_only`**, and optional elsewhere. What it buys — a permission inventory readable before anything runs — is preserved as a posture you can choose rather than the only path.
+
+**Corrected 2026-09-11 (#5825 stage 3, lead-coder ruling 3):** an earlier draft of this line conditioned the requirement on `read_only` and "`ask`-with-`strict_declaration`" — a modifier §2's own dial never defines (4 values, no per-mode modifiers). The owner's 2026-09-06 ruling (§10) accepted "declaration is opt-in"; it never ratified a `strict_declaration` knob, which was this document's own citation error, not a decision anyone made. Reopen condition, stated so it stays a decision rather than silent drift: if someone later wants "catch every actor with an undeclared capability" as an enforced property, that is a **gate** (`scripts/`, CI-checked), not a new dial value — see §5's own "what reyn keeps" framing for why a dial value and a gate answer different questions.
 
 ⚠️ **This is a behaviour change and it is UX-visible.** It needs the owner's ruling, not this document's.
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -837,7 +837,7 @@ permissions:
   web.fetch: allow        # レジストリ fetch への blanket allow（= レガシー alias）
 ```
 
-より細かい制御は skill の `skill.md` が正規のパス・ホストを宣言する形で行います。`startup_guard` が skill+host ごとに初回だけインタラクティブプロンプトを出し、以降はランタイムチェックがサイレントになります（= デフォルトゾーン外のパスは `file.write` モデル、ホストは `http.get` per-host）。
+より細かい制御は skill の `skill.md` が正規のパス・ホストを宣言する形で行います。実使用時点で（startup 時ではない — #5825 段 3: `src/` に startup 時 prompt pass は存在しない）skill+host ごとに 1 回インタラクティブプロンプトが出て、以降はランタイムチェックがサイレントになります（= デフォルトゾーン外のパスは `file.write` モデル、ホストは `http.get` per-host）。
 
 | やりたいこと | 新しい形 |
 |------|-----------|

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1864,7 +1864,7 @@ permissions:
   web.fetch: allow       # blanket allow for the registry fetch (= legacy alias)
 ```
 
-For finer control, the skill's `skill.md` declares the canonical paths and hosts; `startup_guard` prompts the operator once per skill+host, and the runtime check is silent after that (= `file.write` model for paths outside the default zone, `http.get` per-host).
+For finer control, the skill's `skill.md` declares the canonical paths and hosts; the interactive prompt fires once per skill+host, at the point of actual use (not at startup — #5825 stage 3: no startup-time prompt pass exists in `src/`), and the runtime check is silent after that (= `file.write` model for paths outside the default zone, `http.get` per-host).
 
 | Want | New shape |
 |------|-----------|

--- a/tests/security/test_5825_stage3_declaration_optin.py
+++ b/tests/security/test_5825_stage3_declaration_optin.py
@@ -1,0 +1,403 @@
+"""Tier 2: #5825 stage 3 -- FP-0069 §5's own acceptance (owner-accepted
+2026-09-06, "declaration is opt-in"), pinned directly.
+
+architect's own framing of this stage's deliverable: "段3の成果物は変える
+より固定する側に寄る" -- the audit found that file / http.get / network are
+ALREADY just-in-time (no declaration -> ask, not a hard raise); `require_tool`'s
+own "not declared" raise is unreachable (#5848 deleted the TOOL-axis
+constraint it depended on); `require_mcp` stays declaration-required as a
+DELIBERATE policy exception (§6: "operator-declared surfaces ... unchanged");
+`require_secret_write` stays declaration-required as a DELIBERATE structural
+exception (§5's own opt-in logic is "a declaration's absence is safe because
+the gate can ASK instead" -- `require_secret_write` has no `bus` parameter at
+all, so it structurally cannot ask; making it optional would not create a
+prompt, it would delete the gate). Nothing in `src/` needed to CHANGE for §5
+to already be true. What was missing is what this file adds: without a
+pinned acceptance, the next PR that reintroduces a mandatory declaration on
+any of the JIT gates goes green, because nothing here would have been
+watching.
+
+## §5's own acceptance, verbatim (architect draft, lead-coder-adopted)
+
+    宣言を config から消しても、attended な run が「拒否」ではなく
+    「1 度 訊かれて続行」になること。
+    赤にする方法: どれか 1 つの gate に「宣言が無ければ raise」を
+    bus を引く前に 1 行 戻す。
+
+Four criteria per §5-subject gate (① ② ③ from the acceptance's own "ask,
+not raise" claim; ④ is the REQUIRED companion architect's own review added --
+without it, "the declaration became MEANINGLESS" and "the declaration became
+OPTIONAL" are indistinguishable, since both would still see ① pass):
+
+1. no declaration + the bus answers YES/ALWAYS -> returns (no raise)
+2. no declaration + the bus answers NO -> raises (the operator's own answer,
+   not the missing declaration)
+3. no declaration + bus=None -> raises (§4's own fail-closed: unattended
+   means denied, never "pending")
+4. WITH a declaration that is already pre-approved -> returns WITHOUT ever
+   touching the bus (proves the declaration still does something -- it
+   remains a real fast path, not a no-op the JIT ask would produce anyway)
+
+## Population is DERIVED, never a hand-typed list (architect's own design)
+
+`_require_gates()` walks the real `PermissionResolver` class via
+`inspect.getmembers` -- the SAME shape architect's own audit command used.
+Classification (`_OUT_OF_SCOPE` / `_POLICY_EXCEPTION` / `_DEAD` /
+`_STRUCTURAL_EXCEPTION` / `_SUBJECT_GATES`) is a reasoned, hand-maintained
+table (necessarily -- WHY a gate is excluded is a policy judgment no
+signature can derive), but its own COMPLETENESS is machine-checked:
+`test_every_gate_is_classified_exactly_once` fails loud if a NEW `require_*`
+method lands uncovered by any bucket, or is claimed by more than one.
+
+## The 5 things this stage was explicitly told not to write
+
+`startup_guard` (does not exist in `src/`), `strict_declaration` (not in
+§2's dial, dropped from §5 by lead-coder ruling 3 -- see
+docs/deep-dives/proposals/0069-permission-posture-dial.md's own correction),
+"will become a hard error in a future release" (the opposite of what §5
+settled), a posture branch inside the resolver (none of the below reads
+`permissions.mode` at all -- the opt-in is the SAME behaviour in every
+mode except `read_only`, which the resolver's own doc-facing §5 correction
+names as the one mode declaration stays required in, unchanged by this
+file), and `require_tool` counted as a passing JIT gate (it is `_DEAD`
+below, excluded from `_SUBJECT_GATES` on purpose).
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from reyn.intervention_choices import ALWAYS, NO, YES
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _FakeBus:
+    """Real RequestBus-compatible fake that pre-answers with a scripted
+    choice -- same pattern test_5825_require_network.py / test_require_
+    file_jit_ask_1505.py already establish. No mocks."""
+
+    def __init__(self, choice: str) -> None:
+        self._choice = choice
+        self.asks: "list[UserIntervention]" = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.asks.append(iv)
+        return InterventionAnswer(text=self._choice, choice_id=self._choice)
+
+
+def _resolver(tmp_path: Path, *, config: "dict | None" = None) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=config or {}, project_root=tmp_path, interactive=True,
+    )
+
+
+# ── population + classification (derived, not hand-typed) ───────────────
+
+
+def _require_gates() -> "list[str]":
+    """Every `require_*` method on the real `PermissionResolver` class --
+    architect's own audit command (`inspect.getmembers(PermissionResolver,
+    callable)`, filtered to the `require_` prefix)."""
+    return sorted(
+        name for name, _ in inspect.getmembers(PermissionResolver, callable)
+        if name.startswith("require_")
+    )
+
+
+def _has_param(name: str, param: str) -> bool:
+    sig = inspect.signature(getattr(PermissionResolver, name))
+    return param in sig.parameters
+
+
+# decl=False: the axis this gate covers has no per-workflow declared list at
+# all (size/trust checks, or a docstring-stated "no declaration required")
+# -- structurally outside §5's own subject ("the declaration"), not merely
+# exempted from it.
+_OUT_OF_SCOPE = frozenset({
+    "require_media_load", "require_plugin_git_run_code_trust", "require_web_fetch",
+})
+
+# decl=True, bus=True, but §6 names this an operator-declared surface
+# ("hooks, MCP servers, skill_install ... unchanged") -- the declaration
+# here is the operator's own inventory, not LLM ceremony §5 exists to
+# remove. Reopen condition: none stated -- §6 itself would need to change.
+_POLICY_EXCEPTION = frozenset({"require_mcp"})
+
+# decl=True, bus=True, but #5848 deleted the AgentLayer TOOL-axis
+# constraint / decl.tool this gate's own "not declared" raise depended on
+# -- the raise is UNREACHABLE (its own docstring says so). Counting it as
+# a passing JIT gate would be a vacuous green (six-questions ④): nothing
+# ever exercises the raise branch to prove it doesn't fire.
+_DEAD = frozenset({"require_tool"})
+
+# decl=True, bus=False -- §5's own opt-in logic ("no declaration is safe
+# because the gate can ask instead") cannot apply: there is no bus to ask
+# with. Architect ruling 2 (adopted): stays declaration-required.
+# Reopen condition (grep-able, not "someday"): the day `require_secret_
+# write` gains a `bus` parameter -- see
+# `test_the_bus_less_structural_exception_is_exactly_one_gate` below,
+# which is that reopen condition, executable.
+_STRUCTURAL_EXCEPTION = frozenset({"require_secret_write"})
+
+# decl=True, bus=True, none of the above -- §5's actual subject. Verified
+# ALREADY just-in-time (architect's audit, #5825 stage 3): no declaration
+# asks via `bus`, never raises for the declaration's absence alone.
+_SUBJECT_GATES = frozenset({
+    "require_file_read", "require_file_write", "require_http_get", "require_network",
+})
+
+
+def test_the_require_gate_population_has_not_shrunk_to_nothing() -> None:
+    """Tier 1: vacuity floor -- if the real scan ever finds 0 (or a
+    handful) of `require_*` gates, the classification tests below would
+    trivially "pass" over an empty or near-empty population. `>= 10`
+    pins architect's own real count as the floor a broken scan cannot
+    quietly slip under."""
+    assert len(_require_gates()) >= 10, _require_gates()
+
+
+def test_every_gate_is_classified_exactly_once() -> None:
+    """Tier 1: the load-bearing completeness witness -- a NEW `require_*`
+    method landing on `PermissionResolver` with no entry in any bucket
+    above is UNCLASSIFIED, and this test goes red for it specifically
+    (not folded silently into `_SUBJECT_GATES` by omission, and not
+    silently ignored). Also guards against a gate claimed by two buckets
+    at once, which would hide which policy actually governs it."""
+    gates = frozenset(_require_gates())
+    buckets = [_OUT_OF_SCOPE, _POLICY_EXCEPTION, _DEAD, _STRUCTURAL_EXCEPTION, _SUBJECT_GATES]
+    union = frozenset().union(*buckets)
+    assert union == gates, (
+        f"unclassified: {gates - union}, "
+        f"classified but no longer exists: {union - gates}"
+    )
+    total_len = sum(len(b) for b in buckets)
+    assert total_len == len(union), "a gate is claimed by more than one bucket"
+
+
+def test_out_of_scope_gates_are_exactly_the_ones_with_no_decl_parameter() -> None:
+    """Tier 1: `_OUT_OF_SCOPE`'s own membership is DERIVED, not asserted
+    by fiat -- every gate whose signature has no `decl` parameter at all
+    must be in this bucket, and nothing else may be (a hand-typed set
+    that silently drifted from the real signatures would be caught
+    here)."""
+    derived = frozenset(n for n in _require_gates() if not _has_param(n, "decl"))
+    assert derived == _OUT_OF_SCOPE, (derived, _OUT_OF_SCOPE)
+
+
+def test_the_bus_less_structural_exception_is_exactly_one_gate() -> None:
+    """Tier 1: architect's own adopted re-open condition, executable --
+    quoted directly from #5825's own thread: "{name for name in require_
+    gates if has_decl(name) and not has_bus(name)} == {'require_secret_
+    write'}". Goes red in EITHER direction: `require_secret_write` gains
+    a `bus` parameter (its own structural reason for staying declaration-
+    required is now gone -- re-open the exception), OR a DIFFERENT gate
+    becomes decl-but-busless (a new, unreviewed instance of the same
+    structural shape, landing without anyone deciding whether it also
+    needs the exception)."""
+    derived = frozenset(
+        n for n in _require_gates() if _has_param(n, "decl") and not _has_param(n, "bus")
+    )
+    assert derived == _STRUCTURAL_EXCEPTION, (derived, _STRUCTURAL_EXCEPTION)
+
+
+# ── the 4-criterion acceptance bundle, one §5-subject gate at a time ────
+# Each function below is ONE of the 4 declared-gate criteria applied to
+# ONE of the 4 `_SUBJECT_GATES` -- 4x4 = 16 tests. Grouped by gate so a
+# single gate's own regression reads as one clear block, not scattered.
+
+
+# ── require_file_read ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_file_read_no_decl_yes_returns(tmp_path: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Tier 2: ① no declaration + the bus answers YES -> returns, not
+    raises. The zone root defaults to the resolver's own project_root, so the
+    probe path must live under a GENUINELY separate directory, not merely
+    a subdirectory of tmp_path (read defaults broad -- zone-root and
+    below -- so anything under tmp_path is IN scope, the opposite of
+    what "no declaration, outside scope" needs)."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path_factory.mktemp("outside_zone") / "secret.txt")
+    await r.require_file_read(PermissionDecl(), outside, "skill_x", bus=_FakeBus(YES))
+
+
+@pytest.mark.asyncio
+async def test_file_read_no_decl_no_raises(tmp_path: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Tier 2: ② no declaration + the bus answers NO -> raises (the
+    operator's own answer, not the missing declaration, is why)."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path_factory.mktemp("outside_zone") / "secret.txt")
+    with pytest.raises(PermissionError):
+        await r.require_file_read(PermissionDecl(), outside, "skill_x", bus=_FakeBus(NO))
+
+
+@pytest.mark.asyncio
+async def test_file_read_no_decl_no_bus_raises(tmp_path: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Tier 2: ③ no declaration + bus=None -> raises (§4 fail-closed:
+    unattended means denied)."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path_factory.mktemp("outside_zone") / "secret.txt")
+    with pytest.raises(PermissionError):
+        await r.require_file_read(PermissionDecl(), outside, "skill_x", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_file_read_pre_approved_returns_without_touching_bus(tmp_path: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Tier 2: ④ a path already approved (the declaration's own fast
+    path) -> returns without the bus ever being asked. `session_approve_path` is
+    the same real, public seam an operator-startup pre-approval would use
+    -- not a private-state poke."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path_factory.mktemp("outside_zone") / "secret.txt")
+    r.session_approve_path(outside, "skill_x", "file.read")
+    bus = _FakeBus(NO)  # would deny if ever asked -- proves it was never asked
+    await r.require_file_read(PermissionDecl(), outside, "skill_x", bus=bus)
+    assert bus.asks == []
+
+
+# ── require_file_write ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_file_write_no_decl_yes_returns(tmp_path: Path) -> None:
+    """Tier 2: ① no declaration + the bus answers YES -> returns, not
+    raises. The default write zone is narrow (`<zone-root>/.reyn`), so a
+    plain path under `tmp_path` is already outside it."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path / "elsewhere" / "out.txt")
+    await r.require_file_write(PermissionDecl(), outside, "skill_x", bus=_FakeBus(YES))
+
+
+@pytest.mark.asyncio
+async def test_file_write_no_decl_no_raises(tmp_path: Path) -> None:
+    """Tier 2: ② no declaration + the bus answers NO -> raises (the
+    operator's own answer, not the missing declaration, is why)."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path / "elsewhere" / "out.txt")
+    with pytest.raises(PermissionError):
+        await r.require_file_write(PermissionDecl(), outside, "skill_x", bus=_FakeBus(NO))
+
+
+@pytest.mark.asyncio
+async def test_file_write_no_decl_no_bus_raises(tmp_path: Path) -> None:
+    """Tier 2: ③ no declaration + bus=None -> raises (§4 fail-closed:
+    unattended means denied)."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path / "elsewhere" / "out.txt")
+    with pytest.raises(PermissionError):
+        await r.require_file_write(PermissionDecl(), outside, "skill_x", bus=None)
+
+
+@pytest.mark.asyncio
+async def test_file_write_pre_approved_returns_without_touching_bus(tmp_path: Path) -> None:
+    """Tier 2: ④ a path already approved (the declaration's own fast
+    path) -> returns without the bus ever being asked."""
+    r = _resolver(tmp_path)
+    outside = str(tmp_path / "elsewhere" / "out.txt")
+    r.session_approve_path(outside, "skill_x", "file.write")
+    bus = _FakeBus(NO)
+    await r.require_file_write(PermissionDecl(), outside, "skill_x", bus=bus)
+    assert bus.asks == []
+
+
+# ── require_http_get ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_http_get_no_decl_yes_returns(tmp_path: Path) -> None:
+    """Tier 2: ① no declaration + the bus answers YES -> returns, not
+    raises (the real #6140/#6141-fixed legacy compat path)."""
+    r = _resolver(tmp_path)
+    await r.require_http_get(PermissionDecl(), "example.com", _FakeBus(YES), "skill_x")
+
+
+@pytest.mark.asyncio
+async def test_http_get_no_decl_no_raises(tmp_path: Path) -> None:
+    """Tier 2: ② no declaration + the bus answers NO -> raises (the
+    operator's own answer, not the missing declaration, is why)."""
+    r = _resolver(tmp_path)
+    with pytest.raises(PermissionError):
+        await r.require_http_get(PermissionDecl(), "example.com", _FakeBus(NO), "skill_x")
+
+
+@pytest.mark.asyncio
+async def test_http_get_no_decl_no_bus_raises(tmp_path: Path) -> None:
+    """Tier 2: ③ no declaration + bus=None -> raises (§4 fail-closed:
+    unattended means denied)."""
+    r = _resolver(tmp_path)
+    with pytest.raises(PermissionError):
+        await r.require_http_get(PermissionDecl(), "example.com", None, "skill_x")
+
+
+@pytest.mark.asyncio
+async def test_http_get_pre_approved_returns_without_touching_bus(tmp_path: Path) -> None:
+    """Tier 2: ④ declared via `session_approve_host` (the SAME per-host
+    key the declared-and-approved path persists to, #571 Phase 7) -- no
+    `decl` needed on the call itself, since a persisted approval short-
+    circuits membership the same way a live declaration would; returns
+    without the bus ever being asked."""
+    r = _resolver(tmp_path)
+    r.session_approve_host("example.com", "skill_x", "http.get")
+    bus = _FakeBus(NO)
+    await r.require_http_get(PermissionDecl(), "example.com", bus, "skill_x")
+    assert bus.asks == []
+
+
+# ── require_network ──────────────────────────────────────────────────────
+# `decl` is accepted for call-site parity but not itself consulted (the
+# gate's own docstring) -- "declared" here means the config/ledger grant
+# `permissions.network: allow` (or a persisted ALWAYS) provides, the
+# actual mechanism #5825① wired.
+
+
+@pytest.mark.asyncio
+async def test_network_no_decl_yes_returns(tmp_path: Path) -> None:
+    """Tier 2: ① no declaration + the bus answers YES -> returns, not
+    raises."""
+    r = _resolver(tmp_path)
+    await r.require_network(PermissionDecl(), _FakeBus(YES), "skill_x", argv=["curl", "x"])
+
+
+@pytest.mark.asyncio
+async def test_network_no_decl_no_raises(tmp_path: Path) -> None:
+    """Tier 2: ② no declaration + the bus answers NO -> raises (the
+    operator's own answer, not the missing declaration, is why)."""
+    r = _resolver(tmp_path)
+    with pytest.raises(PermissionError):
+        await r.require_network(PermissionDecl(), _FakeBus(NO), "skill_x", argv=["curl", "x"])
+
+
+@pytest.mark.asyncio
+async def test_network_no_decl_no_bus_raises(tmp_path: Path) -> None:
+    """Tier 2: ③ no declaration + bus=None -> raises (§4 fail-closed:
+    unattended means denied)."""
+    r = _resolver(tmp_path)
+    with pytest.raises(PermissionError):
+        await r.require_network(PermissionDecl(), None, "skill_x", argv=["curl", "x"])
+
+
+@pytest.mark.asyncio
+async def test_network_pre_approved_returns_without_touching_bus(tmp_path: Path) -> None:
+    """Tier 2: ④ declared via `permissions.network: allow` (config pre-
+    approval, the real mechanism this axis uses) -- returns with
+    bus=None even, proving the config grant alone is the fast path,
+    nothing to ask."""
+    r = _resolver(tmp_path, config={"network": "allow"})
+    await r.require_network(PermissionDecl(), None, "skill_x", argv=["curl", "x"])
+
+
+@pytest.mark.asyncio
+async def test_network_persisted_always_returns_without_touching_bus(tmp_path: Path) -> None:
+    """Tier 2: ④, the OTHER declared-and-approved path for this axis --
+    a prior ALWAYS answer persisted to the ledger, then a later call
+    with a bus that would deny if asked, proving the persisted grant is
+    the fast path."""
+    r = _resolver(tmp_path)
+    await r.require_network(PermissionDecl(), _FakeBus(ALWAYS), "skill_x", argv=["curl", "x"])
+    bus = _FakeBus(NO)
+    await r.require_network(PermissionDecl(), bus, "skill_x", argv=["curl", "x"])
+    assert bus.asks == []


### PR DESCRIPTION
**[tui-coder]** — part of #5825 stage 3 (FP-0069 §5, owner-accepted 2026-09-06 "declaration is opt-in").

## Summary

architect's own audit (on #5825's own thread) found §5 was already true of `require_file_read` / `require_file_write` / `require_http_get` / `require_network` — all already just-in-time (no declaration asks via `bus`, never raises for the declaration's absence alone). `require_tool`'s own "not declared" raise is unreachable (#5848 deleted the constraint it depended on). `require_mcp` stays declaration-required as a deliberate **policy** exception (§6: operator-declared surfaces unchanged). `require_secret_write` stays declaration-required as a deliberate **structural** exception (no `bus` parameter at all — §5's opt-in logic needs a bus to ask with).

**Nothing in `src/` needed to change for §5 to be true.** This stage's deliverable is what pins it (architect's own framing: "成果物は変えるより固定する側に寄る") — without a pinned acceptance, the next PR that reintroduces a mandatory declaration on any JIT gate goes green, because nothing was watching.

## New test file: `tests/security/test_5825_stage3_declaration_optin.py`

- A **derived** population of every `PermissionResolver.require_*` method (`inspect.getmembers`, the same shape architect's own audit command used), with a reasoned classification table whose own completeness is machine-checked — a new `require_*` method landing unclassified (or double-classified) fails loud.
- The exact re-open-condition assertion architect proposed and lead-coder adopted: `{name for name in gates if has_decl(name) and not has_bus(name)} == {"require_secret_write"}` — goes red in either direction.
- The 4-criterion acceptance bundle (① no-decl+YES→return ② no-decl+NO→raise ③ no-decl+bus=None→raise ④ decl+pre-approved→return without ever touching bus) applied to all 4 §5-subject gates, 16 tests total. ④ is the required companion architect's own review added — without it, "the declaration became meaningless" and "the declaration became optional" are indistinguishable.

## Strip-falsify (verified by hand, file-internal Edit only, reverted)

1. Removed `require_http_get`'s `bus=None` raise — criterion ③ went red.
2. Emptied the `_DEAD` classification bucket — the completeness test went red naming the now-unclassified `require_tool`.

Both restored, confirmed green again.

## Doc corrections (both `.md` and `.ja.md`, per CLAUDE.md rule 5 — both falsify something they assert)

- `docs/concepts/runtime/permission-model.{md,ja.md}`: `startup_guard`, named in 5 places, does not exist in `src/` (`git grep -n startup_guard -- src/` is 0 hits) — replaced with the real mechanism (a per-`require_*`-gate JIT prompt, never at startup). The no-declaration `http.get` bullet's "DeprecationWarning ... segmented migration window" language predates #6140/#6141/#6143/#6144 (a real per-host prompt now, never a hard-error roadmap) — corrected to match.
- `docs/deep-dives/proposals/0069-permission-posture-dial.md` §5: dropped `strict_declaration`, a modifier §2's own 4-value dial never defines — lead-coder ruling 3 (#5825 thread): the owner's 2026-09-06 ruling accepted "declaration is opt-in", never a `strict_declaration` knob, which was a citation error in an earlier draft, not a decision anyone made. Reopen condition stated: a future "catch every actor with an undeclared capability" demand is a **gate** (`scripts/`, CI-checked), not a new dial value.

## The 5 things this stage was told not to write (none of them appear)

`startup_guard` (as new code — only removed from docs), `strict_declaration`, "will become a hard error in a future release", a posture branch inside the resolver, `require_tool` counted as a passing JIT gate.

## Gates run (scoped)

- `ruff check .` — clean
- `scripts/test_tier_audit.py --strict` on the new test file — 21/21 OK
- `scripts/verify_module_docstrings.py` — OK
- `scripts/mypy_ratchet.py` — OK (changed-files)
- `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` — all OK
- `mkdocs build --strict` / `check_doc_anchors.py` / `check_retired_config_keys_denylist.py` (docs/ touched) — all OK
- `check_unfiltered_caplog_consumption.py` / `silent_warnings_category_gate.py` — still clean
- diff-scoped pytest — 21/21 passed

## Test plan

- [x] `pytest tests/security/test_5825_stage3_declaration_optin.py` — 21 passed
- [x] (skipped — Visual, standing waiver 2026-08-08)

**Security feature — architect co-vet required**, per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn