### PR TITLE
fix(#6167): _stage_refill_phase1/2 return whether progress happened, not True

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -3602,7 +3602,11 @@ class RecoveryLadder:
     def _stage_refill_phase1(self) -> bool:
         """ADR-0044 refill, Phase 1: if ``tail`` still holds non-summary
         content above ``_tail_tokens_floor``, trim half of it (skipping any
-        reserved summary element) into ``raw_middle`` and return ``True``.
+        reserved summary element) into ``raw_middle`` and return whether
+        anything actually moved (#5890/#6167: ``bool(_removed)``, not an
+        unconditional ``True`` -- ``_split_off_non_summary`` is itself
+        allowed to remove zero items, so the return value now reflects
+        what happened, not merely that this branch was entered).
         Returns ``False`` (no mutation) when the predicate does not hold —
         this fuses the former bare ``elif`` condition and its body into
         one call so :meth:`_run_one_iteration`'s own escalation chain AND
@@ -3625,6 +3629,19 @@ class RecoveryLadder:
         # Phase 1 "handles" the overflow every iteration while moving
         # nothing, starving the reservation ladder's own floor-check
         # (below) of ever being reached.
+        #
+        # #5890/#6167 (architect, ADR-0049 §1's own N-decreases invariant):
+        # `_split_off_non_summary`'s own docstring allows it to remove
+        # ZERO items ("takes as many as there are ... by making no
+        # progress") -- `_removed` being non-empty here depends ENTIRELY
+        # on the `_has_non_summary` guard above, at THIS call site, not
+        # on anything this function's own return value asserts. `return
+        # True` below used to claim "progress happened" regardless of
+        # whether it actually did; a future guard-less call site would
+        # return True while removing nothing, and N's strict decrease
+        # would break silently -- no exception, no False, just a
+        # progress claim that was never checked against the mutation it
+        # describes.
         _non_summary_tail_count = sum(
             1 for t in self.tail
             if not (isinstance(t, dict) and t.get("role") == SUMMARY_MESSAGE_ROLE)
@@ -3632,7 +3649,7 @@ class RecoveryLadder:
         chunk = max(_non_summary_tail_count // 2, 1)
         _removed, self.tail = _split_off_non_summary(self.tail, chunk, from_end=False)
         self.raw_middle.extend(_removed)
-        return True
+        return bool(_removed)
 
     def _stage_refill_phase2(self) -> bool:
         """ADR-0044 refill, Phase 2: same as :meth:`_stage_refill_phase1`
@@ -3645,22 +3662,38 @@ class RecoveryLadder:
             return False
         # Phase 2: trim head half → raw_middle. #5531 PR-2: same skip
         # and same `_has_non_summary` guard as Phase 1's own branch.
+        #
+        # #5890/#6167: same N-decreases dependency as Phase 1's own
+        # comment above -- `_removed` being non-empty here depends
+        # entirely on the `_has_non_summary` guard above, not on
+        # anything this function's own return asserts.
         _non_summary_head_count = sum(
             1 for t in self.head
             if not (isinstance(t, dict) and t.get("role") == SUMMARY_MESSAGE_ROLE)
         )
         chunk = max(_non_summary_head_count // 2, 1)
         _removed, self.head = _split_off_non_summary(self.head, chunk, from_end=True)
-        self.raw_middle = _removed + self.raw_middle
-        # #5531 §10 (table #14's own asymmetry, corrected): Phase 2
-        # PREPENDS to raw_middle — a stale ``_compact_attempt_len``
-        # ("the first N turns failed") would now name a DIFFERENT
-        # prefix than the one that fact was ever true of. Phase 1
-        # (below-this-branch's sibling, APPENDS to the end) does NOT
-        # reset — the prefix stays unchanged there, so the knowledge
-        # stays valid.
-        self._compact_attempt_len = None
-        return True
+        if _removed:
+            self.raw_middle = _removed + self.raw_middle
+            # #5531 §10 (table #14's own asymmetry, corrected): Phase 2
+            # PREPENDS to raw_middle — a stale ``_compact_attempt_len``
+            # ("the first N turns failed") would now name a DIFFERENT
+            # prefix than the one that fact was ever true of. Phase 1
+            # (below-this-branch's sibling, APPENDS to the end) does NOT
+            # reset — the prefix stays unchanged there, so the knowledge
+            # stays valid.
+            #
+            # #5890/#6167 (architect ruling ②): guarded on `_removed`
+            # itself now, not merely on this method having been called --
+            # the reset's own reason ("PREPENDS, so the prefix changed")
+            # is only true when a prepend actually happened. `_removed`
+            # empty means nothing was prepended, the prefix `_compact_
+            # attempt_len` describes is unchanged, and the knowledge it
+            # carries is still valid -- discarding it here would be the
+            # same "throw away a fact that is still true" mistake Phase 1
+            # deliberately does NOT make on its own append-only branch.
+            self._compact_attempt_len = None
+        return bool(_removed)
 
     def _stage_halve_room(self) -> None:
         """ADR-0044 — halve the room. Reached once ``raw_middle`` is


### PR DESCRIPTION
**[tui-coder]** —

Closes #6167
part of #5890

## What

`_stage_refill_phase1`/`_stage_refill_phase2` returned an unconditional `True` after their guard-passed branch, even though `_split_off_non_summary` is itself documented to allow removing zero items ("takes as many as there are ... by making no progress"). At the two *existing* call sites the `_has_non_summary` guard already guarantees `_removed` is non-empty, so today's behavior is unaffected — this closes a latent gap: a future guard-less 3rd call site would otherwise silently claim progress while making none, breaking ADR-0049 §1's strict-decrease (N) dependency with no exception and no `False`.

- `_stage_refill_phase1`/`_stage_refill_phase2`: `return True` → `return bool(_removed)`.
- Ruling ②: `_stage_refill_phase2`'s `self._compact_attempt_len = None` reset moved inside `if _removed:` — the reset's own stated reason ("PREPENDS, so the prefix changed") only holds when a prepend actually happened; if `_removed` is empty, the prefix is unchanged and the pre-existing knowledge is still valid.
- Added inline comments at both sites naming the N-decrease dependency explicitly (per lead-coder ruling: this belongs in code comments, not an ADR edit — ADR-0049 is immutable once ACCEPTED).
- **No gate added** in this PR — structural fix; the dependency a gate would police disappears with this change. A future census-style gate for a hypothetical 3rd call site is deferred to a separate issue.

## Tests — none added (lead-coder ruling, following #6155's own precedent)

An earlier version of this PR added 2 tests that constructed a real `RecoveryLadder` directly and `monkeypatch.setattr` the module-level pure function `_has_non_summary` to always return `True`, fabricating a guard-less call site on an all-summary `tail`/`head`. Reviewer's ruling: this scenario is unreachable through either real call site today, so the test itself is "only a configuration this test itself constructed" (six-questions Q3) and the monkeypatch counts as a lying stand-in under the no-fakes policy — a same-shaped `monkeypatch.setattr` used elsewhere in this codebase is precedent, not permission. Since behavior is 0-bit changed at both real call sites, there is no new property for a test to protect; the existing 88 diff-scoped tests (all green, unchanged) are the witness. Both tests were removed.

**Strip-falsify performed during review, before the 2 tests were removed** (verbatim result, preserved here since the tests it exercised no longer exist in the diff): reverted `return bool(_removed)` → `return True` via in-file Edit (no `git checkout`/`stash`/`restore`) — both tests went RED (`assert True is False`). Reverted back via in-file Edit — GREEN again.

Zero behavior change confirmed for both existing call sites (both are `if`/`elif` truthy checks, and the guard already guarantees `_removed` is non-empty there): 88 pre-existing diff-scoped tests across `test_pr_n6_compaction_overflow_retry.py`/`test_chat_compaction_engine.py`/`test_chat_compaction_engine_11axis.py`, all green.

## Gates

- `ruff check .` — clean
- `scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py` — OK
- `scripts/mypy_ratchet.py` — 183 findings, all baselined (unchanged from before this PR)
- `scripts/test_tier_audit.py --strict tests/services/test_pr_n6_compaction_overflow_retry.py` — 41/41 OK
- tests/-path-conditional gates (test file touched, net-zero diff): `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` — all OK
- Diff-scoped pytest only (CI runs the full suite) — not waiting on CI per dispatch.

## Test plan
- [x] Diff-scoped pytest green (88/88 across the 3 established regression files, no test file diff)
- [x] Strip-falsify performed and verbatim result reported above
- [x] (skipped — no UI surface) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn