### PR TITLE
fix(#5825 §3): permissions.network: deny checked unconditionally, not only when sandbox policy is already closed

### DIFF
--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -360,19 +360,37 @@ async def run_sandboxed_exec(
 
     # #5825 ①: the op's own REQUEST to run with network enabled (architect
     # ruling, issue #5825, 2026-09-06 — "ask is where a *request* meets a
-    # *closed* boundary"). Called ONLY when BOTH are true: the op explicitly
-    # asks (op.network is True) AND the resolved policy has it OFF
-    # (policy.network is False). A policy that already has network on
-    # (compat / unbounded) is untouched — require_network is not called at
-    # all, byte-identical to before this field existed (see
-    # SandboxedExecIROp.network's own docstring: "the op can REQUEST
-    # network, never FORCE it past a narrower operator policy"). On grant,
-    # replace THIS call's policy so every downstream read (backend.run, the
-    # started/completed events below) sees what was actually enforced —
-    # never the op's own unvalidated request field (#1339's own rule,
-    # applied to this new axis the same way it already applies to every
-    # other one).
-    if op.network and not policy.network:
+    # *closed* boundary"). On grant, replace THIS call's policy so every
+    # downstream read (backend.run, the started/completed events below)
+    # sees what was actually enforced — never the op's own unvalidated
+    # request field (#1339's own rule, applied to this new axis the same
+    # way it already applies to every other one).
+    #
+    # #5825 §3 fix (owner-ruled security gap, #5825's own census):
+    # `require_network` is now called for EVERY `op.network is True`
+    # request, not only when `policy.network is False` — the OLD guard
+    # here (`if op.network and not policy.network:`) skipped this call
+    # entirely whenever the resolved policy already had network on
+    # (compat / `unbounded`), which meant `permissions.network: deny`
+    # (the operator's own floor) was NEVER CONSULTED under those modes —
+    # a config deny silently did nothing. `policy_already_open=policy.
+    # network` tells `require_network` the ask/grant axis is moot (never
+    # widened past what the policy already granted); the FLOOR check
+    # inside it runs unconditionally either way — see that method's own
+    # docstring for the corrected ordering.
+    # #5825 §3 review (architect census, lead-coder ruling): raise
+    # unconditionally when no resolver is attached — NOT only when
+    # `policy.network` is already False. "no resolver, so the deny
+    # cannot be checked" must never be read as "no deny exists" — that
+    # is the exact reentry of this issue's own defect shape through a
+    # different door (a resolver-less context silently treated as
+    # equivalent to "nothing to gate"). The 38-of-54 `require_*` call
+    # sites that DO silently skip when their resolver is `None` are not
+    # a precedent to follow here — the function this fix touches has
+    # always raised in that case (see the pre-existing message below,
+    # unchanged), and this fix's own job is to make the FLOOR check
+    # unconditional, not to introduce a NEW silent-skip path alongside it.
+    if op.network:
         if ctx.permission_resolver is None:
             raise PermissionError(
                 "network access for this exec was requested (network: "
@@ -381,6 +399,7 @@ async def run_sandboxed_exec(
         await ctx.permission_resolver.require_network(
             ctx.permission_decl, ctx.intervention_bus, ctx.actor,
             argv=reported_argv, agent_name=ctx.agent_name or ctx.actor,
+            policy_already_open=policy.network,
         )
         policy = dataclasses.replace(policy, network=True)
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -339,16 +339,21 @@ class SandboxedExecIROp(BaseModel):
     REAL reader this time (`op_runtime/sandboxed_exec.py`'s own seam):
     `True` is a REQUEST, not a grant (same "declaration is intent, the
     prompt is the grant" framing `require_http_get`'s own docstring
-    states) — read ONLY when the resolved policy already has network
-    OFF (`policy.network is False`), at which point it triggers
-    `PermissionResolver.require_network` (config pre-approval, a
-    persisted ledger grant, or an interactive ask) before the policy for
-    THIS call is replaced with `network=True` and the process spawns.
-    `False` (the default) changes nothing — the sandbox's own resolved
-    policy governs, exactly as before this field existed. A policy that
-    already has network ON (compat / `unbounded`) never calls
-    `require_network` at all, regardless of this field's value — the op
-    can REQUEST network, never force it past a narrower operator policy.
+    states) — every request (`True`) now calls
+    `PermissionResolver.require_network` (#5825 §3 fix: the FLOOR,
+    `permissions.network: deny`, is checked unconditionally; the ask/
+    grant axis — config pre-approval, a persisted ledger grant, or an
+    interactive ask — only runs when the resolved policy does not
+    already have network OFF) before the policy for THIS call is
+    replaced with `network=True` and the process spawns. `False` (the
+    default) changes nothing — the sandbox's own resolved policy governs,
+    exactly as before this field existed. A policy that already has
+    network ON (compat / `unbounded`) skips the ask/grant part of
+    `require_network` (nothing left to ask), but NOT the floor check —
+    see that method's own docstring for the corrected ordering (#5825
+    §3 closed a real gap here: the floor used to be skipped too, so a
+    configured `permissions.network: deny` silently did nothing under
+    those modes).
     """
     #5838 段4: `cmd` — a shell command line, XOR `argv` (validated below,
     # same "exactly one of" shape `PresentIROp`/`RenderTemplateIROp` already

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -2201,6 +2201,7 @@ class PermissionResolver:
         *,
         argv: "list[str] | None" = None,
         agent_name: str = "",
+        policy_already_open: bool = False,
     ) -> None:
         """Gate a ``sandboxed_exec`` call's REQUEST to run with network
         enabled (#5825 ①, architect ruling 2026-09-06).
@@ -2218,28 +2219,44 @@ class PermissionResolver:
         key only (see :data:`KEY_NETWORK`), same shape as
         :data:`KEY_WEB_FETCH`.
 
-        Called ONLY when the op explicitly REQUESTS network
-        (``op.network is True``) against a resolved policy that has it
-        OFF (``policy.network is False``) — see
-        ``op_runtime/sandboxed_exec.py``'s own seam docstring. A policy
-        that already has network on (compat / ``unbounded``) never
-        reaches this method at all, regardless of the op's request — an
-        op can ask for network, never force it past a narrower operator
-        policy.
+        Called for EVERY ``op.network is True`` request (#5825 §3 fix,
+        owner-ruled security gap — architect co-vet required; corrects
+        an EARLIER, WRONG shape of this docstring, quoted and refuted
+        below) — see ``op_runtime/sandboxed_exec.py``'s own seam
+        docstring for the call site. ``policy_already_open`` (new)
+        carries whether the resolved policy already has network on
+        (compat / ``unbounded``): the FLOOR below still applies either
+        way; only steps 2-4 (the ask/grant axis) are skipped when it is
+        ``True``, since a policy already open has nothing left to ask —
+        never widened past what the policy already granted.
+
+        The claim this docstring made before #5825's own census found
+        the gap — "a policy that already has network on never reaches
+        this method at all" — was FALSE in exactly the way that
+        mattered: it meant ``permissions.network: deny`` (the operator's
+        own floor) was silently never consulted under ``unbounded``/
+        ``compat``, the one case #5825 §3 exists to close. The floor is
+        now unconditional; only the ask/grant axis stays conditional on
+        the policy not already being open.
 
         Order (owner ruling 2026-09-06, FP-0069 §6.1/§10 — "declared →
         silent, undeclared → ask", corrected from an earlier "undeclared
-        → deny" draft):
+        → deny" draft; step 1 corrected AGAIN by #5825 §3 to actually run
+        unconditionally, matching what this text always claimed):
 
         1. **Floor**: ``permissions.network: deny`` (config) → denies,
-           without asking — the operator's floor always wins.
-        2. **Declared**: ``permissions.network: allow`` (config
+           without asking, REGARDLESS of ``policy_already_open`` — the
+           operator's floor always wins.
+        2. **Already open**: ``policy_already_open`` — the resolved
+           policy already grants network; nothing left to ask or check,
+           returns (no ledger read/write for this call).
+        3. **Declared**: ``permissions.network: allow`` (config
            pre-approval) OR a persisted ledger grant under
            ``<actor>/network/*`` (a prior ALWAYS answer, #5052
            agent-scope convention) → passes silently, no ask.
-        3. **Ask**: an interactive ``bus`` is available → prompts once,
+        4. **Ask**: an interactive ``bus`` is available → prompts once,
            persists an ALWAYS/NEVER choice to the SAME ledger key.
-        4. **No bus** (non-interactive / headless) → denies — the same
+        5. **No bus** (non-interactive / headless) → denies — the same
            "bus=None is not a pause, it's a deny" posture
            ``require_http_get``'s own legacy-compat path already applies.
 
@@ -2277,6 +2294,14 @@ class PermissionResolver:
                 f"network access for this exec denied by config "
                 f"({KEY_NETWORK}: deny)."
             )
+        if policy_already_open:
+            # #5825 §3: the floor above already ran (unconditionally).
+            # The resolved policy already grants network -- the ask/
+            # grant axis below is moot; returning here, never widening
+            # past what the policy already had, is the ONLY change this
+            # branch makes to the call sites that used to skip this
+            # method entirely.
+            return
         if self._is_config_approved(KEY_NETWORK):
             return
         key = f"{actor}/network/*"

--- a/tests/core/test_5825_sandboxed_exec_network_seam.py
+++ b/tests/core/test_5825_sandboxed_exec_network_seam.py
@@ -95,10 +95,20 @@ def _started_events(collected: list) -> list:
 
 
 @pytest.mark.asyncio
-async def test_policy_already_open_skips_require_network(tmp_path: Path) -> None:
-    """Tier 2: policy.network already True (compat/unbounded) -> require_network
-    is NEVER called, regardless of the op's own request -- byte-identical to
-    before this field existed (SandboxedExecIROp.network's own docstring)."""
+async def test_policy_already_open_with_no_config_runs_without_asking(tmp_path: Path) -> None:
+    """Tier 2: policy.network already True (compat/unbounded), no
+    ``permissions.network`` config either way -- runs without asking,
+    regardless of the op's own request.
+
+    #5825 §3 fix (renamed from ``test_policy_already_open_skips_require_
+    network``, which is now inaccurate): ``require_network`` IS called for
+    every ``op.network is True`` request as of #5825 §3 (see that method's
+    own ``policy_already_open`` parameter) -- what stays true, and what
+    this test actually asserts, is the OBSERVABLE behavior: no ask, no
+    sandboxed_exec_started change. See ``test_config_network_deny_blocks_
+    an_already_open_policy`` below for the accept-side witness that the
+    call now genuinely happens (a configured deny DOES fire here, where
+    it silently did not before #5825 §3)."""
     bus = _FakeBus(NO)  # would deny if ever asked -- proves it was never asked
     ctx, collected = _make_ctx(tmp_path, bus=bus, network_policy=True)
     op = SandboxedExecIROp(kind="sandboxed_exec", argv=["true"], network=True)
@@ -110,6 +120,40 @@ async def test_policy_already_open_skips_require_network(tmp_path: Path) -> None
     await settle(ctx.events)
     (started,) = _started_events(collected)
     assert started.data["network"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_network_deny_blocks_an_already_open_policy(tmp_path: Path) -> None:
+    """Tier 2: #5825 §3 -- the accept-side witness for the security gap
+    the census found. ``permissions.network: deny`` (the operator's own
+    floor) must block a run even when the resolved sandbox policy ALREADY
+    has network on (``network_policy=True`` -- compat/``unbounded``).
+
+    Before #5825 §3: the call site's own guard (`if op.network and not
+    policy.network:`) skipped ``require_network`` entirely whenever
+    ``policy.network`` was already ``True`` -- the floor inside
+    ``require_network`` (checked first, unconditionally, in that method's
+    own body) was therefore NEVER REACHED, and a configured
+    ``permissions.network: deny`` silently did nothing under
+    compat/``unbounded``.
+
+    Strip-falsifier (performed during review): reverting the call site's
+    guard to ``if op.network and not policy.network:`` (dropping the
+    unconditional call) makes this test fail -- the run succeeds instead
+    of raising, because ``require_network`` (and its floor check) is
+    never reached."""
+    bus = _FakeBus(YES)  # would grant if ever asked -- proves the floor denies first
+    ctx, collected = _make_ctx(
+        tmp_path, bus=bus, network_policy=True, config={"network": "deny"},
+    )
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["true"], network=True)
+
+    with pytest.raises(PermissionError, match="denied by config"):
+        await run_sandboxed_exec(op, ctx)
+
+    assert bus.asks == []
+    await settle(ctx.events)
+    assert collected == []
 
 
 @pytest.mark.asyncio
@@ -210,6 +254,43 @@ async def test_no_permission_resolver_denies_a_network_request_fail_closed(
         permission_decl=PermissionDecl(),
         permission_resolver=None,
         default_sandbox_policy={"network": False},
+        sandbox_backend=_SuccessBackend(),
+    )
+    op = SandboxedExecIROp(kind="sandboxed_exec", argv=["true"], network=True)
+
+    with pytest.raises(PermissionError, match="no permission resolver"):
+        await run_sandboxed_exec(op, ctx)
+
+    await settle(ctx.events)
+    assert collected == []
+
+
+@pytest.mark.asyncio
+async def test_no_permission_resolver_denies_even_against_an_already_open_policy(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #5825 §3 review (lead-coder correction, architect census) —
+    the SAME fail-closed posture as the sibling test above, but with
+    ``policy.network`` already ``True`` (compat/``unbounded``-shaped).
+
+    Before this correction, a resolver-less context with an already-open
+    policy would have silently skipped the whole gate (no raise) — "no
+    resolver, so the config deny cannot be checked" must never be read as
+    "no deny exists"; that is this issue's own defect shape re-entering
+    through a different door. The function's own pre-existing behavior
+    (raise when no resolver, see the sibling test) is what this case now
+    matches too, unconditionally of ``policy.network``."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    collected = collect_events(events)
+    workspace = Workspace(events=events, base_dir=project_root)
+    ctx = OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        default_sandbox_policy={"network": True},  # already open — compat/unbounded
         sandbox_backend=_SuccessBackend(),
     )
     op = SandboxedExecIROp(kind="sandboxed_exec", argv=["true"], network=True)


### PR DESCRIPTION
**[tui-coder]** —

part of #5825

⚠️ **security-sensitive — requires architect co-vet AND CI green before merge (owner/lead-coder ruling), not self-mergeable even once CI passes.**

## Security gap (found by #5825's own census, not speculation)

`require_network`'s own floor check (`permissions.network: deny`, checked first, unconditionally, inside that method's own body) was **never reached** whenever the resolved sandbox policy already had network on (`compat` / `unbounded` — the majority of modes). The call site's own guard, `if op.network and not policy.network:`, skipped calling `require_network` entirely in that case — a configured `permissions.network: deny` silently did nothing under those modes, contradicting FP-0069 §8's own acceptance line ("A capability denied by a restrict layer stays denied in every mode, unbounded included").

architect's own AST census of all 54 `require_*` call sites in `src/` confirms this shape exists at exactly this **ONE** site — not searched for or duplicated anywhere else in this PR, per that same census. The other 3 axes census already checked (file/write/mcp) do not have this pattern (their own `EffectivePermission` conjunction is mode-unaware by construction) and are untouched here.

## Fix (owner-ruled direction)

Deny is checked **unconditionally**; only the ask/grant side stays conditional on the policy not already being open — the same deny-raises/allow-returns asymmetry #6148 established earlier tonight for a different gate, kept deliberately separate rather than folded into one condition.

`PermissionResolver.require_network` gains a new keyword-only `policy_already_open: bool = False` parameter. The floor (`_is_config_denied`) runs first, unconditionally, exactly as it already did; when `policy_already_open` is `True`, the method returns immediately right after that check — the ask/grant axis never runs, never widened past what the policy already granted. `sandboxed_exec.py`'s own call site now invokes `require_network` for **every** `op.network is True` request, passing `policy_already_open=policy.network`.

## Review correction (lead-coder, mid-implementation, architect census)

When no `permission_resolver` is attached at all, this now raises **unconditionally** (previously: only when `policy.network` was already `False`). "No resolver, so the deny cannot be checked" must never be read as "no deny exists" — that would reopen this exact defect shape through a different door. This deliberately does **not** follow the silent-skip pattern the dominant 38-of-54 other `require_*` call sites use when their own resolver is `None` — this specific function has always raised in that case, and that precedent is what this fix extends.

`dataclasses.replace(policy, network=True)` (the #1339 "emit what was actually enforced" rule) still runs immediately after a successful `require_network` call, unconditionally — harmless no-op when policy was already open, keeps `sandboxed_exec_started`'s own `network=policy.network` field honest either way (architect co-vet point, flagged before implementation).

## Doc/comment fixes (CLAUDE.md: describing comments stale the moment code changes)

`require_network`'s own docstring and `SandboxedExecIROp.network`'s own field docstring (`schemas/models.py`) both explicitly claimed "a policy that already has network on never reaches this method at all" — the exact claim this fix falsifies. Both corrected in place, old claim quoted and refuted rather than silently deleted.

## Tests

- Renamed `test_policy_already_open_skips_require_network` → `test_policy_already_open_with_no_config_runs_without_asking` (old name's claim is now false; the observable behavior it asserts still holds).
- New: `test_config_network_deny_blocks_an_already_open_policy` — accept-side witness for the security gap itself.
- New: `test_no_permission_resolver_denies_even_against_an_already_open_policy` — the review-correction's own accept-side witness.

**Strip-falsify** (both performed via in-file Edit, reverted after):
1. Reverting the call site to `if op.network and not policy.network:` → `test_config_network_deny_blocks_an_already_open_policy` goes RED.
2. Reverting the no-resolver branch to its old `if not policy.network:` guard → `test_no_permission_resolver_denies_even_against_an_already_open_policy` goes RED.

## Gates

- `ruff check .` — clean
- `scripts/verify_module_docstrings.py` (permissions.py, sandboxed_exec.py, models.py) — OK
- `scripts/mypy_ratchet.py` — 183 findings, all baselined
- `scripts/test_tier_audit.py --strict` — 8/8 OK, 0 Tier-4
- tests/-path-conditional gates — all OK
- Diff-scoped + adjacent pytest — not waiting on CI per dispatch (co-vet + CI both required before merge, per ruling above).

## Pytest (diff-scoped + directly adjacent)

`test_5825_sandboxed_exec_network_seam.py` (8) + `test_5825_require_network.py` + `test_5825_stage3_declaration_optin.py` + `test_5825_permission_posture_dial.py` + `test_5825_stage2_bounded_mode.py` + `test_sandbox_model_completion_1339.py` + `test_op_sandboxed_exec.py` — **all green (118/118)**.

## Test plan
- [x] Diff-scoped + adjacent pytest green (118/118)
- [x] Strip-falsify performed and verbatim result reported above (both rounds)
- [x] (skipped — no UI surface) Visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzYAXF8WFTxR2JPMZSoDfn