### PR TITLE
fix(#6174): no-controller head/tail budget fallback stops fabricating a split

### DIFF
--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -652,9 +652,11 @@ def resolve_effective_trigger_and_budgets(
     *,
     phase: "str | None" = None,
     read_cap_config: Any = None,
-) -> "tuple[int, int, int]":
+) -> "tuple[int, int | None, int | None]":
     """Return ``(effective_trigger, head_budget, tail_budget)`` — #2957 PR-B
-    single SSoT for this lookup.
+    single SSoT for this lookup. #6174: ``head_budget``/``tail_budget`` are
+    ``None`` when no compaction_controller is wired (see the ``else``
+    branch below) — a real caller must handle that, not assume ``int``.
 
     Before PR-B, :class:`RouterHistoryBuffer` (``_resolve_budgets``) and
     :class:`~reyn.runtime.services.context_budget_advisor.ContextBudgetAdvisor`
@@ -687,8 +689,19 @@ def resolve_effective_trigger_and_budgets(
     passes none today (falls back to the shipped default — see
     ``_check_resource_within_budget``'s own docstring for what that means).
     """
-    engine = getattr(compaction_controller, "_engine", None) if compaction_controller is not None else None
-    budgets = getattr(engine, "budgets", None)
+    # #6174 (architect finding): a bare ``getattr(..., None)`` here used to
+    # swallow ANY ``AttributeError`` — including one raised INSIDE
+    # ``_engine``'s own property body (it lazily runs
+    # ``compaction_engine_factory``, #3671 follow-up) — and relabel a real
+    # engine-construction FAILURE as "no budgets", falling through to the
+    # fallback below in silence. "No controller wired" and "controller
+    # wired but its engine failed to build" are different facts; only the
+    # first degrades here — the second must propagate.
+    if compaction_controller is None:
+        engine = None
+    else:
+        engine = compaction_controller._engine
+    budgets = engine.budgets if engine is not None else None
     if budgets is not None:
         effective_trigger, head_budget, tail_budget = (
             budgets.effective_trigger, budgets.head_budget, budgets.tail_budget,
@@ -696,12 +709,22 @@ def resolve_effective_trigger_and_budgets(
     else:
         from reyn.llm.model_budget import get_max_input_tokens
         effective_trigger = get_max_input_tokens(model, events=events)
-        fallback = effective_trigger // 4
-        head_budget, tail_budget = fallback, fallback
+        # #6174: no compaction_controller wired at all — head/tail budgets
+        # are genuinely UNKNOWN here, not "25% of the window each". The
+        # prior ``effective_trigger // 4`` invented a number nothing
+        # measured and silently discarded component_weights' own
+        # asymmetry (shipped default head=10% / tail=15%, NOT a 1:1
+        # split — CompactionEngine.compute_budgets). A caller that
+        # actually needs a head/tail split without a controller has no
+        # basis to derive one here; it must decide, not this function.
+        head_budget, tail_budget = None, None
     _check_resource_within_budget(model, phase, effective_trigger, events, read_cap_config)
     # #4477: 4th instance of the resource/budget comparison class — the
-    # compaction batch's own byte cap vs head+tail's combined token budget.
-    _check_compaction_batch_within_budget(model, phase, head_budget, tail_budget, events)
+    # compaction batch's own byte cap vs head+tail's combined token
+    # budget. #6174: meaningless without a real head/tail split — skip
+    # when the fallback above left them unknown.
+    if head_budget is not None and tail_budget is not None:
+        _check_compaction_batch_within_budget(model, phase, head_budget, tail_budget, events)
     return effective_trigger, head_budget, tail_budget
 
 
@@ -1155,13 +1178,16 @@ class RouterHistoryBuffer:
                 messages[i].pop(f, None)
         return messages
 
-    def _resolve_budgets(self) -> tuple[int, int, int]:
+    def _resolve_budgets(self) -> "tuple[int, int | None, int | None]":
         """Return (effective_trigger, head_budget, tail_budget).
 
         #2957 PR-B: delegates to the module-level
         ``resolve_effective_trigger_and_budgets`` — single SSoT shared with
         ``ContextBudgetAdvisor._get_effective_trigger`` (previously each
-        reimplemented this lookup independently).
+        reimplemented this lookup independently). #6174: head_budget/
+        tail_budget are ``None`` when no compaction_controller is wired —
+        see that function's own docstring; :meth:`decompose_history_for_
+        retry`, this method's one caller, must handle that case itself.
         """
         return resolve_effective_trigger_and_budgets(
             self._compaction_controller, self._model, self._events,
@@ -1590,6 +1616,23 @@ class RouterHistoryBuffer:
             raw_middle: list = []
             tail: list = []
         else:
+            # #6174: head_budget/tail_budget are only None when no
+            # compaction_controller is wired — never the case for the one
+            # production caller (Session._build_history_compaction_bundle
+            # patches a real controller before the first turn runs) and
+            # not exercised by any test that reaches this branch today
+            # (the tests that construct a compaction_controller=None
+            # buffer all stay under effective_trigger, taking the
+            # "everything fits" branch above). Asserting loudly here, not
+            # inventing a split, keeps that true instead of assuming it.
+            if head_budget is None or tail_budget is None:
+                raise RuntimeError(
+                    "decompose_history_for_retry: history overflowed "
+                    f"effective_trigger ({effective_trigger}) but no "
+                    "compaction_controller is wired, so head/tail budgets "
+                    "are unknown -- retry-shrink cannot trim without them "
+                    "(#6174)."
+                )
             head = trim_head(wire_turns, head_budget, self._model, use_chars4=use_chars4)
             tail = trim_tail(wire_turns, tail_budget, self._model, use_chars4=use_chars4)
             # raw_middle = turns strictly between head and tail (by identity).

--- a/tests/runtime/test_6174_no_controller_budget_fallback.py
+++ b/tests/runtime/test_6174_no_controller_budget_fallback.py
@@ -1,0 +1,142 @@
+"""Tier 1/2: #6174 — the no-compaction-controller fallback must not fabricate
+a head/tail split, and an engine-construction failure must not be silently
+relabeled as "no budgets".
+
+Real defect (lead-coder, #6174, ``origin/main``): the fallback branch of
+``resolve_effective_trigger_and_budgets`` used to split
+``effective_trigger // 4`` evenly between ``head_budget``/``tail_budget`` —
+a number nothing measured, and one that silently discarded
+``component_weights``' own asymmetry (shipped default head=10% / tail=15%,
+never 1:1 — ``CompactionEngine.compute_budgets``). Separately, the
+``getattr(compaction_controller, "_engine", None)`` lookup swallowed ANY
+``AttributeError`` — including one raised from INSIDE ``_engine``'s own
+property body (it lazily builds a real ``CompactionEngine`` via
+``compaction_engine_factory``, #3671 follow-up) — so a genuine engine-
+construction failure looked identical to "no controller wired".
+
+Census (e2e-coder, #6174, reported over broker): the fallback's
+``compaction_controller is None`` branch is unreachable in production
+(``Session._build_history_compaction_bundle`` patches a real controller
+before any turn runs) but IS a deliberate, documented test-double shape
+several existing tests rely on
+(``test_live_model_budget_consumers_1752.py``'s own docstring: "so the
+window comes straight from the model") — so the fix is a type change
+(``None``, not a fabricated int) plus a loud guard at the one real
+consumer, not a bare ``raise`` inside
+``resolve_effective_trigger_and_budgets`` itself (that would break those
+legitimate doubles).
+
+Real instances throughout (CLAUDE.md mock ban) — ``RouterHistoryBuffer``/
+``CompactionController`` construction mirrors
+``tests/runtime/test_build_history_producer_calls_2939.py`` and
+``tests/runtime/test_5765_compaction_range_covers_head_gap.py``'s own
+minimal patterns.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.llm.model_budget import get_max_input_tokens
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.compaction_controller import CompactionController
+from reyn.runtime.services.router_history_buffer import (
+    RouterHistoryBuffer,
+    resolve_effective_trigger_and_budgets,
+)
+
+
+def _controller(factory) -> CompactionController:
+    """Real CompactionController — only ``_engine``'s factory varies per test."""
+    return CompactionController(
+        event_log=EventLog(),
+        config=CompactionConfig(),
+        history_from_disk=lambda after_seq: ([], False),
+        latest_summary=lambda: None,
+        compaction_engine_factory=factory,
+        history_appender=lambda m: None,
+        # Production shape (session.py's own make_summary_message lambda,
+        # #5765): covers_from_seq is a REQUIRED keyword-only argument.
+        # Never actually called by either test below (both fail before
+        # a real compaction pass would invoke it) — kept real-shaped
+        # anyway, mirrors test_5765_compaction_range_covers_head_gap.py.
+        make_summary_message=lambda rendered, structured, covers, *, covers_from_seq: ChatMessage(
+            role="summary", content=rendered, seq=0,
+            meta={
+                "structured": structured,
+                "covers_through_seq": covers,
+                "covers_from_seq": covers_from_seq,
+            },
+        ),
+        render_summary=lambda s: str(s),
+    )
+
+
+def test_no_controller_fallback_returns_none_not_a_fabricated_split():
+    """Tier 1: no compaction_controller — head/tail budgets are None, not
+    ``effective_trigger // 4``.
+
+    Falsification: the pre-#6174 code returned two EQUAL, non-None ints
+    here (``effective_trigger // 4`` for both); this asserts both the type
+    (None) and that the old same-value pair is not silently resurrected.
+    """
+    effective_trigger, head_budget, tail_budget = resolve_effective_trigger_and_budgets(
+        None, "openai/gpt-4", events=None,
+    )
+    assert effective_trigger == get_max_input_tokens("openai/gpt-4")
+    assert head_budget is None
+    assert tail_budget is None
+
+
+def test_engine_construction_failure_propagates_not_silently_falls_back():
+    """Tier 2: a real engine-construction failure must reach the caller, not
+    be relabeled "no budgets" by the getattr-with-default lookup.
+
+    Falsification: the pre-#6174 ``getattr(compaction_controller, "_engine",
+    None)`` caught this exact ``AttributeError`` (raised from INSIDE the
+    property body, not from a missing attribute) and fell through to the
+    fallback branch — this test would see a clean ``(effective_trigger,
+    None, None)`` return instead of the exception below.
+    """
+    def _factory():
+        raise AttributeError("boom -- simulated engine-construction failure")
+
+    controller = _controller(_factory)
+    with pytest.raises(AttributeError, match="boom"):
+        resolve_effective_trigger_and_budgets(controller, "openai/gpt-4", events=None)
+
+
+def test_decompose_history_for_retry_raises_loudly_rather_than_fabricate_a_split():
+    """Tier 2: ``decompose_history_for_retry``'s own overflow branch is the
+    one real consumer of head_budget/tail_budget (router_history_buffer.py
+    :1593-1594) — when they are unknown (no controller) and the history
+    genuinely overflows, it must raise, never invent a split to trim by.
+
+    Falsification: the pre-#6174 code passed the fabricated
+    ``effective_trigger // 4`` straight into ``trim_head``/``trim_tail``
+    here — this test would see a clean 5-tuple return instead of
+    ``RuntimeError``.
+    """
+    model = "openai/gpt-4"  # small real window (8K) — cheap to overflow
+    trigger = get_max_input_tokens(model)
+    # chars4 estimate: ~4 chars/token — sized well past the trigger, not
+    # just past it (a tight margin risked a flaky pass/fail on wire-dict
+    # wrapping overhead).
+    big_content = "x" * (trigger * 20)
+    history = [ChatMessage(role="user", content=big_content, seq=1)]
+
+    buf = RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=CompactionConfig(use_chars4_estimate=True),
+        compaction_controller=None,
+        model_fn=lambda: model,
+        events=None,
+        media_store=None,
+        router_host=None,
+        universal_wrappers_enabled=False,
+        non_interactive=False,
+    )
+
+    with pytest.raises(RuntimeError, match="no compaction_controller is wired"):
+        buf.decompose_history_for_retry()


### PR DESCRIPTION
**[e2e-coder]** — part of #5890, closes #6174's own finding.

## Census (reported over broker, before implementing)

`compaction_controller is None` reaches `RouterHistoryBuffer`/
`ContextBudgetAdvisor` production construction only via
`Session._build_history_compaction_bundle` (`session.py:7009`/`:7130`),
and it is patched to a real `CompactionController` in the SAME builder,
before the first turn ever runs (`:7124`). `CompactionController._engine`
always builds a real `CompactionEngine` (its factory has no "built but
absent" case — its own docstring), and `CompactionEngine._budgets` is
always set in `__init__`. So the fallback branch never fires in
production.

It IS a deliberate, documented test-double shape though:
`test_live_model_budget_consumers_1752.py`'s own docstring says
`compaction_controller=None` is used "so the window comes straight from
the model". 12 test files construct `RouterHistoryBuffer` directly; all
either pass `None` (this shape) or a real controller — no test passes a
stub lacking `_engine`. None of them consume `head_budget`/`tail_budget`
from the `None`-controller fallback (only `effective_trigger`, the `[0]`
element).

## What changed

1. `resolve_effective_trigger_and_budgets`'s fallback branch: dropped
   `effective_trigger // 4` (a number nothing measured, and one that
   silently discarded `component_weights`' own head=10%/tail=15%
   asymmetry — `CompactionEngine.compute_budgets`). Returns `None` for
   both now; return type is `tuple[int, int | None, int | None]`.
   `raise` was NOT used here — it would have broken the legitimate
   test-double shape above.
2. `getattr(compaction_controller, "_engine", None)` (architect finding)
   swallowed an `AttributeError` raised from INSIDE `_engine`'s own
   property body (its factory constructing a real `CompactionEngine`),
   not just a genuinely-missing attribute — a real engine-construction
   failure looked identical to "no controller wired" and fell through
   to the same fallback, silently. Direct attribute access now lets
   that propagate; only `compaction_controller is None` itself degrades.
3. The one real consumer of `head_budget`/`tail_budget`
   (`RouterHistoryBuffer.decompose_history_for_retry`'s overflow branch,
   `:1593-1594`) now raises `RuntimeError` if it ever actually receives
   `None` there, instead of passing a fabricated split into
   `trim_head`/`trim_tail`. `_check_compaction_batch_within_budget` is
   skipped (not called with `None`) in the same branch.

`ContextBudgetAdvisor._get_effective_trigger` (`context_budget_advisor.py
:115`) only reads `[0]` (`effective_trigger`) from the same function —
unaffected by the type change.

## Test plan

- [x] `ruff check` (both changed files)
- [x] `python scripts/test_tier_audit.py --strict tests/runtime/test_6174_no_controller_budget_fallback.py`
- [x] `python scripts/verify_module_docstrings.py` (both changed files)
- [x] `python scripts/mypy_ratchet.py` — 183 findings, all baselined, no new
- [x] `python scripts/flat_tests_ratchet.py`, `check_bare_tests_import_reference.py`, `check_file_depth_reference.py`, `check_subprocess_reyn_pin.py`, `check_no_core_dep_importorskip.py`, `suspected_time_dependence_ratchet.py` (tests/ path-conditional)
- [x] `python scripts/user_facing_lang_gate.py` (src/reyn/ path-conditional)
- [x] `python scripts/check_tests_path_literal_reference.py`
- [x] New test file green: 3/3 (fallback returns `None`, engine-construction failure propagates, decompose raises rather than fabricate)
- [x] All 12 existing tests that directly construct `RouterHistoryBuffer`, plus 2 `resolve_effective_trigger_and_budgets`-sharing invariant tests (`test_4477_compaction_batch_budget_invariant.py`, `test_4381_pr1_resource_budget_invariant.py`) and 2 `ContextBudgetAdvisor` tests, each run individually — all green
- [x] (skipped — Visual, standing waiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG4zbNaVg65hPHMqna69S
