### PR TITLE
docs(#5890 stage 1): section_token_caps is an LLM hint, not an enforced bound

### DIFF
--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -1019,7 +1019,18 @@ class SafetyConfig:
 
 @dataclass
 class CompactionSectionCaps:
-    """Per-section token budgets for chat_summary BODY."""
+    """Per-section token budgets for chat_summary BODY.
+
+    #5890: only ``topic_arc`` is an enforced cap — it alone goes through
+    a deterministic bound (LLM re-summarize, then ``hard_truncate_
+    summary``) after the LLM returns. The other four fields are
+    serialised into the compactor prompt as size GUIDANCE only and are
+    never checked against their own field here — an operator reading
+    "caps" in this class's own name would reasonably expect all five to
+    be enforced; they are not (see docs/reference/config/reyn-yaml.md's
+    own "chat.compaction.section_token_caps fields" section for the
+    full asymmetry and why it is a real, currently-open gap, not a
+    closed decision)."""
     topic_arc: int = field(default=200, metadata={"axis": Axis.BOUNDING})
     decisions: int = field(default=400, metadata={"axis": Axis.BOUNDING})
     pending: int = field(default=400, metadata={"axis": Axis.BOUNDING})


### PR DESCRIPTION
**[e2e-coder]** — part of #5890, stage 1.

## What

One docstring line on `CompactionSectionCaps` (`src/reyn/config/chat.py`).
No mechanism added, no behavior change, no test (docstring-only — this
is not something CI can catch; it's a naming-vs-reality gap, not a defect
a gate would fire on).

## Why no mechanism is added

Stage 1 originally asked for a new enforcement layer over the four
unenforced `section_token_caps` fields (`decisions`/`pending`/
`session_user_facts`/`artifacts_referenced`). lead-coder retracted that
after re-reading `prompt/compaction.py:80-87`'s own comment (quoted
verbatim):

> WHEN: only on the overshoot path (T2) — the produced topic_arc exceeds
> its body_budget after the main compaction call.
> WHY: LLM-judgment loss (preserve decision-relevant, drop least
> essential) replaces the blind char-cut of hard_truncate; the
> deterministic floor (T3) still applies after this pass.

`body` already has a bounding subject: T2 (LLM re-compression via
`RESUMMARIZE_SYSTEM_PROMPT`) then T3 (`hard_truncate_summary`, a
deterministic floor) — both driven by `ComputedBudgets.body_budget`,
applied to `topic_arc` only (`engine.py:2810-2826`). My own #5890 census
(reported over broker, not re-run here) found zero other consumers of
`body_budget` across the full non-test source tree — that part of the
finding stands. What was wrong was the read of what that finding meant:
the missing enforcement is at the *per-section-field-within-body*
granularity, which ADR-0048 §1 never asked for. Lead-coder's own words
on the correction: 「主体が居るか」は要求された粒度で問う — "does a
bounding subject exist" has to be asked at the granularity that was
actually required, not at whichever granularity turns up unenforced.

So: no new layer. The one real gap is that `CompactionSectionCaps`'s own
class name and field name ("caps") promise something for all five
fields that only one of them gets. The docstring line names that.

## Pre-existing docs cross-reference

`docs/reference/config/reyn-yaml.md`'s own "`chat.compaction.
section_token_caps` fields" section already documents this exact
asymmetry in full ("Only `topic_arc` is an enforced cap... This is a
real, current asymmetry, not a design intentionally scoped that way").
That section predates this PR — flagging it here since it's the closest
thing to a decision record for this gap, and the code docstring should
point a reader there.

## Test plan

- [x] `ruff check src/reyn/config/chat.py` — pass
- [x] `python scripts/verify_module_docstrings.py src/reyn/config/chat.py` — pass
- [x] `python scripts/mypy_ratchet.py` — pass (183 findings, all baselined)
- [x] direct import/construct sanity check — `CompactionSectionCaps()` defaults unchanged
- [x] (skipped — docstring-only, no behavior change, no test required per dispatch)
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
