### PR TITLE
docs(part of #6083): agui-transport.md's uniform-10s control-POST claim is stale since #6105

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -457,12 +457,20 @@ cover detection.
 
 The same thin client runs two request kinds through one `httpx` client with
 two timeout policies (#5894). The SSE stream keeps an unbounded read
-(`read=None`) — a live stream legitimately reads forever. Every
-client→server **control POST** (a turn submit, an intervention answer, a
-cancel, the heartbeat) is a bounded round-trip and gets its own read timeout,
+(`read=None`) — a live stream legitimately reads forever. A client→server
+**control POST** (a turn submit, an intervention answer, a cancel, the
+heartbeat) is normally a bounded round-trip and gets its own read timeout,
 10s by default (`REYN_AGUI_CONTROL_TIMEOUT_S` overrides it; one constant, one
-place — `remote_client.post_control`). A control POST the server does not
-answer within it is a **non-delivery**, not a wait: `cancel_inflight` returns
+place — `remote_client._read_timeout_for`/`post_control`). **The bound
+applies BY PAYLOAD CLASS, not uniformly (#6083 ⑵-a):** one class
+(`transport.agui.protocol.LONG_RUNNING_PAYLOAD_TYPES`, currently just
+`attach_request`) has a server-side handler whose duration is genuinely
+unbounded (a first-attach session load replaying its persisted WAL history),
+so `_read_timeout_for` returns `None` (matching the SSE stream's own
+unbounded policy) for that class instead of the 10s default — applying the
+bounded default there would misread a slow-but-succeeding attach as a
+timed-out failure. A control POST the server does not answer within its
+(non-`None`) timeout is a **non-delivery**, not a wait: `cancel_inflight` returns
 the empty summary the `ClientTransport` contract reserves for "not
 confirmed", and the Textual TUI draws a row under the `cancel requested…` row
 it drew the instant the key was pressed. Which failure it was is TYPED


### PR DESCRIPTION
**[docs-maintainer]** — doc-drift sweep result (owner-flagged, PRs #6104/#6105/#6107/#6109/#6110/#6114/#6115). One real drift found.

## What's stale

`docs/reference/runtime/agui-transport.md` asserted "**Every** client→server control POST ... is a bounded round-trip and gets its own read timeout, 10s by default" — true before #6105, false after: #6105 introduced `LONG_RUNNING_PAYLOAD_TYPES` (currently just `attach_request`, a genuinely-unbounded server-side operation), so `remote_client._read_timeout_for` now returns `None` for that class instead of the 10s default. The bound applies **by payload class**, not uniformly — #6105's own title.

## Sweep result (for the record)

Checked #6104, #6105, #6107, #6109, #6110, #6114, #6115 — `#6107`/`#6109` already fixed their own doc drift in the same PR (out of scope here). Of the remaining 5, only #6105 left a stale claim; #6104/#6110/#6114/#6115 were checked (exhaustive `git grep` across `docs/` for every materially-changed identifier/behavior) and left nothing falsified.

Describing doc (mirrors the mechanism narratively, not an ADR) — fixed to match the implementation, no decision changed.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — 0 dangling
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
