### PR TITLE
fix(#6142): narrow bare web.fetch read to the undeclared-host branch

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1956,7 +1956,9 @@ class PermissionResolver:
         - ``web.fetch: allow`` config pre-approves any host without
           prompting (= equivalent to selecting ALWAYS for all hosts).
         - The legacy ``web.fetch`` session/saved approval still
-          authorises any host while the deprecation period is active.
+          authorises any UNDECLARED host (#6142: narrowed — it can no
+          longer short-circuit a DECLARED http.get host, specific or
+          wildcard, which always reaches its own per-host prompt now).
 
         ``bus`` is required when the wildcard path or the
         legacy-fallback path needs to prompt; sync contexts (=
@@ -2011,44 +2013,25 @@ class PermissionResolver:
             host, actor, "http.get", agent_name=agent_name,
         ):
             return
-        # Legacy session/saved ``web.fetch`` approval still authorises
-        # every host — #6140 ②(lead-coder BLOCKING, PR #6141): this
-        # branch's OWN legacy-http.get path stops WRITING new grants
-        # here as of #6140's fix (below) — but ``require_web_fetch``
-        # (a SEPARATE method/tool, deliberately untouched by #6140 —
-        # lead-coder's own 2nd BLOCKING on this PR) still writes under
-        # this SAME bare `KEY_WEB_FETCH` key whenever an operator
-        # answers ALWAYS to a `web_fetch` tool prompt. This read cannot
-        # tell that grant apart from an http.get-axis one — reading a
-        # web_fetch-tool consent as blanket http.get authorization for
-        # ANY host is a real, CURRENTLY reachable conflation, not just
-        # pre-#6140 residue. Narrowing this read's own scope is tracked
-        # at #6142 together with the pre-#6140-residue removal (the
-        # concrete removal condition — never a bare, dateless window).
-        # Dropping the read outright today would turn a working non-
-        # interactive run into a hard `PermissionError` for anyone
-        # holding either shape of grant.
-        if self._saved.get(KEY_WEB_FETCH) or self._session.get(KEY_WEB_FETCH):
-            # #6140/#6141 BLOCKING ⓑ (lead-coder, measured): a bare
-            # `warnings.warn(DeprecationWarning, ...)` NEVER reaches an
-            # operator in production — Python's own default filter is
-            # `('ignore', None, DeprecationWarning, None, 0)` for any
-            # module that is not `__main__`, and `permissions.py` never
-            # is. pytest's own `filterwarnings` config is what made the
-            # warning visible in THIS module's own test, not anything
-            # true of a real run. `logger.warning` bypasses the warnings
-            # filter system entirely and always reaches `reyn.log`.
-            logger.warning(
-                "HTTP access to host %r authorised by a LEGACY blanket "
-                "'web.fetch' approval — it covers EVERY host, not just "
-                "this one, and cannot be narrowed (its own key carries "
-                "no host). To end it: remove the 'web.fetch' entry "
-                "from this project's approvals.yaml; each host will "
-                "then be asked about individually and recorded "
-                "per-host going forward. Tracked for removal at #6142.",
-                host,
-            )
-            return
+        # #6142 (lead-coder BLOCKING, PR #6141 round-2, filed #6142, fixed
+        # here): the bare `KEY_WEB_FETCH` legacy-compat check used to sit
+        # HERE, before the declared-membership routing below, so ANY
+        # grant under that ambiguous key — including one `require_web_
+        # fetch` (a SEPARATE tool/method, deliberately untouched — `web.
+        # fetch` is the CORRECT key for its own axis) writes whenever an
+        # operator answers ALWAYS to a `web_fetch` tool prompt — silently
+        # authorised even a DECLARED http.get host, bypassing that host's
+        # own unambiguous per-host prompt. `KEY_WEB_FETCH` carries no
+        # axis marker at all, so the read cannot tell those grant shapes
+        # apart by inspecting the grant itself — narrowing had to work by
+        # restricting WHERE this ambiguous key is even consulted, not by
+        # teaching the read to recognise a distinction the key itself
+        # does not encode. Moved into the "no declaration at all" branch
+        # below, the ONLY place this key's original, unambiguous meaning
+        # ("http.get axis, no declaration, treat like legacy default-
+        # allow") ever applied — a DECLARED decl (specific or wildcard)
+        # now always reaches its own per-host prompt, never short-
+        # circuited by this ambiguous key.
 
         # #1199 S3.1b-2c-2: the host-MEMBERSHIP decision (specific OR wildcard)
         # routes through the unified model (NETWORK_HOST axis) — pure decl
@@ -2113,6 +2096,48 @@ class PermissionResolver:
         # "cried wolf every time" shape, just moved from silent to noisy.
         # "declaring it stops the repeat ask" belongs IN the prompt text
         # itself (one line, below), not as a second, separate emission.
+        #
+        # #6142: the bare-key legacy short-circuit lives HERE, and only
+        # here — the one place its original, unambiguous meaning applies
+        # ("http.get axis, no declaration, default-allow via a prior
+        # blanket answer"). It still covers two shapes that share this
+        # exact key with no way to tell them apart: (1) a pre-#6140
+        # grant already on disk (this path no longer writes that shape
+        # itself — #6141) and (2) an ALWAYS answer to the SEPARATE
+        # `web_fetch` tool prompt (`require_web_fetch`, deliberately
+        # untouched — `web.fetch` is the correct key for ITS OWN axis).
+        # Dropping this read outright would turn a working non-
+        # interactive run into a hard `PermissionError` for anyone
+        # holding either shape of grant; narrowing it to fire ONLY when
+        # there is no declared http.get membership (this branch) is what
+        # closes the #6142 defect — a DECLARED host (specific or
+        # wildcard) can no longer be silently covered by either shape,
+        # because that path now never reaches this check. `logger.
+        # warning` (not `warnings.warn`) — #6140/#6141 BLOCKING ⓑ
+        # (lead-coder, measured): a bare `DeprecationWarning` never
+        # reaches an operator in production (Python's default filter
+        # ignores it outside `__main__`); `logger.warning` always
+        # reaches `reyn.log`. This IS the operator's only notice for
+        # this branch (unlike the real interactive prompt just below,
+        # which covers the "no declaration" case on its own per #6143 —
+        # here execution returns immediately, no prompt ever runs, so
+        # there is no second channel to duplicate).
+        if self._saved.get(KEY_WEB_FETCH) or self._session.get(KEY_WEB_FETCH):
+            logger.warning(
+                "HTTP access to host %r authorised by a LEGACY blanket "
+                "'web.fetch' approval (either a pre-#6140 grant, or an "
+                "ALWAYS answer to the separate web_fetch tool prompt) "
+                "— it covers every UNDECLARED host, not just this one, "
+                "and cannot be narrowed further (its own key carries no "
+                "host). A DECLARED http.get host is never covered by "
+                "this grant. To end it: remove the 'web.fetch' entry "
+                "from this project's approvals.yaml; each host will "
+                "then be asked about individually and recorded "
+                "per-host going forward. Tracked for removal at #6146.",
+                host,
+            )
+            return
+
         if bus is None:
             raise PermissionError(
                 f"HTTP access to host {host!r} not declared and no "
@@ -2140,9 +2165,11 @@ class PermissionResolver:
         # does NOT close every way a bare `KEY_WEB_FETCH` grant can
         # still be created — `require_web_fetch` (a separate method,
         # deliberately untouched here) still writes under that same
-        # bare key; see the `:1947`-area read's own comment above for
-        # why that residual reach, and its removal, are tracked at
-        # #6142 rather than folded into this fix.
+        # bare key. #6142 (fixed above, in this same branch) narrowed
+        # WHERE that ambiguous key is read so it can never cover a
+        # DECLARED host any more; it still covers an UNDECLARED one
+        # like this call — removing that residual reach entirely is
+        # tracked at #6146, not folded into either fix.
         # `agent_name=agent_name` (below): matches the DECLARED per-host
         # path's own call a few lines up — the SAME agent dimension
         # `_scope_covers_agent` needs to check/record a saved grant

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -2032,6 +2032,21 @@ class PermissionResolver:
         # allow") ever applied — a DECLARED decl (specific or wildcard)
         # now always reaches its own per-host prompt, never short-
         # circuited by this ambiguous key.
+        #
+        # Population impact (architect, #6142 co-vet — record this for
+        # whoever closes #6146): an operator who BOTH (a) holds a bare
+        # `web.fetch` grant (either shape) AND (b) has a DECLARED
+        # `http.get` entry for a host they have not yet approved
+        # per-host now sees a NEW interactive prompt for that host —
+        # one this narrowing itself introduces, since the declared path
+        # never reaches the bare-key read (or its `logger.warning`)
+        # any more. That population gets no notice explaining WHY the
+        # prompt reappeared — the warning only fires on the undeclared
+        # path, which this population's declared host never takes.
+        # #6146 removing the undeclared-axis reach too would change
+        # this SAME population's experience a second time; whoever
+        # closes it should account for that, not assume this fix
+        # already covers the full transition.
 
         # #1199 S3.1b-2c-2: the host-MEMBERSHIP decision (specific OR wildcard)
         # routes through the unified model (NETWORK_HOST axis) — pure decl

--- a/tests/security/test_6140_http_get_legacy_scope.py
+++ b/tests/security/test_6140_http_get_legacy_scope.py
@@ -10,21 +10,28 @@ Real ``PermissionResolver`` + a real interactive-choice ``InterventionBus``
 throughout (the ``_ChoiceBus`` shape ``test_5052_approval_scope_dimension.
 py`` / ``test_5236_permission_approval_granted_audit_event.py`` already
 establish) — no mocks. Each of the 3 issue-body acceptance criteria gets
-its own test, plus two lead-coder BLOCKING rounds on PR #6141:
+its own test, plus two lead-coder BLOCKING rounds on PR #6141 and the
+follow-up #6142 fix:
 
 - Round 1 (#6140's own ② — "the window names no end"): the bare-key READ
   that survives for a PRE-#6140 persisted grant must be VISIBLE and name
-  its own concrete removal condition (#6142), never a dateless
-  "deprecation window" repeated silently.
+  its own concrete removal condition, never a dateless "deprecation
+  window" repeated silently.
 - Round 2, finding B (measured): a bare ``warnings.warn(...,
   DeprecationWarning)`` never reaches a real operator (Python's own
   default filter ignores ``DeprecationWarning`` outside ``__main__``) —
   the fix uses ``logger.warning`` instead, asserted here via ``caplog``.
 - Round 2, finding A (measured, ``permissions.py:2634`` on
   ``origin/main``): ``require_web_fetch`` — a separate method/tool,
-  deliberately untouched by this PR — still writes a NEW grant under
-  the same bare ``KEY_WEB_FETCH`` key, which ``require_http_get``'s own
-  surviving read then honors for ANY host. Documented, not fixed, here.
+  deliberately untouched — still writes a NEW grant under the same bare
+  ``KEY_WEB_FETCH`` key, which ``require_http_get``'s own surviving read
+  then honors for ANY host, DECLARED or not. Filed as #6142.
+- #6142 (this same PR, narrowing fix): the bare-key read is scoped to
+  fire ONLY in the "no declaration at all" branch — a DECLARED http.get
+  host (specific or wildcard) can no longer be silently covered by
+  either shape of bare-key grant, closing finding A for the declared
+  axis. The undeclared axis keeps both shapes covered by design (same
+  as round 1's pre-#6140-residue case) — full removal tracked at #6146.
 """
 from __future__ import annotations
 
@@ -232,28 +239,31 @@ def test_a_pre_6140_blanket_grant_still_authorises_but_now_logs_with_an_end(
     matching = [r for r in caplog.records if "any.example.com" in r.getMessage()]
     assert matching, f"expected a warning naming the legacy grant, got {caplog.records!r}"
     message = matching[0].getMessage()
-    assert "6142" in message, f"expected the removal-condition issue number in the log: {message!r}"
+    assert "6146" in message, f"expected the removal-condition issue number in the log: {message!r}"
     assert "approvals.yaml" in message, f"expected how-to-end instructions in the log: {message!r}"
 
 
-# ── finding A (lead-coder BLOCKING #2, measured): require_web_fetch can
-#      still CREATE a new bare-key grant require_http_get then reads ──
+# ── #6142 (lead-coder BLOCKING round 2, measured, PR #6141): require_web_
+#      fetch's ALWAYS creates a bare-key grant that require_http_get then
+#      reads for an unrelated host. Narrowed (not removed) here: still
+#      covers an UNDECLARED host (deliberate, same as the test above);
+#      no longer covers a DECLARED one (the fix's own acceptance test). ──
 
 
-def test_a_web_fetch_tool_approval_is_read_by_require_http_get_for_any_host(
+def test_a_web_fetch_always_grant_still_covers_an_undeclared_host_by_design(
     tmp_path: Path,
 ) -> None:
-    """Tier 2: accept -- documents (does NOT claim to close) a real,
-    CURRENTLY-reachable conflation lead-coder's own review measured:
-    ``require_web_fetch`` (a separate tool/method, deliberately
-    untouched by this fix) still writes under the bare ``KEY_WEB_FETCH``
-    key when an operator answers ALWAYS to a `web_fetch` tool prompt.
-    ``require_http_get``'s own ``:1947`` read cannot distinguish that
-    grant from an http.get-axis one, so a web_fetch-tool consent is
-    read as blanket http.get authorization for ANY host -- not merely
-    pre-#6140 residue. Narrowing this read's own scope is tracked at
-    #6142, same as the pre-#6140-residue removal -- NOT fixed by this
-    PR (require_web_fetch is out of #6140's own scope)."""
+    """Tier 2: accept -- documents the DELIBERATELY-RETAINED half of the
+    #6142 narrowing: ``require_web_fetch`` (a separate tool/method,
+    deliberately untouched) still writes under the bare ``KEY_WEB_FETCH``
+    key when an operator answers ALWAYS to a `web_fetch` tool prompt, and
+    ``require_http_get``'s own undeclared-host compat branch still reads
+    it -- the SAME accepted-by-design behavior as the pre-#6140-residue
+    case above (``KEY_WEB_FETCH`` carries no axis marker, so the read
+    cannot tell a web_fetch-tool consent apart from a legacy http.get
+    grant; narrowing works by restricting WHERE the key is read, not by
+    inspecting the grant). Full removal (both holders) is tracked at
+    #6146, not fixed by #6142."""
     bus_fetch = _ChoiceBus("always")
     resolver_a = _resolver(tmp_path)
     asyncio.run(resolver_a.require_web_fetch("https://example.com/page", bus_fetch))
@@ -267,6 +277,43 @@ def test_a_web_fetch_tool_approval_is_read_by_require_http_get_for_any_host(
         )
     )
     assert bus_http_get.requests == [], (
-        "the web_fetch-tool grant was read as http.get authorization for an "
-        "unrelated host -- the conflation this test documents, tracked at #6142"
+        "an UNDECLARED host must still be covered by a web_fetch-tool ALWAYS "
+        "grant -- this is the retained half of #6142's narrowing, not a "
+        "regression; full removal is tracked at #6146"
+    )
+
+
+def test_a_web_fetch_always_grant_does_not_short_circuit_a_declared_wildcard_host(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept -- #6142's own acceptance criterion (lead-coder):
+    an ALWAYS answer to the ``web_fetch`` tool must NOT silently cover a
+    DECLARED wildcard ``http.get`` host any more -- that host must still
+    reach its own per-host prompt, exactly as if no ``web.fetch`` grant
+    existed at all. This is the actual defect #6142 closes (the sibling
+    test above documents what #6142 deliberately does NOT close).
+
+    FALSIFY: reverting the fix (checking the bare ``KEY_WEB_FETCH`` key
+    before the declared-membership routing, as the code did pre-#6142)
+    makes this go red -- ``bus_c.requests == []``, because the bare-key
+    short-circuit would find the web_fetch-tool grant before the
+    declared per-host prompt ever runs."""
+    bus_fetch = _ChoiceBus("always")
+    resolver_a = _resolver(tmp_path)
+    asyncio.run(resolver_a.require_web_fetch("https://example.com/page", bus_fetch))
+    assert bus_fetch.requests
+
+    bus_c = _ChoiceBus("no")
+    resolver_c = _resolver(tmp_path)
+    wildcard_decl = PermissionDecl(http_get=[{"host": "*"}])
+    with pytest.raises(PermissionError, match="denied"):
+        asyncio.run(
+            resolver_c.require_http_get(
+                wildcard_decl, "c.example.com", bus_c, _ACTOR,
+            )
+        )
+    assert bus_c.requests, (
+        "the declared-wildcard host C must still be prompted per-host -- an "
+        "empty list means the web_fetch-tool ALWAYS grant short-circuited "
+        "it (the #6142 defect)."
     )


### PR DESCRIPTION
**[e2e-coder]** — lead-coder dispatch (#6142, filed as a follow-up from PR #6141's round-2 review, cherry-picked here after #6141 merged before this fix landed). ⚠️ **architect co-vet required before merge** (security surface, same as #6141).

Closes #6142

## What was broken
`require_http_get`'s own `:1947`-area bare-`KEY_WEB_FETCH` read fired before declared-membership routing, so ANY grant under that ambiguous key — including one `require_web_fetch` (a separate tool/method, deliberately untouched — `web.fetch` is the correct key for its own axis) writes whenever an operator answers ALWAYS to a `web_fetch` tool prompt — silently authorised even a DECLARED http.get host (specific or wildcard), bypassing that host's own unambiguous per-host prompt. Measured by lead-coder in #6141's round-2 review.

## Fix — narrow the read, not drop it
`KEY_WEB_FETCH` carries no axis marker, so the read cannot distinguish a legacy http.get fallback grant from a web_fetch-tool consent by inspecting the grant itself — narrowing works by restricting **where** the key is consulted. Moved the bare-key check into the "no declaration at all" branch, the only place its original, unambiguous meaning ever applied. A DECLARED host now always reaches its own per-host prompt, never short-circuited by this ambiguous key.

The undeclared axis keeps both shapes of bare-key grant covered by design (pre-#6140 residue, and a live `web_fetch`-tool ALWAYS) — dropping the read there too would turn a working non-interactive run into a hard `PermissionError` for anyone holding either grant; #6142's own body names that as a separate decision (telemetry signal or a deliberate cutover).

**Relationship to #6146**: #6146 tracks the FULL removal of the remaining undeclared-axis reach (both holders) — filed as this PR's own remainder, not fixed here; #6142 only closes the DECLARED-axis defect.

## Rebase note
Cherry-picked onto current `main`, which already carries #6143/#6144's own separate fix removing a duplicate `warnings.warn` nudge from this same function's "no declaration" branch (that branch already falls into a real interactive prompt, so a second notice channel was redundant). Unrelated to this PR's own `logger.warning`, which fires on an early return with **no** prompt at all, so has no duplicate-channel concern.

## Tests
Two new, on top of #6141's existing 5: the declared-wildcard breadth witness (#6142's own acceptance criterion — strip-falsified: reverting the narrowing makes it go red, `DID NOT RAISE PermissionError`) and a sibling documenting the deliberately-retained undeclared-axis behavior.

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py` (183, all baselined), `test_tier_audit.py --strict` (7/7 OK, 0 Tier-4), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `check_tests_path_literal_reference.py`, `flat_tests_ratchet.py`.

## Pytest (diff-scoped + directly-adjacent, foreground)
`pytest tests/security/test_6140_http_get_legacy_scope.py tests/security/test_1199_s31b2c2_http_get.py tests/security/test_5052_approval_scope_dimension.py tests/security/test_5236_permission_approval_granted_audit_event.py tests/security/test_permission_collapse_phase3.py -q` → **39 passed**.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. Architect co-vet and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
