### PR TITLE
fix(#5890 stage 2): mid-floor spill's own offered population now covers tail

### DIFF
--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -423,14 +423,28 @@ class RouterLoopDriver:
         seq_fn: "Callable[[int, dict], int]",
     ) -> "list[tuple[int, dict]]":
         """#5592 (owner ruling, "1 request = 面 × 同一 Spillability";
-        "head と tail を混ぜない") — within ONE face (a raw_middle slice,
-        ``head``, or ``tail`` — the caller never mixes faces into one
-        call), try the highest-priority non-empty ``Spillability`` tier's
-        eligible candidates (FIRST_CHOICE, else LAST_RESORT; ``NEVER``
-        excluded — same ``_eligible``/``_by_size_desc`` shape
-        ``_spill_candidates`` already established), largest-first,
-        actually spilling (persists via ``spill_turn_content``) up to K
-        of them.
+        "head と tail を混ぜない") — try the highest-priority non-empty
+        ``Spillability`` tier's eligible candidates (FIRST_CHOICE, else
+        LAST_RESORT; ``NEVER`` excluded — same ``_eligible``/
+        ``_by_size_desc`` shape ``_spill_candidates`` already
+        established) within ``turns``, largest-first, actually spilling
+        (persists via ``spill_turn_content``) up to K of them.
+
+        The owner ruling this cites named HEAD and TAIL specifically
+        (``_attempt_reactive_spill``'s own per-face-staged search: never
+        combines them into one call, for the cost reason #5592 itself
+        states below). ``_spill_batch_for_retry`` (#5890 §2, a SEPARATE
+        caller of this same method) treats ``raw_middle``'s own offered
+        prefix and ``tail`` as ONE combined ``turns`` list instead — the
+        two rungs answer different questions (this file's own
+        ``_attempt_reactive_spill`` proactively spills BEFORE an
+        overflow, face by face, to avoid an unnecessary request against
+        a face that already has room; ``_spill_batch_for_retry`` runs
+        AFTER an overflow, as `retry_loop`'s own rung①, where the
+        candidate POPULATION is what #5890 §2 widened, not the request
+        cadence) — this method itself does not enforce either
+        convention; it simply tiers/sorts/spills whatever list it is
+        handed.
 
         K is the ONE thing ``spill_granularity`` controls — unlimited
         (the whole tier) for ``"tier"`` (the default: #5592's own accept
@@ -1132,11 +1146,17 @@ class RouterLoopDriver:
         # about to (re-)offer to ``compact()`` this attempt (#5592,
         # correcting #9.6's own "never a slice" claim — see
         # ``_spill_batch_from_offered``'s own docstring, engine.py)
-        # — never head/tail, a SEPARATE population this closure
-        # never sees (see ``_attempt_reactive_spill`` for that
-        # face; retry_loop only calls this when raw_middle is
-        # non-empty, which coincides exactly with a compact()-
-        # origin overflow).
+        # — #5890 §2: as of that PR, ``candidates`` also carries
+        # ``tail`` appended after the raw_middle prefix (engine.py's
+        # own ``_run_one_iteration`` builds this combined list and
+        # re-splits it back afterward — this method stays unaware of
+        # the boundary, treating the whole thing as one flat
+        # candidate list, same as before). ``head`` is still never
+        # included (retry_loop only calls this when raw_middle is
+        # non-empty, which coincides exactly with a compact()-origin
+        # overflow) — see ``_attempt_reactive_spill`` for the
+        # SEPARATE, per-face-staged head/mid/tail search that face
+        # belongs to instead.
         #
         # #5592 (owner ruling, "1 request = 面 × 同一
         # Spillability"): returns a WHOLE BATCH now, not one

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -4423,17 +4423,82 @@ class RecoveryLadder:
                 self._compact_attempt_len if self._compact_attempt_len is not None
                 else len(self.raw_middle)
             )
-            _offered_for_shrink = self.raw_middle[:_current_attempt]
+            # #5890 §2 (architect + lead-coder ruling, correcting the
+            # original "reorder spill before refill" brief -- spill
+            # ALREADY runs before refill; what was missing is what spill
+            # SEARCHES): `offered` used to be ONLY `raw_middle`'s own
+            # offered prefix -- `tail` was never a spill candidate on
+            # this rung, even though `tail`'s own turns are exactly as
+            # eligible (same Spillability declarations, same
+            # `is_already_spilled`/`spill_turn_content` mechanism
+            # `_attempt_reactive_spill`'s own tail face already uses).
+            # `_offered_for_shrink` now covers BOTH -- `pool` is the
+            # SAME list object (aliased, not a second copy) so
+            # `shrink_pool_after_overflow`'s own `pool[idx] =
+            # replacement` (unchanged -- see that function's own
+            # docstring) mutates this combined list in place; the
+            # tail-appended re-split below is what turns it back into
+            # `self.raw_middle`/`self.tail` afterward. No new predicate,
+            # no new field -- ``is_already_spilled``'s own VALUE check
+            # (not turn identity) already makes a turn spilled from
+            # `tail` correctly recognised as "already spilled" if a
+            # later refill ever moves it into `raw_middle` and it is
+            # re-offered here (see that method's own docstring) — this
+            # rung's own bounded-termination measure does not regress.
+            _offered_for_shrink = self.raw_middle[:_current_attempt] + self.tail
+            # #5890 §2 (lead-coder BLOCKING, PR review): the re-split below
+            # is only correct while `spill_fn` (via `shrink_pool_after_
+            # overflow`'s own `pool[idx] = replacement`) does IN-PLACE
+            # REPLACEMENT ONLY -- never appends, removes, or reorders.
+            # That is true TODAY (the shared function's own docstring:
+            # "pool is mutated IN PLACE via spill_fn's returned (index,
+            # replacement) edits"), but nothing STRUCTURALLY forced it --
+            # a future spill_fn that ever changed the list's length would
+            # silently shift the raw_middle/tail boundary with no
+            # exception and no test failure (the exact "declaration with
+            # no enforcement" shape #6168 closed elsewhere tonight, for a
+            # different invariant). Capturing the expected length here and
+            # checking it below turns "only replaces" from an assumption
+            # into something this call site itself enforces.
+            _expected_len_after_spill = len(_offered_for_shrink)
             try:
                 # #5898: off the loop — same reason as the controller's own
                 # call site: the spill batch inside estimates, hashes and
                 # writes each candidate's whole body.
                 self._compact_attempt_len = await asyncio.to_thread(
                     shrink_pool_after_overflow,
-                    self.raw_middle, _offered_for_shrink, _current_attempt,
+                    _offered_for_shrink, _offered_for_shrink, _current_attempt,
                     spill_fn=self._spill_fn or (lambda _offered: []),
                     saw_byte_limit=self._last_recover_is_byte_limit,
                 )
+                if len(_offered_for_shrink) != _expected_len_after_spill:
+                    # `raise`, never `assert` (asserts vanish under
+                    # `-O`) -- this invariant is load-bearing for
+                    # correctness, not a debugging aid.
+                    raise RuntimeError(
+                        f"spill_fn changed the offered candidate count "
+                        f"from {_expected_len_after_spill} to "
+                        f"{len(_offered_for_shrink)} -- the re-split below "
+                        f"assumes spill only REPLACES entries in place "
+                        f"(never appends/removes/reorders); with a "
+                        f"changed length, the raw_middle/tail boundary "
+                        f"below would silently misplace entries between "
+                        f"the two lists (e.g. raw_middle's own tail-end "
+                        f"entries becoming tail's own head, or vice "
+                        f"versa) rather than raising here."
+                    )
+                # #5890 §2: re-split the (spill-mutated, same-length)
+                # combined list back into its two real homes — the first
+                # `_current_attempt` entries are raw_middle's own OFFERED
+                # prefix (the remainder of raw_middle past that point was
+                # never part of `_offered_for_shrink` and is untouched,
+                # appended back unchanged); everything after that boundary
+                # is `tail`.
+                self.raw_middle = (
+                    _offered_for_shrink[:_current_attempt]
+                    + self.raw_middle[_current_attempt:]
+                )
+                self.tail = _offered_for_shrink[_current_attempt:]
             except UnrecoveredError as _mid_floor_exc:
                 # #5712: the shared function's own message says "a single
                 # candidate alone" (caller-neutral wording); RecoveryLadder
@@ -4442,6 +4507,16 @@ class RecoveryLadder:
                 # (test_4947_stage1_floor_names_413_when_it_is_a_byte_limit)
                 # — plus the byte-limit wire-bytes clause this class alone
                 # can compute (needs SP/head/tail/new_msg).
+                #
+                # #5890 §2 (lead-coder ruling): this message is the
+                # MID_FLOOR terminal's own contract — an operator reads it
+                # to learn what was exhausted. "in raw_middle" was
+                # accurate when that was the only population spill ever
+                # searched; now that `_offered_for_shrink` also covers
+                # `tail`, the OLD wording would UNDER-claim what was
+                # actually tried, not merely go stale cosmetically — fixed
+                # in this same PR because the contract changed, not
+                # because the old wording broke.
                 raise UnrecoveredError(
                     (
                         "HTTP 413 (a request-BODY-BYTE limit) recurred "
@@ -4450,7 +4525,7 @@ class RecoveryLadder:
                     ) + "compacting a single raw_middle turn alone — mid "
                     "cannot be split any further (the turn-count floor), "
                     "and spilling every available candidate in raw_middle "
-                    "did not resolve this either." + (
+                    "or tail did not resolve this either." + (
                         _learned_byte_limit_clause(
                             last_accepted_wire_bytes=self._last_accepted_wire_bytes,
                             last_rejected_wire_bytes=self._last_rejected_wire_bytes,

--- a/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
+++ b/tests/runtime/test_5296_pr2_byte_reduction_same_turn_retry.py
@@ -1485,7 +1485,7 @@ def test_spill_population_exhausted_reports_count_and_breakdown_when_all_never(
             _push(session, "user", f"tail filler {i} " * 8, spillability=Spillability.NEVER)
             _push(session, "assistant", f"tail reply {i} " * 8, spillability=Spillability.NEVER)
 
-        head, raw_middle, _tail, _summary, _ = (
+        head, raw_middle, tail, _summary, _ = (
             session._loop_driver._history_buffer.decompose_history_for_retry()
         )
         # #5514 §7-1: spillability doesn't influence decompose's OWN
@@ -1503,7 +1503,17 @@ def test_spill_population_exhausted_reports_count_and_breakdown_when_all_never(
             "test setup sanity: this test's own point is a population that "
             "is ENTIRELY never — some raw_middle turn isn't"
         )
+        # #5890 §2: `tail` (the "tail filler"/"tail reply" pushes above)
+        # is now ALSO part of the population this rung offers to
+        # spill_fn (see the bound below) — must be entirely NEVER too,
+        # for the SAME reason raw_middle must be: this test's own point
+        # is a population with nothing eligible anywhere in it.
+        assert all(t.get("spillability") == "never" for t in tail), (
+            "test setup sanity: tail must ALSO be entirely never — #5890 "
+            "§2 made it part of the offered population this test measures"
+        )
         raw_middle_population = len(raw_middle)
+        tail_population = len(tail)
 
         events = collect_events(session)
 
@@ -1537,10 +1547,18 @@ def test_spill_population_exhausted_reports_count_and_breakdown_when_all_never(
         # once — so this can be STRICTLY LESS than
         # ``raw_middle_population`` (never pinning the exact
         # ``_attempt_len`` value itself, an algorithm-level detail this
-        # test does not own). Every member of it is still NEVER either
-        # way (the whole history here is NEVER), so the tier breakdown
-        # invariant below still fully accounts for it.
-        assert 0 < only.data["population"] <= raw_middle_population
+        # test does not own).
+        #
+        # #5890 §2 (contract change, not a bug fix — CI caught this
+        # bound the moment the population genuinely widened): `offered`
+        # now ALSO includes the full `tail` alongside raw_middle's own
+        # offered prefix, so the upper bound is
+        # `raw_middle_population + tail_population`, not
+        # `raw_middle_population` alone. Every member of BOTH is still
+        # NEVER either way (the whole history here is NEVER, tail
+        # included — see the sanity assert above), so the tier
+        # breakdown invariant below still fully accounts for it.
+        assert 0 < only.data["population"] <= raw_middle_population + tail_population
         assert only.data["never_count"] == only.data["population"]
         assert only.data["first_choice_count"] == 0
         assert only.data["last_resort_count"] == 0

--- a/tests/runtime/test_5615_attempt_reactive_spill_reachability.py
+++ b/tests/runtime/test_5615_attempt_reactive_spill_reachability.py
@@ -91,8 +91,9 @@ def test_attempt_reactive_spill_receives_a_real_head_candidate_rung1_never_sees(
     candidate. Witnessed via 2 independent, PUBLIC signals: (1) a real
     `tool_result_offloaded` audit-event for the huge content, (2) that
     event's own position in the trace — AFTER rung①'s own
-    `spill_candidate_population_exhausted` (its own `raw_middle`-scoped
-    population, unrelated small content) reports rung①'s own population
+    `spill_candidate_population_exhausted` (its own population — #5890
+    §2: `raw_middle`'s own offered prefix PLUS `tail`, never `head` —
+    unrelated small content either way) reports rung①'s own population
     exhausted, proving rung① itself could not have been the one that
     spilled the huge (`head`-face) candidate — only
     `_attempt_reactive_spill`, called once retry_loop's own attempt

--- a/tests/runtime/test_5890_stage2_spill_offered_includes_tail.py
+++ b/tests/runtime/test_5890_stage2_spill_offered_includes_tail.py
@@ -1,0 +1,100 @@
+"""Tier 2: #5890 §2 — the reactive shrink ladder's rung① (spill, at the
+mid-turn floor) now offers ``tail`` to ``spill_fn`` alongside ``raw_middle``'s
+own slice, not ``raw_middle`` alone.
+
+Root cause (architect + lead-coder ruling, correcting the original "reorder
+spill before refill" brief — spill already runs before refill; what was
+missing is what spill SEARCHES): ``offered`` (``RecoveryLadder.
+_run_one_iteration``, ``engine.py``) used to be built exclusively from
+``raw_middle``'s own offered prefix — a genuinely oversized/pathological
+``tail`` turn was structurally invisible to this rung, no matter how
+eligible its own declared ``Spillability`` was.
+
+This file's own positive control (required by review): ``is_already_spilled``
+is checked BY VALUE (that method's own docstring), so a turn spilled once —
+regardless of which list (``raw_middle`` or ``tail``) it started in — reads
+as already-spilled on any LATER re-scan from either list. This is what makes
+widening the population safe without adding any new state: a future refill
+moving a tail-spilled turn into ``raw_middle`` cannot make measure ④ (the
+population's own progress) go backward — the SAME content is recognised as
+already-spilled wherever it is re-encountered.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.data.workspace.media_store import MediaStore
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+
+
+def _make_real_history_buffer(tmp_path):
+    """Minimal real ``RouterHistoryBuffer`` + ``MediaStore`` — cheap to
+    construct (no I/O beyond what ``spill_turn_content`` itself performs),
+    mirrors ``test_5720_spill_carries_real_turn_provenance.py``'s own
+    established recipe for this exact pair."""
+    history: list = []
+    store = MediaStore(
+        project_root=tmp_path, agent_name="t-agent", session_id="t-session",
+    )
+    return RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(use_chars4_estimate=True),
+        compaction_controller=None,
+        model_fn=lambda: "test-model",
+        events=EventLog(),
+        media_store=store,
+        router_host=None,
+        universal_wrappers_enabled=False,
+        non_interactive=True,
+        history_appender=history.append,
+    ), history
+
+
+def test_is_already_spilled_returns_false_for_a_tail_turns_original_content(tmp_path):
+    """Tier 2: #5890 §2 positive control (required by review) — a turn's
+    ORIGINAL, never-spilled content reads as NOT already-spilled,
+    regardless of which list (``raw_middle`` vs ``tail``) it is being
+    checked FROM. ``is_already_spilled`` takes no turn identity or origin
+    at all (its own docstring: "Checked by VALUE ... the same content
+    string could arrive from a different candidate object") — this test
+    exercises it with a plain ``tail``-shaped turn's own content, never
+    having gone through ``spill_turn_content``, and confirms it is NOT
+    mistaken for an already-spilled preview.
+
+    This is the exact property #5890 §2's own design depends on: if this
+    ever returned ``True`` for original content, widening ``offered`` to
+    include ``tail`` would make the spill rung skip genuinely-fresh tail
+    candidates as if they were already handled — the opposite failure
+    from the one the widening is meant to fix.
+    """
+    history_buffer, _history = _make_real_history_buffer(tmp_path)
+
+    tail_turn_original_content = "a perfectly ordinary tail turn, never spilled"
+
+    assert history_buffer.is_already_spilled(tail_turn_original_content) is False
+
+
+def test_is_already_spilled_recognises_content_spilled_from_a_tail_turn(tmp_path):
+    """Tier 2: #5890 §2 — the OTHER half of the same value-based
+    guarantee: once a turn's content genuinely IS spilled (regardless of
+    which list it came from), ``is_already_spilled`` recognises the
+    RESULT as already-spilled. This is what closes the "tail-spilled
+    turn later re-scanned as mid" hazard #5890 §2's own review named: a
+    future refill moving this exact content into ``raw_middle`` would
+    still correctly skip it here, by value, never re-spilling it and
+    never double-counting it as fresh progress."""
+    history_buffer, _history = _make_real_history_buffer(tmp_path)
+
+    original_content = "TAIL_OVERSIZED_RESULT " * 2000
+    assert history_buffer.is_already_spilled(original_content) is False
+
+    spilled_preview = history_buffer.spill_turn_content(
+        original_content, chain_id="c1", tool="tail_turn", seq=1,
+    )
+    assert spilled_preview is not None, "expected a real spill (media_store is configured)"
+    assert spilled_preview != original_content
+
+    assert history_buffer.is_already_spilled(spilled_preview) is True
+    # The ORIGINAL content (as opposed to the preview it turned into) is
+    # of course no longer present anywhere — this checks the ONE thing
+    # #5890 §2 depends on: the preview itself must not be re-offered.

--- a/tests/services/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/services/test_pr_n6_compaction_overflow_retry.py
@@ -1265,6 +1265,162 @@ def test_5367_3_spill_before_raise_resolves_byte_limit_mid_split_floor(tmp_path)
     )
 
 
+def test_5890_stage2_offered_population_at_mid_floor_includes_tail(tmp_path) -> None:
+    """Tier 2: #5890 §2 — the mid-floor spill rung's own ``offered``
+    population now includes ``tail``, not just ``raw_middle``'s own
+    slice. Before this fix, a genuinely spillable turn sitting in
+    ``tail`` was structurally invisible to this rung — ``spill_fn`` was
+    never even CALLED with it, no matter how eligible its own declared
+    ``Spillability`` was.
+
+    ``raw_middle`` holds ONE turn ``compact()`` 413s on unconditionally
+    (mirrors ``test_5367_3_spill_unavailable_still_raises_with_accurate_
+    message``'s own engine — genuinely unresolvable by ANYTHING this
+    rung can do, since spill only ever REPLACES content, never removes
+    the turn that carries it). ``tail`` holds ONE large, genuinely
+    spillable turn. Spilling ``tail``'s own turn cannot (and is not
+    expected to) resolve ``raw_middle``'s own compact() failure — the
+    property under test is only whether ``spill_fn`` is OFFERED the tail
+    turn's content at all, not whether the episode overall recovers (it
+    does not: ``UnrecoveredError(MID_FLOOR)`` still eventually raises,
+    one iteration later than a compact()-only trace would, since
+    ``tail``'s own content — once spilled — correctly stops appearing as
+    a fresh candidate on the NEXT pass, per ``is_already_spilled``'s own
+    value-based check).
+
+    Falsification (performed during review): reverting
+    ``_offered_for_shrink`` to ``self.raw_middle[:_current_attempt]``
+    (dropping ``+ self.tail``) makes this test's own tail marker never
+    appear in any ``spill_fn`` call — the assertion below goes from
+    finding it to not finding it at all.
+    """
+    cfg = _make_cfg()
+
+    class _AlwaysBlockedOnMidEngine(_OverflowingEngine):
+        """compact() 413s unconditionally, regardless of what happens to
+        tail — genuinely unresolvable by this rung, so any eventual
+        MID_FLOOR here is expected, not a test bug."""
+
+        async def compact(self, input_chunk, *, covers_through=None):
+            raise _FakeStatusError("compact 413", status_code=413)
+
+    engine = _AlwaysBlockedOnMidEngine(fail_compact=False)
+    learner = TokenMultiplierLearner(storage_path=tmp_path / "m.json")
+
+    raw_middle = [{
+        "role": "tool", "content": "UNSPILLABLE_MID_BLOCKER", "seq": 1,
+        "spillability": "never",
+    }]
+    tail = [{
+        "role": "tool", "content": "TAIL_OVERSIZED_RESULT", "seq": 2,
+        "spillability": "first_choice",
+    }]
+    new_msg = {"role": "user", "content": "q", "seq": 999}
+
+    offered_calls: "list[list[str]]" = []
+
+    def _spill_fn(candidates: "list[dict]") -> "list[tuple[int, dict]]":
+        offered_calls.append([t.get("content") for t in candidates])
+        for idx, turn in enumerate(candidates):
+            if turn.get("content") == "TAIL_OVERSIZED_RESULT":
+                return [(idx, {**turn, "content": "REF: tail turn spilled"})]
+        return []
+
+    async def _always_413_main_call(**kwargs):
+        raise ContextOverflowError("main_call 413") from _FakeStatusError(
+            "Request Entity Too Large", status_code=413,
+        )
+
+    with pytest.raises(UnrecoveredError) as excinfo:
+        asyncio.run(retry_loop(
+            SP="sp", payload=RetryPayload(
+                head=[], raw_middle=raw_middle,
+                tail=tail, new_msg=new_msg,
+                seq_by_id={},
+            ), cfg=cfg, model="test-model",
+            engine=engine,  # type: ignore[arg-type]
+            learner=learner,
+            main_call=_always_413_main_call,
+            spill_fn=_spill_fn,
+        ))
+
+    all_offered_contents = [c for call in offered_calls for c in call]
+    assert "TAIL_OVERSIZED_RESULT" in all_offered_contents, (
+        f"expected the tail turn's own content to be offered to spill_fn "
+        f"at least once (population widened, #5890 §2) — got "
+        f"calls={offered_calls!r}"
+    )
+    # raw_middle's own compact()-blocking content is untouched by this
+    # rung (spill only ever replaces, never removes the turn that keeps
+    # failing) — the episode still correctly reaches the mid floor.
+    assert excinfo.value.terminal is RetryLoopTerminal.MID_FLOOR
+
+
+def test_5890_stage2_length_changing_spill_fn_raises_instead_of_silently_misplacing(
+    tmp_path,
+) -> None:
+    """Tier 2: #5890 §2 (lead-coder BLOCKING, PR review) — the raw_middle/
+    tail re-split after spill assumes ``spill_fn`` only REPLACES entries
+    in place (``shrink_pool_after_overflow``'s own ``pool[idx] =
+    replacement``), never changes the offered list's own LENGTH. That was
+    true by convention but structurally UNENFORCED — a future ``spill_fn``
+    that ever appended/removed/reordered would silently shift the
+    raw_middle/tail boundary with no exception and no test failure. This
+    test drives a ``spill_fn`` that violates the assumption (mutates the
+    length of the list it is handed) and confirms the call site now
+    RAISES rather than proceeding to mis-split.
+
+    Uses a raw_middle with 2 turns (``_current_attempt == 2``, not the
+    mid=1 floor) so ``shrink_pool_after_overflow`` itself returns
+    normally (halves ``attempt_len``, no ``UnrecoveredError``) — the
+    length check inside the ``try`` block is what must catch this, not
+    the pre-existing ``except UnrecoveredError`` branch.
+
+    Falsification (performed during review): removing the
+    ``len(_offered_for_shrink) != _expected_len_after_spill`` check
+    (reverting to the un-enforced form) makes this test go RED — no
+    exception is raised, and ``self.raw_middle``/``self.tail`` would
+    silently end up misaligned instead (unobservable through
+    ``retry_loop``'s own public return value, which is exactly why the
+    enforcement belongs at this call site and not in a test reading
+    private state).
+    """
+    cfg = _make_cfg()
+    engine = _OverflowingEngine(fail_compact=True)
+    learner = TokenMultiplierLearner(storage_path=tmp_path / "m.json")
+
+    raw_middle = [
+        {"role": "tool", "content": "mid-1", "seq": 1},
+        {"role": "tool", "content": "mid-2", "seq": 2},
+    ]
+    tail = [{"role": "tool", "content": "tail-1", "seq": 3}]
+    new_msg = {"role": "user", "content": "q", "seq": 999}
+
+    def _length_changing_spill_fn(candidates: "list[dict]") -> "list[tuple[int, dict]]":
+        # Simulates the violation this test exists to catch: a spill_fn
+        # that changes the offered list's own length (real production
+        # spill_fn implementations never do this — this is the
+        # deliberately-wrong double the strip-falsify needs).
+        candidates.append({"role": "tool", "content": "smuggled", "seq": 998})
+        return []
+
+    async def _unreachable(**kwargs):
+        raise AssertionError("main_call must not be reached — the guard raises first")
+
+    with pytest.raises(RuntimeError, match="spill_fn changed the offered candidate count"):
+        asyncio.run(retry_loop(
+            SP="sp", payload=RetryPayload(
+                head=[], raw_middle=raw_middle,
+                tail=tail, new_msg=new_msg,
+                seq_by_id={},
+            ), cfg=cfg, model="test-model",
+            engine=engine,  # type: ignore[arg-type]
+            learner=learner,
+            main_call=_unreachable,
+            spill_fn=_length_changing_spill_fn,
+        ))
+
+
 def test_terminal_distinguishes_mid_floor_from_room_floor(tmp_path) -> None:
     """Tier 2: #5531 §10 / ADR-0044 (owner: "don't make the doc follow a
     wrong implementation" — the doc's own "travels as a structured value,


### PR DESCRIPTION
**[tui-coder]** —

part of #5890

## Correction to the original brief

Spill already runs before refill (`RecoveryLadder._run_one_iteration`'s own rung order was never wrong). What was missing is what spill **SEARCHES** — `offered` (the candidate list handed to `spill_fn`) was built exclusively from `raw_middle`'s own offered prefix. A genuinely oversized, declaredly-spillable turn sitting in `tail` was structurally invisible to this rung — `spill_fn` was never even called with it.

## Fix

`_offered_for_shrink` (`RecoveryLadder._run_one_iteration`) is now `self.raw_middle[:_current_attempt] + self.tail`. This same list object is passed as **both** `pool` and `offered` to `shrink_pool_after_overflow` (aliased, not a second copy) — that shared function's own `pool[idx] = replacement` mutation mechanism is completely unchanged; what changes is which list the caller hands it. After a successful call, the caller re-splits the combined list back into `self.raw_middle`'s own offered prefix and `self.tail` — no new field, no new predicate.

**Enforcement (review round 1)**: the offered list's own length is captured before the call and checked after; a mismatch `raise`s (never `assert`) with a message naming what would otherwise silently happen — turning "spill only replaces" from an assumption into something this call site enforces.

**Safety argument**: `is_already_spilled` is checked BY VALUE, not by turn identity — a tail-spilled turn later moved into `raw_middle` by a refill is correctly recognised as already-spilled wherever it is re-encountered.

## MID_FLOOR message

Widened: "spilling every available candidate in raw_middle" → "... **in raw_middle or tail**" — the contract changed, not because the old wording broke. No existing test pinned that exact substring (searched, found none).

## Contract-change fix (CI-caught, review round 3 — lead-coder's own named review-scope gap)

`spill_candidate_population_exhausted`'s own `population` field is now raw_middle's offered prefix count **plus** tail's own count, not raw_middle's alone. `test_5296_pr2_byte_reduction_same_turn_retry.py`'s own `test_spill_population_exhausted_reports_count_and_breakdown_when_all_never` pinned `population <= raw_middle_population`, which the widened population now genuinely exceeds (CI: `47 <= 46`, correctly red — this is a contract change, not a bug). Fixed: the bound is now `raw_middle_population + tail_population`, plus a new sanity assert that `tail` is ALSO entirely `NEVER` (this test's own point is a population with nothing eligible anywhere in it).

Per lead-coder's request, I audited every OTHER test referencing this same event (`test_5615_attempt_reactive_spill_reachability.py`) for other pinned fields — it only asserts existence/ordering, never population/tier-count VALUES, so it needed no assertion change; I did correct its own docstring's now-imprecise "raw_middle-scoped population" phrase (the test's own actual claim — `head` is untouched by rung① — stays true and unaffected).

## Doc/comment fixes (CLAUDE.md: describing comments stale the moment code changes)

`_spill_batch_for_retry`'s own "never head/tail, a SEPARATE population" comment; `_spill_batch_within_face`'s own general "the caller never mixes faces into one call" docstring line, scoped to name which caller still follows that discipline.

## Tests

- `test_5890_stage2_offered_population_at_mid_floor_includes_tail` — tail turn's content proven OFFERED to `spill_fn`, episode still correctly reaches `MID_FLOOR`.
- `test_5890_stage2_length_changing_spill_fn_raises_instead_of_silently_misplacing` (review round 2) — enforcement test.
- New file `tests/runtime/test_5890_stage2_spill_offered_includes_tail.py`: positive control (`is_already_spilled` False on original, True on spilled).
- Updated (CI-caught, contract change): `test_spill_population_exhausted_reports_count_and_breakdown_when_all_never`.

**Strip-falsify** (both performed via in-file Edit, reverted after):
1. Dropping `+ self.tail` → mid-floor test RED (tail marker never offered).
2. Disabling the length-mismatch check → length-changing test RED (a DIFFERENT exception, one iteration later, instead of the expected `RuntimeError`).

## Gates

- `ruff check .` — clean
- `scripts/verify_module_docstrings.py` (engine.py, router_loop_driver.py) — OK
- `scripts/mypy_ratchet.py` — 183 findings, all baselined
- `scripts/test_tier_audit.py --strict` (4 changed/new test files) — 62/62 OK, 0 Tier-4
- tests/-path-conditional gates — all OK
- No new gate (structural widening of an existing, already-safe-by-value predicate)
- Diff-scoped + adjacent pytest — not waiting on CI per dispatch (but CI's own red on round 3 was read and fixed).

## Pytest (diff-scoped + directly adjacent)

`test_pr_n6_compaction_overflow_retry.py` (43) + `test_chat_compaction_engine.py` + `test_chat_compaction_engine_11axis.py` + the new file (2) + `test_5296_pr2_byte_reduction_same_turn_retry.py` (15) + `test_5615_attempt_reactive_spill_reachability.py` (2) — **all green (62/62 shown; 92/92 including the compaction-engine files from earlier rounds)**.

## Test plan
- [x] Diff-scoped + adjacent pytest green
- [x] Strip-falsify performed and verbatim result reported above (both rounds)
- [x] (skipped — no UI surface) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn