### PR TITLE
fix(#6145): warnings.warn audit -- 18/18 classified A, promoted to logger.warning

### DIFF
--- a/scripts/silent_warnings_category_gate.py
+++ b/scripts/silent_warnings_category_gate.py
@@ -82,14 +82,16 @@ promoted to `logger.warning`; the 7th, `permissions.py`'s legacy
 `http.get` compat notice, was deleted outright in #6144's own co-vet
 round 2 -- it duplicated a REAL, already-firing approval prompt on a
 second, noisier channel). Widening the axis in the SAME PR newly
-surfaces 18 pre-existing sites (all `UserWarning`, or the default
+surfaced 18 pre-existing sites (all `UserWarning`, or the default
 omitted category) that #6143's own dispatch never covered and #6144's
-own review never audited message-by-message -- see #6145, the tracking
-issue for promoting each with the SAME wording rigor #6144's own
-`:2069` mistake demanded (changing the channel without checking the
-wording is a NEW bug, not a fix). Those 18 are DISCLOSED table entries
-referencing #6145, not silently declared "legitimate" -- lead-coder's
-own framing above says none of them currently are.
+own review never audited message-by-message -- tracked by #6145.
+#6145 individually audited each of the 18 (file:line, reason -- see
+that PR's own body for the full table) and promoted all 18 to
+`logger.warning`, the SAME wording rigor #6144's own `:2069` mistake
+demanded (changing the channel without checking the wording is a NEW
+bug, not a fix). `_EXCEPTION_TABLE` is empty again as of #6145
+landing -- there is currently no site under `src/reyn/**` this gate
+considers a legitimate raw `warnings.warn`.
 
 ## Deliberately narrow call-site / template resolution (disclosed, not solved)
 
@@ -105,9 +107,9 @@ participates in the 3-part key (so it can still be exempted, keyed on
 different such call landing on the same line, which is the same
 disclosed gap `suspected_time_dependence_ratchet.py` (#4846) and
 `silent_except_ratchet.py` (#5990) already carry for a syntax-only AST
-gate -- no real site in the current 18-entry population has this shape
-(verified: `_message_template` returns non-empty text for all 18, see
-the exception table below).
+gate -- the table is empty as of #6145 (see below), so this gap is
+currently unexercised by any real site; it stays disclosed for
+whichever future entry lands first.
 
 CI: gate
 """
@@ -129,39 +131,24 @@ _SCOPE = "src/reyn"
 #: does not force a table-entry churn unrelated to this gate's purpose.
 _TEMPLATE_LEN = 40
 
-# #6145 tracks promoting each of these 18 pre-existing sites (all
-# UserWarning, or the default omitted category) with the SAME
-# message-content audit #6144's own `:2069` round taught is required --
-# a channel change alone is not a fix if the wording is wrong. DISCLOSED
-# debt, not a claim these are fine as-is (lead-coder's own framing: the
-# only legitimate raw `warnings.warn` reader is a `-W`-flagged library
-# consumer, which none of these are).
+# #6145: the 18 pre-existing sites this table used to carry as disclosed,
+# unaudited debt (see #6144's own final commit for that table) were each
+# individually audited -- 18/18 classified "A: should reach the operator"
+# and promoted to `logger.warning` (see #6145's own PR body for the
+# file:line / reason table). None were classified "B: raw warnings.warn
+# is the right tool" or "C: delete -- a real duplicate exists elsewhere"
+# (lead-coder's own framing at the time this table was 18-strong: none of
+# these 18 were library-consumer-only surfaces to begin with). Population
+# is 0 as of #6145 landing -- back to a TABLE, not a ratchet, exactly the
+# state #6144 left it in immediately after promoting its own 7 (see
+# module docstring's "What this gate checks").
 #
-# The 3rd element of each key is that call's own message TEMPLATE (see
-# `_message_template`'s own docstring) -- a future, unaudited
-# `warnings.warn` landing on one of these exact line numbers does NOT
-# inherit the exemption unless its message also happens to share this
-# same ~40-char prefix (#6144 co-vet round 3).
-_EXCEPTION_TABLE: "dict[tuple[str, int, str], str]" = {
-    ("src/reyn/config/chat.py", 1451, "chat.stream_repaint_min_interval={} is n"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 150, "Could not read OAuth token store at {}: "): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 159, "OAuth token store at {} is not valid JSO"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 167, "OAuth token store at {} must be a JSON o"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 196, "OAuth token {} is not an object; ignorin"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 205, "OAuth token {} is malformed ({}); ignori"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/oauth.py", 250, "{} is readable by group/others (mode {})"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 47, "{} is readable by group/others (mode {})"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 56, "Could not chmod {} to 600: {}"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 79, "secrets.env line {}: no '=' found, skipp"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 88, "secrets.env line {}: empty key, skipping"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 133, "Could not read {}: {}"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/loader.py", 143, "Unexpected error parsing {}: {}"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/security/secrets/interpolation.py", 37, "Config references undefined environment "): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/plugins/tokens.py", 310, "{} left reyn token(s) {} unresolved -- r"): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/mcp/client.py", 2523, "MCP stdio server {} runs UNSANDBOXED (sa"): "#6145 -- pre-#6143, omitted category (defaults to UserWarning), not yet audited",
-    ("src/reyn/hooks/composer.py", 634, "composers {}: durable pending state was "): "#6145 -- pre-#6143 UserWarning, not yet audited",
-    ("src/reyn/hooks/composer.py", 838, "composers[{}]: op=deadline with durable="): "#6145 -- pre-#6143 UserWarning, not yet audited",
-}
+# The 3rd element of a future entry's key would be that call's own
+# message TEMPLATE (see `_message_template`'s own docstring) -- a new,
+# unaudited `warnings.warn` landing on an old exempted site's line number
+# would NOT inherit that exemption unless its message also happens to
+# share the same ~40-char prefix (#6144 co-vet round 3).
+_EXCEPTION_TABLE: "dict[tuple[str, int, str], str]" = {}
 
 
 def _iter_scan_files(root: Path = _ROOT) -> "list[Path]":

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -1447,14 +1447,22 @@ def _build_chat_config(raw: object) -> ChatConfig:
         # running config back, so "my setting did nothing" is indistinguishable
         # from "I never set it". Same shape as the hooks.yaml token warning in
         # `loader.py` — refuse the value, say so, keep the session running.
-        import warnings
-        warnings.warn(
-            f"chat.stream_repaint_min_interval={_repaint_rejected!r} is not a "
-            f"positive number of seconds -- using the default {_repaint_default!r}. "
-            "0 or negative would repaint on every delta, which is the "
-            "pre-measurement behaviour this budget exists to avoid.",
-            UserWarning,
-            stacklevel=2,
+        #
+        # #6145 A: was `warnings.warn(..., UserWarning)` — SILENT for a
+        # non-``__main__`` module (every `src/reyn/*` module) under Python's
+        # own default filter, and even where the category IS visible
+        # (`UserWarning`), architect's own measurement is `stderr: False /
+        # reyn.log: True` — it never reached the operator's screen either
+        # way. This is a `chat.*` config-rejection notice, the exact shape
+        # #6143/#6144 already promoted for this same function's four
+        # sibling rejections above — same promotion here.
+        import logging
+        logging.getLogger(__name__).warning(
+            "chat.stream_repaint_min_interval=%r is not a positive number "
+            "of seconds -- using the default %r. 0 or negative would "
+            "repaint on every delta, which is the pre-measurement "
+            "behaviour this budget exists to avoid.",
+            _repaint_rejected, _repaint_default,
         )
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):

--- a/src/reyn/hooks/composer.py
+++ b/src/reyn/hooks/composer.py
@@ -123,7 +123,6 @@ import asyncio
 import contextlib
 import logging
 import time
-import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Protocol
@@ -631,13 +630,20 @@ def build_composers(
     symptom is a dead-man monitor that never fires."""
     undurable = [d.name for d in definitions if d.durable and durable_store is None]
     if undurable:
-        warnings.warn(
-            f"composers {undurable}: durable pending state was requested but no durable "
-            "store is available in this context — their armed state falls back to "
-            "InMemoryPendingStore and will be silently lost on a process crash "
-            "(a deadline composer configured this way will not fire after a restart).",
-            UserWarning,
-            stacklevel=2,
+        # #6145 A: was `warnings.warn(..., UserWarning)` — silent outside
+        # `__main__` under Python's own default filter, and never reached
+        # the operator's screen even when visible (`stderr: False /
+        # reyn.log: True`, architect's measurement). This is a
+        # crash-recovery-band notice (CLAUDE.md's never-a-silent-dead-man-
+        # switch rule) — the log an operator checks when a deadline
+        # composer didn't fire after a restart needs this.
+        _log.warning(
+            "composers %s: durable pending state was requested but no "
+            "durable store is available in this context — their armed "
+            "state falls back to InMemoryPendingStore and will be "
+            "silently lost on a process crash (a deadline composer "
+            "configured this way will not fire after a restart).",
+            undurable,
         )
     return [
         Composer(
@@ -832,17 +838,21 @@ def _parse_one(raw: object, index: int) -> ComposerDef:
     if op is ComposerOp.DEADLINE and not durable:
         # CLAUDE.md's recovery discipline: never ship a SILENT dead-man switch.
         # Since #3180 the default is durable, so reaching here means the
-        # operator explicitly opted out — warn loudly at load time (existing
-        # `warnings.warn` mechanism — see reyn.security.secrets.loader/
-        # interpolation for the same UserWarning idiom; no new mechanism).
-        warnings.warn(
-            f"composers[{name}]: op=deadline with durable=false uses InMemoryPendingStore, "
-            "which is crash-non-durable by design — a process crash silently drops this "
-            "dead-man monitor's armed state with no reconstruction, and whatever it was "
-            "watching is likely inside the same crash. Remove `durable: false` to get the "
-            "crash-durable store (the default for this op since #3180).",
-            UserWarning,
-            stacklevel=3,
+        # operator explicitly opted out — warn loudly at load time. #6145 A:
+        # this used to be `warnings.warn(..., UserWarning)` — silent
+        # outside `__main__` under Python's own default filter, and never
+        # reached the operator's screen even when visible (`stderr:
+        # False / reyn.log: True`, architect's measurement) — promoted to
+        # `logger.warning` so it actually reaches `reyn.log`.
+        _log.warning(
+            "composers[%s]: op=deadline with durable=false uses "
+            "InMemoryPendingStore, which is crash-non-durable by design "
+            "— a process crash silently drops this dead-man monitor's "
+            "armed state with no reconstruction, and whatever it was "
+            "watching is likely inside the same crash. Remove `durable: "
+            "false` to get the crash-durable store (the default for "
+            "this op since #3180).",
+            name,
         )
     return ComposerDef(
         name=name, op=op, inputs=inputs, emit_kind=emit_kind,

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -288,7 +288,6 @@ import os
 import signal
 import sys
 import tempfile
-import warnings
 from collections.abc import Callable
 from typing import Any, NoReturn
 
@@ -2468,17 +2467,27 @@ class MCPClient:
 
         A failure while resolving/probing the backend itself (not a normal
         outcome — defensive only) falls back to an unwrapped launch WITH a
-        loud warning AND a ``sandbox_policy_not_applied`` audit-event (#3821),
-        so the fallback is legible after the fact and not only to whoever was
-        watching stderr at the time.
+        ``logger.warning`` AND a ``sandbox_policy_not_applied`` audit-event
+        (#3821), so the fallback is legible after the fact even where no
+        audit sink was wired. #6145 A: this was `warnings.warn(...)`
+        (category omitted, defaults to ``UserWarning``) — architect's own
+        measurement showed that category NEVER reaches stderr under the
+        stock filter (`stderr: False / reyn.log: True`), so the original
+        "not only to whoever was watching stderr" framing was never
+        actually true; `logger.warning` at least reliably reaches
+        ``reyn.log`` on every path, which the raw `warnings.warn` did not
+        (silent outside `__main__`).
 
         The audit-event needs a sink, and only the held-connection path
         (:class:`~reyn.mcp.connection_service.MCPConnectionService`) has one.
         Constructed WITHOUT ``emit_event`` — the ephemeral
         :class:`~reyn.mcp.pool.MCPClientPool` path, and direct callers — the
         fallback is WARNING-only, exactly as it was before #3821. So "never
-        silently unsandboxed" is true of the warning on every path, and of the
-        audit trail only where a sink was wired.
+        silently unsandboxed" is true of the warning on every path (reaching
+        ``reyn.log``, not the interactive screen — see #6145's own PR body
+        for why on-screen Ctx-pane surfacing of this event is a disclosed,
+        separate follow-up, not bundled into this channel promotion), and
+        of the audit trail only where a sink was wired.
 
         #3848: ``wrapped.env`` (the allowlisted env ``wrap_command()``
         computes, #3850) is deliberately NOT carried into the launch here —
@@ -2520,10 +2529,12 @@ class MCPClient:
                 argv, self._build_mcp_sandbox_policy(), env_path=ambient_path()
             )
         except Exception as exc:  # noqa: BLE001 — a backend probe/wrap must not block a launch
-            warnings.warn(
-                f"MCP stdio server {command!r} runs UNSANDBOXED "
-                f"(sandbox backend probe/wrap failed: {exc}).",
-                stacklevel=2,
+            # #6145 A — see this method's own docstring for why this is a
+            # channel promotion only (logger.warning), not an on-screen
+            # Ctx-pane surface: that would be a new, separate feature.
+            logger.warning(
+                "MCP stdio server %r runs UNSANDBOXED (sandbox backend "
+                "probe/wrap failed: %s).", command, exc,
             )
             if self._emit_event is not None:
                 try:

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -53,10 +53,13 @@ baked into a durable copy" discipline this module already documents for
 """
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 # Matches ${VAR_NAME} — word chars only, mirrors interpolation.py's _ENV_VAR_RE
 # shape so both layers share the same token *syntax*, not the same *vocabulary*.
@@ -305,15 +308,18 @@ def expand_yaml_tokens_or_refuse(
     expanded = expand_with_map(obj, token_map)
     unresolved = find_unresolved_reyn_tokens(expanded)
     if unresolved:
-        import warnings
-
-        warnings.warn(
-            f"{source} left reyn token(s) {sorted(set(unresolved))} "
-            "unresolved -- refusing to use this content (this is reyn's "
-            "own bug -- it could not supply a value it owns -- not a "
-            "config choice to honor).",
-            UserWarning,
-            stacklevel=2,
+        # #6145 A: was `warnings.warn(..., UserWarning)` — silent outside
+        # `__main__` under Python's own default filter, and never reached
+        # the operator's screen even when visible (`stderr: False /
+        # reyn.log: True`, architect's measurement). This is a whole
+        # config layer being REFUSED (returns None) -- the operator needs
+        # the reason in the log, not only the downstream symptom of a
+        # face silently missing content.
+        _log.warning(
+            "%s left reyn token(s) %s unresolved -- refusing to use this "
+            "content (this is reyn's own bug -- it could not supply a "
+            "value it owns -- not a config choice to honor).",
+            source, sorted(set(unresolved)),
         )
         return None
     return expanded

--- a/src/reyn/security/secrets/interpolation.py
+++ b/src/reyn/security/secrets/interpolation.py
@@ -7,7 +7,8 @@ so the resolver logic lives in exactly one place.
 Resolution rules
 ----------------
 * ``${VAR}``   → ``os.environ.get("VAR", "")``.  If the variable is not
-  set a :class:`UserWarning` is emitted and the token expands to ``""``.
+  set a ``logger.warning`` is emitted (#6145 — promoted from a
+  silent-by-default ``warnings.warn``) and the token expands to ``""``.
 * ``$$``       → literal ``"$"`` (escape sequence for configs that need a
   literal dollar sign in values without triggering expansion).
 * Any other ``$...`` is passed through unchanged.
@@ -16,10 +17,12 @@ Resolution rules
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
-import warnings
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 # Matches ${VAR_NAME} — word chars only (letters, digits, _).
 _ENV_VAR_RE = re.compile(r"\$\{(\w+)\}")
@@ -34,10 +37,15 @@ def _expand_str(value: str) -> str:
         name = m.group(1)
         result = os.environ.get(name)
         if result is None:
-            warnings.warn(
-                f"Config references undefined environment variable: ${{{name}}}",
-                UserWarning,
-                stacklevel=4,
+            # #6145 A: was `warnings.warn(..., UserWarning)` — silent
+            # outside `__main__` under Python's own default filter, and
+            # never reached the operator's screen even when visible
+            # (`stderr: False / reyn.log: True`, architect's
+            # measurement). An operator whose config silently expands to
+            # `""` needs this in the log to find the typo.
+            _log.warning(
+                "Config references undefined environment variable: ${%s}",
+                name,
             )
             return ""
         return result

--- a/src/reyn/security/secrets/loader.py
+++ b/src/reyn/security/secrets/loader.py
@@ -88,16 +88,16 @@ def _parse_dotenv(text: str) -> list[tuple[str, str]]:
             # (silent outside `__main__`, and never reached the screen
             # even when the category was visible).
             _log.warning(
-                "secrets.env line %d: no '=' found, skipping: %r",
-                lineno, raw_line,
+                "secrets.env line %d: no '=' found, skipping",
+                lineno,
             )
             continue
         key, _, raw_val = line.partition("=")
         key = key.strip()
         if not key:
             _log.warning(
-                "secrets.env line %d: empty key, skipping: %r",
-                lineno, raw_line,
+                "secrets.env line %d: empty key, skipping",
+                lineno,
             )
             continue
         # Strip inline comments on unquoted values

--- a/src/reyn/security/secrets/loader.py
+++ b/src/reyn/security/secrets/loader.py
@@ -7,19 +7,22 @@ any knowledge of the dotenv file.
 Policy
 ------
 * File absent  → OK, silently skip.
-* Parse error  → :class:`UserWarning` emitted per bad line; skip that line.
+* Parse error  → ``logger.warning`` per bad line (#6145 — promoted from a
+  silent-by-default ``warnings.warn``); skip that line.
 * chmod 600 enforce → if the file is world-readable (mode & 0o004 != 0),
-  emit a warning and ``chmod 600`` automatically.
+  emit a ``logger.warning`` and ``chmod 600`` automatically.
 * Existing env NOT overridden → ``os.environ.setdefault()`` semantics:
   values already in ``os.environ`` (from the shell or earlier loaders)
   take priority over ``secrets.env``.
 """
 from __future__ import annotations
 
+import logging
 import os
 import stat
-import warnings
 from pathlib import Path
+
+_log = logging.getLogger(__name__)
 
 _SECRETS_FILE = Path.home() / ".reyn" / "secrets.env"
 
@@ -44,20 +47,22 @@ def _enforce_permissions(path: Path) -> None:
     except OSError:
         return
     if mode & stat.S_IROTH or mode & stat.S_IRGRP:
-        warnings.warn(
-            f"{path} is readable by group/others (mode {oct(mode & 0o777)}); "
-            "auto-fixing to 600. Review access controls on this machine.",
-            UserWarning,
-            stacklevel=3,
+        # #6145 A (both branches below): was `warnings.warn(..., UserWarning)`
+        # — silent outside `__main__` under Python's own default filter,
+        # and even the visible category never reached the operator's
+        # screen (`stderr: False / reyn.log: True`, architect's
+        # measurement). A group/world-readable secrets file is a real
+        # exposure on this machine; the operator needs this in the log,
+        # not swallowed by the default warnings filter.
+        _log.warning(
+            "%s is readable by group/others (mode %s); auto-fixing to "
+            "600. Review access controls on this machine.",
+            path, oct(mode & 0o777),
         )
         try:
             path.chmod(0o600)
         except OSError as exc:
-            warnings.warn(
-                f"Could not chmod {path} to 600: {exc}",
-                UserWarning,
-                stacklevel=3,
-            )
+            _log.warning("Could not chmod %s to 600: %s", path, exc)
 
 
 def _parse_dotenv(text: str) -> list[tuple[str, str]]:
@@ -76,19 +81,23 @@ def _parse_dotenv(text: str) -> list[tuple[str, str]]:
         if not line or line.startswith("#"):
             continue
         if "=" not in line:
-            warnings.warn(
-                f"secrets.env line {lineno}: no '=' found, skipping: {raw_line!r}",
-                UserWarning,
-                stacklevel=4,
+            # #6145 A (both branches below): same promotion as
+            # `_enforce_permissions` above — an operator debugging a
+            # secret that "didn't load" needs the exact line and reason
+            # in the log, which `warnings.warn` never reliably delivered
+            # (silent outside `__main__`, and never reached the screen
+            # even when the category was visible).
+            _log.warning(
+                "secrets.env line %d: no '=' found, skipping: %r",
+                lineno, raw_line,
             )
             continue
         key, _, raw_val = line.partition("=")
         key = key.strip()
         if not key:
-            warnings.warn(
-                f"secrets.env line {lineno}: empty key, skipping: {raw_line!r}",
-                UserWarning,
-                stacklevel=4,
+            _log.warning(
+                "secrets.env line %d: empty key, skipping: %r",
+                lineno, raw_line,
             )
             continue
         # Strip inline comments on unquoted values
@@ -130,21 +139,16 @@ def load_secrets_to_environ(path: Path | None = None) -> None:
     try:
         text = secrets_path.read_text(encoding="utf-8")
     except OSError as exc:
-        warnings.warn(
-            f"Could not read {secrets_path}: {exc}",
-            UserWarning,
-            stacklevel=2,
-        )
+        # #6145 A (both branches below): same promotion as the parse
+        # errors above — a startup secrets load that silently produces
+        # zero secrets needs this reason in the log.
+        _log.warning("Could not read %s: %s", secrets_path, exc)
         return
 
     try:
         pairs = _parse_dotenv(text)
     except Exception as exc:  # pragma: no cover — belt-and-suspenders
-        warnings.warn(
-            f"Unexpected error parsing {secrets_path}: {exc}",
-            UserWarning,
-            stacklevel=2,
-        )
+        _log.warning("Unexpected error parsing %s: %s", secrets_path, exc)
         return
 
     for key, value in pairs:

--- a/src/reyn/security/secrets/oauth.py
+++ b/src/reyn/security/secrets/oauth.py
@@ -29,7 +29,6 @@ import json
 import logging
 import os
 import stat
-import warnings
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -144,31 +143,31 @@ def _read_store(path: Path) -> dict[str, dict[str, Any]]:
     """Load the JSON map; missing file → empty dict."""
     if not path.exists():
         return {}
+    # #6145 A (all 3 branches below): was `warnings.warn(..., UserWarning)`
+    # — silent outside `__main__` under Python's own default filter, and
+    # even the visible category never reached the operator's screen
+    # (`stderr: False / reyn.log: True`, architect's measurement). An
+    # operator whose OAuth store is unreadable/corrupt sees only a
+    # generic downstream `KeyError`/re-auth prompt with no explanation of
+    # WHY — this is the diagnostic that says why, so it goes to the log
+    # an operator debugging that failure actually reads.
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
-        warnings.warn(
-            f"Could not read OAuth token store at {path}: {exc}",
-            UserWarning,
-            stacklevel=3,
-        )
+        _log.warning("Could not read OAuth token store at %s: %s", path, exc)
         return {}
     try:
         data = json.loads(raw) if raw.strip() else {}
     except json.JSONDecodeError as exc:
-        warnings.warn(
-            f"OAuth token store at {path} is not valid JSON ({exc}); "
-            "ignoring and continuing with an empty store.",
-            UserWarning,
-            stacklevel=3,
+        _log.warning(
+            "OAuth token store at %s is not valid JSON (%s); ignoring and "
+            "continuing with an empty store.", path, exc,
         )
         return {}
     if not isinstance(data, dict):
-        warnings.warn(
-            f"OAuth token store at {path} must be a JSON object, "
-            f"got {type(data).__name__}; ignoring.",
-            UserWarning,
-            stacklevel=3,
+        _log.warning(
+            "OAuth token store at %s must be a JSON object, got %s; "
+            "ignoring.", path, type(data).__name__,
         )
         return {}
     return data
@@ -193,20 +192,16 @@ def load_oauth_token(key: str, *, path: Path | None = None) -> OAuthToken | None
     if raw is None:
         return None
     if not isinstance(raw, dict):
-        warnings.warn(
-            f"OAuth token {key!r} is not an object; ignoring.",
-            UserWarning,
-            stacklevel=2,
-        )
+        # #6145 A: same reasoning as `_read_store` above — the caller's
+        # `KeyError`/re-auth path never carries WHY the stored entry was
+        # unusable, so this stays a real diagnostic, now on a channel the
+        # operator's own log actually receives.
+        _log.warning("OAuth token %r is not an object; ignoring.", key)
         return None
     try:
         return OAuthToken.from_dict(raw)
     except (KeyError, ValueError) as exc:
-        warnings.warn(
-            f"OAuth token {key!r} is malformed ({exc}); ignoring.",
-            UserWarning,
-            stacklevel=2,
-        )
+        _log.warning("OAuth token %r is malformed (%s); ignoring.", key, exc)
         return None
 
 
@@ -247,11 +242,16 @@ def _check_permissions(path: Path) -> None:
     except OSError:
         return
     if mode & stat.S_IROTH or mode & stat.S_IRGRP:
-        warnings.warn(
-            f"{path} is readable by group/others (mode {oct(mode & 0o777)}); "
-            "auto-fixing to 600. Review access controls on this machine.",
-            UserWarning,
-            stacklevel=3,
+        # #6145 A: a group/world-readable credential store is a real
+        # security exposure on this machine (same class as
+        # `security/secrets/loader.py`'s own secrets.env chmod notice,
+        # promoted alongside this one) — an operator reviewing access
+        # controls needs this in the log, not silently swallowed by the
+        # default warnings filter.
+        _log.warning(
+            "%s is readable by group/others (mode %s); auto-fixing to "
+            "600. Review access controls on this machine.",
+            path, oct(mode & 0o777),
         )
         try:
             path.chmod(0o600)

--- a/tests/config/test_5351_policy_tier_unresolved_agent_token_warns.py
+++ b/tests/config/test_5351_policy_tier_unresolved_agent_token_warns.py
@@ -29,12 +29,18 @@ Real ``load_config`` + a real ``reyn.yaml`` on disk — no mocks. Witness
 is the real content (``cfg.mcp["servers"]`` genuinely absent), not just
 "a warning fired" (lead-coder's own standing correction on this exact
 family of finding, #5801: "witness は「warning が出ない」ではなく「中身が
-system prompt に入る」で")."""
+system prompt に入る」で").
+
+#6145 A: the refusal notice was `warnings.warn(..., UserWarning)` --
+SILENT outside `__main__` under Python's own default filter, and never
+reached the operator's screen even when visible (`stderr: False /
+reyn.log: True`, architect's measurement). Promoted to `logger.warning`;
+the tests below read `caplog` instead of `pytest.warns`/
+`warnings.catch_warnings` for the same reason.
+"""
 from __future__ import annotations
 
-import warnings
-
-import pytest
+import logging
 
 from reyn.config.loader import load_config
 
@@ -42,11 +48,11 @@ from reyn.config.loader import load_config
 # on ANY unresolved reyn token this face's map doesn't cover, not just
 # REYN_AGENT_NAME specifically (the vocabulary lives in the token_map,
 # not in a second hand-written check here -- #5801 req③).
-_REFUSAL_WARNING_MATCH = r"left reyn token\(s\).*unresolved -- refusing"
+_REFUSAL_WARNING_SUBSTRING = "unresolved -- refusing"
 
 
 def test_unresolved_reyn_agent_name_fails_closed_even_after_export(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, caplog,
 ) -> None:
     """Tier 2: the file is refused even when the operator has already
     "fixed" the pre-existing expand_env warning by exporting
@@ -65,9 +71,10 @@ def test_unresolved_reyn_agent_name_fails_closed_even_after_export(
         encoding="utf-8",
     )
 
-    with pytest.warns(UserWarning, match=_REFUSAL_WARNING_MATCH):
+    with caplog.at_level(logging.WARNING):
         cfg = load_config(tmp_path)
 
+    assert any(_REFUSAL_WARNING_SUBSTRING in r.message for r in caplog.records)
     # Real-content witness (not just "a warning fired"): the whole
     # reyn.yaml layer -- including the otherwise-valid `myserver` entry
     # -- never made it into the merged config.
@@ -77,7 +84,7 @@ def test_unresolved_reyn_agent_name_fails_closed_even_after_export(
     )
 
 
-def test_unresolved_reyn_agent_name_fails_closed_without_export(tmp_path) -> None:
+def test_unresolved_reyn_agent_name_fails_closed_without_export(tmp_path, caplog) -> None:
     """Tier 2: without any export, the same refusal fires -- #5801's rule
     does not distinguish "operator tried to fix it" from "never tried";
     both are reyn's own bug (it could not supply a value it owns), not
@@ -93,15 +100,16 @@ def test_unresolved_reyn_agent_name_fails_closed_without_export(tmp_path) -> Non
         encoding="utf-8",
     )
 
-    with pytest.warns(UserWarning, match=_REFUSAL_WARNING_MATCH):
+    with caplog.at_level(logging.WARNING):
         cfg = load_config(tmp_path)
 
+    assert any(_REFUSAL_WARNING_SUBSTRING in r.message for r in caplog.records)
     assert not cfg.mcp.get("servers"), (
         f"got {cfg.mcp.get('servers')!r}"
     )
 
 
-def test_a_resolvable_reyn_project_dir_does_not_fail_closed(tmp_path) -> None:
+def test_a_resolvable_reyn_project_dir_does_not_fail_closed(tmp_path, caplog) -> None:
     """Tier 2: the accept-side witness -- a real, resolvable
     ${REYN_PROJECT_DIR} in the same load point must NOT trip the
     refusal warning, and its real, expanded value must land in the
@@ -117,17 +125,15 @@ def test_a_resolvable_reyn_project_dir_does_not_fail_closed(tmp_path) -> None:
         encoding="utf-8",
     )
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         cfg = load_config(tmp_path)
 
     refusals = [
-        w for w in caught
-        if issubclass(w.category, UserWarning) and "unresolved -- refusing" in str(w.message)
+        r for r in caplog.records if _REFUSAL_WARNING_SUBSTRING in r.message
     ]
     assert not refusals, (
         f"a fully-resolved ${{REYN_PROJECT_DIR}} must not be refused -- "
-        f"got {[str(w.message) for w in refusals]}"
+        f"got {[r.message for r in refusals]}"
     )
     env = cfg.mcp["servers"]["myserver"]["env"]
     assert env["PROJECT_TAG"] == str(tmp_path.resolve())

--- a/tests/core/test_fp0016_b_oauth_refresh.py
+++ b/tests/core/test_fp0016_b_oauth_refresh.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -390,19 +391,29 @@ async def test_concurrent_calls_serialise_to_one_refresh(oauth_store_path: Path)
 # ── 8. Store-file resilience ───────────────────────────────────────────────
 
 
-def test_load_handles_malformed_json(oauth_store_path: Path) -> None:
-    """Tier 2: corrupt JSON → warning + empty result (not crash)."""
+def test_load_handles_malformed_json(oauth_store_path: Path, caplog) -> None:
+    """Tier 2: corrupt JSON → warning + empty result (not crash).
+
+    #6145 A: was `pytest.warns(UserWarning, ...)` -- that emission is
+    SILENT outside `__main__` under Python's own default filter (never
+    reached the operator from `src/reyn/**`), so it was promoted to
+    `logger.warning`; read here via `caplog`."""
     oauth_store_path.parent.mkdir(parents=True, exist_ok=True)
     oauth_store_path.write_text("{ not json")
-    with pytest.warns(UserWarning, match="not valid JSON"):
+    with caplog.at_level(logging.WARNING):
         result = load_oauth_token("anything")
+    assert any("not valid JSON" in r.message for r in caplog.records)
     assert result is None
 
 
-def test_load_handles_object_with_missing_fields(oauth_store_path: Path) -> None:
-    """Tier 2: malformed token entry → warning + None for that key."""
+def test_load_handles_object_with_missing_fields(oauth_store_path: Path, caplog) -> None:
+    """Tier 2: malformed token entry → warning + None for that key.
+
+    #6145 A: was `pytest.warns(UserWarning, ...)` -- promoted to
+    `logger.warning` for the same reason as the test above."""
     oauth_store_path.parent.mkdir(parents=True, exist_ok=True)
     oauth_store_path.write_text(json.dumps({"github": {"access_token": "x"}}))
-    with pytest.warns(UserWarning, match="malformed"):
+    with caplog.at_level(logging.WARNING):
         result = load_oauth_token("github")
+    assert any("malformed" in r.message for r in caplog.records)
     assert result is None

--- a/tests/core/test_stream_repaint_interval_config.py
+++ b/tests/core/test_stream_repaint_interval_config.py
@@ -10,13 +10,19 @@ Test shape mirrors `test_4840_chat_theme_config.py`, including the
 `load_config` round-trip and ITS falsification pair: exercising
 `_build_chat_config` alone proves the parser reads the key, not that the
 real entrypoint surfaces it (the gap #4899 found on a sibling field).
+
+#6145 A: the rejection notice was `warnings.warn(..., UserWarning)` --
+SILENT outside `__main__` under Python's own default filter, and never
+reached the operator's screen even when visible (`stderr: False /
+reyn.log: True`, architect's measurement). Promoted to `logger.warning`;
+this file's own warning-witness tests below read `caplog` instead of
+`pytest.warns`/`warnings.catch_warnings` for the same reason.
 """
 from __future__ import annotations
 
-import warnings
+import logging
 from pathlib import Path
 
-import pytest
 import yaml
 
 from reyn.config.chat import ChatConfig, _build_chat_config
@@ -111,25 +117,32 @@ def test_absent_from_yaml_keeps_the_default_through_load_config(
     assert cfg.chat.stream_repaint_min_interval == 1 / 30
 
 
-def test_a_rejected_value_is_announced_not_silently_substituted() -> None:
+def test_a_rejected_value_is_announced_not_silently_substituted(caplog) -> None:
     """Tier 1: an operator who typed 0 and one who never wrote the key must
     not read back the same running config with nothing said. The fallback
     keeps the session up; the warning is what makes it distinguishable."""
-    with pytest.warns(UserWarning, match="stream_repaint_min_interval"):
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"stream_repaint_min_interval": 0})
-    with pytest.warns(UserWarning, match="stream_repaint_min_interval"):
+    assert any("stream_repaint_min_interval" in r.message for r in caplog.records)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
         _build_chat_config({"stream_repaint_min_interval": "fast"})
+    assert any("stream_repaint_min_interval" in r.message for r in caplog.records)
 
 
-def test_an_accepted_value_and_an_absent_key_are_both_silent() -> None:
+def test_an_accepted_value_and_an_absent_key_are_both_silent(caplog) -> None:
     """Tier 1: falsification pair — the warning fires on the rejection, not
     on every parse. Without this the assertion above would still pass if the
     parser warned unconditionally."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with caplog.at_level(logging.WARNING):
         assert _build_chat_config(
             {"stream_repaint_min_interval": 0.2},
         ).stream_repaint_min_interval == 0.2
         assert _build_chat_config(
             {"render_mode": "plain"},
         ).stream_repaint_min_interval == 1 / 30
+    # #6144 unfiltered-caplog-consumption gate: filtered to the subject
+    # (never a bare `caplog.records == []`) -- under `-n auto` an
+    # unrelated test's record on a different logger can land in the same
+    # capture window.
+    assert not any("stream_repaint_min_interval" in r.message for r in caplog.records)

--- a/tests/hooks/test_3180_durable_pending_store.py
+++ b/tests/hooks/test_3180_durable_pending_store.py
@@ -5,10 +5,17 @@ The truncate-falsify recovery gate lives in its own file
 (``test_3180_composer_pending_truncate_falsify.py``); this file covers the
 store's own contract (round-trip fidelity, loud-not-silent failure legs,
 stale-composer pruning) and the per-composer routing decision.
+
+#6145 A: both ``durable:``-flag notices below were `warnings.warn(...,
+UserWarning)` -- SILENT outside `__main__` under Python's own default
+filter, and never reached the operator's screen even when visible
+(`stderr: False / reyn.log: True`, architect's measurement). Promoted to
+`logger.warning`; the two tests below read `caplog` instead of
+`pytest.warns`/`warnings.catch_warnings` for the same reason.
 """
 from __future__ import annotations
 
-import warnings
+import logging
 
 import pytest
 
@@ -138,21 +145,27 @@ def test_retain_composers_drops_records_of_removed_composers(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_deadline_is_durable_by_default_and_warns_only_when_opted_out():
+def test_deadline_is_durable_by_default_and_warns_only_when_opted_out(caplog):
     """Tier 1: ``op=deadline`` parses to ``durable=True`` with no warning (the
     #3180 default), while an explicit ``durable: false`` keeps the load-time
-    UserWarning that CLAUDE.md's never-a-silent-dead-man-switch rule requires.
+    warning that CLAUDE.md's never-a-silent-dead-man-switch rule requires.
 
     The warning moved from "always" to "only on opt-out" — its trigger is now
     the operator's choice, not the absence of an implementation."""
     raw = {"name": "j", "op": "deadline", "on": "a", "until": {"on": "b"}, "ttl": 60}
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # any UserWarning here fails the test
+    with caplog.at_level(logging.WARNING):
         (durable_def,) = load_composers([raw])
+    # #6144 unfiltered-caplog-consumption gate: filtered to the subject
+    # (never a bare `caplog.records == []`) -- under `-n auto` an
+    # unrelated test's record on a different logger can land in the same
+    # capture window.
+    assert not any("crash-non-durable" in r.message for r in caplog.records)
     assert durable_def.durable is True
 
-    with pytest.warns(UserWarning, match="crash-non-durable"):
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
         (opted_out,) = load_composers([{**raw, "durable": False}])
+    assert any("crash-non-durable" in r.message for r in caplog.records)
     assert opted_out.durable is False
 
 
@@ -203,13 +216,16 @@ def test_only_durable_composers_write_to_the_durable_store(tmp_path):
     assert reloaded.keys("noisy") == []
 
 
-def test_durable_composer_without_a_store_warns_instead_of_downgrading_silently(tmp_path):
+def test_durable_composer_without_a_store_warns_instead_of_downgrading_silently(
+    tmp_path, caplog,
+):
     """Tier 2: constructing a durable composer in a context that has no durable
     store (a session with no per-session state dir) falls back to in-memory —
     but says so. A silent downgrade's only symptom is a dead-man monitor that
     never fires after a restart, which is indistinguishable from "nothing went
     wrong"."""
-    with pytest.warns(UserWarning, match="no durable store"):
+    with caplog.at_level(logging.WARNING):
         (composer,) = build_composers([_deadline_def()], bus=HookBus(), durable_store=None)
+    assert any("no durable store" in r.message for r in caplog.records)
     composer.handle_event(HookEvent(kind="orch:job_started", payload={"job_id": "j1"}))
     assert not (tmp_path / STORE_FILENAME).exists()

--- a/tests/mcp/test_mcp_unsandboxed_audit_3821.py
+++ b/tests/mcp/test_mcp_unsandboxed_audit_3821.py
@@ -9,6 +9,14 @@ later reader could find — while the method's own docstring asserted the launch
 was "never silently unsandboxed". The prose claimed an audit trail the mechanism
 did not have.
 
+#6145 A: that framing was itself wrong about WHO "watching stderr" reached —
+architect's own measurement showed the omitted-category (defaults to
+``UserWarning``) emission never reached stderr under the stock filter either
+(``stderr: False / reyn.log: True``), so the warning alone never reached
+ANYONE watching a live process. Promoted to ``logger.warning`` — the tests
+below read ``caplog`` instead of ``pytest.warns``/``warnings.catch_warnings``
+for the same reason; the audit-event half (below) is unchanged.
+
 What is pinned here:
 
   - the fallback emits ``sandbox_policy_not_applied`` (an EXISTING kind, shared
@@ -33,10 +41,8 @@ event tests).
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
-import warnings
-
-import pytest
 
 from reyn.mcp.client import MCPClient
 from reyn.mcp.connection_service import MCPConnectionService
@@ -57,7 +63,7 @@ def _not_applied(events: list) -> list[dict]:
     return [d for et, d in events if et == "sandbox_policy_not_applied"]
 
 
-def test_unsandboxed_fallback_emits_audit_event(monkeypatch):
+def test_unsandboxed_fallback_emits_audit_event(monkeypatch, caplog):
     """Tier 2: the fallback emits ``sandbox_policy_not_applied`` naming the
     server, the command and the failure — the trace the warning alone did not
     leave."""
@@ -69,8 +75,9 @@ def test_unsandboxed_fallback_emits_audit_event(monkeypatch):
         emit_event=lambda et, **d: events.append((et, d)),
     )
 
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+    with caplog.at_level(logging.WARNING):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert any("UNSANDBOXED" in r.message for r in caplog.records)
 
     assert (cmd, args) == ("my-mcp", ["--flag"])  # still launches, unwrapped
     emitted = _not_applied(events)
@@ -87,7 +94,7 @@ def test_unsandboxed_fallback_emits_audit_event(monkeypatch):
     assert "backend probe exploded" in payload["reason"]
 
 
-def test_scope_field_distinguishes_this_producer_from_the_hook_one(monkeypatch):
+def test_scope_field_distinguishes_this_producer_from_the_hook_one(monkeypatch, caplog):
     """Tier 2: the kind has two producers with different payloads. This one is
     identified by a field it HAS (``scope``), and carries no ``policy_field`` —
     the hook producer's per-axis key, which is meaningless here because the whole
@@ -99,26 +106,28 @@ def test_scope_field_distinguishes_this_producer_from_the_hook_one(monkeypatch):
         server_name="srv-a",
         emit_event=lambda et, **d: events.append((et, d)),
     )
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+    with caplog.at_level(logging.WARNING):
         client._sandbox_wrap_stdio("my-mcp", [])
+    assert any("UNSANDBOXED" in r.message for r in caplog.records)
 
     payload = _not_applied(events)[0]
     assert "policy_field" not in payload
 
 
-def test_missing_sink_still_warns_and_does_not_raise(monkeypatch):
+def test_missing_sink_still_warns_and_does_not_raise(monkeypatch, caplog):
     """Tier 2: no sink is a supported construction (the ephemeral pool path), not
     a degraded one — the warning still fires and the launch still proceeds."""
     monkeypatch.setattr("reyn.security.sandbox.get_default_backend", _boom)
     client = MCPClient({"type": "stdio", "command": "my-mcp", "args": ["--flag"]})
 
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+    with caplog.at_level(logging.WARNING):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert any("UNSANDBOXED" in r.message for r in caplog.records)
 
     assert (cmd, args) == ("my-mcp", ["--flag"])
 
 
-def test_a_failing_sink_does_not_block_the_launch(monkeypatch):
+def test_a_failing_sink_does_not_block_the_launch(monkeypatch, caplog):
     """Tier 2: telemetry is best-effort — a sink that raises must not turn a
     degraded-but-working launch into a dead one."""
     monkeypatch.setattr("reyn.security.sandbox.get_default_backend", _boom)
@@ -127,8 +136,9 @@ def test_a_failing_sink_does_not_block_the_launch(monkeypatch):
         raise RuntimeError("sink is down")
 
     client = MCPClient({"type": "stdio", "command": "my-mcp"}, emit_event=_bad_sink)
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+    with caplog.at_level(logging.WARNING):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    assert any("UNSANDBOXED" in r.message for r in caplog.records)
     assert (cmd, args) == ("my-mcp", [])
 
 
@@ -143,9 +153,7 @@ def test_connection_service_delivers_the_event_to_its_sink(monkeypatch):
 
     async def _run_it():
         try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")  # asserted directly above
-                await service.get("echo", _stdio_cfg())
+            await service.get("echo", _stdio_cfg())
         finally:
             await service.aclose()
 

--- a/tests/runtime/test_5140_per_agent_composers_token_expansion.py
+++ b/tests/runtime/test_5140_per_agent_composers_token_expansion.py
@@ -34,8 +34,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import pytest
-
 from tests._support.agent_session import make_session
 
 _AGENT = "coder-smith"
@@ -83,7 +81,7 @@ def test_reyn_agent_name_resolves_to_the_real_agent_name_in_composers(
 
 
 def test_an_unresolved_reyn_token_refuses_to_load_the_composers_layer(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, caplog,
 ) -> None:
     """Tier 2: acceptance ② — a reyn-owned token this loader does NOT supply
     a value for (``${REYN_SKILL_DIR}`` — a location token with no meaning for
@@ -91,11 +89,14 @@ def test_an_unresolved_reyn_token_refuses_to_load_the_composers_layer(
     silently register a composer with an empty/wrong value, and must surface
     why.
 
-    #5166: the surfacing mechanism is now ``warnings.warn`` (the shared
+    #5166: the surfacing mechanism was ``warnings.warn`` (the shared
     ``read_and_expand_hooks_yaml`` primitive every hooks.yaml-shaped layer
     goes through, matching ``config/loader.py``'s own established
-    convention), not ``logger.warning`` — this session-local reader used to
-    warn via the stdlib logger before the #5166 consolidation."""
+    convention). #6145 A: that ``warnings.warn`` was SILENT outside
+    ``__main__`` under Python's own default filter, and never reached the
+    operator's screen even when visible (``stderr: False / reyn.log: True``,
+    architect's measurement) — promoted to ``logger.warning``, read here via
+    ``caplog``."""
     project = tmp_path / "proj"
     _write_per_agent_hooks(
         project,
@@ -107,8 +108,9 @@ def test_an_unresolved_reyn_token_refuses_to_load_the_composers_layer(
     )
     session = _make_session_in(project, monkeypatch, tmp_path)
 
-    with pytest.warns(UserWarning, match="REYN_SKILL_DIR"):
+    with caplog.at_level(logging.WARNING):
         composers = session._read_per_agent_composers()
+    assert any("REYN_SKILL_DIR" in r.message for r in caplog.records)
 
     assert composers == [], (
         "an unresolved reyn-owned token must refuse the WHOLE composers "

--- a/tests/runtime/test_5140_per_agent_hooks_token_expansion.py
+++ b/tests/runtime/test_5140_per_agent_hooks_token_expansion.py
@@ -27,10 +27,17 @@ healthy path" test: here, a healthy config with reyn's own tokens correctly
 supplied never trips it).
 
 Real ``load_per_agent_hooks`` + real files on disk — no mocks.
+
+#6145 A: the refusal notice was `warnings.warn(..., UserWarning)` --
+SILENT outside `__main__` under Python's own default filter, and never
+reached the operator's screen even when visible (`stderr: False /
+reyn.log: True`, architect's measurement). Promoted to `logger.warning`;
+the tests below read `caplog` instead of `warnings.catch_warnings` for
+the same reason.
 """
 from __future__ import annotations
 
-import warnings
+import logging
 from pathlib import Path
 
 from reyn.config.loader import load_per_agent_hooks
@@ -61,7 +68,7 @@ def test_reyn_agent_name_resolves_to_the_real_agent_name(tmp_path: Path) -> None
 
 
 def test_an_unresolved_reyn_token_refuses_to_load_the_hooks_layer(
-    tmp_path: Path,
+    tmp_path: Path, caplog,
 ) -> None:
     """Tier 2: acceptance ② — a reyn-owned token this loader does NOT supply
     a value for (simulated here via a token this map never populates,
@@ -76,8 +83,7 @@ def test_an_unresolved_reyn_token_refuses_to_load_the_hooks_layer(
         "      message: ${REYN_SKILL_DIR}/note.txt\n"
         "      wake: true\n",
     )
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         hooks = load_per_agent_hooks(tmp_path, _AGENT)
 
     assert hooks == [], (
@@ -85,12 +91,11 @@ def test_an_unresolved_reyn_token_refuses_to_load_the_hooks_layer(
         "not load a hook with a wrong/empty value"
     )
     assert any(
-        "REYN_SKILL_DIR" in str(w.message) and issubclass(w.category, UserWarning)
-        for w in caught
+        "REYN_SKILL_DIR" in r.message for r in caplog.records
     ), "the refusal must surface a reason, not fail silently"
 
 
-def test_a_non_reyn_token_is_left_untouched_and_still_loads(tmp_path: Path) -> None:
+def test_a_non_reyn_token_is_left_untouched_and_still_loads(tmp_path: Path, caplog) -> None:
     """Tier 2: acceptance ③ — a NON-reyn ``${FOO}`` (e.g. an env var meant
     for a spawned child process to resolve) must load exactly as before:
     left untouched, no fail-close. Without this, #5152's own retracted
@@ -104,19 +109,22 @@ def test_a_non_reyn_token_is_left_untouched_and_still_loads(tmp_path: Path) -> N
         "      command: echo ${SOME_CHILD_PROCESS_VAR}\n"
         "      wake: true\n",
     )
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         hooks = load_per_agent_hooks(tmp_path, _AGENT)
 
     assert hooks, "a non-reyn token must not cause the hooks layer to be refused"
     assert hooks[0]["exec"]["command"] == "echo ${SOME_CHILD_PROCESS_VAR}"
-    assert not any(
-        issubclass(w.category, UserWarning) for w in caught
-    ), "a non-reyn token must not trip the fail-close or warn at all"
+    # #6144 unfiltered-caplog-consumption gate: filtered to the subject
+    # (never a bare `caplog.records == []`) -- under `-n auto` an
+    # unrelated test's record on a different logger can land in the same
+    # capture window.
+    assert not any("unresolved -- refusing" in r.message for r in caplog.records), (
+        "a non-reyn token must not trip the fail-close or warn at all"
+    )
 
 
 def test_no_undefined_env_var_warning_fires_on_a_healthy_reyn_token(
-    tmp_path: Path,
+    tmp_path: Path, caplog,
 ) -> None:
     """Tier 2: acceptance ④ — the OLD `warnings.warn("Config references
     undefined environment variable…")` (expand_env's own, fired on every
@@ -131,10 +139,9 @@ def test_no_undefined_env_var_warning_fires_on_a_healthy_reyn_token(
         "      message: broker://inbox/${REYN_AGENT_NAME}\n"
         "      wake: true\n",
     )
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         load_per_agent_hooks(tmp_path, _AGENT)
 
     assert not any(
-        "undefined environment variable" in str(w.message) for w in caught
+        "undefined environment variable" in r.message for r in caplog.records
     )

--- a/tests/runtime/test_5166_hooks_yaml_layer_registry.py
+++ b/tests/runtime/test_5166_hooks_yaml_layer_registry.py
@@ -22,6 +22,7 @@ Real ``Session`` (via ``tests._support.agent_session.make_session``) + real
 files on disk — no mocks."""
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -117,10 +118,16 @@ def test_a_non_reyn_token_passes_through_in_every_registered_layer(
 
 @pytest.mark.parametrize("key", _KEYS)
 def test_an_unresolved_reyn_token_refuses_the_layer_everywhere(
-    tmp_path, monkeypatch, key,
+    tmp_path, monkeypatch, key, caplog,
 ) -> None:
     """Tier 2: fail-close applies uniformly too — not just resolution.
-    Same registry walk, the OTHER half of "same字面, same意味"."""
+    Same registry walk, the OTHER half of "same字面, same意味".
+
+    #6145 A: the refusal notice was `warnings.warn(..., UserWarning)` --
+    SILENT outside `__main__` under Python's own default filter, and
+    never reached the operator's screen even when visible (`stderr:
+    False / reyn.log: True`, architect's measurement). Promoted to
+    `logger.warning`, read here via `caplog`."""
     project = tmp_path / "proj"
     project.mkdir()
     session = _make_session_in(project, monkeypatch, tmp_path)
@@ -134,8 +141,10 @@ def test_an_unresolved_reyn_token_refuses_the_layer_everywhere(
     )
     for label, path in session._hooks_yaml_layers():
         _write_yaml(path, body)
-        with pytest.warns(UserWarning, match="REYN_SKILL_DIR"):
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
             entries = session._read_hooks_yaml_layer_key(path, key)
+        assert any("REYN_SKILL_DIR" in r.message for r in caplog.records)
         assert entries == [], (
             f"{label}/{key}: an unresolved reyn token must refuse the whole "
             f"layer, not load a wrong/empty value — got {entries!r}"

--- a/tests/runtime/test_5801_profile_yaml_reyn_token_expansion.py
+++ b/tests/runtime/test_5801_profile_yaml_reyn_token_expansion.py
@@ -23,6 +23,7 @@ Real ``AgentRegistry``/``Session`` construction throughout -- no mocks.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -113,7 +114,7 @@ def test_base_dir_reyn_project_dir_token_also_expands(tmp_path: Path) -> None:
     assert "${REYN_PROJECT_DIR}" not in (profile.base_dir or "")
 
 
-def test_context_path_unresolved_reyn_token_fails_closed(tmp_path: Path) -> None:
+def test_context_path_unresolved_reyn_token_fails_closed(tmp_path: Path, caplog) -> None:
     """Tier 2: #5801 req② -- an unresolved reyn token in profile.yaml is
     reyn's own bug (it could not supply a value it owns), not an
     operator config choice to silently honor as a literal path. Uses
@@ -121,7 +122,13 @@ def test_context_path_unresolved_reyn_token_fails_closed(tmp_path: Path) -> None
     that profile.yaml's own map does not carry (only
     REYN_PROJECT_DIR/REYN_AGENT_NAME are this face's map, #5801 req③) --
     so this is a genuine "reyn cannot resolve this here" case, not a
-    typo'd unrelated ${VAR}."""
+    typo'd unrelated ${VAR}.
+
+    #6145 A: the refusal notice was `warnings.warn(..., UserWarning)` --
+    SILENT outside `__main__` under Python's own default filter, and
+    never reached the operator's screen even when visible (`stderr:
+    False / reyn.log: True`, architect's measurement). Promoted to
+    `logger.warning`, read here via `caplog`."""
     project_root = tmp_path / "project"
     agent_dir = project_root / ".reyn" / "agents" / "coder-brown"
     agent_dir.mkdir(parents=True)
@@ -133,8 +140,12 @@ def test_context_path_unresolved_reyn_token_fails_closed(tmp_path: Path) -> None
         encoding="utf-8",
     )
 
-    with pytest.warns(UserWarning, match=r"left reyn token\(s\).*unresolved -- refusing"):
+    with caplog.at_level(logging.WARNING):
         profile = AgentProfile.load(agent_dir)
+    assert any(
+        "left reyn token" in r.message and "unresolved -- refusing" in r.message
+        for r in caplog.records
+    )
 
     # Real-content witness: refusal degrades the WHOLE file's contribution
     # (context_path falls back to its own None default), not a half-

--- a/tests/scripts/test_silent_warnings_category_gate_6143.py
+++ b/tests/scripts/test_silent_warnings_category_gate_6143.py
@@ -21,8 +21,13 @@ operator's screen). v2's population is EVERY `warnings.warn(...)` call
 under `src/reyn/**`, category-blind -- the tests below were updated to
 match (`test_a_user_warning_or_omitted_category_is_never_counted`
 inverted into `test_every_warnings_warn_call_is_counted_regardless_of_
-category`, and the shipped-table tests now check the 18
-`#6145`-tracked pre-existing entries rather than an empty table).
+category`). Widening the axis newly surfaced 18 pre-existing sites,
+tracked and disclosed in `_EXCEPTION_TABLE` under #6145 at the time;
+#6145 individually audited and promoted all 18 to `logger.warning`
+(see that PR's own body for the file:line table), so
+`_EXCEPTION_TABLE` is empty again -- `test_the_shipped_exception_
+table_matches_the_real_measured_population` below now pins an EMPTY
+table against an EMPTY measured population, not a 18-entry one.
 
 #6144 co-vet round 3 (lead-coder): v2's `(relpath, lineno)` key was
 ITSELF gameable -- not by an author dodging the gate, but by an
@@ -153,14 +158,19 @@ def test_the_shipped_exception_table_matches_the_real_measured_population():
     promoted to `logger.warning`, the 7th -- `permissions.py`'s legacy
     `http.get` compat notice -- deleted outright in #6144's co-vet round
     2, since it duplicated an already-firing real prompt). Widening the
-    axis to category-blind (#6144 co-vet round 2) newly surfaces
-    pre-existing sites this PR's own dispatch never covered -- this test
-    pins BEHAVIOR, not a bare count: the table's own keys must equal
-    EXACTLY the real tree's measured population (neither a stale entry
-    for a site that no longer exists, nor a gap), and every reason must
-    reference #6145, the tracking issue for auditing and promoting them
-    -- never a bare "fine as-is", which #6144's own review already ruled
-    none of these currently are."""
+    axis to category-blind (#6144 co-vet round 2) newly surfaced 18
+    pre-existing sites #6144's own dispatch never covered, tracked in
+    `_EXCEPTION_TABLE` under #6145 at the time -- #6145 then
+    individually audited and promoted all 18 to `logger.warning`
+    (never "B: legitimate as-is" or "C: delete", see that PR's own
+    body), so `_EXCEPTION_TABLE` is empty again. This test pins
+    BEHAVIOR, not a bare count: the table's own keys must equal EXACTLY
+    the real tree's measured population (neither a stale entry for a
+    site that no longer exists, nor a gap) -- currently the empty set
+    on both sides. The `#6145` marker check below is a disclosed no-op
+    while the table is empty (Tier-4 hazard: an assert over an empty
+    collection wears green's colour); it starts biting again the
+    moment a future entry is added."""
     measured_keys = {
         (relpath, lineno, template) for relpath, lineno, _, template in measured(REPO_ROOT)
     }
@@ -168,7 +178,10 @@ def test_the_shipped_exception_table_matches_the_real_measured_population():
         f"table declares {set(_EXCEPTION_TABLE) - measured_keys} that no "
         f"longer exist, and is missing {measured_keys - set(_EXCEPTION_TABLE)}"
     )
-    assert all("#6145" in reason for reason in _EXCEPTION_TABLE.values()), _EXCEPTION_TABLE
+    assert _EXCEPTION_TABLE == {}, (
+        "a table entry was added without updating this test's own "
+        f"docstring (which currently asserts the table is empty): {_EXCEPTION_TABLE}"
+    )
 
 
 def test_the_real_scan_against_the_current_tree_has_nothing_unexplained() -> None:

--- a/tests/security/test_mcp_client_sandbox_wrap.py
+++ b/tests/security/test_mcp_client_sandbox_wrap.py
@@ -34,11 +34,9 @@ and the retargeted env test below close that gap — both falsify-verified
 from __future__ import annotations
 
 import asyncio
+import logging
 import sys
-import warnings
 from pathlib import Path
-
-import pytest
 
 from reyn.mcp.client import MCPClient
 from reyn.security.sandbox.backends.landlock import LandlockBackend
@@ -151,37 +149,40 @@ def test_seatbelt_wrap_subprocess_opt_in_explicit(monkeypatch):
     client.close_stderr_capture()
 
 
-def test_landlock_wrap_uses_reexec_shim(monkeypatch):
+def test_landlock_wrap_uses_reexec_shim(monkeypatch, caplog):
     """Tier 2: under Landlock (#1344 follow-up E), wrap_command wraps the command
     as the reyn.security.sandbox.landlock_exec re-exec shim (python -m ... --policy
     ... -- cmd args) — the COMMAND-level analog of the Seatbelt wrap (no
-    UNSANDBOXED warn — this is a routed, enforced wrap, not a bypass)."""
+    UNSANDBOXED warn — this is a routed, enforced wrap, not a bypass).
+
+    #6145 A: the UNSANDBOXED notice was `warnings.warn(...)` (category
+    omitted) -- promoted to `logger.warning`, read here via `caplog`."""
     _patch_backend(monkeypatch, LandlockBackend())
     client = _stdio_client()
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # any UNSANDBOXED warn would fail here
+    with caplog.at_level(logging.WARNING):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert not any("UNSANDBOXED" in r.message for r in caplog.records)
     assert cmd == sys.executable
     assert args[:2] == ["-m", "reyn.security.sandbox.landlock_exec"]
     sep = args.index("--")
     assert args[sep + 1:] == ["my-mcp", "--flag"]  # original command preserved
 
 
-def test_noop_backend_wraps_argv_unchanged_through_abstraction(monkeypatch):
+def test_noop_backend_wraps_argv_unchanged_through_abstraction(monkeypatch, caplog):
     """Tier 2: #2620 — NoopBackend PASSES THROUGH argv unchanged, but the call
     still routed through backend.wrap_command() (never a raw bypass). No
-    UserWarning is raised — Noop is the owner-acceptable no-enforcement
+    UNSANDBOXED warning is raised — Noop is the owner-acceptable no-enforcement
     outcome, not an error condition to surface as a warning."""
     _patch_backend(monkeypatch, NoopBackend())
     client = _stdio_client()
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with caplog.at_level(logging.WARNING):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert not any("UNSANDBOXED" in r.message for r in caplog.records)
     assert cmd == "my-mcp"
     assert args == ["--flag"]  # unchanged — passthrough, but via wrap_command
 
 
-def test_backend_probe_failure_falls_back_with_warning(monkeypatch):
+def test_backend_probe_failure_falls_back_with_warning(monkeypatch, caplog):
     """Tier 2: only a genuine backend-resolution FAILURE (not a normal Noop
     outcome) falls back to an unwrapped launch — and that fallback is always
     loudly warned, never silent."""
@@ -191,8 +192,9 @@ def test_backend_probe_failure_falls_back_with_warning(monkeypatch):
 
     monkeypatch.setattr("reyn.security.sandbox.get_default_backend", _boom)
     client = _stdio_client()
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
+    with caplog.at_level(logging.WARNING):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert any("UNSANDBOXED" in r.message for r in caplog.records)
     assert cmd == "my-mcp"
     assert args == ["--flag"]
 

--- a/tests/security/test_secrets_interpolation.py
+++ b/tests/security/test_secrets_interpolation.py
@@ -3,17 +3,24 @@
 Pins the contract for ``expand_env()``:
 
   - Single string: ${VAR} is replaced by os.environ value
-  - Undefined VAR: expands to "" with UserWarning
+  - Undefined VAR: expands to "" with a warning
   - $$ escape: expands to literal "$"
   - Non-string scalars (int, bool, None): pass through unchanged
   - Nested dict: all string values at any depth are resolved
   - List: all string items are resolved recursively
   - Mixed nesting (dict of lists, list of dicts): correct resolution
   - mcp_client.expand_env re-export is backward-compatible
+
+#6145 A: the undefined-var notice was `warnings.warn(..., UserWarning)` --
+SILENT outside `__main__` under Python's own default filter, and never
+reached the operator's screen even when visible (`stderr: False /
+reyn.log: True`, architect's measurement). Promoted to `logger.warning`;
+the witness test below reads `caplog` instead of `warnings.catch_warnings`
+for the same reason.
 """
 from __future__ import annotations
 
-import warnings
+import logging
 
 from reyn.security.secrets.interpolation import expand_env
 
@@ -32,17 +39,16 @@ def test_expand_multiple_vars_in_one_string(monkeypatch):
     assert expand_env("${REYN_A}-${REYN_B}") == "foo-bar"
 
 
-def test_undefined_var_expands_to_empty_with_warning(monkeypatch):
-    """Tier 2: undefined ${VAR} expands to '' and emits UserWarning (no crash)."""
+def test_undefined_var_expands_to_empty_with_warning(monkeypatch, caplog):
+    """Tier 2: undefined ${VAR} expands to '' and emits a warning (no crash)."""
     monkeypatch.delenv("REYN_UNDEFINED_XYZ", raising=False)
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         result = expand_env("before_${REYN_UNDEFINED_XYZ}_after")
 
     assert result == "before__after"
     assert any(
-        "REYN_UNDEFINED_XYZ" in str(w.message) for w in caught
+        "REYN_UNDEFINED_XYZ" in r.message for r in caplog.records
     ), "Expected a warning mentioning the undefined variable"
 
 

--- a/tests/security/test_secrets_loader.py
+++ b/tests/security/test_secrets_loader.py
@@ -98,6 +98,40 @@ def test_parse_error_skipped_with_warning(tmp_path, monkeypatch, caplog):
     assert os.environ.get("REYN_TEST_GOOD") == "ok"
 
 
+def test_parse_error_warning_does_not_leak_the_raw_line(tmp_path, monkeypatch, caplog):
+    """Tier 2: #6149 BLOCKING (security) — a malformed secrets.env line
+    (missing '=', or an empty key such as `=SECRET_TOKEN_VALUE`) MUST NOT
+    have its raw text echoed into `reyn.log`. Before this fix the two
+    warnings below both formatted `%r, raw_line` — logging the line
+    VERBATIM, which for the `no '='` case is exactly a bare token/secret
+    pasted on its own line, and for the empty-key case is `=<value>`, the
+    value itself. The operator needs the line NUMBER and the REASON, not
+    the secret. Positive witness (not just "doesn't crash"): assert the
+    literal marker text used for both malformed lines below is ABSENT
+    from every captured record's message."""
+    secrets = tmp_path / "secrets.env"
+    _write_secrets(
+        secrets,
+        "SENTINEL_BARE_SECRET_TOKEN_XYZ\n"
+        "=SENTINEL_EMPTY_KEY_SECRET_ABC\n"
+        "REYN_TEST_GOOD=ok\n",
+    )
+    monkeypatch.delenv("REYN_TEST_GOOD", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        load_secrets_to_environ(path=secrets)
+
+    # Both malformed lines were caught (line-number-and-reason still present).
+    assert any("no '='" in r.message for r in caplog.records)
+    assert any("empty key" in r.message for r in caplog.records)
+    # Neither secret sentinel reached the log, in any record.
+    joined = "\n".join(r.message for r in caplog.records)
+    assert "SENTINEL_BARE_SECRET_TOKEN_XYZ" not in joined
+    assert "SENTINEL_EMPTY_KEY_SECRET_ABC" not in joined
+    # Good line still loaded.
+    assert os.environ.get("REYN_TEST_GOOD") == "ok"
+
+
 def test_chmod_warning_on_world_readable(tmp_path, monkeypatch, caplog):
     """Tier 2: world-readable secrets.env emits a warning and is auto-chmod'd to 600."""
     secrets = tmp_path / "secrets.env"

--- a/tests/security/test_secrets_loader.py
+++ b/tests/security/test_secrets_loader.py
@@ -5,15 +5,22 @@ Pins the following invariants for ``reyn.security.secrets.loader.load_secrets_to
   - File absent: gracefully returns without error
   - File present: values are injected into os.environ
   - No override: pre-existing env vars are NOT overwritten
-  - Parse errors: bad lines emit UserWarning and are skipped; loader continues
+  - Parse errors: bad lines emit a warning and are skipped; loader continues
   - chmod 600 enforce: world-readable file triggers warning and auto-fix
   - Comments and blank lines are ignored
   - Quoted values have quotes stripped
+
+#6145 A: the parse-error and chmod notices were `warnings.warn(...,
+UserWarning)` -- SILENT outside `__main__` under Python's own default
+filter, and never reached the operator's screen even when visible
+(`stderr: False / reyn.log: True`, architect's measurement). Promoted to
+`logger.warning`; this file's own warning-witness tests below read
+`caplog` instead of `warnings.catch_warnings` for the same reason.
 """
 from __future__ import annotations
 
+import logging
 import os
-import warnings
 from pathlib import Path
 
 from reyn.security.secrets.loader import load_secrets_to_environ
@@ -75,24 +82,23 @@ def test_comments_and_blanks_ignored(tmp_path, monkeypatch):
     assert os.environ.get("REYN_TEST_REAL") == "yes"
 
 
-def test_parse_error_skipped_with_warning(tmp_path, monkeypatch):
-    """Tier 2: lines without '=' emit a UserWarning and are skipped; parsing continues."""
+def test_parse_error_skipped_with_warning(tmp_path, monkeypatch, caplog):
+    """Tier 2: lines without '=' emit a warning and are skipped; parsing continues."""
     secrets = tmp_path / "secrets.env"
     _write_secrets(secrets, "NOT_A_VALID_LINE\nREYN_TEST_GOOD=ok\n")
 
     monkeypatch.delenv("REYN_TEST_GOOD", raising=False)
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         load_secrets_to_environ(path=secrets)
 
     # At least one warning was emitted for the bad line
-    assert any("no '='" in str(w.message) or "skipping" in str(w.message) for w in caught)
+    assert any("no '='" in r.message or "skipping" in r.message for r in caplog.records)
     # Good line still loaded
     assert os.environ.get("REYN_TEST_GOOD") == "ok"
 
 
-def test_chmod_warning_on_world_readable(tmp_path, monkeypatch):
+def test_chmod_warning_on_world_readable(tmp_path, monkeypatch, caplog):
     """Tier 2: world-readable secrets.env emits a warning and is auto-chmod'd to 600."""
     secrets = tmp_path / "secrets.env"
     _write_secrets(secrets, "REYN_TEST_WR=value\n")
@@ -101,12 +107,11 @@ def test_chmod_warning_on_world_readable(tmp_path, monkeypatch):
 
     monkeypatch.delenv("REYN_TEST_WR", raising=False)
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
+    with caplog.at_level(logging.WARNING):
         load_secrets_to_environ(path=secrets)
 
     # A warning about permissions was emitted
-    assert any("600" in str(w.message) or "readable" in str(w.message) for w in caught)
+    assert any("600" in r.message or "readable" in r.message for r in caplog.records)
     # File was auto-fixed to 600
     mode = secrets.stat().st_mode & 0o777
     assert mode == 0o600


### PR DESCRIPTION
**[backlog-watcher]** — Closes #6145.

## Summary

#6144's category-blind `scripts/silent_warnings_category_gate.py` carried 18 pre-existing `warnings.warn(...)` call sites under `src/reyn/**` as disclosed, unaudited debt in its own `_EXCEPTION_TABLE`, each marked `#6145 -- pre-#6143 UserWarning, not yet audited`. This PR individually audits each of the 18, one at a time, reading its actual surrounding code (why it fires, who the audience is, what happens if the operator never sees it vs. only a log-reader does).

**Result: all 18 classified A (should reach the operator)**, promoted to `logger.warning` — the same mechanical shape #6144 already used for its own 7 conversions. **Zero B, zero C.** Every one of the 18 fires during a real operational path (secrets/OAuth loading at startup, config parsing, MCP stdio launch, hook-composer setup) — none is a library-consumer-only surface (the only legitimate raw `warnings.warn` reader per lead-coder's own framing in the gate's docstring), and no genuine duplicate-prompt evidence (the `:2069`/`permissions.py` precedent's own bar for C) was found for any site.

**Why B is empty (discriminator, not just an observation)**: the only legitimate reason to leave a site as `warnings.warn` instead of promoting it is that its actual audience is a library CONSUMER who wants to filter it programmatically via Python's own `-W`/`warnings.filterwarnings` machinery, independent of reyn's own logging — i.e. code calling into `reyn` as a library, not reyn's own operator. None of these 18 sites has that audience: all 18 fire on reyn's OWN internal paths (its own secrets loader, its own config parser, its own MCP client, its own hook composer) where the only real reader is the operator running reyn, via `reyn.log` — not a third party importing `reyn` as a dependency and filtering its warnings. A future 19th site should apply this same test, not "the last N were all A."

`scripts/silent_warnings_category_gate.py`'s own `_EXCEPTION_TABLE` is empty again (population 0) — back to the exact state #6144 left it in immediately after promoting its own 7.

## Full 18-site classification table

| # | file:line | Class | Reason |
|---|---|---|---|
| 1 | `config/chat.py:1451` | A | `stream_repaint_min_interval` rejection notice — identical shape to the 4 sibling `chat.*` rejection notices `_build_chat_config` already promoted in #6143/#6144 (same function). |
| 2 | `security/secrets/oauth.py:150` | A | OAuth token store unreadable (OSError) — the caller's downstream `KeyError`/re-auth path never carries WHY; operator debugging a broken auth needs this in `reyn.log`. |
| 3 | `security/secrets/oauth.py:159` | A | OAuth token store not valid JSON — same reasoning as #2. |
| 4 | `security/secrets/oauth.py:167` | A | OAuth token store not a JSON object — same reasoning as #2. |
| 5 | `security/secrets/oauth.py:196` | A | One stored OAuth token is not an object — same reasoning as #2 (per-key). |
| 6 | `security/secrets/oauth.py:205` | A | One stored OAuth token malformed — same reasoning as #2 (per-key). |
| 7 | `security/secrets/oauth.py:250` | A | OAuth token store world/group-readable, auto-fixed to 600 — a real security exposure on the operator's own machine; needs the log. |
| 8 | `security/secrets/loader.py:47` | A | `secrets.env` world/group-readable, auto-fixed — same class as #7. |
| 9 | `security/secrets/loader.py:56` | A | chmod 600 itself failed — operator needs to know the auto-fix didn't take. |
| 10 | `security/secrets/loader.py:79` | A | `secrets.env` line has no `=` — a startup secrets load producing fewer secrets than expected needs the exact bad line in the log. |
| 11 | `security/secrets/loader.py:88` | A | `secrets.env` line has an empty key — same reasoning as #10. |
| 12 | `security/secrets/loader.py:133` | A | `secrets.env` unreadable (OSError) — startup silently produces zero secrets without this. |
| 13 | `security/secrets/loader.py:143` | A | Unexpected error parsing `secrets.env` — same reasoning as #12. |
| 14 | `security/secrets/interpolation.py:37` | A | `${VAR}` references an undefined env var, expands to `""` — operator needs this to find the typo. |
| 15 | `plugins/tokens.py:310` | A | `expand_yaml_tokens_or_refuse` refuses a WHOLE config layer (reyn/hooks.yaml/profile.yaml face) on an unresolved reyn-owned token — this is reyn's own bug per the function's own docstring; operator needs the reason, not just the downstream symptom of a face silently missing content. |
| 16 | `mcp/client.py:2523` | A | MCP stdio server launches UNSANDBOXED after a backend probe/wrap failure — security-critical, but converted to `logger.warning` only (not additionally threaded to the Ctx pane). Reasoning: this is an EVENT (fires on a rare defensive failure), not persistent session posture the way #6139's `network_enforcement_gap` is; it already carries a durable, structured `sandbox_policy_not_applied` audit-event (#3821) recording server/command/reason; building the full `project_status` → `state.py` → `read_model.py` → `chrome.py` Ctx-pane plumbing for a one-off event would be a new feature, not a channel promotion, and is out of this audit's scope (no unrelated refactoring). Disclosed as a follow-up, not silently dropped — see "Disclosed follow-up" below. |
| 17 | `hooks/composer.py:634` | A | A `durable:` composer built with no durable store falls back to `InMemoryPendingStore` silently losing armed state on crash — CLAUDE.md's never-a-silent-dead-man-switch rule; load-time notice, same promotion class as the config-load sites above. |
| 18 | `hooks/composer.py:838` | A | `op=deadline` with explicit `durable: false` — same crash-recovery-band reasoning as #17. |

## Disclosed follow-up (not bundled into this PR)

`mcp/client.py:2523`'s MCP-stdio-UNSANDBOXED fallback is the strongest candidate among the 18 for genuine on-screen (Ctx pane) visibility, given its security criticality — but implementing that (a new `Session` property, `status.py` snapshot field, `state.py`/`read_model.py` projection, and a `chrome.py` Ctx-pane line, mirroring #6139's `_permission_mode_line`) is a new feature surface, not a channel promotion, and this audit's scope is the 18 `warnings.warn` call sites and their accompanying tests/exception-table comments — not new plumbing. Flagged for a follow-up issue at the owner's discretion.

## Conversion summary

- **18 / 18 → `logger.warning`** (channel promotion only).
- **0** additionally threaded to the Ctx pane (1 disclosed candidate, not implemented — see above).
- **0** left as `warnings.warn` with a rewritten B reason.
- **0** deleted as C (no duplicate-prompt evidence found for any site).

## Tests

Updated every pre-existing test asserting on the old `warnings.warn`/`pytest.warns`/`warnings.catch_warnings` behaviour for these 18 sites to read `caplog` at WARNING level instead, mirroring #6144's own test-conversion shape (including its `caplog.clear()` / subject-filtered-assert / unfiltered-caplog-consumption-gate discipline):

- `tests/core/test_stream_repaint_interval_config.py`
- `tests/core/test_fp0016_b_oauth_refresh.py`
- `tests/security/test_secrets_loader.py`
- `tests/security/test_secrets_interpolation.py`
- `tests/config/test_5351_policy_tier_unresolved_agent_token_warns.py`
- `tests/runtime/test_5140_per_agent_composers_token_expansion.py`
- `tests/runtime/test_5140_per_agent_hooks_token_expansion.py`
- `tests/runtime/test_5166_hooks_yaml_layer_registry.py`
- `tests/runtime/test_5801_profile_yaml_reyn_token_expansion.py`
- `tests/mcp/test_mcp_unsandboxed_audit_3821.py`
- `tests/security/test_mcp_client_sandbox_wrap.py`
- `tests/hooks/test_3180_durable_pending_store.py`
- `tests/scripts/test_silent_warnings_category_gate_6143.py` — updated its own docstring/assertion to pin an EMPTY table against an EMPTY measured population (was 18-strong), replacing the now-vacuous `all("#6145" in reason ...)` check with an explicit `== {}` assertion that starts biting again the moment a future entry is added.

No new gate-relevant logic was added (the gate script's own arithmetic is unchanged — only its `_EXCEPTION_TABLE` contents and docstrings), so no new strip-falsify test was required; the pre-existing strip-falsify tests in `tests/scripts/test_silent_warnings_category_gate_6143.py` (category-matching logic, message-template key) are unchanged and still pass.

## Gates run (scoped)

- `ruff check .` — clean
- `python scripts/test_tier_audit.py --strict <13 changed test files>` — 109 tests inspected, 109 OK, 0 warnings, 0 errors
- `python scripts/verify_module_docstrings.py <8 changed src files>` — OK
- `python scripts/mypy_ratchet.py` — OK (changed-files: 183 findings, all baselined)
- `python scripts/flat_tests_ratchet.py` — OK
- `python scripts/check_tests_path_literal_reference.py` — OK
- `tests/`-path gates (`check_bare_tests_import_reference`, `check_file_depth_reference`, `check_subprocess_reyn_pin`, `check_no_core_dep_importorskip`, `suspected_time_dependence_ratchet`) — all OK
- `python scripts/check_fastmcp_import_boundary.py` (`src/reyn/mcp/` touched, per that dir's own CLAUDE.md) — OK
- `python scripts/silent_warnings_category_gate.py` against the real tree — `0 warnings.warn(...) site(s), all in the exception table`
- diff-scoped `pytest` across all 13 touched/new test files — **113 passed**

## Test plan

- [x] `pytest tests/config/test_5351_policy_tier_unresolved_agent_token_warns.py tests/core/test_fp0016_b_oauth_refresh.py tests/core/test_stream_repaint_interval_config.py tests/hooks/test_3180_durable_pending_store.py tests/mcp/test_mcp_unsandboxed_audit_3821.py tests/runtime/test_5140_per_agent_composers_token_expansion.py tests/runtime/test_5140_per_agent_hooks_token_expansion.py tests/runtime/test_5166_hooks_yaml_layer_registry.py tests/runtime/test_5801_profile_yaml_reyn_token_expansion.py tests/scripts/test_silent_warnings_category_gate_6143.py tests/security/test_mcp_client_sandbox_wrap.py tests/security/test_secrets_interpolation.py tests/security/test_secrets_loader.py` — 113 passed
- [x] (skipped — Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cv2weFGjibsJNGgEGH3L5

