### PR TITLE
feat(#6093 stage 1): ChatMessage.kind -- FRAME/MATERIAL choke point for 17 _append_history( sites

### DIFF
--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -18,6 +18,13 @@ choke point in ``__init__``, required (no default) whenever
 next-turn projection, an operator's restored TUI, both, or neither"
 (``role`` alone conflates Reyn-internal chrome with producer-authored
 content meant for the model — see that enum's own docstring).
+
+``HistoryEntryKind`` (#6093 §1) is a THIRD declared axis, same
+one-field/one-choke-point shape — defaulted (not required) to
+``UNSPECIFIED`` — answering "is this entry Reyn's own OS chrome
+(FRAME), or content someone/something outside Reyn's own OS layer
+produced (MATERIAL)?" (see that enum's own docstring for the census
+of the 4 previously-unshared vocabularies this replaces).
 """
 from __future__ import annotations
 
@@ -519,6 +526,125 @@ def _normalize_disclosure(value: object, *, role: str, meta: dict) -> "Disclosur
     )
 
 
+class HistoryEntryKind(StrEnum):
+    """#6093 §1 — answers ONE question: "is this entry Reyn's own OS
+    chrome, or is it MATERIAL someone/something outside Reyn's own OS
+    layer produced?" Vocabulary taken verbatim from this file's own
+    prose (:class:`Spillability`'s own docstring, #5514): "reyn's own
+    ★FRAME (``notify_turn_cancelled``) and ★MATERIAL (``template_push``)
+    share ``role=="system"``" — the census that led to this field found
+    that same FRAME/MATERIAL split already informally present but never
+    given a field, spread across FOUR different keys with no shared
+    vocabulary (a bare ``meta["kind"]`` string, ``meta["origin"]``,
+    ``meta["source"]``, and a second, unrelated ``meta["kind"]``
+    spelling holding a :class:`~reyn.runtime.turn_origin.TurnOrigin`
+    member) across the 17 ``_append_history(`` call sites (``git grep
+    -n '_append_history(' -- src/``).
+
+    Deliberately NOT :class:`~reyn.runtime.turn_origin.TurnOrigin`
+    (architect ruling, #6093 §1): ``TurnOrigin`` answers "which
+    PRODUCER authored this MATERIAL" — a question that does not even
+    apply to a FRAME entry (there is no producer to name), and it has
+    no member for what a FRAME entry actually IS (``"turn_cancelled"``
+    is not among its 11 members, all of which name a MATERIAL
+    provenance). This field does not replace ``origin``/``TurnOrigin``
+    or either existing ``meta["kind"]`` spelling — it answers a
+    logically PRIOR question (frame vs material), leaving "which
+    producer" exactly where it already lived.
+
+    ``StrEnum`` for the same reason ``Spillability``/``Disclosure`` are:
+    a value persisted to ``history.jsonl`` via ``asdict`` + ``json.dumps``
+    must serialise to its own wire string, and a value read back as a
+    plain ``str`` must still compare equal to the member.
+    """
+
+    #: The safe-side default (see :meth:`default`) — asserts NOTHING
+    #: about which layer this entry belongs to. Every entry constructed
+    #: before this field existed reads back as this value (no backfill,
+    #: #6093 §1 ruling — same forward-only shape as ``ChatMessage.
+    #: origin``: "existing entries written before this field existed
+    #: have no key, which is treated as not-yet-classified").
+    UNSPECIFIED = "unspecified"
+    #: Reyn's own OS chrome — never producer-authored, never something
+    #: the model or an operator should read as conversational content
+    #: (``notify_turn_cancelled``'s ack, a canned retry-exhausted reply).
+    FRAME = "frame"
+    #: Content someone or something OUTSIDE Reyn's own OS layer produced
+    #: — a user prompt, an LLM reply, a tool result, a hook push, a
+    #: ride-along, an inter-agent message (``template_push`` and every
+    #: other #5514 "deliverable", in that docstring's own vocabulary).
+    MATERIAL = "material"
+
+    @classmethod
+    def default(cls) -> "HistoryEntryKind":
+        """#6093 §1 (architect ruling): the safe-side default is
+        ``UNSPECIFIED``, never ``FRAME`` or ``MATERIAL`` — an omitted
+        declaration must not silently claim EITHER layer. The same
+        asymmetry ``Spillability.default()`` names for its own axis
+        (verbatim): a missing declaration must degrade to "not yet
+        classified", never assert the answer to a question nobody
+        actually answered. Concretely: a discriminator reading this
+        field must treat ``UNSPECIFIED`` as *not applicable* — never as
+        a 3rd member of either side of the FRAME/MATERIAL split."""
+        return cls.UNSPECIFIED
+
+
+def _normalize_history_entry_kind(value: object) -> HistoryEntryKind:
+    """#6093 §1: ``ChatMessage.__init__``'s ONE normalization point for
+    ``kind`` — every one of the 17 ``_append_history(`` call sites funnels
+    through here, including ``ChatMessage(**raw)`` from a read-back
+    ``history.jsonl`` line.
+
+    - ``None`` (omitted at a call site, or a pre-#6093 persisted line
+      with no ``kind`` key at all) → :meth:`HistoryEntryKind.default`
+      (``UNSPECIFIED``) — see that method's own docstring for why this
+      must not fall to either real member. This is what lets all 16 of
+      the 17 call sites this PR does not touch keep working unchanged:
+      an entry that never declares ``kind`` is simply not-yet-classified,
+      never silently misclassified.
+    - Already a ``HistoryEntryKind`` member → passed through unchanged.
+    - A plain ``str`` that names a real member (the read-back case) →
+      converted to that member.
+    - Anything else — an unrecognized string (a future value this
+      version's enum doesn't have yet, or a corrupted history line) —
+      degrades to :meth:`HistoryEntryKind.default` (``UNSPECIFIED``)
+      rather than raising.
+
+      SAME safe-side judgment as ``_normalize_spillability`` (lead-coder
+      BLOCKING correction, #6093 review — an earlier version of this
+      function raised here instead, reasoning by a DIFFERENT precedent,
+      ``Disclosure``'s own required-value raise; that precedent does not
+      apply: ``Disclosure`` is required with no default, so a bad value
+      IS a caller bug to surface loudly. ``kind`` has a real, safe-side
+      default — the exact shape ``_normalize_spillability``'s own
+      docstring already argues for: "an unrecognized string … degrades
+      to ``Spillability.default()`` rather than raising", "an unreadable
+      declaration must degrade availability, never fail the turn").
+      Concretely: this function is reached from ``ChatMessage(**raw)``
+      on every ``history.jsonl`` read-back (``Session._parse_history_
+      line``) — raising here would mean (1) a NEWER build's ``kind``
+      value could never be read back by an OLDER build, and (2) one
+      corrupted/foreign-written history line could fail loading the
+      WHOLE session on restart, for a field whose own default is
+      already "not yet classified". Degrading to ``UNSPECIFIED`` also
+      satisfies #6093 §1's own default ruling directly (the default
+      "must not fall to either real member... never assert the answer
+      to a question nobody actually answered") — the same value an
+      omitted declaration produces, which is correct: an unrecognized
+      string is not more informative than no declaration at all.
+    """
+    if value is None:
+        return HistoryEntryKind.default()
+    if isinstance(value, HistoryEntryKind):
+        return value
+    if isinstance(value, str):
+        try:
+            return HistoryEntryKind(value)
+        except ValueError:
+            return HistoryEntryKind.default()
+    return HistoryEntryKind.default()
+
+
 # #73: typed (not form-sniffed) tool-outcome classification, stamped on a
 # ``role="tool"`` message's ``meta`` at PERSIST time by the ONE place that
 # already knows the classification (``router_loop.py``'s tool-result
@@ -831,6 +957,13 @@ class ChatMessage:
     # including how a pre-#5678 persisted line supplies one via
     # ``_migrate_legacy_chat_message`` rather than this raising.
     disclosure: "Disclosure | None" = None
+    # #6093 §1: the ONE declaration point — see ``HistoryEntryKind``'s
+    # own docstring and ``_normalize_history_entry_kind`` for the full
+    # contract. Defaults to ``HistoryEntryKind.default()``
+    # (``UNSPECIFIED``) — omitted at 16 of the 17 existing
+    # ``_append_history(`` call sites, all unaffected by this field's
+    # addition.
+    kind: HistoryEntryKind = field(default_factory=HistoryEntryKind.default)
 
     def __init__(
         self,
@@ -852,6 +985,11 @@ class ChatMessage:
         # ``role="system"``, irrelevant (stays ``None``) for every other
         # role.
         disclosure: "Disclosure | str | None" = None,
+        # #6093 §1: see ``_normalize_history_entry_kind`` — omitted
+        # (``None``) at every call site this PR does not touch, which
+        # normalizes to ``HistoryEntryKind.UNSPECIFIED``, never either
+        # real member.
+        kind: "HistoryEntryKind | str | None" = None,
     ) -> None:
         # Reject the pre-#383 ``"agent"`` spelling. Migration of on-disk
         # ``history.jsonl`` entries happens at load time via
@@ -874,6 +1012,7 @@ class ChatMessage:
         self.name = name
         self.spillability = _normalize_spillability(spillability)
         self.disclosure = _normalize_disclosure(disclosure, role=role, meta=self.meta)
+        self.kind = _normalize_history_entry_kind(kind)
         # #5896 P0 (owner-hit, 2026-09-07): a plain instance attribute, NOT
         # a dataclass field — deliberately NO class-level annotation, so
         # `dataclasses.fields()`/`asdict()`/`__eq__`/`repr()` never see it.
@@ -908,7 +1047,7 @@ class ChatMessage:
         codebase in-place-mutates ANY field ``asdict(self)`` can see
         (``role`` / ``content`` / ``ts`` / ``seq`` / ``meta`` /
         ``tool_calls`` / ``tool_call_id`` / ``name`` / ``spillability`` /
-        ``disclosure`` — all 9 dataclass fields, not just
+        ``disclosure`` / ``kind`` — all 11 dataclass fields, not just
         ``content``/``meta``) AFTER a message becomes resident.
         Confirmed by reading every in-place write to any of them across
         the whole of ``src/`` (lead-coder review, PR #5945 BLOCKING —
@@ -932,7 +1071,7 @@ class ChatMessage:
         ``dataclasses.replace()`` goes back through ``__init__`` (this
         cache is reset to ``None`` there), so a copy never inherits a
         stale value from the original. If a future change adds an
-        in-place write to any of the 9 fields AFTER a message is
+        in-place write to any of the 11 fields AFTER a message is
         resident, this cache goes silently stale — re-run this same
         search (``.content =`` / ``.meta[...] =`` / ``.seq =`` / etc.,
         across ``src/``, not just ``runtime/``) before trusting it

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -87,6 +87,7 @@ from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
     SPILLED_META_KEY,
     ChatMessage,
     Disclosure,
+    HistoryEntryKind,
     Spillability,
     _now_iso,
     compaction_coverage_from_summary,
@@ -9126,6 +9127,22 @@ class Session:
         _rendered = _render_mid_turn_injection(kind, payload)
         self._append_history(ChatMessage(
             role=_rendered["role"], content=_rendered["content"], ts=_now_iso(),
+            # #6093 §1 (architect ruling, "producer に名乗らせない — 穴は
+            # 1 つだけ"): ``meta`` below is a multi-producer queue's own
+            # dict, passed through WHOLESALE — the one call site among
+            # the 17 where a producer could stuff an arbitrary
+            # ``meta["kind"]`` string. ``kind=`` (this ``ChatMessage``'s
+            # OWN, unrelated field, see ``HistoryEntryKind``) is set
+            # EXPLICITLY here, as a positional-independent keyword the OS
+            # itself supplies from ``kind``/``_rendered`` (the trusted
+            # local, this function's own inbox-arbiter pop above) — never
+            # read from ``payload``/``meta`` — so nothing in the
+            # producer-supplied dict can make this entry claim
+            # ``HistoryEntryKind.FRAME``. Every ``MID_TURN_INJECTABLE``
+            # member (CLIENT_INPUT/AGENT_REQUEST/EXTERNAL_MESSAGE/HOOK)
+            # is content from OUTSIDE Reyn's own OS layer — MATERIAL,
+            # unconditionally, regardless of which member this is.
+            kind=HistoryEntryKind.MATERIAL,
             meta=payload.get("meta") or {},
             # #5514 §4 (traced, still undecided): this item came off
             # ``self._inbox``, a generic multi-producer queue

--- a/tests/runtime/test_6093_history_entry_kind.py
+++ b/tests/runtime/test_6093_history_entry_kind.py
@@ -1,0 +1,201 @@
+"""Tier 2: #6093 §1 — the ``HistoryEntryKind`` axis (``ChatMessage.kind``):
+normalization contract (omitted → UNSPECIFIED, unknown string degrades to
+UNSPECIFIED — both at fresh construction and on the ``ChatMessage(**raw)``
+read-back path) and the one call site (``Session._commit_mid_turn_
+injection``) a producer's own ``meta`` dict could otherwise use to forge a
+FRAME claim.
+
+No structural/source-scanning test on the 17 ``_append_history(`` call
+sites themselves (lead-coder BLOCKING, PR review): the choke point is
+enforced by ``Session._append_history``'s own SIGNATURE (``msg:
+ChatMessage``), not by a call-site count — a floor test on that count
+answers no one's "whose bug is it" question (a legitimate consolidation of
+call sites would make it fail for no real defect), and reading source text
+to scan for it is a gate's shape, not a behavioral test's.
+
+Real ``Session`` throughout for the end-to-end producer-forgery test (the
+same convention ``test_5677_mid_turn_injection_wire_rendering.py`` uses) —
+no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage, HistoryEntryKind
+from reyn.runtime.turn_origin import TurnOrigin
+from tests._support.agent_session import make_session
+
+AGENT = "6093-history-entry-kind-agent"
+
+
+def _make_session(tmp_path: Path, name: str):
+    state_log = StateLog(tmp_path / f"{name}.wal")
+    session = make_session(
+        agent_name=AGENT, state_log=state_log, snapshot_path=tmp_path / f"{name}.json",
+    )
+    return session, state_log
+
+
+# ---------------------------------------------------------------------------
+# Normalization contract — the ONE choke point in ChatMessage.__init__
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_kind_normalizes_to_unspecified():
+    """Tier 2: #6093 §1 accept — a caller that never passes ``kind=`` (16
+    of the 17 existing ``_append_history(`` call sites, all untouched by
+    this issue) gets ``HistoryEntryKind.UNSPECIFIED`` — never a raise,
+    never a silent guess at FRAME or MATERIAL. This is what lets the
+    choke-point design cover 17 call sites while editing only 1."""
+    msg = ChatMessage(role="user", content="hi")
+    assert msg.kind is HistoryEntryKind.UNSPECIFIED
+
+
+def test_none_kind_normalizes_to_unspecified():
+    """Tier 2: an explicit ``kind=None`` is the same as omitting it —
+    both spellings a read-back ``history.jsonl`` line without a ``kind``
+    key can produce via ``ChatMessage(**raw)``."""
+    msg = ChatMessage(role="assistant", content="ok", kind=None)
+    assert msg.kind is HistoryEntryKind.UNSPECIFIED
+
+
+def test_frame_and_material_round_trip_unchanged():
+    """Tier 2: accept — both real members pass through ``__init__``
+    unchanged, the overwhelmingly common in-process path."""
+    msg_frame = ChatMessage(
+        role="assistant", content="canned reply", kind=HistoryEntryKind.FRAME,
+    )
+    assert msg_frame.kind is HistoryEntryKind.FRAME
+    msg_material = ChatMessage(
+        role="assistant", content="llm output", kind=HistoryEntryKind.MATERIAL,
+    )
+    assert msg_material.kind is HistoryEntryKind.MATERIAL
+
+
+def test_kind_as_plain_string_naming_a_real_member_converts():
+    """Tier 2: the read-back case — a value persisted via ``asdict`` +
+    ``json.dumps`` comes back as a plain ``str`` (``"frame"``/
+    ``"material"``/``"unspecified"``), and ``ChatMessage(**raw)`` must
+    still produce the real enum member, not a bare string."""
+    msg = ChatMessage(role="tool", content="result", kind="material")
+    assert msg.kind is HistoryEntryKind.MATERIAL
+    assert isinstance(msg.kind, HistoryEntryKind)
+
+
+def test_unknown_kind_string_degrades_to_unspecified_fresh_construction():
+    """Tier 2: #6093 §1 accept (lead-coder BLOCKING correction, PR review)
+    — an unrecognized ``kind`` string degrades to ``UNSPECIFIED`` rather
+    than raising. SAME safe-side judgment as ``_normalize_spillability``
+    (that function's own docstring, verbatim: "an unrecognized string …
+    degrades to ``Spillability.default()`` rather than raising"), not
+    ``Disclosure``'s required-value raise — ``kind`` has a real,
+    safe-side default, ``Disclosure`` does not.
+
+    Strip-falsifier: changing the ``except ValueError: return
+    HistoryEntryKind.default()`` branch in
+    ``_normalize_history_entry_kind`` back to a bare ``raise`` makes
+    this test go RED (an unhandled ``ValueError`` instead of a
+    successful construction)."""
+    msg = ChatMessage(role="user", content="x", kind="not_a_real_kind")
+    assert msg.kind is HistoryEntryKind.UNSPECIFIED
+
+
+def test_unknown_kind_string_degrades_on_the_read_back_path_too():
+    """Tier 2: #6093 §1 accept — the path this matters most for:
+    ``ChatMessage(**raw)`` from a read-back ``history.jsonl`` line
+    (``Session._parse_history_line``). A future build's ``kind`` member
+    (not yet in THIS build's enum), or one corrupted/foreign-written
+    line, must not fail loading it — degrading to UNSPECIFIED here is
+    what lets an older build read a newer build's history, and what
+    keeps one bad line from failing the WHOLE session's restart.
+
+    Strip-falsifier: same as
+    ``test_unknown_kind_string_degrades_to_unspecified_fresh_construction``
+    — a bare ``raise`` in ``_normalize_history_entry_kind`` would instead
+    raise here, inside the exact call shape ``ChatMessage(**raw)``
+    performs on every restart."""
+    raw = {
+        "role": "assistant", "content": "hi", "ts": "t1", "seq": 2,
+        "kind": "some_future_or_corrupted_value",
+    }
+    msg = ChatMessage(**raw)
+    assert msg.kind is HistoryEntryKind.UNSPECIFIED
+
+
+# ---------------------------------------------------------------------------
+# Legacy read-back — an old history.jsonl line with no `kind` key at all
+# ---------------------------------------------------------------------------
+
+
+def test_reading_back_a_pre_6093_history_line_does_not_crash():
+    """Tier 2: #6093 §1 accept — forward-only, no backfill (architect
+    ruling): a persisted line written before this field existed has no
+    ``kind`` key at all. ``ChatMessage(**raw)`` for such a line must
+    still construct successfully, with ``kind`` resolving to
+    UNSPECIFIED — the same "not yet classified, never backfilled" shape
+    ``ChatMessage.origin`` already uses (session.py's own comment,
+    verbatim: "existing entries written before this field existed have
+    no key ... never backfilled")."""
+    pre_6093_raw = {
+        "role": "user", "content": "old line", "ts": "t0", "seq": 1,
+        "meta": {"chain_id": "c1"},
+    }
+    msg = ChatMessage(**pre_6093_raw)
+    assert msg.kind is HistoryEntryKind.UNSPECIFIED
+
+
+# ---------------------------------------------------------------------------
+# Positive control — the ONE call site a multi-producer queue's own dict
+# passes through wholesale (session.py's `_commit_mid_turn_injection`,
+# `meta=payload.get("meta") or {}`) must NOT let a producer forge `kind`.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_injection_kind_is_os_assigned_not_producer_supplied(tmp_path):
+    """Tier 2: #6093 §1 accept — positive control. A producer stages a
+    mid-turn AGENT_REQUEST injection whose own ``meta`` dict claims
+    ``kind="frame"`` (an attempted forgery — this producer's queue item
+    is genuinely MATERIAL, content from outside Reyn's own OS layer).
+    The committed history entry's ``.kind`` must be the OS-assigned
+    ``HistoryEntryKind.MATERIAL``, never the producer's claimed value —
+    proving ``kind=`` at this call site is set from the trusted local
+    (the inbox item's own ``TurnOrigin``), not read out of
+    ``payload["meta"]``.
+
+    Strip-falsifier: changing ``kind=HistoryEntryKind.MATERIAL`` at
+    ``Session._commit_mid_turn_injection``'s ``ChatMessage(...)`` call to
+    instead read ``payload.get("meta", {}).get("kind")`` would make this
+    test go RED (the entry would carry the producer's forged ``"frame"``
+    string, unrecognized as a real member and raising, or — if read
+    unvalidated — silently claiming FRAME)."""
+    session, state_log = _make_session(tmp_path, "forge")
+    await session._put_inbox(
+        TurnOrigin.AGENT_REQUEST,
+        {
+            "from_agent": "peer-agent", "request": "please redo step 1",
+            "chain_id": "c1",
+            # The forgery attempt: a producer-controlled meta dict
+            # claiming this entry is Reyn's own FRAME chrome.
+            "meta": {"kind": "frame"},
+        },
+    )
+    injections = await session.peek_mid_turn_injections()
+    (only,) = injections
+
+    before_len = len(session.history)
+    await session._commit_mid_turn_injection(only["msg_id"])
+
+    assert len(session.history) == before_len + 1
+    entry = session.history[-1]
+    # The OS-assigned field: never the producer's claim.
+    assert entry.kind is HistoryEntryKind.MATERIAL
+    # The producer's own meta dict is otherwise passed through unchanged
+    # (this test is not about censoring meta — only about the SEPARATE
+    # `.kind` field never reading from it).
+    assert entry.meta.get("kind") == "frame"
+
+    await state_log.aclose()


### PR DESCRIPTION
**[tui-coder]** —

part of #6093

## What

Adds a THIRD declared axis to `ChatMessage`, same one-field/one-choke-point shape as `Spillability`/`Disclosure`: `HistoryEntryKind` (`UNSPECIFIED` / `FRAME` / `MATERIAL`), normalized in `__init__` via the new `_normalize_history_entry_kind`.

**Root problem** (architect census, #6093 §1): "who is this entry" was spread across FOUR unshared vocabularies at the 17 `_append_history(` call sites — a bare `meta["kind"]` string (`"turn_cancelled"`), a second `meta["kind"]` spelling holding a `TurnOrigin` member, `meta["origin"]` (2 policy values), and `meta["source"]` (a free string) — with no field distinguishing Reyn's own OS chrome (FRAME: `notify_turn_cancelled`, a canned retry-exhausted reply) from producer-authored content (MATERIAL: everything else).

Vocabulary taken verbatim from this file's own prose (`Spillability`'s docstring: "reyn's own FRAME (`notify_turn_cancelled`) and MATERIAL (`template_push`) share `role=="system"`") rather than inventing new terms — per lead-coder's explicit instruction. Deliberately NOT `TurnOrigin` (no `turn_cancelled` member, and it answers a different question — which producer, not frame-vs-material) and does not touch the 4 existing keys' own meaning.

**Choke point**: every `_append_history(` call funnels through `ChatMessage.__init__` (`session.py:4375`'s own docstring already names this, and `Session._append_history`'s own SIGNATURE — `msg: ChatMessage` — is what actually enforces it), so adding the field there covers all 17 sites; **16 of them are UNCHANGED** — `kind=` omitted normalizes to `UNSPECIFIED`, the safe-side default (never FRAME or MATERIAL — `Spillability.default()`'s own asymmetry).

**An unrecognized non-`None` string degrades to `UNSPECIFIED` rather than raising** — SAME safe-side judgment as `_normalize_spillability` (**lead-coder BLOCKING correction, round 1**: an earlier version of this raised instead, reasoning by the wrong precedent — `Disclosure`'s own required-value raise does not apply here, since `kind` has a real, safe-side default and `Disclosure` does not). This matters most on the `ChatMessage(**raw)` read-back path (`Session._parse_history_line`): raising would mean a newer build's `kind` value could never be read back by an older build, and one corrupted/foreign-written history line could fail loading the WHOLE session on restart.

**The ONE site touched**: `Session._commit_mid_turn_injection` — the one `_append_history(` call whose `meta=payload.get("meta") or {}` passes a multi-producer queue's own dict through wholesale. `kind=HistoryEntryKind.MATERIAL` is now set explicitly there from the trusted local (the inbox item's own `TurnOrigin`), never read out of the producer-supplied payload — closing the one path a producer could otherwise use to claim FRAME via a forged `meta["kind"]`.

No backfill (forward-only, architect ruling) — a pre-#6093 persisted line has no `kind` key and normalizes to `UNSPECIFIED` on read-back, the same shape `ChatMessage.origin` already uses for its own forward-only field.

## Tests

`tests/runtime/test_6093_history_entry_kind.py` (8 tests):
- Normalization contract: omitted/`None` → `UNSPECIFIED`; both real members round-trip; a plain string naming a real member converts (the read-back case); an unknown string degrades to `UNSPECIFIED` — both at fresh construction and specifically on the `ChatMessage(**raw)` read-back path.
- Legacy read-back: a pre-#6093 line with no `kind` key constructs successfully as `UNSPECIFIED`.
- **Positive control** (real `Session`, no mocks): stages a mid-turn `AGENT_REQUEST` injection whose own `meta` claims `kind="frame"` (a forgery attempt), commits it, and asserts the entry's `.kind` is the OS-assigned `MATERIAL` — never the producer's claim — while `meta["kind"]` itself is left untouched (`"frame"`), proving the two are genuinely independent.

**Removed in review, round 2 (lead-coder BLOCKING)**: 2 structural/source-scanning tests (a floor-count on `_append_history(` call sites + its own vacuity guard). Dropped rather than fixed — the choke point is enforced by `Session._append_history`'s own type signature, not by a call-site count; a floor test answers no one's "whose bug is it" question (a legitimate consolidation of call sites would fail it for no real defect), and scanning source text for a count is a gate's shape, not a behavioral test's — correctly, no gate is being added for this issue either.

Strip-falsifiers noted inline in each remaining test's own docstring.

## Gates

- `ruff check .` — clean
- `scripts/verify_module_docstrings.py src/reyn/runtime/chat_message.py src/reyn/runtime/session.py` — OK
- `scripts/mypy_ratchet.py` — 183 findings, all baselined
- `scripts/test_tier_audit.py --strict tests/runtime/test_6093_history_entry_kind.py` — 8/8 OK, 0 Tier-4
- tests/-path-conditional gates: `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` — all OK
- Diff-scoped pytest (not the full suite; CI runs that) — not waiting on CI per dispatch.

## Pytest (diff-scoped + directly adjacent)

New file (8/8) + `test_5678_disclosure_axis.py` (15) + `test_5580_chat_message_spillability_round_trip.py` (5) + `test_5677_mid_turn_injection_wire_rendering.py` (10) + `test_5896_p0_resident_bytes_cache.py`/`test_5973_resident_body_bytes_types.py`/`test_5973_bounded_materialization.py` (15) + `test_5851_d7_top_history_rows.py` (8) + `test_chat_message_e_full_schema.py` (17) + `test_multi_session_restore.py` (1) — **all green (79/79)**.

## Open (disclosed, not silently skipped) — per lead-coder's own "開いてほしい面"

I read the `_render_mid_turn_injection` body and `session.py`'s `_commit_mid_turn_injection` in full (the touched site). I did **not** open `compaction_controller.py`'s `summary_msg` or `inter_agent_messaging.py`'s `history_meta` construction — this PR does not touch either of those 2 call sites (both stay at the safe-side `UNSPECIFIED` default, unaffected), so their internals were not load-bearing for this change.

## Test plan
- [x] Diff-scoped + adjacent pytest green (79/79)
- [x] Strip-falsify noted per-test in docstrings
- [x] (skipped — no UI surface) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn