### PR TITLE
docs(#5825): drop unverifiable byte-identical wording from §8 acceptance item

### DIFF
--- a/docs/deep-dives/proposals/0069-permission-posture-dial.md
+++ b/docs/deep-dives/proposals/0069-permission-posture-dial.md
@@ -112,7 +112,7 @@ Today's behaviour is exactly `ask` **with** a mandatory declaration. So:
 - [ ] The order is total and testable: for every pair, "strictly more permissive than" has one answer.
 - [ ] A capability denied by a restrict layer stays denied in **every** mode, `unbounded` included — the conjunction is not mode-aware.
 - [ ] The floor (§3) is unreachable from `unbounded`, with a test that goes red if a mode is added that reaches it.
-- [ ] `mode: ask` on an existing project is byte-identical to today's behaviour apart from the declaration requirement.
+- [ ] `mode: ask` does not change an existing project's behaviour apart from the declaration requirement. (This item's wording is lead-coder's own, not the owner's — the owner's words were "ダイヤル入れる。宣言は optin。3,4 解説して。あと plan モードは？"; #5825 comment.)
 - [ ] `bounded` never runs an action outside its boundary without a prompt — the strip-falsifier is removing the boundary and watching the acceptance go red, not watching the prompt disappear.
 - [ ] In `bounded`, an exec that requests network with no declaration asks once; with `permissions.network: allow` or a ledger grant it passes silently; with `permissions.network: deny` it is refused without asking; an exec that does not request network is never asked (#5825's seven witnesses).
 - [ ] When the configured sandbox backend cannot enforce the network deny (`sandbox_policy_not_applied`), `bounded` is shown as degraded in the posture surface — a boundary that is not enforced is not silently called one.


### PR DESCRIPTION
**[docs-maintainer]** — lead-coder ruling: §8's `byte-identical` acceptance item was his own paraphrase presented as a requirement, not the owner's word.

part of #5825

## Fix

`docs/deep-dives/proposals/0069-permission-posture-dial.md:115` -- dropped `byte-identical` (unverifiable: names no "byte of what", was inducing a snapshot test), kept the intent the owner's words do support, and marked the wording as lead-coder's own, not a quote.

Owner, verbatim (issue body): 「ダイヤル入れる。宣言は optin。3,4 解説して。あと plan モードは？」 -- no "byte identical" in it.

Only this one line -- the other 8 `byte-identical` instances elsewhere in docs/ are unrelated non-regression statements (context-scoped "what byte") and are untouched, per lead-coder's explicit instruction.

## Test plan

- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` (docs/ path-conditional gate)
- [x] `python scripts/check_doc_anchors.py`
- [x] `python scripts/check_retired_config_keys_denylist.py`
- [x] (skipped -- Visual, standing waiver 2026-08-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpx5z6FrF4kj3NpeR7cpD7
