### PR TITLE
feat(part of #5890 stage 0-b): NewType EntryBudget/LoweredFloor/Shortfall at produce/move sites

### DIFF
--- a/src/reyn/runtime/services/compaction_controller.py
+++ b/src/reyn/runtime/services/compaction_controller.py
@@ -37,6 +37,7 @@ from reyn.services.compaction.engine import (
     CompactionEngine,
     CompactionOverflowError,
     HistoryChunkToCompact,
+    Shortfall,
     classify_compact_overflow,
     estimate_tokens_for_any_turn,
     select_fold_candidates_for_shortfall,
@@ -608,7 +609,7 @@ class CompactionController:
             # request is not the shortfall question.
             candidates = list(unprotected)
         else:
-            shortfall = unprotected_tokens - main_M_room
+            shortfall = Shortfall(unprotected_tokens - main_M_room)
             candidates = select_fold_candidates_for_shortfall(
                 unprotected, shortfall, model, use_chars4=use_chars4,
             )

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -59,7 +59,7 @@ import logging
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, NewType, Union
 
 from reyn.llm.json_parse import loads_lenient
 from reyn.llm.litellm_bootstrap import (
@@ -77,6 +77,46 @@ if TYPE_CHECKING:
     from reyn.runtime.services.token_multiplier_learner import TokenMultiplierLearner
 
 logger = logging.getLogger(__name__)
+
+# #5890 stage 0-b (architect measurement, lead-coder ruling): three token
+# quantities this module previously carried as bare ``int`` were shown to
+# be confusable with each other at real production/consumption sites --
+# ``NewType`` closes exactly those sites (an assignment or a constructor
+# call whose target is one of these types), never the comparisons that
+# read them (measured: mypy accepts a cross-type ``>``/``>=`` comparison,
+# and a plain-``int`` value passed where one of these types is expected as
+# a function argument, silently -- see the residue comments at each
+# surviving open site below, in ``_stage_halve_room`` and
+# ``select_fold_candidates_for_shortfall``).
+#
+# Deliberately does NOT distinguish head from tail (the "compartment"
+# axis) -- #5890 stage 0-b's own investigation found zero real sites
+# where a head value was mistaken for a tail value or vice versa; adding
+# a 4th/5th type pair for that axis would be inventing coverage for a
+# confusion nobody has shown. If that axis ever needs its own type, this
+# is not where the case for it lives.
+EntryBudget = NewType("EntryBudget", int)
+"""The immutable, entry-time budget allocated to one compartment (head or
+tail) from ``ComputedBudgets`` -- what ``component_weights`` configured,
+never reassigned after :class:`RecoveryLadder.__init__`."""
+
+LoweredFloor = NewType("LoweredFloor", int)
+"""The CURRENT floor for one compartment -- starts equal to that
+compartment's own :data:`EntryBudget`, and is reassigned downward by
+:meth:`RecoveryLadder._stage_halve_room`'s own ladder. Reading ``min``
+instead of a name that says "current, possibly lowered" is exactly the
+confusion #5890 stage 0-a's own rename (``_tail_min_tokens`` /
+``_head_min_tokens`` -> ``_tail_tokens_floor`` / ``_head_tokens_floor``)
+already fixed at the attribute-name level; this type closes the same gap
+at the type level."""
+
+Shortfall = NewType("Shortfall", int)
+"""How many tokens over the available room the unprotected middle
+currently is -- :func:`select_fold_candidates_for_shortfall`'s own
+``shortfall_tokens`` parameter. A DELTA, never a budget or a floor
+(#5890 stage 0-b, architect's own reading of ``engine:2099``'s pre-
+existing ``int``-vs-``int`` comparison as the real-confusion witness for
+this type)."""
 
 # ---------------------------------------------------------------------------
 # Token-counter fallback tracking (Axis 10)
@@ -2066,7 +2106,7 @@ def trim_tail(
 
 def select_fold_candidates_for_shortfall(
     turns: list,
-    shortfall_tokens: int,
+    shortfall_tokens: "Shortfall",
     model: str = "",
     *,
     use_chars4: bool = False,
@@ -3451,8 +3491,13 @@ class RecoveryLadder:
 
         bg = engine.budgets
         self._bg = bg
-        self._head_tokens_floor = bg.head_budget
-        self._tail_tokens_floor = bg.tail_budget
+        # #5890 stage 0-b: the ladder's floor STARTS at the entry-time
+        # budget (an ``EntryBudget``), moved explicitly into the
+        # mutable ``LoweredFloor`` slot this ladder actually reassigns
+        # (:meth:`_stage_halve_room` below) -- never a bare ``int`` in
+        # between.
+        self._head_tokens_floor: "LoweredFloor" = LoweredFloor(EntryBudget(bg.head_budget))
+        self._tail_tokens_floor: "LoweredFloor" = LoweredFloor(EntryBudget(bg.tail_budget))
         self._use_chars4 = cfg.use_chars4_estimate
 
         self._last_recover_cause: str | None = None
@@ -3640,6 +3685,29 @@ class RecoveryLadder:
                 saw_byte_limit=self._last_recover_is_byte_limit,
             )
         self._t_max_override = _candidate
+        # #5890 stage 0-b: `_room` and `_candidate` (above) do NOT carry
+        # an `EntryBudget`/`LoweredFloor` annotation, and this is a
+        # DELIBERATE choice, not an oversight -- architect's own
+        # self-correction on this PR's own dispatch: `_room: int` would
+        # satisfy the LETTER of "give it a distinguishing type" while
+        # adding zero real checking (an `int` annotation is not a
+        # distinguishing type), and would make the still-open gap LESS
+        # visible, not more -- a reader would see an annotation and
+        # reasonably assume it means something. `_room` itself is
+        # neither a budget nor a floor: it is the undivided POOL
+        # `_head_tokens_floor`/`_tail_tokens_floor` are about to be
+        # apportioned FROM (the same concept `ComputedBudgets.
+        # main_M_room` names one layer up) -- #5890's own investigation
+        # found no real site where `_room` was mistaken for an
+        # `EntryBudget` or a `LoweredFloor`, so inventing a 4th type for
+        # it here would be coverage with no confusion behind it (the
+        # same "compartment axis" restraint the type definitions above
+        # already apply). Measured directly (mypy 2.3.0, #5890): the
+        # `_candidate <= _reserved` comparison above, and every
+        # arithmetic step through this method that stays in plain
+        # `int`, produces ZERO findings if an `EntryBudget` is silently
+        # substituted for a `LoweredFloor` anywhere in this chain --
+        # this is real, disclosed, and NOT closed by this PR.
         _room = _candidate - _reserved
         # head/tail apportion `room` by their own component_weights
         # share, renormalised over just the two of them (body/new_msg
@@ -3648,14 +3716,32 @@ class RecoveryLadder:
         # an even split rather than raising here — a config validity
         # question belongs to `assert_static_bounds` at startup, not
         # a mid-turn recovery path.
+        #
+        # #5890 stage 0-b: `min()`/`int()`/`sum()` erase a `NewType`
+        # back to its plain base type -- measured directly (mypy 2.3.0):
+        # `int(...)` below returns bare `int`, not `LoweredFloor`, with
+        # zero mypy findings at the call itself; the SAME is true of
+        # `min()` over two different `NewType`s and of `sum()`. The
+        # check only survives here because the RESULT is immediately
+        # wrapped in the explicit `LoweredFloor(...)` constructor call
+        # below, at the point it is stored -- using either expression
+        # directly in a comparison (rather than storing it first) would
+        # make the check vanish SILENTLY, with nothing to see at the
+        # comparison site itself. This erasure is not something this
+        # PR closes -- `NewType` has no mechanism to survive stdlib
+        # numeric builtins, and wrapping every one of them would still
+        # leave the same gap the moment a caller un-wraps the result
+        # into a bare local before using it.
         _cw = self._cfg.component_weights
         _head_tail_weight = _cw.get("head", 0) + _cw.get("tail", 0)
         if _head_tail_weight > 0:
-            self._head_tokens_floor = int((_cw.get("head", 0) / _head_tail_weight) * _room)
-            self._tail_tokens_floor = _room - self._head_tokens_floor
+            self._head_tokens_floor = LoweredFloor(
+                int((_cw.get("head", 0) / _head_tail_weight) * _room)
+            )
+            self._tail_tokens_floor = LoweredFloor(_room - self._head_tokens_floor)
         else:
-            self._head_tokens_floor = _room // 2
-            self._tail_tokens_floor = _room - self._head_tokens_floor
+            self._head_tokens_floor = LoweredFloor(_room // 2)
+            self._tail_tokens_floor = LoweredFloor(_room - self._head_tokens_floor)
         # #5531 PR-2 (owner: "下限を割ったことが見える" — visible with
         # the shipped config, not just inferable from a shrunk wire):
         # this ladder just lowered the floor below what

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -795,9 +795,9 @@ class ComputedBudgets:
     HistoryChunkToCompact.section_token_caps.
     """
     main_pool: int          # T_max - T_SP  (main session's available tokens)
-    head_budget: int        # tokens reserved for HEAD slice
+    head_budget: "EntryBudget"  # tokens reserved for HEAD slice (#5890 stage 0-b)
     body_budget: int        # tokens reserved for BODY (summary)
-    tail_budget: int        # tokens reserved for TAIL slice
+    tail_budget: "EntryBudget"  # tokens reserved for TAIL slice (#5890 stage 0-b)
     new_msg_budget: int     # tokens reserved for incoming user message
     B_M: int                # compactor LLM's own input budget
     main_M_room: int        # main session's middle room (after head+tail+new_msg)
@@ -875,9 +875,9 @@ def compute_budgets(
     effective_trigger = min(main_M_room, B_M)
     return ComputedBudgets(
         main_pool=main_pool,
-        head_budget=head,
+        head_budget=EntryBudget(head),  # #5890 stage 0-b: entry-time budget, load-bearing
         body_budget=body,
-        tail_budget=tail,
+        tail_budget=EntryBudget(tail),  # #5890 stage 0-b: entry-time budget, load-bearing
         new_msg_budget=new_msg,
         B_M=B_M,
         main_M_room=main_M_room,


### PR DESCRIPTION
**[tui-coder]** — part of #5890 stage 0-b, contract at https://github.com/tya5/reyn/issues/5890#issuecomment-5637045889 (+ 2 corrections: #issuecomment-5637070802 on `_room`/`_candidate`, and a broker-confirmed scope addition below).

## Summary

Adds 3 `NewType`s to `engine.py`, closing the exact confusion #5890's own falsify-first probes measured (4 probes run and reported before writing any of this code — see the probe reports on the issue thread):

- `EntryBudget` — the immutable, entry-time per-compartment budget from `ComputedBudgets` (never reassigned).
- `LoweredFloor` — the CURRENT floor, reassigned downward by `_stage_halve_room`'s own ladder. Same rename motivation as stage 0-a's `_tail_min_tokens`/`_head_min_tokens` → `_tail_tokens_floor`/`_head_tokens_floor`, one layer down at the type level.
- `Shortfall` — a delta (how far over available room the unprotected middle is), never a budget or a floor.

Deliberately does **not** distinguish head from tail (the "compartment" axis) — #5890's own investigation found zero real sites where a head value was mistaken for a tail value; a comment at the type definitions says so explicitly.

## Touch sites — produce/move only, per dispatch

- The ladder's own init — `EntryBudget` moved explicitly into `LoweredFloor` via `LoweredFloor(EntryBudget(...))`.
- `_stage_halve_room`'s own re-derivation — wrapped in `LoweredFloor(...)` at each reassignment.
- `select_fold_candidates_for_shortfall`'s own `shortfall_tokens` parameter, retyped to `Shortfall`.
- **`src/reyn/runtime/services/compaction_controller.py:612`** (1 line + 1 import) — `Shortfall`'s own REAL production site (`shortfall = Shortfall(unprotected_tokens - main_M_room)`). **Not in lead-coder's own dispatch** (written engine.py-scoped) — flagged mid-implementation over broker, lead-coder approved the 2-file scope explicitly ("(a) です... 他の判定・他の値には手を出さないこと" — confirmed only this one line + the import touched, nothing else in that file).

## Deliberately NOT touched

The 8 comparison sites — measured directly (mypy 2.3.0): a cross-`NewType` comparison, and a `NewType` value passed where a plain `int` parameter is expected, both produce ZERO mypy findings.

`_room`/`_candidate` (the halving method's own pool variable) do **not** get an `EntryBudget`/`LoweredFloor`/new-4th-type annotation either — architect's own self-correction on this dispatch: `_room: int` would satisfy the letter of "annotate it" while adding zero real checking, and would make the still-open gap LESS visible (a reader sees an annotation and assumes it means something). A residue comment at `_room`'s own derivation states plainly what stays open and why, per `docs/deep-dives/contributing/comments.md`'s own "write what breaks, not 'do not touch'" form.

## Gate residue: NOT attempted here

The `min()`/`int()`/`sum()` type-erasure through stdlib numeric builtins is disclosed, not solved — `NewType` has no mechanism to survive them. A future population-counting gate over `NewType` constructor call sites (`git grep -nE '\b(EntryBudget|LoweredFloor|Shortfall)\('`) is explicitly deferred, per dispatch.

## Witness: `mypy_ratchet`, not a runtime test (per dispatch)

No new runtime behavior exists to pin — `NewType` is identity-erased at runtime. Strip-falsified by hand (file-internal Edit only, reverted; no `git checkout`/`stash`/`restore`): removed the `LoweredFloor(...)` wrapper at the ladder's own init site:

```
src/reyn/services/compaction/engine.py:3486: error: Incompatible types in assignment (expression has type "EntryBudget", variable has type "LoweredFloor")  [assignment]
```

`mypy_ratchet.py` (changed-files mode): **FAILED** — "1 new (file, error-code) pair(s) not in the baseline: engine.py [assignment]". Restored; `mypy_ratchet.py` returns to OK (183 findings, all baselined, unchanged from before this PR).

Diff-scoped pytest (existing behavior unchanged, confirmatory only — not the load-bearing witness): 106/106 passed.

## Gates run (scoped)

- `ruff check .` — clean
- `scripts/verify_module_docstrings.py` — OK
- `scripts/mypy_ratchet.py` — OK (changed-files, 183 findings, all baselined)
- diff-scoped pytest across both files' relevant test coverage — 106/106 passed

## Test plan

- [x] No new runtime test — no new runtime behavior to pin (types are erased at runtime); `mypy_ratchet` is the witness, per dispatch
- [x] (skipped — Visual, standing waiver 2026-08-08)

part of #5890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn