### PR TITLE
fix(#6146): remove the bare web.fetch read entirely from require_http_get

### DIFF
--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1955,10 +1955,11 @@ class PermissionResolver:
         - ``web.fetch: deny`` config overrides any wildcard permission.
         - ``web.fetch: allow`` config pre-approves any host without
           prompting (= equivalent to selecting ALWAYS for all hosts).
-        - The legacy ``web.fetch`` session/saved approval still
-          authorises any UNDECLARED host (#6142: narrowed — it can no
-          longer short-circuit a DECLARED http.get host, specific or
-          wildcard, which always reaches its own per-host prompt now).
+        - The legacy ``web.fetch`` session/saved approval NO LONGER
+          authorises any host (#6146 — removed the last of the bare-key
+          reach; #6142 had already narrowed it off the DECLARED axis).
+          Every undeclared host now always prompts (or raises, with no
+          bus) regardless of any bare ``web.fetch`` grant on disk.
 
         ``bus`` is required when the wildcard path or the
         legacy-fallback path needs to prompt; sync contexts (=
@@ -2013,40 +2014,20 @@ class PermissionResolver:
             host, actor, "http.get", agent_name=agent_name,
         ):
             return
-        # #6142 (lead-coder BLOCKING, PR #6141 round-2, filed #6142, fixed
-        # here): the bare `KEY_WEB_FETCH` legacy-compat check used to sit
-        # HERE, before the declared-membership routing below, so ANY
-        # grant under that ambiguous key — including one `require_web_
-        # fetch` (a SEPARATE tool/method, deliberately untouched — `web.
-        # fetch` is the CORRECT key for its own axis) writes whenever an
-        # operator answers ALWAYS to a `web_fetch` tool prompt — silently
-        # authorised even a DECLARED http.get host, bypassing that host's
-        # own unambiguous per-host prompt. `KEY_WEB_FETCH` carries no
-        # axis marker at all, so the read cannot tell those grant shapes
-        # apart by inspecting the grant itself — narrowing had to work by
-        # restricting WHERE this ambiguous key is even consulted, not by
-        # teaching the read to recognise a distinction the key itself
-        # does not encode. Moved into the "no declaration at all" branch
-        # below, the ONLY place this key's original, unambiguous meaning
-        # ("http.get axis, no declaration, treat like legacy default-
-        # allow") ever applied — a DECLARED decl (specific or wildcard)
-        # now always reaches its own per-host prompt, never short-
-        # circuited by this ambiguous key.
-        #
-        # Population impact (architect, #6142 co-vet — record this for
-        # whoever closes #6146): an operator who BOTH (a) holds a bare
-        # `web.fetch` grant (either shape) AND (b) has a DECLARED
-        # `http.get` entry for a host they have not yet approved
-        # per-host now sees a NEW interactive prompt for that host —
-        # one this narrowing itself introduces, since the declared path
-        # never reaches the bare-key read (or its `logger.warning`)
-        # any more. That population gets no notice explaining WHY the
-        # prompt reappeared — the warning only fires on the undeclared
-        # path, which this population's declared host never takes.
-        # #6146 removing the undeclared-axis reach too would change
-        # this SAME population's experience a second time; whoever
-        # closes it should account for that, not assume this fix
-        # already covers the full transition.
+        # History (#6140 -> #6141 -> #6142 -> #6146): the bare
+        # `KEY_WEB_FETCH` legacy-compat check used to sit HERE, before
+        # the declared-membership routing below, so ANY grant under that
+        # ambiguous key — including one `require_web_fetch` (a SEPARATE
+        # tool/method, deliberately untouched — `web.fetch` is the
+        # CORRECT key for its own axis) writes whenever an operator
+        # answers ALWAYS to a `web_fetch` tool prompt — silently
+        # authorised even a DECLARED http.get host, bypassing that
+        # host's own unambiguous per-host prompt. #6142 narrowed it to
+        # fire only in the "no declaration at all" branch below (a
+        # DECLARED decl, specific or wildcard, now always reaches its
+        # own per-host prompt, never short-circuited by this key).
+        # #6146 (below) removed the check ENTIRELY — the undeclared
+        # axis it used to cover now also always prompts.
 
         # #1199 S3.1b-2c-2: the host-MEMBERSHIP decision (specific OR wildcard)
         # routes through the unified model (NETWORK_HOST axis) — pure decl
@@ -2112,46 +2093,52 @@ class PermissionResolver:
         # "declaring it stops the repeat ask" belongs IN the prompt text
         # itself (one line, below), not as a second, separate emission.
         #
-        # #6142: the bare-key legacy short-circuit lives HERE, and only
-        # here — the one place its original, unambiguous meaning applies
-        # ("http.get axis, no declaration, default-allow via a prior
-        # blanket answer"). It still covers two shapes that share this
-        # exact key with no way to tell them apart: (1) a pre-#6140
-        # grant already on disk (this path no longer writes that shape
-        # itself — #6141) and (2) an ALWAYS answer to the SEPARATE
-        # `web_fetch` tool prompt (`require_web_fetch`, deliberately
-        # untouched — `web.fetch` is the correct key for ITS OWN axis).
-        # Dropping this read outright would turn a working non-
-        # interactive run into a hard `PermissionError` for anyone
-        # holding either shape of grant; narrowing it to fire ONLY when
-        # there is no declared http.get membership (this branch) is what
-        # closes the #6142 defect — a DECLARED host (specific or
-        # wildcard) can no longer be silently covered by either shape,
-        # because that path now never reaches this check. `logger.
-        # warning` (not `warnings.warn`) — #6140/#6141 BLOCKING ⓑ
-        # (lead-coder, measured): a bare `DeprecationWarning` never
-        # reaches an operator in production (Python's default filter
-        # ignores it outside `__main__`); `logger.warning` always
-        # reaches `reyn.log`. This IS the operator's only notice for
-        # this branch (unlike the real interactive prompt just below,
-        # which covers the "no declaration" case on its own per #6143 —
-        # here execution returns immediately, no prompt ever runs, so
-        # there is no second channel to duplicate).
-        if self._saved.get(KEY_WEB_FETCH) or self._session.get(KEY_WEB_FETCH):
-            logger.warning(
-                "HTTP access to host %r authorised by a LEGACY blanket "
-                "'web.fetch' approval (either a pre-#6140 grant, or an "
-                "ALWAYS answer to the separate web_fetch tool prompt) "
-                "— it covers every UNDECLARED host, not just this one, "
-                "and cannot be narrowed further (its own key carries no "
-                "host). A DECLARED http.get host is never covered by "
-                "this grant. To end it: remove the 'web.fetch' entry "
-                "from this project's approvals.yaml; each host will "
-                "then be asked about individually and recorded "
-                "per-host going forward. Tracked for removal at #6146.",
-                host,
-            )
-            return
+        # #6146 (lead-coder dispatch, closes the arc #6140 -> #6141 -> #6142
+        # -> #6146 started): the bare-`KEY_WEB_FETCH` legacy short-circuit
+        # that used to live HERE is now REMOVED, not merely narrowed. It
+        # covered two shapes with no way to tell them apart: (1) a
+        # pre-#6140 grant already on disk and (2) an ALWAYS answer to the
+        # SEPARATE `web_fetch` tool prompt (`require_web_fetch`,
+        # deliberately untouched — `web.fetch` is the correct key for
+        # ITS OWN axis). #6142 narrowed its reach to only the undeclared
+        # axis (a DECLARED host was already protected); #6146's own
+        # closing condition — #6150 landed first, making `web_fetch.py`'s
+        # own fallback reject "resolver present, bus absent" instead of
+        # silently degrading — means an operator who genuinely still
+        # needs non-interactive undeclared-http.get access now has a
+        # real, supported path (declare `http.get` explicitly) instead
+        # of an implicit one this ambiguous key used to paper over.
+        # Every undeclared-host call now ALWAYS reaches the real prompt
+        # path below — never silently authorised by either grant shape
+        # again. Two distinct routes end in `PermissionError`, and
+        # they are NOT the same branch (architect co-vet, #6146 BLOCKING
+        # — do not conflate them when next touching this):
+        #   - `bus is None` (the `if bus is None:` check just below) —
+        #     reachable ONLY through the narrow fallback #6150 already
+        #     guards (`web_fetch.py`'s own OpContext synthesis refuses
+        #     "resolver present, bus absent" outright before ever
+        #     reaching here).
+        #   - A REAL session's bus is NEVER `None` — a no-listener
+        #     session resolves to `AuditOnlyInterventionBridge`'s own
+        #     typed, reason'd refusal bus instead (`session.py`'s
+        #     `_make_router_intervention_bus` docstring: "NO listener ->
+        #     a typed, reason'd REFUSAL ... NEVER a stamped bus"). That
+        #     refusal makes `_approve()` below return `False`, and THIS
+        #     is the route an actual non-interactive real session takes
+        #     to `PermissionError("... denied.")` — not the `bus is
+        #     None` branch.
+        #
+        # Population impact (record for anyone auditing this change):
+        # an operator who holds a bare `web.fetch` grant (either shape)
+        # AND has a DECLARED `http.get` entry already got a NEW prompt
+        # for that declared host at #6142/#6148 (silently — no notice
+        # explained why). This removal is that SAME population's SECOND
+        # experience change: their remaining UNDECLARED hosts now also
+        # prompt (or refuse/deny, non-interactively, via whichever route
+        # above applies) instead of being silently covered. Declaring
+        # `http.get` explicitly (a standing per-host grant) is the
+        # supported way to keep such a run non-interactive going
+        # forward.
 
         if bus is None:
             raise PermissionError(
@@ -2180,11 +2167,12 @@ class PermissionResolver:
         # does NOT close every way a bare `KEY_WEB_FETCH` grant can
         # still be created — `require_web_fetch` (a separate method,
         # deliberately untouched here) still writes under that same
-        # bare key. #6142 (fixed above, in this same branch) narrowed
-        # WHERE that ambiguous key is read so it can never cover a
-        # DECLARED host any more; it still covers an UNDECLARED one
-        # like this call — removing that residual reach entirely is
-        # tracked at #6146, not folded into either fix.
+        # bare key. #6142 narrowed WHERE that ambiguous key was read so
+        # it could never cover a DECLARED host; #6146 (above, in this
+        # same branch) removed the read of it ENTIRELY, so this call —
+        # the only remaining path that ever reads it — never does
+        # either. `require_web_fetch`'s own grant is now write-only:
+        # nothing in `require_http_get` consults it any more.
         # `agent_name=agent_name` (below): matches the DECLARED per-host
         # path's own call a few lines up — the SAME agent dimension
         # `_scope_covers_agent` needs to check/record a saved grant

--- a/tests/security/test_6140_http_get_legacy_scope.py
+++ b/tests/security/test_6140_http_get_legacy_scope.py
@@ -3,40 +3,30 @@
 FETCH`` constant (no host in the key at all), so ONE "Allow fetching from
 {host!r}?" answer silently authorised EVERY future host — including hosts
 a DIFFERENT actor's own DECLARED wildcard would otherwise have prompted
-for individually (the ``:1947`` bare-key short-circuit fired before that
-per-host prompt ever ran).
+for individually (the bare-key short-circuit fired before that per-host
+prompt ever ran).
 
 Real ``PermissionResolver`` + a real interactive-choice ``InterventionBus``
 throughout (the ``_ChoiceBus`` shape ``test_5052_approval_scope_dimension.
 py`` / ``test_5236_permission_approval_granted_audit_event.py`` already
 establish) — no mocks. Each of the 3 issue-body acceptance criteria gets
-its own test, plus two lead-coder BLOCKING rounds on PR #6141 and the
-follow-up #6142 fix:
+its own test, plus the full #6140 -> #6141 -> #6142 -> #6146 arc:
 
-- Round 1 (#6140's own ② — "the window names no end"): the bare-key READ
-  that survives for a PRE-#6140 persisted grant must be VISIBLE and name
-  its own concrete removal condition, never a dateless "deprecation
-  window" repeated silently.
-- Round 2, finding B (measured): a bare ``warnings.warn(...,
-  DeprecationWarning)`` never reaches a real operator (Python's own
-  default filter ignores ``DeprecationWarning`` outside ``__main__``) —
-  the fix uses ``logger.warning`` instead, asserted here via ``caplog``.
-- Round 2, finding A (measured, ``permissions.py:2634`` on
-  ``origin/main``): ``require_web_fetch`` — a separate method/tool,
-  deliberately untouched — still writes a NEW grant under the same bare
-  ``KEY_WEB_FETCH`` key, which ``require_http_get``'s own surviving read
-  then honors for ANY host, DECLARED or not. Filed as #6142.
-- #6142 (this same PR, narrowing fix): the bare-key read is scoped to
-  fire ONLY in the "no declaration at all" branch — a DECLARED http.get
-  host (specific or wildcard) can no longer be silently covered by
-  either shape of bare-key grant, closing finding A for the declared
-  axis. The undeclared axis keeps both shapes covered by design (same
-  as round 1's pre-#6140-residue case) — full removal tracked at #6146.
+- #6140/#6141: the legacy path stops WRITING new bare-key grants —
+  indexed per-host instead, same shape a DECLARED grant uses.
+- #6141 round 2 / #6142: the bare-key READ (still needed for backward
+  compat with an ALREADY-persisted grant) is narrowed to fire only for
+  an UNDECLARED host — a DECLARED host (specific or wildcard) can never
+  be silently covered by it.
+- #6146 (this file's own current state): the bare-key READ is REMOVED
+  ENTIRELY. Every undeclared host now always reaches the real
+  interactive prompt (or raises, with no bus) — a pre-#6140 grant
+  already on disk, or a `require_web_fetch`-tool ALWAYS answer, no
+  longer authorises anything in `require_http_get`.
 """
 from __future__ import annotations
 
 import asyncio
-import logging
 from pathlib import Path
 
 import pytest
@@ -192,95 +182,83 @@ def test_the_legacy_grant_is_indexed_per_host_not_under_the_bare_key(
     )
 
 
-# ── the surviving bare-key READ (pre-#6140 grants): visible, not silent ──
+# ── #6146: the bare-key READ is gone -- neither remaining holder shape
+#      authorises an undeclared host any more ─────────────────────────
 
 
-def test_a_pre_6140_blanket_grant_still_authorises_but_now_logs_with_an_end(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+def test_a_pre_6140_blanket_grant_no_longer_authorises_an_undeclared_host(
+    tmp_path: Path,
 ) -> None:
-    """Tier 2: accept -- lead-coder BLOCKING (PR #6141): the ``:1947``-area
-    bare-``KEY_WEB_FETCH`` READ is intentionally kept (dropping it would
-    turn a working non-interactive run into a hard ``PermissionError``
-    for anyone still holding a PRE-#6140 grant) -- but #6140's own ②
-    ("the window names no end") means keeping it silent is not
-    acceptable either. A real pre-#6140-shaped ledger entry (the bare
-    key, no host) is written directly here -- never through the FIXED
-    code path, which can no longer produce this shape at all -- to
-    reproduce exactly what an operator's already-existing approvals.yaml
-    looks like.
+    """Tier 2: accept -- #6146's own acceptance criterion ⑴: a NON-
+    INTERACTIVE run (``bus=None``) that relied on a pre-#6140 blanket
+    ``web.fetch`` approval to cover an undeclared host now gets a hard
+    ``PermissionError``, not silent success. A real pre-#6140-shaped
+    ledger entry (the bare key, no host) is written directly here --
+    the fixed code path can no longer produce this shape at all -- to
+    reproduce exactly what an operator's already-existing
+    approvals.yaml looks like.
 
-    Uses ``logger.warning`` (``caplog``), never ``warnings.warn`` — a
-    2nd lead-coder BLOCKING on this same PR, measured: Python's own
-    default filter is ``('ignore', None, DeprecationWarning, None, 0)``
-    for any module that is not ``__main__`` (``permissions.py`` never
-    is), so a bare ``warnings.warn(DeprecationWarning, ...)`` never
-    reaches an operator in production — only pytest's own
-    ``filterwarnings`` config made an earlier version of this test look
-    green. ``caplog`` reads the real logging pipeline `reyn.log` itself
-    writes through, not a pytest-only filter override.
-
-    FALSIFY: removing the ``logger.warning(...)`` call at the ``:1947``
-    read site makes this go red (``caplog.records`` empty) while the
-    grant still silently authorises the host -- the exact "invisible,
-    not just backward-compatible" shape this test exists to catch.
-    """
+    FALSIFY: restoring the removed bare-key short-circuit (checking
+    ``self._saved.get(KEY_WEB_FETCH)`` and returning early) makes this
+    go red -- no ``PermissionError`` is raised, the call returns
+    silently instead."""
     ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").append_approval(
         KEY_WEB_FETCH, True, "workspace",
     )
 
-    bus = _ChoiceBus("no")  # must NEVER be consulted -- already short-circuited
     resolver = _resolver(tmp_path)
-    with caplog.at_level(logging.WARNING, logger="reyn.security.permissions.permissions"):
+    with pytest.raises(PermissionError, match="no interactive bus"):
         asyncio.run(
-            resolver.require_http_get(PermissionDecl(), "any.example.com", bus, _ACTOR)
+            resolver.require_http_get(PermissionDecl(), "any.example.com", None, _ACTOR)
         )
-    assert bus.requests == [], "control arm: the legacy blanket grant must still short-circuit"
-
-    matching = [r for r in caplog.records if "any.example.com" in r.getMessage()]
-    assert matching, f"expected a warning naming the legacy grant, got {caplog.records!r}"
-    message = matching[0].getMessage()
-    assert "6146" in message, f"expected the removal-condition issue number in the log: {message!r}"
-    assert "approvals.yaml" in message, f"expected how-to-end instructions in the log: {message!r}"
 
 
-# ── #6142 (lead-coder BLOCKING round 2, measured, PR #6141): require_web_
-#      fetch's ALWAYS creates a bare-key grant that require_http_get then
-#      reads for an unrelated host. Narrowed (not removed) here: still
-#      covers an UNDECLARED host (deliberate, same as the test above);
-#      no longer covers a DECLARED one (the fix's own acceptance test). ──
-
-
-def test_a_web_fetch_always_grant_still_covers_an_undeclared_host_by_design(
+def test_a_pre_6140_blanket_grant_no_longer_short_circuits_the_interactive_prompt(
     tmp_path: Path,
 ) -> None:
-    """Tier 2: accept -- documents the DELIBERATELY-RETAINED half of the
-    #6142 narrowing: ``require_web_fetch`` (a separate tool/method,
-    deliberately untouched) still writes under the bare ``KEY_WEB_FETCH``
-    key when an operator answers ALWAYS to a `web_fetch` tool prompt, and
-    ``require_http_get``'s own undeclared-host compat branch still reads
-    it -- the SAME accepted-by-design behavior as the pre-#6140-residue
-    case above (``KEY_WEB_FETCH`` carries no axis marker, so the read
-    cannot tell a web_fetch-tool consent apart from a legacy http.get
-    grant; narrowing works by restricting WHERE the key is read, not by
-    inspecting the grant). Full removal (both holders) is tracked at
-    #6146, not fixed by #6142."""
+    """Tier 2: accept -- the interactive-bus sibling of the test above:
+    even WITH a bus available, a pre-#6140 blanket grant no longer
+    short-circuits the real per-host prompt -- the operator is asked
+    about this host exactly as if no legacy grant existed at all."""
+    ApprovalLedger(tmp_path / ".reyn" / "approvals.jsonl").append_approval(
+        KEY_WEB_FETCH, True, "workspace",
+    )
+
+    bus = _ChoiceBus("always")
+    resolver = _resolver(tmp_path)
+    asyncio.run(
+        resolver.require_http_get(PermissionDecl(), "any.example.com", bus, _ACTOR)
+    )
+    assert bus.requests, (
+        "the pre-#6140 blanket grant short-circuited the prompt -- an "
+        "empty list means the removed bare-key read is somehow still live"
+    )
+
+
+def test_a_web_fetch_always_grant_no_longer_covers_an_undeclared_host(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: accept -- #6146's own acceptance criterion ⑴, the SECOND
+    holder shape: a NON-INTERACTIVE run that relied on an ALWAYS answer
+    to the SEPARATE ``web_fetch`` tool prompt (``require_web_fetch``,
+    deliberately untouched -- ``web.fetch`` is the correct key for ITS
+    OWN axis) to implicitly cover an undeclared ``http.get`` host now
+    also gets a hard ``PermissionError``.
+
+    FALSIFY: restoring the removed bare-key short-circuit makes this go
+    red -- no ``PermissionError`` is raised."""
     bus_fetch = _ChoiceBus("always")
     resolver_a = _resolver(tmp_path)
     asyncio.run(resolver_a.require_web_fetch("https://example.com/page", bus_fetch))
     assert bus_fetch.requests, "control arm: the web_fetch prompt must have fired"
 
-    bus_http_get = _ChoiceBus("no")  # must NEVER be consulted -- short-circuited
     resolver_b = _resolver(tmp_path)
-    asyncio.run(
-        resolver_b.require_http_get(
-            PermissionDecl(), "totally-unrelated-host.example", bus_http_get, _ACTOR,
+    with pytest.raises(PermissionError, match="no interactive bus"):
+        asyncio.run(
+            resolver_b.require_http_get(
+                PermissionDecl(), "totally-unrelated-host.example", None, _ACTOR,
+            )
         )
-    )
-    assert bus_http_get.requests == [], (
-        "an UNDECLARED host must still be covered by a web_fetch-tool ALWAYS "
-        "grant -- this is the retained half of #6142's narrowing, not a "
-        "regression; full removal is tracked at #6146"
-    )
 
 
 def test_a_web_fetch_always_grant_does_not_short_circuit_a_declared_wildcard_host(

--- a/tests/security/test_6140_http_get_legacy_scope.py
+++ b/tests/security/test_6140_http_get_legacy_scope.py
@@ -189,14 +189,21 @@ def test_the_legacy_grant_is_indexed_per_host_not_under_the_bare_key(
 def test_a_pre_6140_blanket_grant_no_longer_authorises_an_undeclared_host(
     tmp_path: Path,
 ) -> None:
-    """Tier 2: accept -- #6146's own acceptance criterion ⑴: a NON-
-    INTERACTIVE run (``bus=None``) that relied on a pre-#6140 blanket
-    ``web.fetch`` approval to cover an undeclared host now gets a hard
-    ``PermissionError``, not silent success. A real pre-#6140-shaped
-    ledger entry (the bare key, no host) is written directly here --
-    the fixed code path can no longer produce this shape at all -- to
-    reproduce exactly what an operator's already-existing
-    approvals.yaml looks like.
+    """Tier 2: accept -- one branch of #6146's own acceptance criterion
+    ⑴: witnesses, via ``bus=None`` (the narrow fallback route #6150
+    already guards -- NOT a real session's own non-interactive path),
+    that the removed bare-key read is genuinely gone -- the shortest
+    possible witness that ``PermissionError`` is now reached at all.
+    A REAL session's non-interactive route (no listener -> bus IS
+    present -> ``AuditOnlyInterventionBridge``'s own typed refusal ->
+    ``_approve()`` returns ``False`` -> ``PermissionError("... denied.")``)
+    is OUTSIDE what this test covers -- the sibling test below,
+    ``..._no_longer_short_circuits_the_interactive_prompt`` (a real
+    bus, ``bus.requests`` non-empty), is the live-route witness. A real
+    pre-#6140-shaped ledger entry (the bare key, no host) is written
+    directly here -- the fixed code path can no longer produce this
+    shape at all -- to reproduce exactly what an operator's already-
+    existing approvals.yaml looks like.
 
     FALSIFY: restoring the removed bare-key short-circuit (checking
     ``self._saved.get(KEY_WEB_FETCH)`` and returning early) makes this
@@ -239,11 +246,16 @@ def test_a_web_fetch_always_grant_no_longer_covers_an_undeclared_host(
     tmp_path: Path,
 ) -> None:
     """Tier 2: accept -- #6146's own acceptance criterion ⑴, the SECOND
-    holder shape: a NON-INTERACTIVE run that relied on an ALWAYS answer
-    to the SEPARATE ``web_fetch`` tool prompt (``require_web_fetch``,
-    deliberately untouched -- ``web.fetch`` is the correct key for ITS
-    OWN axis) to implicitly cover an undeclared ``http.get`` host now
-    also gets a hard ``PermissionError``.
+    holder shape: witnesses, via ``bus=None`` (the narrow fallback
+    route #6150 already guards -- NOT a real session's own non-
+    interactive path, see the sibling test above for that distinction),
+    that an ALWAYS answer to the SEPARATE ``web_fetch`` tool prompt
+    (``require_web_fetch``, deliberately untouched -- ``web.fetch`` is
+    the correct key for ITS OWN axis) no longer implicitly covers an
+    undeclared ``http.get`` host -- ``PermissionError`` is reached at
+    all, where it used to return silently. A real session's own non-
+    interactive route (bus present -> refusal -> ``_approve()`` False)
+    is outside what this test covers.
 
     FALSIFY: restoring the removed bare-key short-circuit makes this go
     red -- no ``PermissionError`` is raised."""


### PR DESCRIPTION
**[e2e-coder]** — lead-coder dispatch (#6146), closing the arc #6140 → #6141 → #6142 → #6146. ⚠️ **architect co-vet required before merge** (security surface, same as #6141/#6148).

Closes #6146

## What this removes
`require_http_get`'s own bare-`KEY_WEB_FETCH` legacy-compat read (already narrowed off the DECLARED-host axis by #6142) is now REMOVED ENTIRELY. Every undeclared host always reaches the real prompt path below — neither remaining holder shape authorises anything any more:
1. A pre-#6140 blanket approval already persisted on an operator's `approvals.yaml`.
2. An ALWAYS answer to the SEPARATE `web_fetch` tool prompt (`require_web_fetch` — a different tool/method, deliberately untouched; `web.fetch` is the correct key for ITS OWN axis).

## Precondition confirmed
#6150 already landed: `web_fetch.py`'s fallback `OpContext` synthesis now rejects outright ("resolver present, bus absent") rather than silently degrading (`src/reyn/tools/web_fetch.py:100-107`, confirmed via direct read — its own comment already says `#6146 co-vet`). A caller with a real `PermissionResolver` can no longer silently reach `require_http_get` with no bus to prompt on.

## ⑴ Non-interactive-run impact (required disclosure — route corrected per architect co-vet)
A non-interactive run that relied on either a pre-#6140 blanket approval OR a `web_fetch`-tool ALWAYS answer to cover an undeclared `http.get` host now gets a hard `PermissionError` instead of silent success. In a real session (no listener), the bus itself is still present — `AuditOnlyInterventionBridge` returns a typed, reason'd refusal (`session.py:11707-11710`) rather than `None` — so `_approve()` sees that refusal and returns `False`, raising `PermissionError("... denied.")`; this is NOT the `bus is None` branch (that branch is reachable only through the narrow fallback #6150 already guards, `web_fetch.py:100-107`). Declaring `http.get` explicitly (a standing per-host grant) is the supported way to keep that run non-interactive going forward.

## ⑵ Second experience change (required disclosure)
For an operator who holds a bare `web.fetch` grant AND has a DECLARED `http.get` entry, this is their **SECOND** experience change — the first was #6142/#6148 (a new prompt for the declared host, silently, no notice explaining why). This removal changes their remaining UNDECLARED hosts too: they now also prompt (or raise, non-interactively) instead of being silently covered.

## Tests
Replaced the two tests that asserted the (now-removed) silent-coverage behavior with 3 asserting the opposite: a pre-#6140 grant no longer authorises non-interactively (raises) or short-circuits the interactive prompt (still asks); a `web_fetch`-tool ALWAYS grant no longer authorises an undeclared host non-interactively. The declared-axis test (#6142's own acceptance criterion) is unchanged. 8 tests total, all passing.

Strip-falsified: restored the removed bare-key check — all 3 new tests went RED (2× `DID NOT RAISE PermissionError`, 1× empty `bus.requests` proving the silent short-circuit). Reverted, confirmed green.

## Gates (all green)
`ruff`, `verify_module_docstrings.py`, `mypy_ratchet.py` (183, all baselined), `test_tier_audit.py --strict` (8/8 OK, 0 Tier-4), `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `check_tests_path_literal_reference.py`, `flat_tests_ratchet.py`.

## Pytest (diff-scoped + directly-adjacent, foreground)
`test_6140_http_get_legacy_scope.py` + `test_1199_s31b2c2_http_get.py` + `test_5052_approval_scope_dimension.py` + `test_5236_permission_approval_granted_audit_event.py` + `test_permission_collapse_phase3.py` → **40 passed**. `test_web_fetch_unified.py` + `test_permission_prompt_phrasing.py` + `test_fp0063_arc_witness.py` → **25 passed**.

## Comments (permissions.py)
Every stale `#6142`/`#6146` reference in the touched function updated to reflect the final removed state, not left describing an intermediate narrowing as if still current.

Not writing a TESTS-READ/BLOCKING-CLEARED marker myself. Architect co-vet and merge are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S

