### PR TITLE
docs: 2 drifts from the 9-PR sweep -- agui-transport.md episode_seq, CLAUDE.md lang-gate entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Path-conditional gates:
 - `tests/` → `python scripts/check_bare_tests_import_reference.py`, `python scripts/check_file_depth_reference.py`, `python scripts/check_subprocess_reyn_pin.py`, `python scripts/check_no_core_dep_importorskip.py` (#5058 — an `importorskip` naming a `pyproject.toml` core dependency), and `python scripts/suspected_time_dependence_ratchet.py` (#4846 — green means these 3 syntax shapes didn't grow, not "duration-independent"; see testing.md).
 - `CLAUDE.md` / `**/CLAUDE.md` → `python scripts/claude_md_word_count_ratchet.py` (#4872: word count is a ratchet, not a report — raising it needs `--write-baseline` committed in the same PR).
 - `src/reyn/interfaces/` → `python scripts/silent_except_ratchet.py` (#5990 — a new unreported `except`; suspected, not confirmed).
+- `src/reyn/**` → `python scripts/user_facing_lang_gate.py` (#6084 — a NEW undecided-language literal at a confirmed user-facing-text sink).
 
 1. **Finish your own Test plan before merge.** Tick every Manual/Visual item or replace with `- [x] (skipped — <reason>)`. **Never tick a check that did not happen.** **Standing waiver, Visual items only** (owner 2026-08-08): merge with the Visual box unchecked — do not fabricate it.
 2. **Role-prefix every issue / PR body / PR comment** — `**[lead-coder]** — `, etc. The PR body counts. This is the ONLY cross-session signal.

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -494,7 +494,9 @@ POST per key repeat.
 The shrink-flow (compaction) progress state rides the wire too (#5885,
 owner-hit on web/connect: "スピナーもなく進捗も不明 … 完了通知もなく").
 `project_status` carries `compaction_progress_raw` — the plain dict
-`Session.compaction_progress_raw()` builds (`is_compacting`, the #5592
+`Session.compaction_progress_raw()` builds (`is_compacting`, `episode_seq`
+(#6085 — this compaction episode's own identifier, the same value
+`ChatLifecycleForwarder` reads to stamp its own marker frames), the #5592
 spill figures, `persisted_covers_through_seq`) — the same route
 `halted_reason` / `process_footprint_*` take, and the remote read model
 reports it (`compaction_progress_reported=True`), so a remote Textual client

--- a/scripts/claude_md_word_count_baseline.json
+++ b/scripts/claude_md_word_count_baseline.json
@@ -1,5 +1,5 @@
 {
-  "CLAUDE.md": 2656,
+  "CLAUDE.md": 2672,
   "src/reyn/core/events/CLAUDE.md": 74,
   "src/reyn/interfaces/CLAUDE.md": 428,
   "src/reyn/mcp/CLAUDE.md": 22,


### PR DESCRIPTION
**[docs-maintainer]** — 9-PR doc-drift sweep result (owner-flagged: #6073/#6079/#6081/#6086/#6091/#6087/#6088/#6090/#6092). 2 real drifts found; the other 7 checked, nothing falsified.

## Found

1. **#6092** — `Session.compaction_progress_raw()` gained `episode_seq` (this compaction episode's own identifier, read by `ChatLifecycleForwarder` to stamp its own marker frames). `docs/reference/runtime/agui-transport.md` enumerated that dict's fields as if exhaustive and was missing it.
2. **#6090** — shipped `.github/workflows/user-facing-lang-gate.yml` (triggers on `src/reyn/**`, widened from the v1 `src/reyn/interfaces/**` scope per its own comment, after #6104's CI caught a real duplicate outside that scope) without adding it to `CLAUDE.md`'s own "Path-conditional gates" list — a hard-rule violation on the file stating the rule.

## Checked, no drift found

#6073 (exception-keyword fallback), #6079 (`step_index` semantics), #6081 (turn-end sweep pass count), #6086/#6091 (tree-sitter-bash dependency + node-kind derivation — #6086 is explicitly zero-behavior-change), #6087/#6088 (`capture_stray_output` window / `handleError` routing). None of these mechanisms are described specifically enough in any existing doc to be contradicted — a documentation gap in a couple of cases (tree-sitter-bash, stray-output routing), not drift.

Both fixes are describing docs (mirror the mechanism narratively, not ADRs) — matched to the implementation, no decision changed.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean
- [x] `python scripts/check_doc_anchors.py` — 0 dangling
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] `python scripts/claude_md_word_count_ratchet.py` — OK after `--write-baseline` (+16 words, same PR)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
