### PR TITLE
fix(#6093 stage 2): hook push is role="user", a real conversational turn

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -127,6 +127,7 @@ from reyn.runtime.chat_message import (
     TOOL_STATUS_ERROR,
     TOOL_STATUS_META_KEY,
     Disclosure,
+    HistoryEntryKind,
 )
 
 from ._meta_keys import RESULT_KIND_KEY, RESULT_META_KEY
@@ -303,6 +304,41 @@ def project_restored_frames(
             continue
         if role == "user":
             meta = m.meta or {}
+            # #6093 stage ②: a hook push (E, wake=true) now persists as
+            # role="user" (a real conversational turn — see
+            # Session._handle_hook_message's own docstring) so it is
+            # correctly recognised as "already delivered" rather than
+            # RE-invented as a synthetic seed. But `role=="user"` alone
+            # no longer means "the operator typed this" the way it did
+            # before that change — dispatching on `role` HERE (what this
+            # branch used to do unconditionally) would relabel a hook's
+            # own words as the operator's own in the restored transcript
+            # (`app.py`'s `_history_turns`: `"you" if kind == "user" else
+            # "reyn"`, keyed off the very `OutboxMessage.kind` this branch
+            # assigns below). `kind` (stage ①'s field) is the declared
+            # discriminator for exactly this: `HistoryEntryKind.MATERIAL`
+            # is the value ONLY a non-operator producer (today: the hook
+            # push) declares on a role="user" entry — genuine operator
+            # input never passes `kind=` at its own call site
+            # (`_handle_inbox_text`'s construction), so it stays
+            # `UNSPECIFIED` and is unaffected by this branch.
+            if m.kind is HistoryEntryKind.MATERIAL:
+                # Mirror the LIVE rendering this same push already got
+                # when it first arrived (`_handle_hook_message`'s own
+                # `OutboxMessage(kind="system", text=attributed, ...)`
+                # push, unchanged by stage ②) — restore stays visually
+                # consistent with what the operator actually saw live,
+                # never "you" for words they did not write.
+                text = m.text
+                if text.strip():
+                    frames.append(
+                        OutboxMessage(
+                            kind="system",
+                            text=text,
+                            meta={RESTORED_META_KEY: True, "chain_id": meta.get("chain_id")},
+                        )
+                    )
+                continue
             prompt = meta.get(INTERVENTION_PROMPT_META_KEY)
             if prompt:
                 # #3299 P4: this history entry IS an answered intervention —

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -410,7 +410,10 @@ def _user_frame_meta(attribution: "dict | None") -> dict:
 
 
 def _format_ride_along_attribution(kind: str, name: str, text: str) -> str:
-    """Render an attributed system-role push message: ``[<kind>:<name>] <text>``.
+    """Render an attributed push message's TEXT: ``[<kind>:<name>] <text>``.
+    Renders only the string — the caller decides the entry's ``role``
+    (#6093 §2: the C ride-along sibling below stays ``role="system"``;
+    ``_handle_hook_message``'s own E push is now ``role="user"``).
 
     #1800 slice 5b originally: the single source for the ``[hook:<name>]``
     prefix, shared by the staged-context consumer (C — wake=false
@@ -9697,10 +9700,11 @@ class Session:
             )
         elif kind == TurnOrigin.HOOK:
             # E (wake=true) lifecycle-hook push delivered as a turn trigger:
-            # a system-role [hook:name] message + one router turn (self-
-            # continuation). The attribution + wake binding ride in the
-            # payload (race-free; the slice-7 valve can count hook-driven
-            # turns, and the audit trail attributes the turn to the hook).
+            # a [hook:name] message (#6093 §2: role="user", a real
+            # conversational turn) + one router turn (self-continuation).
+            # The attribution + wake binding ride in the payload
+            # (race-free; the slice-7 valve can count hook-driven turns,
+            # and the audit trail attributes the turn to the hook).
             await self._handle_hook_message(payload)
         elif kind == TurnOrigin.PIPELINE_NUDGE:
             # The empty-text pump that starts an ATTACHED pipeline run
@@ -9818,29 +9822,60 @@ class Session:
     async def _handle_hook_message(self, payload: dict) -> None:
         """#1800 slice 5b: surface an E (wake=true) lifecycle-hook push as one
         router turn (self-continuation). The push is appended as an attributed
-        system-role ``[hook:name]`` message — a NEW message (fidelity: never a
+        ``[hook:name]`` message — a NEW message (fidelity: never a
         silent mutation of an existing one) using the shared
         ``_format_ride_along_attribution`` helper (``kind="hook"`` at this call
         site, always — a hook push by construction) so C and E cannot drift —
         then a single router turn runs.
 
-        #5678/#5686: record IS delivery now — the appended entry (declared
-        ``Disclosure.MODEL``) is what the model actually sees, via the
-        widened ``build_history`` projection, not a SEPARATE text seed
-        passed to ``_run_router_loop`` (which would double-deliver it —
-        see that call site's own comment). This closes two defects at
-        once: E's content used to vanish from every turn AFTER the one it
-        arrived in (excluded from every subsequent projection), and its
-        turn-seed used to reach the model unattributed as a bare
-        ``role="user"`` line (#5686 — RouterLoop.run's own fallback guard
-        fired every time, since a role="system" tail was never
-        recognised as "already delivered")."""
+        #6093 §1/§2 (architect + lead-coder ruling, root-cause fix for the
+        #6093 empty-stop-attractor family): ``role="user"``, not
+        ``role="system"``. The prior ``role="system"`` shape made this
+        entry's tail NOT structurally a conversational turn — the LLM's
+        own next reply after a ``role="system"`` tail had nothing to
+        answer that its own turn-taking training recognises as an
+        inbound message, which is what #6093's own investigation traced
+        the verbatim-repeat failure to (see the issue's own root-cause
+        comment thread). ``kind=HistoryEntryKind.MATERIAL`` (stage ①'s
+        field) records WHY this is safe to place in the user slot without
+        claiming to be the operator's own words: it is content from
+        outside Reyn's own OS layer (a hook push), never Reyn's own
+        chrome (``FRAME`` — ``notify_turn_cancelled`` etc. stay
+        ``role="system"``, unaffected). ``kind`` is also what
+        ``restore.py``'s own projection now reads to avoid mislabeling
+        this entry as the operator's own line in the restored transcript
+        (see that module's own comment on its ``role=="user"`` branch).
+
+        Side effect, stated explicitly per review: this entry now falls
+        into ``COMPACTION_ELIGIBLE_BASE_ROLES`` (``role="user"`` is
+        always eligible) — ``Disclosure`` no longer governs its
+        model-visibility or compaction-eligibility the way it did as a
+        ``role="system"`` entry (``Disclosure`` applies ONLY to
+        ``role="system"``, per ``_normalize_disclosure``; passing it here
+        would silently normalize to ``None`` and govern nothing). This is
+        not an accidental loss of governance — ``role="user"`` was
+        already ALWAYS eligible for every window/compaction filter this
+        codebase has (``is_compaction_eligible``'s own base-role tuple),
+        a STRICTLY WIDER admission than ``Disclosure.MODEL`` ever
+        selectively granted a ``role="system"`` entry, so nothing that
+        used to be visible/eligible stops being so.
+
+        #5678/#5686 (superseded shape, kept for history): record IS
+        delivery — the appended entry is what the model actually sees,
+        not a SEPARATE text seed passed to ``_run_router_loop`` (which
+        would double-deliver it — see that call site's own comment).
+        This still closes both #5678/#5686 defects the same way (E's
+        content no longer vanishes from later turns' projections, and
+        its turn-seed no longer reaches the model unattributed) — only
+        the MECHANISM changed (a real ``role="user"`` conversational
+        turn instead of a widened ``role="system"``/``Disclosure``
+        allowlist admission)."""
         name = payload.get("name", "hook")
         text = payload.get("text", "")
         chain_id = payload.get("chain_id") or new_chain_id()
         attributed = _format_ride_along_attribution(TurnOrigin.HOOK, name, text)
         self._append_history(ChatMessage(
-            role="system",
+            role="user",
             content=attributed,
             ts=_now_iso(),
             meta={"chain_id": chain_id},
@@ -9873,13 +9908,11 @@ class Session:
                 if "spillability" in payload
                 else Spillability.default()
             ),
-            # #5678: a hook push is producer-authored content meant for
-            # the model (this method's own reason for existing) — MODEL,
-            # not INTERNAL. This entry now reaches the model's NEXT-turn
-            # projection too (router_history_buffer.py's allowlist
-            # widening, same PR) — see the run_router_loop call below for
-            # the matching stop-the-double-send half (#5686).
-            disclosure=Disclosure.MODEL,
+            # #6093 §2: this entry's OWN axis (not Disclosure, which does
+            # not apply to role="user" — see this method's own docstring)
+            # — content from outside Reyn's own OS layer, never Reyn's
+            # own chrome.
+            kind=HistoryEntryKind.MATERIAL,
         ))
         await self._put_outbox(OutboxMessage(
             kind="system",

--- a/src/reyn/runtime/turn_origin.py
+++ b/src/reyn/runtime/turn_origin.py
@@ -147,8 +147,10 @@ class TurnOrigin(StrEnum):
     CRON = "cron"
 
     #: A wake=true lifecycle-hook push delivered as a turn trigger (#1800 slice
-    #: 5b): a system-role ``[hook:name]`` message plus one router turn
-    #: (self-continuation). #5747 correction: no mechanism counts
+    #: 5b): a ``[hook:name]`` message (#6093 §2: ``role="user"``, a real
+    #: conversational turn — was ``role="system"`` before that fix) plus
+    #: one router turn (self-continuation). #5747 correction: no mechanism
+    #: counts
     #: consecutive turns of this member — #5561 (owner ruling, 2026-08-30,
     #: verbatim "hook 起動を回数で制限なんて誰も設定できないでしょ")
     #: retired the counter that once did, with no successor. (What, if

--- a/tests/hooks/test_5514_hook_spillability_dispatch.py
+++ b/tests/hooks/test_5514_hook_spillability_dispatch.py
@@ -136,7 +136,10 @@ async def test_declared_spillability_reaches_construction_on_wake_true(
         "spillability": Spillability.NEVER.value,
     })
 
-    (only,) = [m for m in session.history if m.role == "system"]
+    # #6093 §2: _handle_hook_message's own entry is role="user" (a real
+    # conversational turn), not role="system" — see that method's own
+    # docstring.
+    (only,) = [m for m in session.history if m.role == "user"]
     assert only.spillability is Spillability.NEVER
 
 

--- a/tests/hooks/test_hook_composer_reachability_phase5.py
+++ b/tests/hooks/test_hook_composer_reachability_phase5.py
@@ -52,7 +52,7 @@ from reyn.config.chat import SafetyConfig
 from reyn.core.events.state_log import StateLog
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.hooks.schema_registry import build_hook_payload
-from reyn.runtime.chat_message import Disclosure
+from reyn.runtime.chat_message import HistoryEntryKind, is_compaction_eligible
 from reyn.runtime.session import Session
 from reyn.runtime.session_params import ReactivityConfig
 from tests._support.agent_session import make_session
@@ -213,19 +213,36 @@ async def test_composed_event_from_external_input_drives_wake_hook_e2e(tmp_path)
         f"content already in history, not a separate text seed) — "
         f"got {ran!r}"
     )
+    # #6093 §2: _handle_hook_message's own entry is role="user" (a real
+    # conversational turn), not role="system" — see that method's own
+    # docstring.
     matches = [
         m for m in session.history
-        if m.role == "system" and "composed fired!" in m.text
+        if m.role == "user" and "composed fired!" in m.text
     ]
     (only_entry,) = matches  # exactly one — a 2nd or 0 fails to unpack
     assert only_entry.text.startswith("[hook:"), (
         f"the pushed text must land in history attributed with the "
         f"[hook:<name>] prefix (#5686) — got {only_entry.text!r}"
     )
-    assert only_entry.disclosure is not None and only_entry.disclosure >= Disclosure.MODEL, (
-        f"the pushed text's history entry must be declared at least "
-        f"MODEL-disclosed (#5678) so it actually reaches the model's own "
-        f"projection — got {only_entry.disclosure!r}"
+    # #6093 §2: this entry is role="user" now, not role="system" —
+    # Disclosure no longer governs it (applies only to role="system", per
+    # _normalize_disclosure) since role="user" is ALWAYS in
+    # COMPACTION_ELIGIBLE_BASE_ROLES / model-visible, a strictly WIDER
+    # admission than Disclosure.MODEL ever selectively granted a
+    # role="system" entry — reaches the model structurally, not via a
+    # declared axis. What replaces the old Disclosure assertion: this
+    # entry is compaction/window-eligible (is_compaction_eligible), and
+    # its OWN kind (stage ①'s field) records why it may sit in the user
+    # slot without claiming to be the operator's own words.
+    assert is_compaction_eligible(only_entry), (
+        f"the pushed text's history entry must be window/compaction "
+        f"eligible so it actually reaches the model's own projection — "
+        f"role={only_entry.role!r} is not in the always-eligible base set"
+    )
+    assert only_entry.kind is HistoryEntryKind.MATERIAL, (
+        f"a hook push is content from outside Reyn's own OS layer, never "
+        f"Reyn's own chrome — got {only_entry.kind!r}"
     )
 
 

--- a/tests/runtime/test_5678_disclosure_axis.py
+++ b/tests/runtime/test_5678_disclosure_axis.py
@@ -203,9 +203,11 @@ def test_extraction_is_not_vacuous():
     """Tier 2: positive control — if the walk stops finding ANY
     role="system" call (a refactor moves every producer behind a helper,
     a parser regression), the completeness test below passes VACUOUSLY.
-    This pins that the walk still finds the module known to hold FOUR of
-    the six #5678 producers (notify_state_change, notify_turn_cancelled,
-    _handle_hook_message, the C ride-along flush) — a name check, not a
+    This pins that the walk still finds the module known to hold 3 of
+    the original six #5678 producers (notify_state_change,
+    notify_turn_cancelled, the C ride-along flush — #6093 §2 moved the
+    4th, ``_handle_hook_message``'s own E push, to ``role="user"``,
+    outside this AST walk's own scope by design) — a name check, not a
     count, so it survives sites being added or removed elsewhere without
     needing a threshold bump."""
     modules = {module for module, _lineno, _has in _role_system_call_findings()}

--- a/tests/runtime/test_textual_chat_phase5_3273.py
+++ b/tests/runtime/test_textual_chat_phase5_3273.py
@@ -54,7 +54,7 @@ from reyn.interfaces.repl.read_model import (
 )
 from reyn.interfaces.transport.client_transport import ClientTransportStub
 from reyn.interfaces.transport.frames import DisplayFrame
-from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.chat_message import ChatMessage, HistoryEntryKind
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
@@ -400,6 +400,73 @@ def test_projection_skips_blank_text_turns() -> None:
         ChatMessage(role="assistant", content=""),
     ])
     assert frames == []
+
+
+def test_projection_hook_push_entry_does_not_restore_as_operator_frame() -> None:
+    """Tier 1: #6093 §2 (lead-coder BLOCKING, PR review) — a hook push
+    (E, wake=true) now persists as ``role="user"`` (a real conversational
+    turn, see ``Session._handle_hook_message``'s own docstring) so it is
+    structurally recognised as an already-delivered turn. But
+    ``role="user"`` alone must NOT make the restored transcript label it
+    as the operator's own line: ``app.py``'s ``_history_turns`` reads
+    ``"you" if msg.kind == "user" else "reyn"`` off the projected
+    ``OutboxMessage.kind`` — a hook's own words rendered as ``kind="user"``
+    would misattribute them to the operator, the exact defect this test
+    pins shut.
+
+    ``ChatMessage.kind`` (stage ①'s field) is the discriminator: a hook
+    push declares ``HistoryEntryKind.MATERIAL`` (content from outside
+    Reyn's own OS layer, never claiming to be the operator's own
+    keystroke) — never ``"[hook:"`` in the text (that would make the
+    text itself the witness, which the dispatch caught as NOT a valid
+    witness: the label is broken, not the text).
+
+    Strip-falsifier: removing the ``m.kind is HistoryEntryKind.MATERIAL``
+    branch in ``restore.py``'s ``role == "user"`` handling makes this
+    test go RED — the hook entry would fall through to the ordinary
+    ``OutboxMessage(kind="user", ...)`` branch.
+    """
+    frames = project_restored_frames([
+        ChatMessage(
+            role="user", content="[hook:on_idle] status check",
+            kind=HistoryEntryKind.MATERIAL,
+        ),
+    ])
+    # A non-empty log always leads with the resume divider (kind="system")
+    # — the content frame under test is the one after it.
+    (_divider, only) = frames
+    assert only.kind != "user", (
+        f"a hook-authored entry must not restore with the SAME "
+        f"OutboxMessage.kind a genuine operator line uses — got "
+        f"kind={only.kind!r}"
+    )
+
+
+def test_projection_real_operator_input_still_restores_as_user_frame() -> None:
+    """Tier 1: #6093 §2's own positive control — a GENUINE operator turn
+    (``role="user"``, ``kind`` never declared at its own call site —
+    ``_handle_inbox_text``'s construction — so it stays
+    ``HistoryEntryKind.UNSPECIFIED``, the default) must still restore as
+    ``OutboxMessage(kind="user", ...)``, unaffected by the hook-push fix
+    above. Mixed with a hook-push entry in the SAME log (the accept
+    item's own "mix in one real operator input" requirement) so this is
+    not proven in isolation from the fix that changed the sibling
+    branch."""
+    frames = project_restored_frames([
+        ChatMessage(
+            role="user", content="[hook:on_idle] status check",
+            kind=HistoryEntryKind.MATERIAL,
+        ),
+        ChatMessage(role="user", content="what's the plan for today?"),
+    ])
+    kinds = [f.kind for f in frames]
+    assert "user" in kinds, (
+        f"a genuine operator turn (kind never declared, UNSPECIFIED by "
+        f"default) must still restore as OutboxMessage(kind=\"user\") — "
+        f"got kinds={kinds!r}"
+    )
+    user_frame = next(f for f in frames if f.kind == "user")
+    assert user_frame.text == "what's the plan for today?"
 
 
 # ── Tier 2: app hydration end-to-end ──────────────────────────────────────────


### PR DESCRIPTION
**[tui-coder]** —

part of #6093

## Root cause

Traced by direct reading (no speculation — see the issue's own investigation thread, including the two read-only investigations I posted before this dispatch): a wake=true hook push (`Session._handle_hook_message`) persisted as `role="system"`. The LLM's own next reply after a `role="system"` tail had nothing to answer that its own turn-taking training recognises as an inbound message — this is what the verbatim-repeat-of-the-prior-answer failure (the issue's own founding reproduction) traces to.

`RouterLoop.run()`'s own guard at the fallback-seed append site (`:2122`) correctly answers a DIFFERENT, already-settled question ("is this turn's content already in history" — `user_text is None`) and is **not touched here** — reverting the guard was considered and rejected (it would reopen the #5686 defect this same guard already closed: a content-comparison guard fails OPEN the moment rendering diverges, per that fix's own rejected-alternative note).

## Fix

`Session._handle_hook_message`'s `ChatMessage` construction is now `role="user"` (was `role="system"`), `kind=HistoryEntryKind.MATERIAL` (stage ①'s field — content from outside Reyn's own OS layer, never Reyn's own chrome; `FRAME` entries like `notify_turn_cancelled`/the canned retry-exhausted reply stay `role="system"`, unaffected). `disclosure=Disclosure.MODEL` is removed — `Disclosure` applies only to `role="system"` (`_normalize_disclosure`), so it would have silently normalized to `None` and governed nothing.

**Side effect, stated explicitly per review**: this entry now falls into `COMPACTION_ELIGIBLE_BASE_ROLES` (`role="user"` is always eligible) — `Disclosure` no longer governs its model-visibility/compaction-eligibility the way it did as `role="system"`. Not an accidental loss of governance: `role="user"` was already ALWAYS eligible for every window/compaction filter this codebase has, a strictly WIDER admission than `Disclosure.MODEL` ever selectively granted a `role="system"` entry.

## Follow-on fix (lead-coder BLOCKING, architect-found hole)

`restore.py`'s projection dispatched purely on `role` for the display `OutboxMessage.kind` — a restored hook-authored `role="user"` entry would render via `OutboxMessage(kind="user", ...)`, and `app.py`'s own "you"/"reyn" switch (`_history_turns`, keyed off `OutboxMessage.kind=="user"`) would misattribute the hook's own words to the operator in the restored transcript. **Live rendering was unaffected** (`Session._handle_hook_message`'s own `OutboxMessage(kind="system", ...)` push is untouched) — only restore-on-restart.

Fixed: `restore.py`'s `role == "user"` branch now checks `ChatMessage.kind` first — `HistoryEntryKind.MATERIAL` (the value only this one non-operator producer declares on a `role="user"` entry today; genuine operator input never passes `kind=` at its own call site, so it stays `UNSPECIFIED` and is unaffected) renders via `OutboxMessage(kind="system", ...)` instead, mirroring the live rendering this same content already got.

Checked `_ingest_frame` (`app.py`) for any place that re-derives `OutboxMessage.kind` from `role` rather than trusting it as given, per lead-coder's explicit ask — **none found**; the fix at `restore.py` alone is sufficient.

## Doc/comment fixes in the same PR

Per CLAUDE.md ("a describing comment is stale the moment the code it describes changes"): `turn_origin.py`'s `HOOK` member docstring, `session.py`'s `TurnOrigin.HOOK` dispatch-table comment, `_format_ride_along_attribution`'s own docstring (now describes only the shared TEXT-rendering, since role is caller-decided and now differs between the C ride-along (`role="system"`) and E hook push (`role="user"`) siblings), and `test_5678_disclosure_axis.py`'s `test_extraction_is_not_vacuous` docstring (named `_handle_hook_message` as one of 4 `role="system"` producers in `session.py` — now 3, moved by this fix).

## Tests

- 2 existing tests filtered on `m.role == "system"` for the hook entry (`test_5514_hook_spillability_dispatch.py`, `test_hook_composer_reachability_phase5.py`) — updated to `role == "user"`. The latter's own `Disclosure.MODEL` assertion is replaced with `is_compaction_eligible()` (role="user" is always eligible) + `kind is HistoryEntryKind.MATERIAL` (records why it may sit in the user slot).
- New: `test_textual_chat_phase5_3273.py` gains `test_projection_hook_push_entry_does_not_restore_as_operator_frame` (negative) and `test_projection_real_operator_input_still_restores_as_user_frame` (positive control mixing a real operator input into the same log, per review's explicit "accept 2 lines").

**Strip-falsify (both performed via in-file Edit, reverted after)**:
1. Reverting `_handle_hook_message`'s `role="user"` to `role="system"` (with no `disclosure=`) raises `ValueError` inside `ChatMessage.__init__` — the 2 updated hook tests go RED.
2. Reverting `restore.py`'s kind check to a dead branch (`if False and ...`) makes the new negative test go RED (`assert 'user' != 'user'`, fails).

## Gates

- `ruff check .` — clean
- `scripts/verify_module_docstrings.py` (session.py, turn_origin.py, restore.py) — OK
- `scripts/mypy_ratchet.py` — 183 findings, all baselined
- `scripts/test_tier_audit.py --strict` (4 changed test files) — 44/44 OK, 0 Tier-4
- tests/-path-conditional gates: `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py`, `flat_tests_ratchet.py`, `check_tests_path_literal_reference.py` — all OK
- `src/reyn/interfaces/` gate: `silent_except_ratchet.py` — OK (90 sites, all baselined, unchanged)
- `src/reyn/**` gate: `user_facing_lang_gate.py` — OK, 0 findings
- Diff-scoped + adjacent pytest (not the full suite; CI runs that) — not waiting on CI per dispatch.

## Pytest (diff-scoped + directly adjacent)

`test_5514_hook_spillability_dispatch.py` (8) + `test_hook_composer_reachability_phase5.py` (4) + `test_hook_loop_valve_1800_7.py` + `test_5678_disclosure_axis.py` (13) + `test_5677_mid_turn_injection_wire_rendering.py` (10) + `test_3475_mcp_probe_priming_all_turn_kinds.py` + `test_run_prompt_async_3978_p4e.py` + `test_textual_chat_phase5_3273.py` (19) + `test_3694_persist_cancelled_turn_outcome.py` + `test_6093_history_entry_kind.py` — **all green (81/81)**.

## Test plan
- [x] Diff-scoped + adjacent pytest green (81/81)
- [x] Strip-falsify performed and verbatim result reported above
- [x] (skipped — see standing waiver, owner 2026-08-08) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn