### PR TITLE
fix(#6151): isolate Session's child_temp_dir per test by default

### DIFF
--- a/.github/workflows/session-child-temp-dir-isolation-gate.yml
+++ b/.github/workflows/session-child-temp-dir-isolation-gate.yml
@@ -1,0 +1,47 @@
+name: session-child-temp-dir-isolation gate
+
+# #6151: reject any direct `Session(...)` construction in tests/ (outside
+# the two sanctioned helpers, tests/_support/agent_session.py and
+# tests/_support/session.py, which are this fix's own home) that omits
+# child_temp_dir= -- such a construction resolves Session._child_temp_dir
+# to a REAL, SHARED filesystem path (<tempdir>/reyn/<agent_name>/
+# <session_id>), the exact shape #6151 measured colliding across
+# `pytest -n auto` worker processes in CI. See
+# scripts/check_session_child_temp_dir_isolation.py's module docstring
+# for the full design rationale.
+#
+# No diff/base-ref needed -- a whole-tree scan against a baseline of zero,
+# same shape as bare-tests-import-reference-gate.yml /
+# no-core-dep-importorskip-gate.yml. A shallow checkout is enough.
+#
+# Two independent triggers: tests/** (a new/changed direct Session(...)
+# construction) and this gate script's own path (an edit to the gate
+# itself should re-run it).
+on:
+  pull_request:
+    paths:
+      - "tests/**"
+      - "scripts/check_session_child_temp_dir_isolation.py"
+
+permissions:
+  contents: read
+
+jobs:
+  session-child-temp-dir-isolation:
+    name: session-child-temp-dir-isolation gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      # scripts/check_session_child_temp_dir_isolation.py is stdlib-only
+      # (ast / pathlib / sys). No pip install needed.
+      - name: Check no direct Session(...) construction omits child_temp_dir=
+        run: |
+          python scripts/check_session_child_temp_dir_isolation.py

--- a/scripts/check_session_child_temp_dir_isolation.py
+++ b/scripts/check_session_child_temp_dir_isolation.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""#6151 — a test-side ``Session(...)`` construction that omits
+``child_temp_dir=`` resolves ``Session._child_temp_dir`` to
+``<tempdir>/reyn/<agent_name>/<session_id>`` -- a REAL, SHARED filesystem
+path. Two of this repo's own sanctioned test helpers,
+``tests/_support/agent_session.py::make_session`` and
+``tests/_support/session.py::make_session``, both default their own
+``agent_name``/``session_id`` to fixed literals ("alpha"/"main",
+"default"/"main") across hundreds of call sites -- #6151 measured
+``pytest -n auto`` workers racing (create/delete/permission) on that ONE
+shared directory across unrelated tests in different worker processes,
+producing intermittent, hard-to-reproduce CI failures.
+
+Both helpers now isolate this by DEFAULT (an ``isolate_child_temp_dir``
+kwarg, default ``True``, injects a fresh ``tempfile.mkdtemp()``-based
+``child_temp_dir`` per call unless the caller explicitly opts out or
+supplies their own). This gate closes the SECOND entry point: a test
+file that constructs ``reyn.runtime.session.Session`` DIRECTLY (bypassing
+both helpers) gets none of that automatic protection -- #6151's own
+investigation found one such site (``test_skill_invoke_3100.py``'s
+``_session_with_skills``, itself a documented copy-paste of the
+``tests/_support/session.py`` helper body, #3413) already exposed to the
+exact same shared-path shape.
+
+## What counts as a violation
+
+A real ``ast.Call`` whose function resolves to the bare name ``Session``
+(the overwhelmingly common import shape, ``from reyn.runtime.session
+import Session``) inside ``tests/`` -- excluding this repo's own two
+sanctioned helper files, which are the fix's own home, not a caller of
+it -- that has NO ``child_temp_dir=`` keyword argument among its call
+args. A ``Session(...)`` call is deliberately NOT matched by a dotted
+name (``session.Session(...)``) or an aliased import -- this gate's own
+starting population is the ONE real site #6151 already found and fixed
+(re-verified empty as of this gate's own authoring), so a future
+regression of either shape is what this exists to catch, not a claim of
+exhaustive detection against every possible import alias.
+
+CI: gate
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# The fix's own home -- these two helpers ARE the isolation mechanism
+# (their own `Session(...)` call already threads `child_temp_dir=`
+# through their own `isolate_child_temp_dir` param), not a caller this
+# gate should flag.
+_EXEMPT_FILES = frozenset({
+    _TESTS_DIR / "_support" / "agent_session.py",
+    _TESTS_DIR / "_support" / "session.py",
+})
+
+
+def _is_session_call(node: ast.AST) -> bool:
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Session"
+
+
+def _has_child_temp_dir_kwarg(call: ast.Call) -> bool:
+    return any(kw.arg == "child_temp_dir" for kw in call.keywords)
+
+
+def offending_calls(tests_dir: Path = _TESTS_DIR) -> "list[tuple[Path, int]]":
+    """Every direct ``Session(...)`` call under ``tests/`` (outside the 2
+    exempt helper files) missing ``child_temp_dir=``."""
+    offenders: "list[tuple[Path, int]]" = []
+    for path in sorted(tests_dir.rglob("*.py")):
+        if path in _EXEMPT_FILES:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if _is_session_call(node) and not _has_child_temp_dir_kwarg(node):
+                offenders.append((path, node.lineno))
+    return offenders
+
+
+def main() -> int:
+    offenders = offending_calls()
+    if not offenders:
+        print("OK: no direct Session(...) construction in tests/ omits child_temp_dir=.")
+        return 0
+
+    print("session-child-temp-dir-isolation gate FAILED:\n", file=sys.stderr)
+    print(
+        f"{len(offenders)} direct Session(...) construction(s) in tests/ omit "
+        "child_temp_dir= -- each resolves to a SHARED real filesystem path "
+        "(<tempdir>/reyn/<agent_name>/<session_id>) that can collide with "
+        "an unrelated test in a different `pytest -n auto` worker (#6151):",
+        file=sys.stderr,
+    )
+    for path, lineno in offenders:
+        rel = path.relative_to(_ROOT)
+        print(f"  {rel}:{lineno}", file=sys.stderr)
+
+    print(
+        "\nFix: prefer tests/_support/agent_session.py::make_session or "
+        "tests/_support/session.py::make_session (both isolate this by "
+        "default, #6151) over a direct Session(...) construction. If a "
+        "direct construction is genuinely required, pass your own "
+        "child_temp_dir= (e.g. tempfile.mkdtemp(prefix='reyn-test-child-')) "
+        "explicitly -- never the shared default.\n"
+        "\nThis gate's own starting population is zero (#6151's own "
+        "cleanup), so any hit here is a new regression, not inherited debt.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1078,6 +1078,19 @@ class Session:
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
         # Conversation session id WAL entries are recorded under, default "main" (FP-0043 Stage 5)
         session_id: str = "main",
+        # #6151: optional override for the session-owned child-process
+        # scratch dir (#5184's own `_child_temp_dir`). None -> the
+        # existing formula, `<tempdir>/reyn/<agent_name>/<session_id>`,
+        # UNCHANGED for every production caller and any test that wants
+        # to verify that formula itself (test_5184_session_temp_lifetime.
+        # py). Tests use this the same way they use `snapshot_path` above
+        # to redirect I/O to a tmp_path without touching private
+        # attributes — `make_session()` injects a fresh, isolated one by
+        # default (see its own `isolate_child_temp_dir` param) precisely
+        # so MANY tests sharing the same `agent_name`/`session_id`
+        # default ("alpha"/"main") never collide on this ONE real
+        # filesystem path under parallel xdist workers (#6151).
+        child_temp_dir: "str | Path | None" = None,
         # Injectable execution driver seam; None -> default RouterLoopDriver construction
         loop_driver: "ExecutionDriver | None" = None,
         # Pre-built PipelineRegistry from the session factory; None -> empty registry (#2575)
@@ -1440,8 +1453,12 @@ class Session:
         # so sandbox write grants never widen recovery-core permissions. The
         # directory is created lazily by the first child launch; construction
         # alone must not leave an artifact that only run() can clean up.
+        # #6151: `child_temp_dir=` (constructor param, above) overrides the
+        # formula below when given — the default (None) formula is BYTE-
+        # IDENTICAL to before this param existed.
         self._child_temp_dir = (
-            Path(tempfile.gettempdir()) / "reyn" / self._agent.agent_name / session_id
+            Path(child_temp_dir) if child_temp_dir is not None
+            else Path(tempfile.gettempdir()) / "reyn" / self._agent.agent_name / session_id
         )
         # #3705: pass the resolved state root through so an explicitly-
         # supplied workspace_state_dir isn't silently ignored (only used

--- a/tests/_support/agent_session.py
+++ b/tests/_support/agent_session.py
@@ -21,6 +21,7 @@ Session still reads directly in a couple of spots (``_build_retrieval_bundle``,
 """
 from __future__ import annotations
 
+import tempfile
 from typing import Any
 
 from reyn.runtime.agent import Agent
@@ -52,7 +53,9 @@ _AGENT_FIELD_FROM_KWARG = {
 }
 
 
-def make_session(*, role: str | None = None, **kwargs: Any) -> Session:
+def make_session(
+    *, role: str | None = None, isolate_child_temp_dir: bool = True, **kwargs: Any,
+) -> Session:
     """Build a ``Session`` via an explicit ``Agent`` (identity SSoT).
 
     Accepts every kwarg the pre-migration flat ``Session(...)`` call sites
@@ -75,9 +78,27 @@ def make_session(*, role: str | None = None, **kwargs: Any) -> Session:
     dropped by a future edit. ``Agent.agent_name`` itself has no default, so
     omitting it now raises ``TypeError`` immediately instead of falling back
     to a fixed literal.)
-    """
+
+    ``isolate_child_temp_dir`` (#6151): DEFAULT True — injects a fresh,
+    per-call ``child_temp_dir`` (Session's own #6151 override param)
+    UNLESS the caller already passed one explicitly. Root cause: this
+    helper's own defaults are `agent_name` (no default, but MANY call
+    sites literally pass ``"alpha"``) + `session_id` (defaults to
+    ``"main"``, a value many OTHER tests assert on directly — see
+    ``tests/core/test_registry_list_rewind_points_1f.py`` et al, so that
+    default itself must NOT change). Combined, those two produce the
+    SAME real filesystem path, ``<tempdir>/reyn/alpha/main``, for every
+    test that doesn't override either — #6151 measured `-n auto` workers
+    colliding on that ONE shared directory (create/delete/permission
+    races). Isolating the TEMP DIR (not `session_id`, which many tests
+    depend on) removes the sharing without touching either load-bearing
+    default. Pass ``isolate_child_temp_dir=False`` (or an explicit
+    ``child_temp_dir=``) when a test's own subject IS this formula
+    itself — see ``tests/runtime/test_5184_session_temp_lifetime.py``."""
     if role is not None:
         kwargs.setdefault("agent_role", role)
+    if isolate_child_temp_dir and "child_temp_dir" not in kwargs:
+        kwargs["child_temp_dir"] = tempfile.mkdtemp(prefix="reyn-test-child-")
 
     agent_field_kwargs = {
         agent_field: kwargs.pop(kwarg_name)

--- a/tests/_support/session.py
+++ b/tests/_support/session.py
@@ -7,6 +7,7 @@ compaction tests — no unittest.mock).
 from __future__ import annotations
 
 import contextlib
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -79,6 +80,7 @@ def make_session(
     state_log: StateLog | None = None,
     snapshot_path: Path | None = None,
     resolver: ModelResolver | None = None,
+    isolate_child_temp_dir: bool = True,
 ) -> Session:
     """Create a Session whose compaction engine uses a synthetic T_max.
 
@@ -108,6 +110,17 @@ def make_session(
     ``test_skill_invoke_3100.py`` did. Making them explicit optional
     overrides removes that duplication incentive without changing behaviour
     for the 15 existing call sites, none of which pass any of the three.)
+
+    ``isolate_child_temp_dir`` (#6151): DEFAULT True. This helper's own
+    default ``agent_name="default"`` PLUS its ``build_recovery(...)`` call
+    below hardcoding ``"main"`` (not even parameterizable through this
+    signature) means every call site that omits ``agent`` resolves to the
+    SAME real filesystem ``Session._child_temp_dir`` —
+    ``<tempdir>/reyn/default/main`` — a second instance of the SAME defect
+    class ``tests/_support/agent_session.py::make_session`` fixes (#6151):
+    unrelated tests in different `-n auto` workers collided on that one
+    shared directory. Pass ``isolate_child_temp_dir=False`` only if a
+    test's own subject is the raw, unoverridden formula itself.
     """
     if agent is None:
         # Agent is the sole identity SSoT (#3133 Priority-0 step-2 removed
@@ -153,6 +166,12 @@ def make_session(
     # test: the lazy build stays lazy, genuinely exercised, wherever it
     # happens to fire.
     monkeypatch.setattr(_mb, "get_max_input_tokens", lambda model, **kw: t_max)
+    # #6151: see this function's own docstring -- isolates the shared
+    # `<tempdir>/reyn/default/main` formula by default, same escape hatch
+    # (`isolate_child_temp_dir=False`) as agent_session.py's make_session.
+    child_temp_dir = (
+        tempfile.mkdtemp(prefix="reyn-test-child-") if isolate_child_temp_dir else None
+    )
     return Session(
         agent=agent,
         generation_store=generation_store,
@@ -164,6 +183,7 @@ def make_session(
         snapshot_path=snapshot_path,
         resolver=resolver or TEST_MODEL_RESOLVER,
         reactivity=ReactivityConfig(),
+        child_temp_dir=child_temp_dir,
     )
 
 

--- a/tests/runtime/test_5184_session_temp_lifetime.py
+++ b/tests/runtime/test_5184_session_temp_lifetime.py
@@ -22,6 +22,10 @@ def test_constructing_a_session_does_not_create_child_temp_dir(tmp_path: Path) -
         session_id=session_id,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / ".reyn" / "agents" / "test-agent" / "state" / "snapshot.json",
+        # #6151: this test's own subject IS the production child_temp_dir
+        # FORMULA (asserted against `temp_dir` above) — opt out of
+        # make_session's default per-call isolation so it stays exposed.
+        isolate_child_temp_dir=False,
     )
 
     assert not temp_dir.exists()

--- a/tests/runtime/test_6151_child_temp_dir_isolation.py
+++ b/tests/runtime/test_6151_child_temp_dir_isolation.py
@@ -1,0 +1,95 @@
+"""Tier 2: #6151 — two ``make_session()`` calls sharing the SAME
+``agent_name``/``session_id`` defaults (``"alpha"``/``"main"``, respectively
+— the second because MANY tests assert on it directly, see
+``tests/core/test_registry_list_rewind_points_1f.py`` et al, so it cannot
+change) used to compute the SAME real filesystem
+``<tempdir>/reyn/alpha/main`` for ``Session._child_temp_dir``. Under
+``pytest -n auto``, unrelated tests in DIFFERENT worker processes hit this
+exact path concurrently — one worker's create/cleanup racing another's
+mid-write use produced the CI-measured failures (``session temp_dir is not
+writable``, ``the command must queue at least one new block``), lead-coder
+traced to `tests/interfaces/test_5837_exec_slash_stage1.py:29`'s fixed
+``agent_name="alpha"``.
+
+Reads the resolved temp dir through the PUBLIC surface
+``session.router_host.make_router_op_context().temp_dir`` — the same
+sanctioned path ``test_5184_session_temp_lifetime.py`` already
+establishes — never ``session._child_temp_dir`` directly (private state,
+testing.md/Tier 4).
+
+Real ``Session``/``make_session`` throughout — no mocks.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from tests._support.agent_session import make_session
+
+
+def _resolved_temp_dir(session) -> str:
+    """The one PUBLIC read of the resolved child-temp path -- also creates
+    it on disk (the real, lazy production path), so callers clean up.
+    ``default_sandbox_policy["temp_dir"]`` (``resolve_sandbox_policy``'s
+    own public dict-shaped return) is where the SAME value lead-coder's
+    own CI failure message names verbatim (``session temp_dir is not
+    writable: '/tmp/reyn/alpha/main'``) ends up."""
+    ctx = session.router_host.make_router_op_context()
+    return ctx.default_sandbox_policy["temp_dir"]
+
+
+def _session(tmp_path: Path, name: str, *, isolate: bool = True):
+    return make_session(
+        agent_name="alpha",
+        state_log=StateLog(tmp_path / f"{name}.wal"),
+        snapshot_path=tmp_path / f"{name}-snap.json",
+        isolate_child_temp_dir=isolate,
+    )
+
+
+def test_two_sessions_sharing_agent_and_session_id_defaults_get_isolated_temp_dirs(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept -- #6151's own fix. Two sessions built with nothing
+    but the SAME defaults (``agent_name="alpha"``, ``session_id`` omitted
+    -> ``"main"``) must never resolve to the same real child-temp path --
+    the exact shape that collided under `-n auto` workers.
+
+    FALSIFY: passing ``isolate=False`` to both (the pre-#6151 shape) makes
+    this go red -- both land on the identical
+    ``<tempdir>/reyn/alpha/main`` path."""
+    session_a = _session(tmp_path / "a", "a")
+    session_b = _session(tmp_path / "b", "b")
+    dir_a = _resolved_temp_dir(session_a)
+    dir_b = _resolved_temp_dir(session_b)
+    try:
+        assert dir_a != dir_b, (
+            f"two independent sessions collided on the same real filesystem "
+            f"path: {dir_a!r} -- the #6151 defect shape that raced under "
+            f"parallel xdist workers"
+        )
+    finally:
+        shutil.rmtree(dir_a, ignore_errors=True)
+        shutil.rmtree(dir_b, ignore_errors=True)
+
+
+def test_isolate_child_temp_dir_false_preserves_the_pre_6151_shared_formula(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: deny -- the explicit opt-out (`test_5184_session_temp_
+    lifetime.py`'s own use) must still produce the EXACT pre-#6151
+    formula-derived path, byte-identical, so a test verifying that
+    formula itself keeps working unchanged."""
+    session_a = _session(tmp_path / "a", "a", isolate=False)
+    session_b = _session(tmp_path / "b", "b", isolate=False)
+    dir_a = _resolved_temp_dir(session_a)
+    dir_b = _resolved_temp_dir(session_b)
+    try:
+        assert dir_a == dir_b, (
+            "isolate_child_temp_dir=False must reproduce the shared, formula-"
+            "derived path -- this is the control arm proving the opt-out is a "
+            "real escape hatch, not a no-op"
+        )
+    finally:
+        shutil.rmtree(dir_a, ignore_errors=True)

--- a/tests/runtime/test_skill_invoke_3100.py
+++ b/tests/runtime/test_skill_invoke_3100.py
@@ -316,6 +316,12 @@ def _session_with_skills(tmp_path: Path, entries: list[SkillEntry], collisions: 
     generation_store, journal = build_recovery(
         agent.agent_name, snapshot_path, state_log, "main",
     )
+    # #6151: this duplicate's own `agent_name="default"` + hardcoded
+    # `"main"` session_id above is the SAME shared-temp-dir shape
+    # `tests/_support/session.py::make_session` isolates by default —
+    # give this direct construction its own isolated child_temp_dir too.
+    import tempfile
+
     with synthetic_t_max(1_000_000):
         return Session(
             agent=agent,
@@ -330,6 +336,7 @@ def _session_with_skills(tmp_path: Path, entries: list[SkillEntry], collisions: 
             capability_scope=CapabilityScope(
                 available_skills=entries, skill_collisions=collisions or {},
             ),
+            child_temp_dir=tempfile.mkdtemp(prefix="reyn-test-child-"),
         )
 
 


### PR DESCRIPTION
**[e2e-coder]** — lead-coder dispatch (#6151, traced from #6148's own CI, `pytest (3.11)` under `-n auto`).

Closes #6151

## What was broken
`Session._child_temp_dir` resolves to a REAL filesystem path, `<tempdir>/reyn/<agent_name>/<session_id>`. Two sanctioned test helpers — `tests/_support/agent_session.py::make_session` and `tests/_support/session.py::make_session` — both default `agent_name`/`session_id` to fixed literals (`"alpha"`/`"main"`, `"default"`/`"main"`) across 600+ call sites, so nearly every test that doesn't override either collides on the exact same real directory. Under `pytest -n auto`, unrelated tests in different worker processes hit it concurrently — create/delete/permission races produced the CI-measured failures (`session temp_dir is not writable`, `the command must queue at least one new block`). Lead-coder traced `tests/interfaces/test_5837_exec_slash_stage1.py:29`'s fixed `agent_name="alpha"` as the concrete trigger.

## 1 — origin traced
`Path(tempfile.gettempdir()) / "reyn" / agent_name / session_id` (`src/reyn/runtime/session.py`, `#5184`). `session_id` defaults to `"main"` both in `Session.__init__` and in `make_session()`'s own `kwargs.get("session_id", "main")` — a default many OTHER tests assert on directly (`tests/core/test_registry_list_rewind_points_1f.py` et al.), so it cannot change.

## 2 — enumerated by derivation (AST, not by hand)
606 `make_session(...)` call sites pass neither `session_id=` nor `child_temp_dir=` (exposed to the shared shape); 1 direct `Session(...)` construction outside the two helpers (`test_skill_invoke_3100.py`, itself a documented `#3413` copy-paste of the `session.py` helper body).

## 3 — the sharing itself removed (not retry/serialize)
`Session` gains an optional `child_temp_dir=` constructor override (same idiom as its existing `snapshot_path=`), defaulting to `None` — the EXACT prior formula, byte-identical for every production caller and any test verifying that formula itself (`test_5184_session_temp_lifetime.py`, explicitly opted out via a new `isolate_child_temp_dir=False`). Both test helpers now inject a fresh `tempfile.mkdtemp()`-based `child_temp_dir` by DEFAULT unless the caller already supplies one — closing the sharing structurally, with **zero per-call-site edits** across the 606 exposed sites. The 1 direct-construction site got the same treatment individually.

## 4 — forgetting-detection gate, same PR
`scripts/check_session_child_temp_dir_isolation.py`: an AST scan flags any FUTURE direct `Session(...)` construction in `tests/` that omits `child_temp_dir=` (outside the two sanctioned helpers, which are the fix's own home). Starting population: 0. Strip-falsified: a throwaway violating file made the gate fail, naming the exact site; removed, gate returned green.

## Tests
`test_6151_child_temp_dir_isolation.py`: two sessions sharing every default now resolve to different real temp dirs (accept), and the explicit `isolate_child_temp_dir=False` opt-out still reproduces the shared, formula-derived path byte-identical (deny — the escape-hatch witness). Reads the resolved path via the PUBLIC surface (`router_host.make_router_op_context().default_sandbox_policy["temp_dir"]`) — never `Session._child_temp_dir` directly (private-state assertion is Tier 4 per `test_tier_audit.py`). Strip-falsified both ways: disabling the injection made the accept test fail with the exact colliding path (`/tmp/.../reyn/alpha/main`) shown; restoring the old bare-key-style check before membership routing (n/a here — disabling isolation) reproduced it; re-enabled, green again.

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py` (183, all baselined), `test_tier_audit.py --strict` (3/3 OK, 0 Tier-4), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `check_tests_path_literal_reference.py`, `flat_tests_ratchet.py`.

## Pytest (diff-scoped + directly-adjacent, foreground)
`test_6151_child_temp_dir_isolation.py` + `test_5184_session_temp_lifetime.py` + `test_skill_invoke_3100.py` → 27 passed. `test_5837_exec_slash_stage1.py` + `test_5837_exec_slash_stage2_bang.py` (the originally-failing family) → 29 passed. Also spot-checked the 11 AST-flagged "two make_session calls without explicit session_id in one test function" candidates (checked none rely on the default matching between two calls) and every consumer of `tests/_support/session.py::make_session` (8 files) — all green.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
