### PR TITLE
fix(part of #6146): web_fetch's fallback OpContext synthesis had no real guard

### DIFF
--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -127,6 +127,18 @@ class _VisibilityProbeOps:
         from reyn.tools import universal_catalog
         from reyn.tools.types import RouterCallerState, ToolContext
 
+        # #6146 co-vet (lead-coder): this ``RouterCallerState`` carries no
+        # ``op_context_factory`` (schema introspection only — ``universal_
+        # catalog.catalog_entries`` below never calls a tool's own
+        # ``.handler(...)``, so no ``_handle`` ever needs one here). Safe
+        # ONLY because ``permission_resolver=None``: web_fetch.py's own
+        # fallback-synthesis guard (#6146) refuses "a real
+        # PermissionResolver with no op_context_factory to source a bus
+        # from" — if a future change threads a real resolver into this
+        # ToolContext (or a handler invocation is added on this same
+        # path), it hits that guard immediately. Keep this ``None`` unless
+        # you also give this ``RouterCallerState`` a real
+        # ``op_context_factory``.
         tool_ctx = ToolContext(
             events=None,
             permission_resolver=None,

--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -131,14 +131,20 @@ class _VisibilityProbeOps:
         # ``op_context_factory`` (schema introspection only — ``universal_
         # catalog.catalog_entries`` below never calls a tool's own
         # ``.handler(...)``, so no ``_handle`` ever needs one here). Safe
-        # ONLY because ``permission_resolver=None``: web_fetch.py's own
-        # fallback-synthesis guard (#6146) refuses "a real
-        # PermissionResolver with no op_context_factory to source a bus
-        # from" — if a future change threads a real resolver into this
-        # ToolContext (or a handler invocation is added on this same
-        # path), it hits that guard immediately. Keep this ``None`` unless
-        # you also give this ``RouterCallerState`` a real
-        # ``op_context_factory``.
+        # ONLY because ``permission_resolver=None`` — but read what that
+        # guard actually checks before trusting it: web_fetch.py's own
+        # fallback-synthesis guard (#6146) fires on ONE condition,
+        # ``permission_resolver is not None``. It catches a future change
+        # that threads a REAL resolver into this ToolContext while a
+        # handler invocation stays absent-or-present either way. It does
+        # **NOT** catch the other direction: adding a real ``.handler(...)``
+        # call on this same path while ``permission_resolver`` stays
+        # ``None`` runs with NO permission gate at all, silently — the
+        # guard never fires, because its one condition was never true.
+        # If you add a handler invocation here, wire a real
+        # ``permission_resolver`` (and an ``op_context_factory``) at the
+        # SAME time — do not rely on this comment or the guard to catch
+        # the omission for you.
         tool_ctx = ToolContext(
             events=None,
             permission_resolver=None,

--- a/src/reyn/tools/web_fetch.py
+++ b/src/reyn/tools/web_fetch.py
@@ -52,9 +52,23 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         ``web.fetch: deny`` actually raise on the router-invoked
         path (#53 fix).
       Fallback — minimal synthesis from ToolContext fields. Used by
-        narrow test sites that don't exercise permission gating. ``intervention_bus=None`` is acceptable
-        here because the fallback path doesn't have a session bus to
-        reuse anyway.
+        narrow test sites that don't exercise permission gating.
+        ``ToolContext`` has no ``intervention_bus`` field at all, so
+        this fallback's own ``legacy_ctx`` is unconditionally built
+        with ``intervention_bus=None`` (the ``OpContext`` field's own
+        default). #6146 co-vet finding (lead-coder, 2026-09-11): an
+        EARLIER version of this docstring claimed that combination was
+        safe because "the handler will raise the explicit RuntimeError
+        above if a PermissionResolver is also present" — that claim
+        was FALSE. The only such `RuntimeError` in
+        ``op_runtime/web.py`` guards the multimodal/binary-media branch
+        alone (fires only for an image response, ~111 lines below the
+        real gate) — it never runs for ``require_http_get`` itself, so
+        a resolver-present + bus-less fallback call reached that gate
+        with no protection at all. Fixed below: this fallback now
+        raises its OWN ``RuntimeError`` up front whenever
+        ``ctx.permission_resolver`` is present, rather than relying on
+        a guard elsewhere that never covered this path.
     """
     # Lazy import to avoid circular dependency at registry-init time.
     from reyn.core.op_runtime.context import OpContext
@@ -72,10 +86,26 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         legacy_ctx = rs.op_context_factory()
     else:
         # Narrow test sites + future surfaces without a router factory.
-        # ``intervention_bus=None`` is acceptable only because the
-        # fallback path doesn't have any bus to reuse anyway; the
-        # handler will raise the explicit RuntimeError above if a
-        # PermissionResolver is also present.
+        # #6146 co-vet: ``ToolContext`` has no ``intervention_bus`` field,
+        # so this branch's own ``legacy_ctx`` is unconditionally built
+        # with ``intervention_bus=None`` below. A present
+        # ``permission_resolver`` would then reach ``require_http_get``
+        # (and every other gate) with no bus to prompt on — silently
+        # falling back to the "no bus" behaviour (deny for anything not
+        # already approved) instead of the interactive gate a real
+        # PermissionResolver implies. Refuse the combination outright
+        # rather than let it run degraded: a caller that has a real
+        # resolver belongs on the ``op_context_factory`` path above, not
+        # this narrow one.
+        if ctx.permission_resolver is not None:
+            raise RuntimeError(
+                "web_fetch's fallback OpContext synthesis has no "
+                "intervention_bus to offer (ToolContext carries none), but "
+                "ctx.permission_resolver is set -- this combination would "
+                "silently run every permission gate with no bus available. "
+                "Route this call through ctx.router_state.op_context_factory() "
+                "instead, which carries a real InterventionBus."
+            )
         legacy_ctx = OpContext(
             workspace=ctx.workspace,
             events=ctx.events,

--- a/tests/security/test_web_fetch_unified.py
+++ b/tests/security/test_web_fetch_unified.py
@@ -391,3 +391,72 @@ def test_router_invoke_action_web_fetch_allow_no_deny_proceeds(
     assert result.get("kind") == "web_fetch"
     # The deny path would have raised before getting a dict back.
 
+
+# ── #6146: the fallback OpContext synthesis has no bus to offer ──────────
+
+
+def test_fallback_synthesis_refuses_a_resolver_with_no_router_state(tmp_path: Path) -> None:
+    """Tier 2: #6146 co-vet finding (lead-coder) -- ``web_fetch._handle``'s
+    fallback branch (no ``router_state`` at all) unconditionally builds its
+    own ``OpContext`` with ``intervention_bus=None`` (``ToolContext`` has no
+    such field to thread through). Combined with a REAL
+    ``permission_resolver``, that used to run every permission gate with no
+    bus available -- the module's own docstring claimed a `RuntimeError`
+    elsewhere caught this, but that `RuntimeError` only guards the
+    multimodal/binary-media branch (~111 lines later, image responses
+    only), never `require_http_get` itself. The fallback now refuses the
+    combination up front instead."""
+    from reyn.security.permissions.permissions import PermissionResolver
+    from reyn.tools.types import ToolContext
+
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=True)
+    tool_ctx = ToolContext(
+        events=None, permission_resolver=resolver, workspace=None,
+        caller_kind="operator", router_state=None,
+    )
+
+    with pytest.raises(RuntimeError, match="intervention_bus"):
+        asyncio.run(WEB_FETCH.handler({"url": "http://127.0.0.1:1/x"}, tool_ctx))
+
+
+def test_fallback_synthesis_refuses_a_resolver_with_a_factory_less_router_state(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: deny-side companion -- a `router_state` object THAT EXISTS
+    but carries no `op_context_factory` (every field on `RouterCallerState`
+    is individually optional, so a caller can construct one without it)
+    still falls into the SAME fallback branch (`rs.op_context_factory is
+    None`), so the same guard must fire -- not only the "router_state is
+    None entirely" shape the sibling test above covers."""
+    from reyn.security.permissions.permissions import PermissionResolver
+    from reyn.tools.types import RouterCallerState, ToolContext
+
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=True)
+    rs = RouterCallerState()  # op_context_factory left at its own None default
+    tool_ctx = ToolContext(
+        events=None, permission_resolver=resolver, workspace=None,
+        caller_kind="router", router_state=rs,
+    )
+
+    with pytest.raises(RuntimeError, match="intervention_bus"):
+        asyncio.run(WEB_FETCH.handler({"url": "http://127.0.0.1:1/x"}, tool_ctx))
+
+
+def test_fallback_synthesis_with_no_resolver_at_all_is_unaffected() -> None:
+    """Tier 2: deny side -- the guard is scoped to a PRESENT
+    `permission_resolver`; a caller with none (the shape #6146's own
+    guard must not break -- narrow test sites that genuinely don't
+    exercise permission gating) still reaches the real fetch attempt,
+    proving the new raise did not become unconditional."""
+    from reyn.core.events.events import EventLog
+    from reyn.tools.types import ToolContext
+
+    tool_ctx = ToolContext(
+        events=EventLog(), permission_resolver=None, workspace=None,
+        caller_kind="operator", router_state=None,
+    )
+
+    result = asyncio.run(WEB_FETCH.handler({"url": "http://127.0.0.1:1/never-listens"}, tool_ctx))
+    assert isinstance(result, dict)
+    assert result.get("kind") == "web_fetch"
+

--- a/tests/security/test_web_fetch_unified.py
+++ b/tests/security/test_web_fetch_unified.py
@@ -405,13 +405,25 @@ def test_fallback_synthesis_refuses_a_resolver_with_no_router_state(tmp_path: Pa
     elsewhere caught this, but that `RuntimeError` only guards the
     multimodal/binary-media branch (~111 lines later, image responses
     only), never `require_http_get` itself. The fallback now refuses the
-    combination up front instead."""
+    combination up front instead.
+
+    NON-VACUITY (strip-falsified by hand, file-internal Edit only,
+    reverted): removing the new raise makes this test's own call proceed
+    past the guard, reach ``op_runtime/web.py``'s ``_gate_hop``, and hit
+    ``require_http_get(..., bus=None, ...)`` -- which raises
+    ``PermissionError`` on ITS OWN "no interactive bus available"
+    fail-closed path (a real ``events=EventLog()`` is required for the
+    call to get that far at all; a stripped run with ``events=None``
+    only proves the code reaches the FIRST `ctx.events.emit(...)` call,
+    an under-claim caught by lead-coder's own re-read of the first
+    version of this test)."""
+    from reyn.core.events.events import EventLog
     from reyn.security.permissions.permissions import PermissionResolver
     from reyn.tools.types import ToolContext
 
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=True)
     tool_ctx = ToolContext(
-        events=None, permission_resolver=resolver, workspace=None,
+        events=EventLog(), permission_resolver=resolver, workspace=None,
         caller_kind="operator", router_state=None,
     )
 
@@ -428,13 +440,14 @@ def test_fallback_synthesis_refuses_a_resolver_with_a_factory_less_router_state(
     still falls into the SAME fallback branch (`rs.op_context_factory is
     None`), so the same guard must fire -- not only the "router_state is
     None entirely" shape the sibling test above covers."""
+    from reyn.core.events.events import EventLog
     from reyn.security.permissions.permissions import PermissionResolver
     from reyn.tools.types import RouterCallerState, ToolContext
 
     resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=True)
     rs = RouterCallerState()  # op_context_factory left at its own None default
     tool_ctx = ToolContext(
-        events=None, permission_resolver=resolver, workspace=None,
+        events=EventLog(), permission_resolver=resolver, workspace=None,
         caller_kind="router", router_state=rs,
     )
 


### PR DESCRIPTION
**[tui-coder]** — part of #6146's own arc (this is the precursor guard, not #6146 itself, per dispatch).

## Summary

`web_fetch._handle`'s fallback branch (used when there is no `router_state.op_context_factory`) unconditionally builds its own `OpContext` with `intervention_bus=None` — `ToolContext` has no such field to thread through at all. The docstring claimed this was safe because "the handler will raise the explicit RuntimeError above if a PermissionResolver is also present" — **that claim was false**. That `RuntimeError` (`op_runtime/web.py`, ~111 lines later) only guards the multimodal/binary-media branch (image responses, when `multimodal_config` is also set), never `require_http_get` itself. A resolver-present + bus-less fallback call reached that gate with **no protection**: it would just run with `bus=None`, silently degrading to deny-unless-already-approved instead of the interactive gate a real `PermissionResolver` implies.

## Fix

The fallback now raises its own `RuntimeError` up front whenever `ctx.permission_resolver` is present, refusing the combination outright rather than letting it run degraded. Docstring and inline comment rewritten to point at this real guard instead of the false claim.

## Behaviour change — which call sites could go red (corrected per lead-coder co-vet)

Audited every production `ToolContext(...)` construction site (10 total, `src/`). `tools/types.py:356` reads `host.make_router_op_context` as a **direct attribute** (#5822: a host still lacking it raises `AttributeError` at construction, never silently `None`) — so all 3 `router_loop.py` call sites, built via `_build_router_caller_state()`, are structurally guaranteed a real `op_context_factory`. My first pass mis-audited these as factory-less; they are not.

The **one** genuinely factory-less site is `capability_visibility.py`'s `catalog_entries()`, and it's safe today only because its own `ToolContext` sets `permission_resolver=None` — a fragile invariant, since a future change wiring a real resolver into that catalog call would trip the new guard with no visible link to why. Added an explicit comment there naming the dependency.

No test site constructs a `ToolContext` for `web_fetch` with both a real `permission_resolver` and a `router_state` lacking `op_context_factory` either.

**Net: no known production or test call site goes red today.** The 2 new positive tests are themselves the only sites that hit the new raise — by design, to prove it fires.

## Strip-falsify (verified by hand, file-internal Edit only, reverted)

Removed the new raise — both positive tests went red. First pass overclaimed what the failure showed (an `AttributeError` at the first `ctx.events.emit(...)`, since the test's `ctx.events` was `None` — that only proves the code proceeds past the guard, not that it reaches the real gate). Fixed by giving both tests a real `EventLog()`; re-verified: a stripped run now demonstrably reaches `op_runtime/web.py`'s `_gate_hop` and raises `PermissionError` on `require_http_get`'s own "no interactive bus available" fail-closed path — the exact silent-degradation claim, shown directly.

## Gates run (scoped)

- `ruff check .` — clean
- `scripts/test_tier_audit.py --strict` on the touched test file — 20/20 OK
- `scripts/verify_module_docstrings.py` — OK
- `scripts/mypy_ratchet.py` — OK (changed-files)
- `scripts/flat_tests_ratchet.py` / `check_tests_path_literal_reference.py` / `check_bare_tests_import_reference.py` / `check_file_depth_reference.py` / `check_subprocess_reyn_pin.py` / `check_no_core_dep_importorskip.py` / `suspected_time_dependence_ratchet.py` — all OK
- `check_unfiltered_caplog_consumption.py` / `silent_warnings_category_gate.py` — still clean
- diff-scoped pytest — 20/20 passed

## Test plan

- [x] `pytest tests/security/test_web_fetch_unified.py` — 20 passed
- [x] (skipped — Visual, standing waiver 2026-08-08)

**Security-adjacent — architect co-vet required**, per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn